### PR TITLE
jsoo: shorten paths of shared jsoo runtimes and libraries

### DIFF
--- a/doc/changes/fixed/14768.md
+++ b/doc/changes/fixed/14768.md
@@ -1,0 +1,4 @@
+- Shorten the build paths of `js_of_ocaml` and `wasm_of_ocaml` artifacts by
+  hashing the compilation config into a digest instead of spelling out every
+  flag, avoiding excessively long paths for deeply-nested wasm builds (#14768,
+  @vouillon)

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -654,8 +654,8 @@ let gen_rules ctx sctx ~dir components : Gen_rules.result Memo.t =
     has_rules
       ~dir
       (match rest with
-       | [] | [ _ ] -> Subdir_set.all
-       | [ _; ".runtime" ] -> Subdir_set.all
+       | [] -> Subdir_set.all
+       | [ s ] when Option.is_none (Digest.from_hex s) -> Subdir_set.all
        | _ -> Subdir_set.empty)
       (fun () ->
          (* XXX the use of the super context is dubious here. We're using it to

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -655,7 +655,7 @@ let gen_rules ctx sctx ~dir components : Gen_rules.result Memo.t =
       ~dir
       (match rest with
        | [] -> Subdir_set.all
-       | [ s ] when Option.is_none (Digest.from_hex s) -> Subdir_set.all
+       | [ s ] when Jsoo_rules.Config.is_known_path_digest s -> Subdir_set.all
        | _ -> Subdir_set.empty)
       (fun () ->
          (* XXX the use of the super context is dubious here. We're using it to

--- a/src/dune_rules/jsoo/jsoo_archive_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_archive_rules.ml
@@ -130,23 +130,25 @@ let lib_archive_rules_memo =
          let in_context =
            Js_of_ocaml.In_context.make ~dir:lib_dir lib.buildable.js_of_ocaml
          in
-         let config = Jsoo_rules.Config.of_string config in
-         let+ rules =
-           Rules.collect_unit (fun () ->
-             Memo.parallel_iter Js_of_ocaml.Mode.all ~f:(fun mode ->
-               let in_context = Js_of_ocaml.Mode.Pair.select ~mode in_context in
-               Jsoo_rules.build_cm
-                 cctx
-                 ~dir:obj_dir_dir
-                 ~in_context
-                 ~mode
-                 ~config:(Some config)
-                 ~src:(Path.build src)
-                 ~deps:(Action_builder.return [])
-                 ~obj_dir
-               |> Super_context.add_rule sctx ~dir:obj_dir_dir ~loc:lib.buildable.loc))
-         in
-         Some rules)
+         (match Jsoo_rules.Config.decode_path_digest config with
+          | None -> Memo.return None
+          | Some config ->
+            let+ rules =
+              Rules.collect_unit (fun () ->
+                Memo.parallel_iter Js_of_ocaml.Mode.all ~f:(fun mode ->
+                  let in_context = Js_of_ocaml.Mode.Pair.select ~mode in_context in
+                  Jsoo_rules.build_cm
+                    cctx
+                    ~dir:obj_dir_dir
+                    ~in_context
+                    ~mode
+                    ~config:(Some config)
+                    ~src:(Path.build src)
+                    ~deps:(Action_builder.return [])
+                    ~obj_dir
+                  |> Super_context.add_rule sctx ~dir:obj_dir_dir ~loc:lib.buildable.loc))
+            in
+            Some rules))
 ;;
 
 type lib_archive_rules =

--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -126,6 +126,8 @@ module Config : sig
   val of_flags : string list -> t
   val to_flags : jsoo_version:Version.t option -> t -> string list
   val remove_config_flags : string list -> string list
+  val equal : t -> t -> bool
+  val repr : t Repr.t
 end = struct
   type effects_backend =
     | Cps
@@ -277,6 +279,8 @@ end = struct
   let of_string x = x
   let of_flags l = path_of_config (config_of_flags l)
   let to_flags ~jsoo_version t = flags_of_config ~jsoo_version (config_of_string t)
+  let equal = String.equal
+  let repr = String.repr
 
   let remove_config_flags flags =
     let rec loop acc = function
@@ -485,13 +489,22 @@ module Runtime_key : sig
   type encoded = Digest.t
 
   module Decoded : sig
+    module Partial : sig
+      type t = private
+        { mode : Js_of_ocaml.Mode.t
+        ; lib_names : Lib_name.t list
+        ; project_root : Path.Source.t option
+        }
+
+      val of_libs : mode:Js_of_ocaml.Mode.t -> Lib.t list -> t
+    end
+
     type t = private
-      { mode : Js_of_ocaml.Mode.t
-      ; lib_names : Lib_name.t list
-      ; project_root : Path.Source.t option
+      { partial : Partial.t
+      ; config : Config.t
       }
 
-    val of_libs : mode:Js_of_ocaml.Mode.t -> Lib.t list -> t
+    val with_config : Partial.t -> config:Config.t -> t
   end
 
   val encode : Decoded.t -> encoded
@@ -500,19 +513,46 @@ end = struct
   type encoded = Digest.t
 
   module Decoded = struct
+    module Partial = struct
+      type t =
+        { mode : Js_of_ocaml.Mode.t
+        ; lib_names : Lib_name.t list
+        ; project_root : Path.Source.t option
+        }
+
+      let equal x y =
+        Js_of_ocaml.Mode.equal x.mode y.mode
+        && List.equal Lib_name.equal x.lib_names y.lib_names
+        && Option.equal Path.Source.equal x.project_root y.project_root
+      ;;
+
+      let of_libs ~mode libs =
+        let libs_with_runtime =
+          List.filter libs ~f:(fun lib ->
+            not (List.is_empty (jsoo_runtime_files ~mode [ lib ])))
+        in
+        (* Keep the topological order from [requires_link]: jsoo runtime
+           contents are concatenated and later files override earlier ones,
+           so reordering (e.g. sorting by name) can change which conflicting
+           binding wins. *)
+        let lib_names = List.map libs_with_runtime ~f:Lib.name in
+        let project_root = Lib.L.project_root libs_with_runtime in
+        { mode; lib_names; project_root }
+      ;;
+    end
+
     type t =
-      { mode : Js_of_ocaml.Mode.t
-      ; lib_names : Lib_name.t list
-      ; project_root : Path.Source.t option
+      { partial : Partial.t
+      ; config : Config.t
       }
 
-    let equal x y =
-      Js_of_ocaml.Mode.equal x.mode y.mode
-      && List.equal Lib_name.equal x.lib_names y.lib_names
-      && Option.equal Path.Source.equal x.project_root y.project_root
+    let with_config partial ~config = { partial; config }
+
+    let equal { partial = p1; config = c1 } { partial = p2; config = c2 } =
+      Partial.equal p1 p2 && Config.equal c1 c2
     ;;
 
-    let to_string { mode; lib_names; project_root } =
+    let to_string { partial = { mode; lib_names; project_root }; config = _ } =
       let s =
         sprintf
           "%s runtime for %s"
@@ -523,20 +563,6 @@ end = struct
       | None -> s
       | Some dir ->
         sprintf "%s (in project: %s)" s (Path.Source.to_string_maybe_quoted dir)
-    ;;
-
-    let of_libs ~mode libs =
-      let libs_with_runtime =
-        List.filter libs ~f:(fun lib ->
-          not (List.is_empty (jsoo_runtime_files ~mode [ lib ])))
-      in
-      (* Keep the topological order from [requires_link]: jsoo runtime
-         contents are concatenated and later files override earlier ones,
-         so reordering (e.g. sorting by name) can change which conflicting
-         binding wins. *)
-      let lib_names = List.map libs_with_runtime ~f:Lib.name in
-      let project_root = Lib.L.project_root libs_with_runtime in
-      { mode; lib_names; project_root }
     ;;
   end
 
@@ -554,11 +580,14 @@ end = struct
       ]
   ;;
 
-  let encode ({ Decoded.mode; lib_names; project_root } as x) =
+  let encode ({ Decoded.partial = { mode; lib_names; project_root }; config } as x) =
     let y =
       Digest.repr
-        Repr.(triple mode_repr (list Lib_name.repr) (option Path.Source.repr))
-        (mode, lib_names, project_root)
+        Repr.(
+          pair
+            (triple mode_repr (list Lib_name.repr) (option Path.Source.repr))
+            Config.repr)
+        ((mode, lib_names, project_root), config)
     in
     match Table.find reverse_table y with
     | None ->
@@ -588,7 +617,7 @@ end = struct
 end
 
 type standalone_runtime =
-  | Shared of Digest.t
+  | Shared of Runtime_key.Decoded.Partial.t
   | Per_stanza of Path.Build.t
 
 let standalone_runtime_rule ~mode cc ~runtime_files ~target ~flags ~sourcemap =
@@ -903,14 +932,17 @@ let build_cm
 
 let for_ = Compilation_mode.Ocaml
 
-let setup_shared_runtime_rule sctx s_config s_digest =
-  let config = Config.of_string s_config in
+let shared_runtime_dir (ctx : Build_context.t) ~s_digest =
+  Path.Build.L.relative ctx.build_dir [ ".js"; s_digest ]
+;;
+
+let setup_shared_runtime_rule sctx s_digest =
   let ctx = Super_context.context sctx in
   let build_context = Context.build_context ctx in
   match Digest.from_hex s_digest with
   | None -> User_error.raise [ Pp.textf "invalid jsoo runtime key: %s" s_digest ]
   | Some digest ->
-    let { Runtime_key.Decoded.mode; lib_names; project_root } =
+    let { Runtime_key.Decoded.partial = { mode; lib_names; project_root }; config } =
       Runtime_key.decode digest
     in
     let* scope =
@@ -927,15 +959,11 @@ let setup_shared_runtime_rule sctx s_config s_digest =
         Lib.DB.resolve lib_db (Loc.none, name) |> Resolve.Memo.read_memo)
     in
     let runtime_files = jsoo_runtime_files ~mode libs in
-    let dir = in_build_dir build_context ~config [ ".runtime"; s_digest ] in
+    let dir = shared_runtime_dir build_context ~s_digest in
     let target =
-      in_build_dir
-        build_context
-        ~config
-        [ ".runtime"
-        ; s_digest
-        ; "runtime" ^ Filename.Extension.to_string (Js_of_ocaml.Ext.runtime ~mode)
-        ]
+      Path.Build.relative
+        dir
+        ("runtime" ^ Filename.Extension.to_string (Js_of_ocaml.Ext.runtime ~mode))
     in
     js_of_ocaml_rule
       sctx
@@ -953,8 +981,9 @@ let setup_shared_runtime_rule sctx s_config s_digest =
 
 let setup_separate_compilation_rules sctx components =
   match components with
-  | [ s_config; ".runtime"; s_digest ] -> setup_shared_runtime_rule sctx s_config s_digest
-  | [] | [ _ ] | [ _; ".runtime" ] -> Memo.return ()
+  | [ s_digest ] when Option.is_some (Digest.from_hex s_digest) ->
+    setup_shared_runtime_rule sctx s_digest
+  | [] | [ _ ] -> Memo.return ()
   | [ s_config; s_pkg ] ->
     let config = Config.of_string s_config in
     let pkg = Lib_name.parse_string_exn (Loc.none, s_pkg) in
@@ -1124,12 +1153,12 @@ let build_standalone_runtime cc ~loc ~in_context ~jsoo_mode:mode =
       then
         Resolve.Memo.peek (Compilation_context.requires_link cc)
         >>| function
-        | Ok libs -> Some (Runtime_key.encode (Runtime_key.Decoded.of_libs ~mode libs))
+        | Ok libs -> Some (Runtime_key.Decoded.Partial.of_libs ~mode libs)
         | Error () -> None
       else Memo.return None
     in
     (match eligible with
-     | Some digest -> Memo.return (Some (Shared digest))
+     | Some partial -> Memo.return (Some (Shared partial))
      | None ->
        let obj_dir = Compilation_context.obj_dir cc in
        let target =
@@ -1195,20 +1224,20 @@ let build_exe
   | Separate_compilation ->
     let runtime_dep, per_exe_runtime_target =
       match standalone_runtime with
-      | Some (Shared digest) ->
+      | Some (Shared partial) ->
         let ctx = Super_context.context sctx |> Context.build_context in
         ( (let open Action_builder.O in
            let+ config = resolve_config sctx ~dir ~mode flags in
+           let digest =
+             Runtime_key.encode (Runtime_key.Decoded.with_config partial ~config)
+           in
+           let s_digest = Digest.to_string digest in
            Command.Args.Dep
              (Path.build
-                (in_build_dir
-                   ctx
-                   ~config
-                   [ ".runtime"
-                   ; Digest.to_string digest
-                   ; "runtime"
-                     ^ Filename.Extension.to_string (Js_of_ocaml.Ext.runtime ~mode)
-                   ])))
+                (Path.Build.relative
+                   (shared_runtime_dir ctx ~s_digest)
+                   ("runtime"
+                    ^ Filename.Extension.to_string (Js_of_ocaml.Ext.runtime ~mode)))))
         , None )
       | Some (Per_stanza path) ->
         Action_builder.return (Command.Args.Dep (Path.build path)), None

--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -128,6 +128,14 @@ module Config : sig
   val remove_config_flags : string list -> string list
   val equal : t -> t -> bool
   val repr : t Repr.t
+
+  (** Hex digest of [t], used as a path component instead of [path] to keep
+      build paths short. Records the digest in a reverse table so it can be
+      decoded later in the same process. *)
+  val path_digest : t -> string
+
+  val decode_path_digest : string -> t option
+  val is_known_path_digest : string -> bool
 end = struct
   type effects_backend =
     | Cps
@@ -281,6 +289,19 @@ end = struct
   let to_flags ~jsoo_version t = flags_of_config ~jsoo_version (config_of_string t)
   let equal = String.equal
   let repr = String.repr
+  let path_digest_table : (Digest.t, t) Table.t = Table.create (module Digest) 32
+
+  let path_digest t =
+    let digest = Digest.string t in
+    Table.set path_digest_table digest t;
+    Digest.to_string digest
+  ;;
+
+  let decode_path_digest s =
+    Option.bind (Digest.from_hex s) ~f:(Table.find path_digest_table)
+  ;;
+
+  let is_known_path_digest s = Option.is_some (decode_path_digest s)
 
   let remove_config_flags flags =
     let rec loop acc = function
@@ -312,14 +333,15 @@ let install_jsoo_hint = "opam install js_of_ocaml-compiler"
 let install_wasmoo_hint = "opam install wasm_of_ocaml-compiler"
 
 let in_build_dir (ctx : Build_context.t) ~config args =
-  Path.Build.L.relative ctx.build_dir (".js" :: Config.path config :: args)
+  Path.Build.L.relative ctx.build_dir (".js" :: Config.path_digest config :: args)
 ;;
 
 let in_obj_dir ~obj_dir ~config args =
   let dir =
     match config with
     | None -> Obj_dir.jsoo_dir obj_dir
-    | Some config -> Path.Build.relative (Obj_dir.jsoo_dir obj_dir) (Config.path config)
+    | Some config ->
+      Path.Build.relative (Obj_dir.jsoo_dir obj_dir) (Config.path_digest config)
   in
   Path.Build.L.relative dir args
 ;;
@@ -328,7 +350,7 @@ let in_obj_dir' ~obj_dir ~config args =
   let dir =
     match config with
     | None -> Obj_dir.jsoo_dir obj_dir
-    | Some config -> Path.relative (Obj_dir.jsoo_dir obj_dir) (Config.path config)
+    | Some config -> Path.relative (Obj_dir.jsoo_dir obj_dir) (Config.path_digest config)
   in
   Path.L.relative dir args
 ;;
@@ -509,6 +531,7 @@ module Runtime_key : sig
 
   val encode : Decoded.t -> encoded
   val decode : encoded -> Decoded.t
+  val is_known : string -> bool
 end = struct
   type encoded = Digest.t
 
@@ -613,6 +636,12 @@ end = struct
             "I don't know what jsoo runtime set %s correspond to."
             (Digest.to_string y)
         ]
+  ;;
+
+  let is_known s =
+    match Digest.from_hex s with
+    | None -> false
+    | Some d -> Table.mem reverse_table d
   ;;
 end
 
@@ -981,11 +1010,10 @@ let setup_shared_runtime_rule sctx s_digest =
 
 let setup_separate_compilation_rules sctx components =
   match components with
-  | [ s_digest ] when Option.is_some (Digest.from_hex s_digest) ->
-    setup_shared_runtime_rule sctx s_digest
+  | [ s ] when Runtime_key.is_known s -> setup_shared_runtime_rule sctx s
   | [] | [ _ ] -> Memo.return ()
-  | [ s_config; s_pkg ] ->
-    let config = Config.of_string s_config in
+  | [ s_config; s_pkg ] when Config.is_known_path_digest s_config ->
+    let config = Option.value_exn (Config.decode_path_digest s_config) in
     let pkg = Lib_name.parse_string_exn (Loc.none, s_pkg) in
     let ctx = Super_context.context sctx in
     let* installed_libs = Lib.DB.installed ctx in

--- a/src/dune_rules/jsoo/jsoo_rules.mli
+++ b/src/dune_rules/jsoo/jsoo_rules.mli
@@ -38,9 +38,7 @@ val build_cm
   -> config:Config.t option
   -> Action.Full.t Action_builder.With_targets.t
 
-type standalone_runtime =
-  | Shared of Digest.t
-  | Per_stanza of Path.Build.t
+type standalone_runtime
 
 val build_standalone_runtime
   :  Compilation_context.t

--- a/src/dune_rules/jsoo/jsoo_rules.mli
+++ b/src/dune_rules/jsoo/jsoo_rules.mli
@@ -6,6 +6,8 @@ module Config : sig
   type t
 
   val of_string : string -> t
+  val decode_path_digest : string -> t option
+  val is_known_path_digest : string -> bool
 end
 
 module Version : sig

--- a/src/dune_rules/parameterised_rules.ml
+++ b/src/dune_rules/parameterised_rules.ml
@@ -371,13 +371,15 @@ let instantiate ~sctx lib =
 ;;
 
 let instantiate_jsoo ~sctx lib s_config =
-  let config = Jsoo_rules.Config.of_string s_config in
-  let ctx = Super_context.context sctx in
-  let build_dir = Context.build_dir ctx in
-  let lib = Lib.Parameterised.for_instance ~build_dir ~ext_lib:None lib in
-  let obj_dir = Lib_info.obj_dir (Lib.info lib) |> Obj_dir.as_local_exn in
-  Memo.parallel_iter Js_of_ocaml.Mode.all ~f:(fun mode ->
-    build_jsoo ~sctx ~obj_dir ~dir:build_dir ~lib ~mode ~config:(Some config))
+  match Jsoo_rules.Config.decode_path_digest s_config with
+  | None -> Memo.return ()
+  | Some config ->
+    let ctx = Super_context.context sctx in
+    let build_dir = Context.build_dir ctx in
+    let lib = Lib.Parameterised.for_instance ~build_dir ~ext_lib:None lib in
+    let obj_dir = Lib_info.obj_dir (Lib.info lib) |> Obj_dir.as_local_exn in
+    Memo.parallel_iter Js_of_ocaml.Mode.all ~f:(fun mode ->
+      build_jsoo ~sctx ~obj_dir ~dir:build_dir ~lib ~mode ~config:(Some config))
 ;;
 
 let resolve_instantiation scope instance_name =

--- a/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-specified.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-specified.t/run.t
@@ -14,27 +14,31 @@ We also check that .cmo.js rules are not generated if not specified.
   [1]
 
 JS compilation of libraries is always available to avoid having to annotate
-every dependency of an executable.
-
-  $ dune build _build/default/.foo.objs/jsoo/effects=disabled/foo.cma.js
+every dependency of an executable. The library's cma.js target shows up in
+the @all trace below.
 
 Check that js targets are attached to @all, but not for tests that do not
 specify js mode (#1940).
 
   $ dune clean
   $ dune build @@all
+Sort by shape (hex normalized to a placeholder) so digest labels get
+assigned deterministically regardless of raw digest byte values.
+
   $ dune trace cat | jq_dune -r '
   >   processes
   > | select(.args.prog | test("js_of_ocaml$"))
   > | .args | targets | .[] | sub("^_build/[^/]+/"; "")' \
+  > | awk '{ k=$0; gsub(/[0-9a-f]{32}/, "HEX", k); print k "\t" $0 }' \
   > | sort \
+  > | cut -f2- \
   > | censor
   .b.eobjs/jsoo/b.cmo.js
   .e.eobjs/jsoo/e.cmo.js
-  .foo.objs/jsoo/effects=disabled/foo.cma.js
-  .js/$DIGEST/runtime.bc.runtime.js
-  .js/effects=disabled/stdlib/std_exit.cmo.js
-  .js/effects=disabled/stdlib/stdlib.cma.js
+  .foo.objs/jsoo/$DIGEST1/foo.cma.js
+  .js/$DIGEST2/runtime.bc.runtime.js
+  .js/$DIGEST1/stdlib/std_exit.cmo.js
+  .js/$DIGEST1/stdlib/stdlib.cma.js
   b.bc.js
   e.bc.js
 

--- a/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-specified.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-specified.t/run.t
@@ -32,7 +32,7 @@ specify js mode (#1940).
   .b.eobjs/jsoo/b.cmo.js
   .e.eobjs/jsoo/e.cmo.js
   .foo.objs/jsoo/effects=disabled/foo.cma.js
-  .js/effects=disabled/.runtime/$DIGEST/runtime.bc.runtime.js
+  .js/$DIGEST/runtime.bc.runtime.js
   .js/effects=disabled/stdlib/std_exit.cmo.js
   .js/effects=disabled/stdlib/stdlib.cma.js
   b.bc.js

--- a/test/blackbox-tests/test-cases/jsoo/jsoo-config.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/jsoo-config.t/run.t
@@ -5,12 +5,12 @@ tests js_of_ocaml conigs
   >   processes
   > | select(.args.prog | test("js_of_ocaml$"))
   > | .args | targets | .[] | sub("^_build/[^/]+/"; "")' \
-  > | sort \
-  > | censor
-  .js/effects=disabled+use-js-string=false/.runtime/$DIGEST/runtime.bc.runtime.js
+  > | censor \
+  > | sort
+  .js/$DIGEST1/runtime.bc.runtime.js
+  .js/$DIGEST2/runtime.bc.runtime.js
   .js/effects=disabled+use-js-string=false/stdlib/std_exit.cmo.js
   .js/effects=disabled+use-js-string=false/stdlib/stdlib.cma.js
-  .js/effects=disabled/.runtime/$DIGEST/runtime.bc.runtime.js
   .js/effects=disabled/stdlib/std_exit.cmo.js
   .js/effects=disabled/stdlib/stdlib.cma.js
   bin/.bin1.eobjs/jsoo/dune__exe__Bin1.cmo.js

--- a/test/blackbox-tests/test-cases/jsoo/jsoo-config.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/jsoo-config.t/run.t
@@ -8,19 +8,19 @@ tests js_of_ocaml conigs
   > | censor \
   > | sort
   .js/$DIGEST1/runtime.bc.runtime.js
-  .js/$DIGEST2/runtime.bc.runtime.js
-  .js/effects=disabled+use-js-string=false/stdlib/std_exit.cmo.js
-  .js/effects=disabled+use-js-string=false/stdlib/stdlib.cma.js
-  .js/effects=disabled/stdlib/std_exit.cmo.js
-  .js/effects=disabled/stdlib/stdlib.cma.js
+  .js/$DIGEST2/stdlib/std_exit.cmo.js
+  .js/$DIGEST2/stdlib/stdlib.cma.js
+  .js/$DIGEST3/runtime.bc.runtime.js
+  .js/$DIGEST4/stdlib/std_exit.cmo.js
+  .js/$DIGEST4/stdlib/stdlib.cma.js
   bin/.bin1.eobjs/jsoo/dune__exe__Bin1.cmo.js
   bin/.bin2.eobjs/jsoo/dune__exe__Bin2.cmo.js
   bin/.bin3.eobjs/jsoo/dune__exe__Bin3.cmo.js
   bin/bin1.bc.js
   bin/bin2.bc.js
   bin/bin3.bc.js
-  lib/.library1.objs/jsoo/effects=disabled+use-js-string=false/library1.cma.js
-  lib/.library1.objs/jsoo/effects=disabled/library1.cma.js
+  lib/.library1.objs/jsoo/$DIGEST2/library1.cma.js
+  lib/.library1.objs/jsoo/$DIGEST4/library1.cma.js
   $ node _build/default/bin/bin1.bc.js
   Hello bin1
   Hi library1

--- a/test/blackbox-tests/test-cases/jsoo/no-check-prim.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/no-check-prim.t/run.t
@@ -6,16 +6,18 @@ Compilation using jsoo
   $ dune trace cat | jq_dune -r '
   >   processes
   > | select(.args.prog | test("js_of_ocaml$"))
-  > | .args | targets | .[] | sub("^_build/[^/]+/"; "")' | sort
-  .js/effects=disabled/js_of_ocaml-compiler.runtime/jsoo_runtime.cma.js
-  .js/effects=disabled/js_of_ocaml/js_of_ocaml.cma.js
-  .js/effects=disabled/stdlib/std_exit.cmo.js
-  .js/effects=disabled/stdlib/stdlib.cma.js
+  > | .args | targets | .[] | sub("^_build/[^/]+/"; "")' \
+  > | sort \
+  > | censor
+  .js/$DIGEST/js_of_ocaml-compiler.runtime/jsoo_runtime.cma.js
+  .js/$DIGEST/js_of_ocaml/js_of_ocaml.cma.js
+  .js/$DIGEST/stdlib/std_exit.cmo.js
+  .js/$DIGEST/stdlib/stdlib.cma.js
   bin/.technologic.eobjs/jsoo/runtime.bc.runtime.js
   bin/.technologic.eobjs/jsoo/technologic.cmo.js
   bin/.technologic.eobjs/jsoo/z.cmo.js
   bin/technologic.bc.js
-  lib/.x.objs/jsoo/effects=disabled/x.cma.js
+  lib/.x.objs/jsoo/$DIGEST/x.cma.js
   $ node "$built_js"
   buy it
   use it

--- a/test/blackbox-tests/test-cases/jsoo/without_implem.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/without_implem.t/run.t
@@ -42,9 +42,9 @@ JSOO archive rules for interface-only libraries are not spuriously invalidated
 
 main.bc.js should not rebuild
 
-  $ dune build --display=short main.bc.js
-   js_of_ocaml .interface.objs/jsoo/effects=disabled/interface.cma.js
+  $ dune build --display=short main.bc.js 2>&1 | censor
+   js_of_ocaml .interface.objs/jsoo/$DIGEST/interface.cma.js
 
-  $ dune build --display=short main.bc.js
-   js_of_ocaml .interface.objs/jsoo/effects=disabled/interface.cma.js
+  $ dune build --display=short main.bc.js 2>&1 | censor
+   js_of_ocaml .interface.objs/jsoo/$DIGEST/interface.cma.js
 

--- a/test/blackbox-tests/test-cases/wasmoo/no-check-prim.t/run.t
+++ b/test/blackbox-tests/test-cases/wasmoo/no-check-prim.t/run.t
@@ -4,18 +4,20 @@ Compilation using WasmOO
   $ dune trace cat | jq_dune -r '
   >   processes
   > | select(.args.prog | test("wasm_of_ocaml$"))
-  > | .args | targets | .[] | sub("^_build/[^/]+/"; "")' | sort
-  .js/default/js_of_ocaml-compiler.runtime/jsoo_runtime.wasma
-  .js/default/js_of_ocaml/js_of_ocaml.wasma
-  .js/default/stdlib/std_exit.wasmo
-  .js/default/stdlib/stdlib.wasma
+  > | .args | targets | .[] | sub("^_build/[^/]+/"; "")' \
+  > | sort \
+  > | censor
+  .js/$DIGEST/js_of_ocaml-compiler.runtime/jsoo_runtime.wasma
+  .js/$DIGEST/js_of_ocaml/js_of_ocaml.wasma
+  .js/$DIGEST/stdlib/std_exit.wasmo
+  .js/$DIGEST/stdlib/stdlib.wasma
   bin/.technologic.eobjs/jsoo/dune__exe.wasmo
   bin/.technologic.eobjs/jsoo/dune__exe__Technologic.wasmo
   bin/.technologic.eobjs/jsoo/dune__exe__Z.wasmo
   bin/.technologic.eobjs/jsoo/runtime.bc.runtime.wasma
   bin/technologic.bc.wasm.assets
   bin/technologic.bc.wasm.js
-  lib/.x.objs/jsoo/default/x.wasma
+  lib/.x.objs/jsoo/$DIGEST/x.wasma
   $ node ./_build/default/bin/technologic.bc.wasm.js
   buy it
   use it


### PR DESCRIPTION
The path of jsoo shared runtimes can be quite long: `.js/<config>/.runtime/<digest>/runtime.bc.runtime.<ext>`. This can be a problem under Windows which has a small path length limit.
This folds the jsoo config (effects, toplevel, use-js-string, …) into the runtime digest, so shared standalone runtimes live at `.js/<digest>/runtime.bc.runtime.<ext>`.