### PR TITLE
test: print cache metadata as json

### DIFF
--- a/bin/internal.ml
+++ b/bin/internal.ml
@@ -198,6 +198,31 @@ module Sexp_to_csexp = struct
   ;;
 end
 
+module Cache_metadata = struct
+  module Metadata_file = Dune_cache.Local.Artifacts.Metadata_file
+  module Restore_result = Dune_cache.Local.Restore_result
+
+  let command =
+    let doc = "Print a cache metadata file as JSON." in
+    let info = Cmd.info "cache-metadata" ~doc in
+    let term =
+      let+ input =
+        let doc = "Read cache metadata from this file." in
+        Arg.(required & pos 0 (some Arg.path) None & info [] ~docv:"FILE" ~doc:(Some doc))
+      in
+      let input = Arg.Path.path input in
+      match Metadata_file.load input with
+      | Restored metadata ->
+        Json.of_repr Metadata_file.repr metadata |> Json.to_string |> print_endline
+      | Not_found_in_cache ->
+        User_error.raise
+          [ Pp.textf "cache metadata not found: %s" (Path.to_string input) ]
+      | Error exn -> User_error.raise [ Pp.textf "%s" (Printexc.to_string exn) ]
+    in
+    Cmd.v info term
+  ;;
+end
+
 let group =
   Cmd.group
     (Cmd.info "internal")
@@ -207,5 +232,6 @@ let group =
     ; bootstrap_info
     ; Sexp_pp.command
     ; Sexp_to_csexp.command
+    ; Cache_metadata.command
     ]
 ;;

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -276,36 +276,6 @@ let rec normalize_dyn : Dyn.t -> Dyn.t = function
 
 let dyn_of_repr repr value = normalize_dyn (Repr.to_dyn repr value)
 
-let rec json_of_dyn : Dyn.t -> Json.t = function
-  | Opaque -> Json.string "<opaque>"
-  | Unit -> Json.list []
-  | Int value -> Json.int value
-  | Int32 value -> Json.string (Int32.to_string value)
-  | Int64 value -> Json.string (Int64.to_string value)
-  | Nativeint value -> Json.string (Nativeint.to_string value)
-  | Bool value -> Json.bool value
-  | String value -> Json.string value
-  | Bytes value -> Json.string (Bytes.to_string value)
-  | Char value -> Json.string (String.make 1 value)
-  | Float value -> Json.float value
-  | Option None -> `Null
-  | Option (Some value) -> json_of_dyn value
-  | List values -> List.map values ~f:json_of_dyn |> Json.list
-  | Array values -> Array.to_list values |> List.map ~f:json_of_dyn |> Json.list
-  | Tuple values -> List.map values ~f:json_of_dyn |> Json.list
-  | Record fields ->
-    List.map fields ~f:(fun (name, value) -> name, json_of_dyn value) |> Json.assoc
-  | Variant (name, []) -> Json.string name
-  | Variant (name, [ value ]) -> Json.assoc [ name, json_of_dyn value ]
-  | Variant (name, values) ->
-    Json.assoc [ name, Json.list (List.map values ~f:json_of_dyn) ]
-  | Map values ->
-    List.map values ~f:(fun (key, value) ->
-      Json.list [ json_of_dyn key; json_of_dyn value ])
-    |> Json.list
-  | Set values -> Json.list (List.map values ~f:json_of_dyn)
-;;
-
 let rec dune_lang_of_sexp : Sexp.t -> Dune_lang.t = function
   | Atom value -> Dune_lang.atom_or_quoted_string value
   | List values -> List (List.map values ~f:dune_lang_of_sexp)
@@ -388,11 +358,11 @@ let term =
         match format, deps_only with
         | Output_format.Sexp, false -> print_rules_sexp ppf rules
         | Output_format.Sexp, true -> print_rule_deps_only_sexp ppf rules
-        | Json, false -> print_json oc (json_of_dyn (dyn_of_repr rules_repr rules))
+        | Json, false -> print_json oc (Json.of_dyn (dyn_of_repr rules_repr rules))
         | Json, true ->
           print_json
             oc
-            (json_of_dyn (dyn_of_repr deps_only_repr (dep_sets_of_rules rules)))
+            (Json.of_dyn (dyn_of_repr deps_only_repr (dep_sets_of_rules rules)))
       in
       match out with
       | None -> print stdout

--- a/otherlibs/stdune/src/json.ml
+++ b/otherlibs/stdune/src/json.ml
@@ -104,3 +104,31 @@ let list (xs : t list) : t = `List xs
 let int (x : int) : t = `Int x
 let float (x : float) : t = `Float x
 let bool x = `Bool x
+
+let rec of_dyn : Dyn.t -> t = function
+  | Opaque -> string "<opaque>"
+  | Unit -> list []
+  | Int value -> int value
+  | Int32 value -> string (Int32.to_string value)
+  | Int64 value -> string (Int64.to_string value)
+  | Nativeint value -> string (Nativeint.to_string value)
+  | Bool value -> bool value
+  | String value -> string value
+  | Bytes value -> string (Bytes.to_string value)
+  | Char value -> string (String.make 1 value)
+  | Float value -> float value
+  | Option None -> `Null
+  | Option (Some value) -> of_dyn value
+  | List values -> list (List.map values ~f:of_dyn)
+  | Array values -> list (List.map (Array.to_list values) ~f:of_dyn)
+  | Tuple values -> list (List.map values ~f:of_dyn)
+  | Record fields -> assoc (List.map fields ~f:(fun (name, value) -> name, of_dyn value))
+  | Variant (name, []) -> string name
+  | Variant (name, [ value ]) -> assoc [ name, of_dyn value ]
+  | Variant (name, values) -> assoc [ name, list (List.map values ~f:of_dyn) ]
+  | Map values ->
+    List.map values ~f:(fun (key, value) -> list [ of_dyn key; of_dyn value ]) |> list
+  | Set values -> list (List.map values ~f:of_dyn)
+;;
+
+let of_repr repr value = Repr.to_dyn repr value |> of_dyn

--- a/otherlibs/stdune/src/json.mli
+++ b/otherlibs/stdune/src/json.mli
@@ -15,3 +15,5 @@ val list : t list -> t
 val int : int -> t
 val float : float -> t
 val bool : bool -> t
+val of_dyn : Dyn.t -> t
+val of_repr : 'a Repr.t -> 'a -> t

--- a/src/dune_cache/dune_cache.ml
+++ b/src/dune_cache/dune_cache.ml
@@ -4,3 +4,4 @@ module Trimmer = Trimmer
 module Mode = Mode
 module Shared = Shared
 module Layout = Layout
+module Local = Local

--- a/src/dune_cache/local.ml
+++ b/src/dune_cache/local.ml
@@ -79,6 +79,16 @@ module Artifacts = struct
       Path.Local.equal x.path y.path && Option.equal Digest.equal x.digest y.digest
     ;;
 
+    let digest_repr = Repr.view Repr.string ~to_:Digest.to_string
+
+    let repr =
+      Repr.record
+        "cache-metadata-entry"
+        [ Repr.field "path" Path.Local.repr ~get:(fun t -> t.path)
+        ; Repr.field "digest" (Repr.option digest_repr) ~get:(fun t -> t.digest)
+        ]
+    ;;
+
     let digest_to_sexp = function
       | None -> Sexp.Atom "<dir>"
       | Some digest -> Sexp.Atom (Digest.to_string digest)
@@ -115,6 +125,12 @@ module Artifacts = struct
            even though sorting the entres is tempting. *)
         entries : Metadata_entry.t list
       }
+
+    let repr =
+      Repr.record
+        "cache-metadata"
+        [ Repr.field "files" (Repr.list Metadata_entry.repr) ~get:(fun t -> t.entries) ]
+    ;;
 
     let to_sexp { entries } =
       Sexp.List
@@ -156,6 +172,8 @@ module Artifacts = struct
                    ; "computed", Sexp.List (List.map ~f:Metadata_entry.to_sexp t.entries)
                    ])))
     ;;
+
+    let load path = restore_metadata_file path ~of_sexp
 
     let store entries ~mode ~rule_digest : Store_result.t =
       let metadata = { entries } in

--- a/src/dune_cache/local.mli
+++ b/src/dune_cache/local.mli
@@ -49,6 +49,8 @@ module Artifacts : sig
       ; digest : Digest.t option
         (** This digest is always present in case [file_path] points to a file, and absent when it's a directory. *)
       }
+
+    val repr : t Repr.t
   end
 
   module Metadata_file : sig
@@ -58,6 +60,9 @@ module Artifacts : sig
            even though sorting the entres is tempting. *)
         entries : Metadata_entry.t list
       }
+
+    val repr : t Repr.t
+    val load : Path.t -> t Restore_result.t
 
     val store
       :  Metadata_entry.t list

--- a/test/blackbox-tests/dune.jq
+++ b/test/blackbox-tests/dune.jq
@@ -213,6 +213,15 @@ def merlinUnitNameSummary:
 def merlinConfigSummary($names):
   merlinPathSummary + { config: [merlinConfigItemsNamed($names)] };
 
+def cacheMetadataForPath($path):
+  select(.files[].path == $path);
+
+def cacheMetadataWithPathPrefix($prefix):
+  select(.files[].path | startswith($prefix));
+
+def sortCacheMetadataByFirstPath:
+  sort_by(.files[0].path);
+
 def redactedActionTraces:
   [ .[]
   | select(.cat != "config" and .args.digest != null)

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -76,12 +76,43 @@ value in [build_system.ml].
 You will also need to make sure that the cache trimmer treats new and old cache
 entries uniformly.
 
-  $ (cd "$PWD/.xdg-cache/dune/db/meta/v5"; grep -rws . -e 'metadata' | sort ) > out
-  $ cat out | censor
-  ./59/$DIGEST1:((8:metadata)(5:files(8:target_b32:$DIGEST2)))
-  ./78/$DIGEST3:((8:metadata)(5:files(8:target_a32:$DIGEST4)))
+  $ metadata_dir="$PWD/.xdg-cache/dune/db/meta/v5"
+  $ (cd "$metadata_dir"; find . -mindepth 2 -maxdepth 2 -type f | sort) > metadata-paths
+  $ cat metadata-paths | censor
+  ./59/$DIGEST1
+  ./78/$DIGEST2
 
-  $ digest="$(awk -F: '/target_b/ { digest=$1 } END { print digest }' < out)"
+  $ while read path; do dune internal cache-metadata "$metadata_dir/$path"; done < metadata-paths \
+  > | jq -S -s 'include "dune"; sortCacheMetadataByFirstPath' \
+  > | censor
+  [
+    {
+      "files": [
+        {
+          "digest": "$DIGEST1",
+          "path": "target_a"
+        }
+      ]
+    },
+    {
+      "files": [
+        {
+          "digest": "$DIGEST2",
+          "path": "target_b"
+        }
+      ]
+    }
+  ]
+
+  $ digest="$(
+  >   while read path; do
+  >     if dune internal cache-metadata "$metadata_dir/$path" \
+  >        | jq -e 'include "dune"; cacheMetadataForPath("target_b")' >/dev/null
+  >     then
+  >       echo "$path"
+  >     fi
+  >   done < metadata-paths
+  > )"
 
   $ dune_cmd stat size "$PWD/.xdg-cache/dune/db/meta/v5/$digest"
   70
@@ -193,6 +224,67 @@ are part of the same rule.
   $ dune clean _build/default/multi_a _build/default/multi_b
   $ dune cache trim --trimmed-size 1B
   Freed 123B (2 files removed)
+
+Test metadata for multiple file targets produced by the same rule.
+
+  $ reset
+  $ dune build multi_a multi_b
+  $ metadata_dir="$PWD/.xdg-cache/dune/db/meta/v5"
+  $ find "$metadata_dir" -mindepth 2 -maxdepth 2 -type f \
+  > | while read path; do dune internal cache-metadata "$path"; done \
+  > | jq -S -s 'include "dune"; map(cacheMetadataWithPathPrefix("multi_")) | unique | .[]' \
+  > | censor
+  {
+    "files": [
+      {
+        "digest": "$DIGEST1",
+        "path": "multi_a"
+      },
+      {
+        "digest": "$DIGEST2",
+        "path": "multi_b"
+      }
+    ]
+  }
+
+Test metadata for directory targets, which are stored with no digest.
+
+  $ reset
+  $ cat > dune-project <<EOF
+  > (lang dune 3.10)
+  > (using directory-targets 0.1)
+  > EOF
+  $ cat > dune <<EOF
+  > (rule
+  >  (target (dir output))
+  >  (action
+  >   (progn
+  >    (run mkdir output)
+  >    (run mkdir output/child)
+  >    (run touch output/file))))
+  > EOF
+  $ dune build output
+  $ metadata_dir="$PWD/.xdg-cache/dune/db/meta/v5"
+  $ find "$metadata_dir" -mindepth 2 -maxdepth 2 -type f \
+  > | while read path; do dune internal cache-metadata "$path"; done \
+  > | jq -S 'include "dune"; cacheMetadataForPath("output")' \
+  > | censor
+  {
+    "files": [
+      {
+        "digest": null,
+        "path": "output"
+      },
+      {
+        "digest": "$DIGEST",
+        "path": "output/file"
+      },
+      {
+        "digest": null,
+        "path": "output/child"
+      }
+    ]
+  }
 
 TODO: Test trimming priority in the [copy] mode. In PR #4497 we added a test but
 it turned out to be flaky so we subsequently deleted it in #4511.


### PR DESCRIPTION
Add Repr values for cache metadata entries and files, plus an internal cache-metadata printer that renders them as JSON. Update the trim test to use that printer and cover single-file, multi-target, and directory-target metadata.