### PR TITLE
Add support for DragonFly BSD

### DIFF
--- a/bin/ocaml/doc.ml
+++ b/bin/ocaml/doc.ml
@@ -44,7 +44,8 @@ let term =
       let* cmd_name, args =
         match Platform.OS.value with
         | Darwin -> Some ("open", [])
-        | Other | FreeBSD | NetBSD | OpenBSD | Haiku | Linux -> Some ("xdg-open", [])
+        | Other | FreeBSD | NetBSD | OpenBSD | DragonFly | Haiku | Linux ->
+          Some ("xdg-open", [])
         | Windows -> None
       in
       let+ open_command =

--- a/doc/changes/added/14774.md
+++ b/doc/changes/added/14774.md
@@ -1,0 +1,2 @@
+- Add platform support for DragonFly BSD (#14774, fixes same issue with lev
+  as seen on NetBSD in #14484, @mneumann).

--- a/otherlibs/stdune/src/platform.ml
+++ b/otherlibs/stdune/src/platform.ml
@@ -7,6 +7,7 @@ module OS = struct
     | FreeBSD
     | NetBSD
     | OpenBSD
+    | DragonFly
     | Haiku
     | Other
 
@@ -31,6 +32,9 @@ module OS = struct
       ; Repr.case0 "OpenBSD" ~test:(function
           | OpenBSD -> true
           | _ -> false)
+      ; Repr.case0 "DragonFly" ~test:(function
+          | DragonFly -> true
+          | _ -> false)
       ; Repr.case0 "Haiku" ~test:(function
           | Haiku -> true
           | _ -> false)
@@ -50,6 +54,7 @@ module OS = struct
   external is_freebsd : unit -> bool = "stdune_is_freebsd"
   external is_netbsd : unit -> bool = "stdune_is_netbsd"
   external is_openbsd : unit -> bool = "stdune_is_openbsd"
+  external is_dragonfly : unit -> bool = "stdune_is_dragonfly"
   external is_haiku : unit -> bool = "stdune_is_haiku"
 
   let to_dyn = Repr.to_dyn repr
@@ -80,6 +85,8 @@ module OS = struct
     then NetBSD
     else if is_openbsd ()
     then OpenBSD
+    else if is_dragonfly ()
+    then DragonFly
     else if is_haiku ()
     then Haiku
     else Other

--- a/otherlibs/stdune/src/platform.mli
+++ b/otherlibs/stdune/src/platform.mli
@@ -10,6 +10,7 @@ module OS : sig
     | FreeBSD
     | NetBSD
     | OpenBSD
+    | DragonFly
     | Haiku
     | Other
 

--- a/otherlibs/stdune/src/platform_stubs.c
+++ b/otherlibs/stdune/src/platform_stubs.c
@@ -37,6 +37,15 @@ CAMLprim value stdune_is_netbsd(value v_unit) {
 #endif
 }
 
+CAMLprim value stdune_is_dragonfly(value v_unit) {
+  CAMLparam1(v_unit);
+#if defined(__DragonFly__)
+  CAMLreturn(Val_true);
+#else
+  CAMLreturn(Val_false);
+#endif
+}
+
 CAMLprim value stdune_is_haiku(value v_unit) {
   CAMLparam1(v_unit);
 #if defined(__HAIKU__)

--- a/src/dune_scheduler/file_watcher.ml
+++ b/src/dune_scheduler/file_watcher.ml
@@ -295,7 +295,7 @@ let fswatch_backend () =
             [ User_message.command "fswatch"; Pp.text "is available on HaikuPorts" ]
           |> Pp.hovbox
         ]
-      | FreeBSD -> [ User_message.command "pkg install fswatch-mon" ]
+      | FreeBSD | DragonFly -> [ User_message.command "pkg install fswatch-mon" ]
       | _ -> []
     in
     User_error.raise
@@ -318,7 +318,8 @@ let select_watcher_backend () =
   else (
     match Platform.OS.value with
     | Windows -> `Fswatch_win
-    | Linux | Darwin | FreeBSD | OpenBSD | NetBSD | Haiku | Other -> fswatch_backend ())
+    | Linux | Darwin | FreeBSD | OpenBSD | NetBSD | DragonFly | Haiku | Other ->
+      fswatch_backend ())
 ;;
 
 let prepare_sync () =

--- a/src/dune_tui/dune_tui.ml
+++ b/src/dune_tui/dune_tui.ml
@@ -394,5 +394,6 @@ let backend =
   fun () ->
     match (Platform.OS.value : Platform.OS.t) with
     | Windows -> User_error.raise [ Pp.text "TUI is currently not supported on Windows." ]
-    | Linux | Darwin | FreeBSD | OpenBSD | NetBSD | Haiku | Other -> Lazy.force t
+    | Linux | Darwin | FreeBSD | OpenBSD | NetBSD | DragonFly | Haiku | Other ->
+      Lazy.force t
 ;;

--- a/src/lev/src/lev_stubs.c
+++ b/src/lev/src/lev_stubs.c
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 #include <math.h>
-#if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__))
+#if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__))
 #include <sys/wait.h>
 #endif
 #define TAG_WEXITED 0

--- a/src/lev/vendor/ev.c
+++ b/src/lev/vendor/ev.c
@@ -510,7 +510,7 @@
 # endif
 #endif
 
-#if __FreeBSD__
+#if (defined(__FreeBSD__) || defined(__DragonFly__))
 #define EV_USE_INOTIFY 0
 #define EV_USE_KQUEUE 1
 #endif
@@ -3168,7 +3168,9 @@ ev_recommended_backends (void) EV_NOEXCEPT
   flags &= ~EVBACKEND_KQUEUE; /* horribly broken, even for sockets */
   flags &= ~EVBACKEND_POLL;   /* poll is based on kqueue from 10.5 onwards */
 #endif
-#ifdef __FreeBSD__
+#if (defined(__FreeBSD__) || defined(__DragonFly__))
+  /* Unsure if this applies to DragonFly as well, but KQUEUE definitively is the
+   * better choice */
   flags &= ~EVBACKEND_POLL;   /* poll return value is unusable (http://forums.freebsd.org/archive/index.php/t-10270.html) */
 #endif
 

--- a/src/ocaml-blake3-mini/dune
+++ b/src/ocaml-blake3-mini/dune
@@ -37,7 +37,8 @@
     (= %{system} "beos")
     (= %{system} "freebsd")
     (= %{system} "openbsd")
-    (= %{system} "netbsd"))))
+    (= %{system} "netbsd")
+    (= %{system} "dragonfly"))))
  (deps blake3_avx2_x86-64_unix.S)
  (targets blake3_avx2_x86-64%{ext_obj})
  (action
@@ -53,7 +54,8 @@
     (= %{system} "beos")
     (= %{system} "freebsd")
     (= %{system} "openbsd")
-    (= %{system} "netbsd"))))
+    (= %{system} "netbsd")
+    (= %{system} "dragonfly"))))
  (deps blake3_avx512_x86-64_unix.S)
  (targets blake3_avx512_x86-64%{ext_obj})
  (action
@@ -69,7 +71,8 @@
     (= %{system} "beos")
     (= %{system} "freebsd")
     (= %{system} "openbsd")
-    (= %{system} "netbsd"))))
+    (= %{system} "netbsd")
+    (= %{system} "dragonfly"))))
  (deps blake3_sse2_x86-64_unix.S)
  (targets blake3_sse2_x86-64%{ext_obj})
  (action
@@ -85,7 +88,8 @@
     (= %{system} "beos")
     (= %{system} "freebsd")
     (= %{system} "openbsd")
-    (= %{system} "netbsd"))))
+    (= %{system} "netbsd")
+    (= %{system} "dragonfly"))))
  (deps blake3_sse41_x86-64_unix.S)
  (targets blake3_sse41_x86-64%{ext_obj})
  (action
@@ -218,7 +222,8 @@
       (= %{system} "beos")
       (= %{system} "freebsd")
       (= %{system} "openbsd")
-      (= %{system} "netbsd"))))
+      (= %{system} "netbsd")
+      (= %{system} "dragonfly"))))
    (not
     (or
      (= %{architecture} "arm64")


### PR DESCRIPTION
Note, this time I sort "DragonFly" after "OpenBSD". Normally, I'd put it right next to "FreeBSD", as it is most similar to FreeBSD.