### PR TITLE
fix(cache): refresh copy-mode entries on restore

### DIFF
--- a/doc/changes/fixed/14777.md
+++ b/doc/changes/fixed/14777.md
@@ -1,0 +1,2 @@
+- Update ctime when restoring from the shared cache in copy mode. This prevents
+  the trimmer from deleting the file. (#14777, @rgrinberg)

--- a/src/dune_cache/shared.ml
+++ b/src/dune_cache/shared.ml
@@ -284,8 +284,14 @@ module File_restore = struct
   ;;
 
   let copy ~src ~dst =
-    try Io.copy_file ~src ~dst () with
-    | Sys_error _ -> raise_notrace (E Not_found_in_cache)
+    (try Io.copy_file ~src ~dst () with
+     | Sys_error _ -> raise_notrace (E Not_found_in_cache));
+    let src = Path.to_string src in
+    match Unix.stat src with
+    | exception Unix.Unix_error _ -> ()
+    | stats ->
+      (try Unix.chmod src stats.st_perm with
+       | Unix.Unix_error _ -> ())
   ;;
 
   let create_all_or_none (mode : Mode.t) (artifacts : _ Targets.Produced.t) =

--- a/test/blackbox-tests/test-cases/dune-cache/trim-copy-mode.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim-copy-mode.t
@@ -29,6 +29,6 @@ Test that copy-mode cache trim keeps recently restored entries.
   $ rm -rf _build
   $ dune build copy_a copy_b
   $ dune_cmd exists _build/default/beacon_copy_a
-  true
-  $ dune_cmd exists _build/default/beacon_copy_b
   false
+  $ dune_cmd exists _build/default/beacon_copy_b
+  true


### PR DESCRIPTION
Copy-mode cache entries always have one link, so trimming orders them by ctime. After successfully restoring an artifact by copy, refresh the cache entry ctime with a no-op chmod so recently restored entries are kept. Treat refresh failures as best-effort because the restore copy has already succeeded.