### PR TITLE
scheduler: route file watcher events through a fiber channel

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -236,7 +236,7 @@ let () =
     stat.st_size
   in
   let results =
-    Scheduler.Run.go config ~on_event:(fun _ -> ())
+    Scheduler.Run.go config
     @@ fun () ->
     let open Fiber.O in
     (* Prepare the workspace *)

--- a/bench/micro/dune_bench/scheduler_bench.ml
+++ b/bench/micro/dune_bench/scheduler_bench.ml
@@ -21,10 +21,7 @@ let setup =
 
 let prog = Option.value_exn (Bin.which ~path:(Env_path.path Env.initial) "true")
 let run () = Process.run ~display:Quiet ~env:Env.initial Strict prog []
-
-let go ~jobs fiber =
-  Scheduler.Run.go ~on_event:(fun _ -> ()) { config with concurrency = jobs } fiber
-;;
+let go ~jobs fiber = Scheduler.Run.go { config with concurrency = jobs } fiber
 
 let%bench_fun "single" =
   Lazy.force setup;

--- a/bin/build.ml
+++ b/bin/build.ml
@@ -1,13 +1,16 @@
 open Import
 
-let run_build_system ~run_id ~request =
+let run_build_system_impl ?restart_started_at ~run_id ~request () =
   Dune_engine.Build_system.run_action_builder
+    ?restart_started_at
     ~run_id
     (let open Action_builder.O in
      Action_builder.of_memo (Util.setup ()) >>= request)
 ;;
 
-let poll_handling_rpc_build_requests ~(common : Common.t) =
+let run_build_system ~run_id ~request = run_build_system_impl ~run_id ~request ()
+
+let poll_handling_rpc_build_requests build_loop ~(common : Common.t) =
   let open Fiber.O in
   let rpc =
     match Common.rpc common with
@@ -15,9 +18,10 @@ let poll_handling_rpc_build_requests ~(common : Common.t) =
     | `Forbid_builds -> Code_error.raise "rpc server must be allowed in passive mode" []
   in
   Dune_engine.Build_loop.poll_passive
+    build_loop
     ~get_build_request:
       (let+ { kind; outcome } = Dune_rpc_impl.Server.pending_action rpc in
-       ( (fun ~run_id ->
+       ( (fun ~run_id ~restart_started_at ->
            let request setup =
              let root = Common.root common in
              match kind with
@@ -28,32 +32,30 @@ let poll_handling_rpc_build_requests ~(common : Common.t) =
                  ~to_cwd:root.to_cwd
                  ~test_paths
            in
-           run_build_system ~run_id ~request)
+           run_build_system_impl ?restart_started_at ~run_id ~request ())
        , outcome ))
 ;;
 
 let run_build_command_poll_eager ~(common : Common.t) ~config ~request : unit =
-  Scheduler_setup.go_with_rpc_server_and_console_status_reporting
-    ~common
-    ~config
-    (fun () ->
-       let open Fiber.O in
-       (* Run two fibers concurrently. One is responible for rebuilding targets
+  Scheduler_setup.go_with_rpc_server_and_file_watcher ~common ~config (fun () ->
+    let open Fiber.O in
+    (* Run two fibers concurrently. One is responible for rebuilding targets
           named on the command line in reaction to file system changes. The other
           is responsible for building targets named in RPC build requests. *)
-       let+ () =
-         Dune_engine.Build_loop.poll (fun ~run_id -> run_build_system ~run_id ~request)
-       and+ () = poll_handling_rpc_build_requests ~common in
-       ())
+    Dune_engine.Build_loop.run (fun build_loop ->
+      let+ () =
+        Dune_engine.Build_loop.poll build_loop (fun ~run_id ~restart_started_at ->
+          run_build_system_impl ?restart_started_at ~run_id ~request ())
+      and+ () = poll_handling_rpc_build_requests build_loop ~common in
+      ()))
 ;;
 
 let run_build_command_poll_passive ~common ~config ~request:_ : unit =
   (* CR-someday aalekseyev: It would've been better to complain if [request] is
      non-empty, but we can't check that here because [request] is a function.*)
-  Scheduler_setup.go_with_rpc_server_and_console_status_reporting
-    ~common
-    ~config
-    (fun () -> poll_handling_rpc_build_requests ~common)
+  Scheduler_setup.go_with_rpc_server_and_file_watcher ~common ~config (fun () ->
+    Dune_engine.Build_loop.run (fun build_loop ->
+      poll_handling_rpc_build_requests build_loop ~common))
 ;;
 
 let run_build_command_once ~(common : Common.t) ~config ~request =

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -298,16 +298,17 @@ let exec_building_directly ~common ~config ~context ~prog ~args ~no_rebuild =
   | Yes Passive ->
     User_error.raise [ Pp.textf "passive watch mode is unsupported by exec" ]
   | Yes Eager ->
-    Scheduler_setup.go_with_rpc_server_and_console_status_reporting ~common ~config
+    Scheduler_setup.go_with_rpc_server_and_file_watcher ~common ~config
     @@ fun () ->
     let open Fiber.O in
     let on_exit = Console.printf "Program exited with code [%d]" in
-    Dune_engine.Build_loop.poll
-    @@ fun ~run_id ->
-    let* () = Fiber.return () in
-    Console.maybe_clear_screen ~details_hum:[];
-    Dune_engine.Build_system.run ~run_id
-    @@ step ~prog ~args ~common ~no_rebuild ~context ~on_exit
+    Dune_engine.Build_loop.run (fun build_loop ->
+      Dune_engine.Build_loop.poll build_loop
+      @@ fun ~run_id ~restart_started_at ->
+      let* () = Fiber.return () in
+      Console.maybe_clear_screen ~details_hum:[];
+      Dune_engine.Build_system.run ?restart_started_at ~run_id
+      @@ step ~prog ~args ~common ~no_rebuild ~context ~on_exit)
   | No ->
     Scheduler_setup.go_with_rpc_server ~common ~config
     @@ fun () ->

--- a/bin/monitor.ml
+++ b/bin/monitor.ml
@@ -280,11 +280,7 @@ let command =
     let config =
       Dune_config.for_scheduler config ~print_ctrl_c_warning:true ~watch_exclusions:[]
     in
-    Scheduler.Run.go
-      config
-      ~on_event:(fun (_ : Scheduler.Run.Event.t) -> ())
-      ~file_watcher:No_watcher
-      (monitor ~quit_on_disconnect)
+    Scheduler.Run.go config ~file_watcher:No_watcher (monitor ~quit_on_disconnect)
   in
   Cmd.v info term
 ;;

--- a/bin/scheduler_setup.ml
+++ b/bin/scheduler_setup.ml
@@ -1,28 +1,6 @@
 open Import
 open Scheduler
 
-let on_event = function
-  | Run.Event.Build_interrupted ->
-    Console.Status_line.set
-      (Live
-         (fun () ->
-           let progression =
-             match Fiber.Svar.read Build_system.state with
-             | Initializing
-             | Restarting_current_build
-             | Build_succeeded__now_waiting_for_changes
-             | Build_failed__now_waiting_for_changes -> Build_system.Progress.init
-             | Building progress -> progress
-           in
-           Pp.seq
-             (Pp.tag User_message.Style.Error (Pp.verbatim "Source files changed"))
-             (Pp.verbatim
-                (sprintf
-                   ", restarting current build... (%u/%u)"
-                   progression.number_of_rules_executed
-                   progression.number_of_rules_discovered))))
-;;
-
 let rpc server =
   { Root.Rpc.Global.run = Dune_rpc_impl.Server.run server
   ; stop = Dune_rpc_impl.Server.stop server
@@ -35,7 +13,7 @@ let no_build_no_rpc ~config:dune_config f =
     Dune_config.for_scheduler dune_config ~print_ctrl_c_warning:true ~watch_exclusions:[]
   in
   Dune_rules.Clflags.concurrency := config.concurrency;
-  Run.go config ~on_event:(fun _ -> ()) f
+  Run.go config f
 ;;
 
 let go_without_rpc_server ~(common : Common.t) ~config:dune_config f =
@@ -44,7 +22,7 @@ let go_without_rpc_server ~(common : Common.t) ~config:dune_config f =
     Dune_config.for_scheduler dune_config ~print_ctrl_c_warning:true ~watch_exclusions
   in
   Dune_rules.Clflags.concurrency := config.concurrency;
-  Run.go config ~on_event f
+  Run.go config f
 ;;
 
 let go_with_rpc_server ~common ~config f =
@@ -56,11 +34,7 @@ let go_with_rpc_server ~common ~config f =
   go_without_rpc_server ~common ~config f
 ;;
 
-let go_with_rpc_server_and_console_status_reporting
-      ~(common : Common.t)
-      ~config:dune_config
-      run
-  =
+let go_with_rpc_server_and_file_watcher ~(common : Common.t) ~config:dune_config run =
   let rpc_server =
     match Common.rpc common with
     | `Allow server -> server
@@ -80,5 +54,5 @@ let go_with_rpc_server_and_console_status_reporting
     let* () = Root.Rpc.Global.ensure_ready () in
     run ()
   in
-  Run.go config ~file_watcher ~on_event run
+  Run.go config ~file_watcher run
 ;;

--- a/bin/scheduler_setup.mli
+++ b/bin/scheduler_setup.mli
@@ -14,7 +14,7 @@ val go_with_rpc_server
   -> (unit -> 'a Fiber.t)
   -> 'a
 
-val go_with_rpc_server_and_console_status_reporting
+val go_with_rpc_server_and_file_watcher
   :  common:Common.t
   -> config:Dune_config.t
   -> (unit -> 'a Fiber.t)

--- a/src/dune_engine/build_loop.ml
+++ b/src/dune_engine/build_loop.ml
@@ -1,7 +1,32 @@
 open Import
 open Fiber.O
+module Trigger = Fiber.Trigger
 
-type step = run_id:Run_id.t -> (unit, [ `Already_reported ]) Result.t Fiber.t
+type step =
+  run_id:Run_id.t
+  -> restart_started_at:Time.t option
+  -> (unit, [ `Already_reported ]) Result.t Fiber.t
+
+type status =
+  | (* We are not doing a build. Just accumulating invalidations until the next
+       build starts. *)
+    Standing_by
+  | (* Running a build *) Building
+  | (* Cancellation requested. Build jobs are immediately rejected in this
+       state *)
+    Restarting_build
+
+type t =
+  { mutable status : status
+  ; mutable invalidation : Memo.Invalidation.t
+  ; mutable watch_restart_started_at : Time.t option
+  ; mutable build_inputs_changed : Trigger.t
+  ; mutable latest_input_change_run_id : Run_id.t option
+    (* Set whenever an invalidation is recorded. This lets waiters survive
+       another build iteration replacing [build_inputs_changed]. *)
+  ; mutable current_run_id : Run_id.t option
+  ; build_mutex : Fiber.Mutex.t
+  }
 
 let next_run_id = ref 1
 
@@ -24,29 +49,162 @@ let build_finish (build_result : Build_outcome.t) =
     (Constant (Pp.seq message (Pp.verbatim ", waiting for filesystem changes...")))
 ;;
 
-let rec poll_iter t step =
+let invalidation_of_file_events events =
+  List.fold_left events ~init:Memo.Invalidation.empty ~f:(fun acc event ->
+    Memo.Invalidation.combine
+      acc
+      (match (event : Event.File_watcher_event.t) with
+       | Fs_memo_event event -> Fs_memo.handle_fs_event event
+       | Queue_overflow -> Memo.Invalidation.clear_caches ~reason:Event_queue_overflow))
+;;
+
+let show_build_interrupted_status_line () =
+  Console.Status_line.set
+    (Live
+       (fun () ->
+         let progress =
+           match Fiber.Svar.read Build_system.state with
+           | Initializing
+           | Restarting_current_build
+           | Build_succeeded__now_waiting_for_changes
+           | Build_failed__now_waiting_for_changes -> Build_system.Progress.init
+           | Building progress -> progress
+         in
+         Pp.seq
+           (Pp.tag User_message.Style.Error (Pp.verbatim "Source files changed"))
+           (Pp.verbatim
+              (sprintf
+                 ", restarting current build... (%u/%u)"
+                 progress.number_of_rules_executed
+                 progress.number_of_rules_discovered))))
+;;
+
+let current_run_id t =
+  match t.current_run_id with
+  | Some run_id -> run_id
+  | None -> Code_error.raise "expected current build run id" []
+;;
+
+let request_restart t invalidation =
+  let* () = Fiber.return () in
+  if Memo.Invalidation.is_empty invalidation
+  then Fiber.return ()
+  else (
+    let now = Time.now () in
+    let input_change_run_id =
+      match t.status with
+      | Standing_by ->
+        (* Idle changes are represented by [restart = true] on the next
+           build-start event. [build-restart] is emitted only when we cancel an
+           active build below. *)
+        Run_id.Watch !next_run_id
+      | Building | Restarting_build -> current_run_id t
+    in
+    if Option.is_none t.watch_restart_started_at
+    then t.watch_restart_started_at <- Some now;
+    t.invalidation <- Memo.Invalidation.combine t.invalidation invalidation;
+    t.latest_input_change_run_id <- Some input_change_run_id;
+    let* () =
+      match t.status with
+      | Restarting_build | Standing_by -> Fiber.return ()
+      | Building ->
+        show_build_interrupted_status_line ();
+        t.status <- Restarting_build;
+        let+ () = Scheduler.cancel_current_build () in
+        Dune_trace.emit Build (fun () ->
+          Dune_trace.Event.watch_build_restart
+            ~run_id:(Run_id.to_int input_change_run_id)
+            ~reasons:(Memo.Invalidation.details_hum ~max_elements:max_int invalidation)
+            ~at:now)
+    in
+    Trigger.trigger t.build_inputs_changed)
+;;
+
+let rec handle_file_events t file_watcher =
+  File_watcher.read file_watcher
+  >>= function
+  | None ->
+    Scheduler.shutdown ();
+    Fiber.return ()
+  | Some events ->
+    let* () = request_restart t (invalidation_of_file_events events) in
+    handle_file_events t file_watcher
+;;
+
+let run f =
+  let t =
+    { status = Standing_by
+    ; invalidation = Memo.Invalidation.empty
+    ; watch_restart_started_at = None
+    ; build_inputs_changed = Trigger.create ()
+    ; latest_input_change_run_id = None
+    ; current_run_id = None
+    ; build_mutex = Fiber.Mutex.create ()
+    }
+  in
+  match Scheduler.file_watcher () with
+  | None ->
+    ignore (Fs_memo.init ~dune_file_watcher:None : Memo.Invalidation.t);
+    f t
+  | Some file_watcher ->
+    Fs_memo.init ~dune_file_watcher:(Some file_watcher) |> Memo.reset;
+    Fiber.fork_and_join_unit
+      (fun () -> handle_file_events t file_watcher)
+      (fun () ->
+         Fiber.finalize
+           (fun () -> f t)
+           ~finally:(fun () ->
+             File_watcher.close file_watcher;
+             Fiber.return ()))
+;;
+
+let run_current_build t ~run_id step =
+  let restart_started_at = t.watch_restart_started_at in
+  t.invalidation <- Memo.Invalidation.empty;
+  let build_start_input_change_run_id = t.latest_input_change_run_id in
+  let previous_build_inputs_changed = t.build_inputs_changed in
+  t.build_inputs_changed <- Trigger.create ();
+  (* Wake waiters on the previous trigger generation. We replace the trigger at
+     the start of every build so that waiters created during this build observe
+     only changes that happen after the build started. *)
+  let* () = Trigger.trigger previous_build_inputs_changed in
+  (match t.status with
+   | Building -> assert false
+   | Standing_by | Restarting_build -> ());
+  t.status <- Building;
+  t.current_run_id <- Some run_id;
+  let+ outcome =
+    Scheduler.with_current_build_cancellation (Fiber.Cancel.create ()) (fun () ->
+      step ~run_id ~restart_started_at)
+  in
+  let next =
+    match t.status with
+    | Restarting_build -> `Restart
+    | Standing_by | Building ->
+      t.status <- Standing_by;
+      t.current_run_id <- None;
+      t.watch_restart_started_at <- None;
+      `Done
+  in
+  outcome, next, build_start_input_change_run_id
+;;
+
+let rec poll_iter_locked t step =
   let run_id =
     let run_id = Run_id.Watch !next_run_id in
     incr next_run_id;
     run_id
   in
-  let invalidation = Scheduler.Build_loop.pending_invalidation t in
+  let invalidation = t.invalidation in
   if Memo.Invalidation.is_empty invalidation
   then Memo.Metrics.reset ()
   else (
-    Dune_trace.emit Build (fun () ->
-      let reasons = Memo.Invalidation.details_hum ~max_elements:max_int invalidation in
-      Dune_trace.Event.watch_build_restart
-        ~run_id:(Run_id.to_int run_id)
-        ~reasons
-        ~at:(Time.now ()));
     let details_hum = Memo.Invalidation.details_hum invalidation in
     Console.maybe_clear_screen ~details_hum;
     Memo.reset invalidation);
-  Scheduler.Build_loop.start_iteration t;
-  let* res = step ~run_id in
-  match Scheduler.Build_loop.finish_iteration t with
-  | `Restart -> poll_iter t step
+  let* res, next, build_start_input_change_run_id = run_current_build t ~run_id step in
+  match next with
+  | `Restart -> poll_iter_locked t step
   | `Done ->
     let res : Build_outcome.t =
       match res with
@@ -54,7 +212,11 @@ let rec poll_iter t step =
       | Ok () -> Success
     in
     build_finish res;
-    Fiber.return res
+    Fiber.return (res, build_start_input_change_run_id)
+;;
+
+let poll_iter t step =
+  Fiber.Mutex.with_lock t.build_mutex ~f:(fun () -> poll_iter_locked t step)
 ;;
 
 (* Work we're allowed to do between successive polling iterations. this work
@@ -64,28 +226,41 @@ let run_when_idle () : unit =
   Dune_trace.flush ()
 ;;
 
-let poll step =
-  let* t = Scheduler.Build_loop.init () in
+let rec wait_for_build_input_change_after t input_change_run_id =
+  let* () = Fiber.return () in
+  if not (Option.equal Run_id.equal t.latest_input_change_run_id input_change_run_id)
+  then Fiber.return ()
+  else (
+    let trigger = t.build_inputs_changed in
+    let* () = Trigger.wait trigger in
+    wait_for_build_input_change_after t input_change_run_id)
+;;
+
+let poll t step =
   let rec loop () =
-    let* (_ : Build_outcome.t) = poll_iter t step in
+    let* (_ : Build_outcome.t), input_change_run_id = poll_iter t step in
     run_when_idle ();
-    let* () = Scheduler.Build_loop.wait_for_build_input_change t in
+    let* () = wait_for_build_input_change_after t input_change_run_id in
     loop ()
   in
   loop ()
 ;;
 
-let poll_passive ~get_build_request =
-  let* t = Scheduler.Build_loop.init () in
+let poll_passive t ~get_build_request =
   let rec loop () =
     let* step, response_ivar = get_build_request in
     (* Flush before to make the build reproducible. The passive watch mode is
        designed for tests and We want to observe all the change made by the
        test before starting the build. *)
     let* () = Scheduler.flush_file_watcher () in
-    let* res = poll_iter t step in
+    let* res, (_input_change_run_id : Run_id.t option) = poll_iter t step in
     let* () = Fiber.Ivar.fill response_ivar res in
     loop ()
   in
   loop ()
 ;;
+
+module For_tests = struct
+  let wait_for_build_input_change t = Trigger.wait t.build_inputs_changed
+  let inject_memo_invalidation = request_restart
+end

--- a/src/dune_engine/build_loop.mli
+++ b/src/dune_engine/build_loop.mli
@@ -1,15 +1,24 @@
 open Import
 
-(** A build request run by the watch-mode build loop. *)
-type step = run_id:Run_id.t -> (unit, [ `Already_reported ]) Result.t Fiber.t
+(** State shared by watch-mode build loops. *)
+type t
 
-(** [poll step] runs [step] in a loop.
+(** A build request run by the watch-mode build loop. *)
+type step =
+  run_id:Run_id.t
+  -> restart_started_at:Time.t option
+  -> (unit, [ `Already_reported ]) Result.t Fiber.t
+
+(** [run f] initializes watch-mode state and runs [f] with it. *)
+val run : (t -> 'a Fiber.t) -> 'a Fiber.t
+
+(** [poll t step] runs [step] in a loop.
 
     If any source files change in the middle of iteration, it gets canceled.
 
     If [Scheduler.shutdown] is called, the current build will be canceled and
     new builds will not start. *)
-val poll : step -> unit Fiber.t
+val poll : t -> step -> unit Fiber.t
 
 (** [poll_passive] is similar to [poll], but it can be used to drive the
     polling loop explicitly instead of starting new iterations automatically.
@@ -17,5 +26,11 @@ val poll : step -> unit Fiber.t
     The fiber [get_build_request] is run at the beginning of every iteration to
     wait for the build signal. *)
 val poll_passive
-  :  get_build_request:(step * Build_outcome.t Fiber.Ivar.t) Fiber.t
+  :  t
+  -> get_build_request:(step * Build_outcome.t Fiber.Ivar.t) Fiber.t
   -> unit Fiber.t
+
+module For_tests : sig
+  val wait_for_build_input_change : t -> unit Fiber.t
+  val inject_memo_invalidation : t -> Memo.Invalidation.t -> unit Fiber.t
+end

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1099,16 +1099,18 @@ let handle_final_exns exns =
     List.iter exns ~f:report
 ;;
 
-let run ?(run_id = Run_id.Batch) f =
+let run ?restart_started_at ?(run_id = Run_id.Batch) f =
   let finalize_diff_promotion () =
     protect ~f:Diff_promotion.finalize ~finally:Diff_promotion.clear_cache
   in
   let open Fiber.O in
   let f () =
-    let (`Restart restart) = Scheduler.Build_loop.start_build () in
     let start = Time.now () in
     Dune_trace.emit ~buffered:false Build (fun () ->
-      Dune_trace.Event.watch_build_start ~run_id:(Run_id.to_int run_id) ~restart ~start);
+      Dune_trace.Event.watch_build_start
+        ~run_id:(Run_id.to_int run_id)
+        ~restart:(Option.is_some restart_started_at)
+        ~start);
     Dune_trace.reset_alloc_profile ();
     (* CR-someday amokhov: Currently we invalidate cached timestamps on every
        incremental rebuild. This conservative approach helps us to work around
@@ -1145,32 +1147,28 @@ let run ?(run_id = Run_id.Batch) f =
         Error `Already_reported
     in
     Metrics.reset ();
-    let+ () =
-      match run_id with
-      | Batch -> Fiber.return ()
-      | Watch _ -> Scheduler.flush_file_watcher ()
-    in
-    let stop = Time.now () in
-    (match Scheduler.Build_loop.finish_build ~stop with
-     | Restarting -> ()
-     | Finished { restart_duration } ->
-       let alloc_summary =
-         Dune_trace.capture_alloc_profile (`Build (Run_id.to_int run_id))
-       in
-       Dune_trace.emit Build (fun () ->
-         Dune_trace.Event.watch_build_finish
-           ~run_id:(Run_id.to_int run_id)
-           ~outcome:
-             (match outcome with
-              | Ok _ -> `Success
-              | Error `Already_reported -> `Failure)
-           ~start
-           ~stop
-           ~restart_duration);
-       Option.iter alloc_summary ~f:Dune_trace.always_emit);
+    let+ () = Scheduler.flush_file_watcher () in
+    Dune_trace.emit Build (fun () ->
+      let stop = Time.now () in
+      let restart_duration =
+        Option.map restart_started_at ~f:(fun restart_started_at ->
+          Time.diff stop restart_started_at)
+      in
+      Dune_trace.Event.watch_build_finish
+        ~run_id:(Run_id.to_int run_id)
+        ~outcome:
+          (match outcome with
+           | Ok _ -> `Success
+           | Error `Already_reported -> `Failure)
+        ~start
+        ~stop
+        ~restart_duration);
+    Dune_trace.capture_alloc_profile (`Build (Run_id.to_int run_id))
+    |> Option.iter ~f:Dune_trace.always_emit;
     outcome
   in
-  Fiber.Mutex.with_lock State.build_mutex ~f
+  Fiber.Mutex.with_lock State.build_mutex ~f:(fun () ->
+    Scheduler.with_current_build_cancellation (Fiber.Cancel.create ()) f)
 ;;
 
 let run_exn f =
@@ -1181,8 +1179,8 @@ let run_exn f =
   | Error `Already_reported -> raise Dune_util.Report_error.Already_reported
 ;;
 
-let run_action_builder ?run_id request =
-  run ?run_id (fun () ->
+let run_action_builder ?restart_started_at ?run_id request =
+  run ?restart_started_at ?run_id (fun () ->
     let+ (), (_ : Dep.Fact.t Dep.Map.t) =
       Action_builder.evaluate_and_collect_facts request
     in

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -52,7 +52,8 @@ val dep_on_alias_definition : Rules.Dir_rules.Alias_spec.item -> unit Action_bui
 (** {2 Running the build system} *)
 
 val run
-  :  ?run_id:Run_id.t
+  :  ?restart_started_at:Time.t
+  -> ?run_id:Run_id.t
   -> (unit -> 'a Memo.t)
   -> ('a, [ `Already_reported ]) Result.t Fiber.t
 
@@ -60,7 +61,8 @@ val run
 val run_exn : (unit -> 'a Memo.t) -> 'a Fiber.t
 
 val run_action_builder
-  :  ?run_id:Run_id.t
+  :  ?restart_started_at:Time.t
+  -> ?run_id:Run_id.t
   -> unit Action_builder.t
   -> (unit, [ `Already_reported ]) result Fiber.t
 

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -1022,9 +1022,6 @@ let handle_fs_event ({ kind; path } : Dune_scheduler.Event.Fs_memo_event.t)
 
 let init = Watcher.init
 
-(* Register the Fs_memo implementation with the scheduler *)
-let () = Dune_scheduler.Scheduler.set_fs_memo_impl ~handle_fs_event ~init
-
 module Untracked = struct
   let file_digest = Fs_cache.read Fs_cache.Untracked.file_digest
   let path_stat = Fs_cache.read Fs_cache.Untracked.path_stat

--- a/src/dune_engine/fs_memo.mli
+++ b/src/dune_engine/fs_memo.mli
@@ -17,6 +17,12 @@ module Reduced_stats : sig
     }
 end
 
+(** [init] must be called at initialization. Returns the set of nodes that need
+      to be invalidated because they were accessed before [init] was called. *)
+val init : dune_file_watcher:Dune_scheduler.File_watcher.t option -> Memo.Invalidation.t
+
+val handle_fs_event : Dune_scheduler.Event.Fs_memo_event.t -> Memo.Invalidation.t
+
 (** Check if a source or external file exists and declare a dependency on it. *)
 val file_exists : Path.Outside_build_dir.t -> bool Memo.t
 

--- a/src/dune_engine/run_id.ml
+++ b/src/dune_engine/run_id.ml
@@ -1,6 +1,26 @@
+open Import
+
 type t =
   | Batch
   | Watch of int
+
+let repr =
+  Repr.variant
+    "Run_id.t"
+    [ Repr.case0 "Batch" ~test:(function
+        | Batch -> true
+        | Watch _ -> false)
+    ; Repr.case "Watch" Repr.int ~proj:(function
+        | Batch -> None
+        | Watch i -> Some i)
+    ]
+;;
+
+include Repr.Poly (struct
+    type nonrec t = t
+
+    let repr = repr
+  end)
 
 let to_int = function
   | Batch -> 0

--- a/src/dune_engine/run_id.mli
+++ b/src/dune_engine/run_id.mli
@@ -2,4 +2,5 @@ type t =
   | Batch
   | Watch of int
 
+val equal : t -> t -> bool
 val to_int : t -> int

--- a/src/dune_scheduler/dune_scheduler.ml
+++ b/src/dune_scheduler/dune_scheduler.ml
@@ -8,6 +8,7 @@ module For_tests = struct
   module Inotify = Inotify
   module Fsevents = Fsevents
   module Fswatch_win = Fswatch_win
+  module Thread_safe_channel = Thread_safe_channel
 end
 
 module For_benchmarks = struct

--- a/src/dune_scheduler/event.ml
+++ b/src/dune_scheduler/event.ml
@@ -43,40 +43,22 @@ module Fs_memo_event = struct
   let create ~kind ~path = { path; kind }
 end
 
-module Sync_id = Id.Make ()
-
 module File_watcher_event = struct
   type t =
     | Fs_memo_event of Fs_memo_event.t
     | Queue_overflow
-    | Sync of Sync_id.t
-    | Watcher_terminated
 end
 
-type build_input_change =
-  | Fs_event of Fs_memo_event.t
-  | Invalidation of Memo.Invalidation.t
-
 type t =
-  | Build_inputs_changed of build_input_change Nonempty_list.t
-  | File_system_sync of Sync_id.t
-  | File_system_watcher_terminated
   | Shutdown of Shutdown.Reason.t
   | Fiber_fill_ivar of Fiber.fill
   | Job_complete_ready
-
-module Invalidation_event = struct
-  type t =
-    | Invalidation of Memo.Invalidation.t
-    | Filesystem_event of File_watcher_event.t
-end
 
 module Queue = struct
   type event = t
 
   type t =
     { jobs_completed : (job * Proc.Process_info.t) Queue.t
-    ; mutable invalidation_events : Invalidation_event.t list
     ; mutable shutdown_reasons : Shutdown.Reason.Set.t
     ; mutex : Mutex.t
     ; cond : Condition.t
@@ -91,12 +73,10 @@ module Queue = struct
   let create () =
     let jobs_completed = Queue.create () in
     let worker_tasks_completed = Queue.create () in
-    let invalidation_events = [] in
     let shutdown_reasons = Shutdown.Reason.Set.empty in
     let mutex = Mutex.create () in
     let cond = Condition.create () in
     { jobs_completed
-    ; invalidation_events
     ; shutdown_reasons
     ; mutex
     ; cond
@@ -151,43 +131,6 @@ module Queue = struct
         Some Job_complete_ready
     ;;
 
-    let invalidation q =
-      match q.invalidation_events with
-      | [] -> None
-      | events ->
-        let rec process_events acc = function
-          | [] ->
-            q.invalidation_events <- [];
-            Option.map
-              (Nonempty_list.of_list (List.rev acc))
-              ~f:(fun build_input_changes -> Build_inputs_changed build_input_changes)
-          | event :: events ->
-            (match (event : Invalidation_event.t) with
-             | Filesystem_event Watcher_terminated ->
-               q.invalidation_events <- [];
-               Some File_system_watcher_terminated
-             | Filesystem_event (Sync id) ->
-               (match Nonempty_list.of_list (List.rev acc) with
-                | None ->
-                  q.invalidation_events <- events;
-                  Some (File_system_sync id)
-                | Some build_input_changes ->
-                  q.invalidation_events <- event :: events;
-                  Some (Build_inputs_changed build_input_changes))
-             | Filesystem_event (Fs_memo_event event) ->
-               process_events (Fs_event event :: acc) events
-             | Filesystem_event Queue_overflow ->
-               process_events
-                 (Invalidation
-                    (Memo.Invalidation.clear_caches ~reason:Event_queue_overflow)
-                  :: acc)
-                 events
-             | Invalidation invalidation ->
-               process_events (Invalidation invalidation :: acc) events)
-        in
-        process_events [] events
-    ;;
-
     let jobs_completed q =
       Option.map (Queue.pop q.jobs_completed) ~f:(fun (job, proc_info) ->
         Fiber_fill_ivar (Fill (job.ivar, proc_info)))
@@ -210,13 +153,12 @@ module Queue = struct
   let events_in_order =
     (* Event sources are listed in priority order. Signals are the
        highest priority to maximize responsiveness to Ctrl+C.
-       [invalidation] and [worker_tasks_completed] are used for reacting to
-       user input, so their latency is also important.
-       [jobs_completed] and [yield] are where the bulk of the work is done, so
-       they are the lowest priority to avoid starving other things. *)
+       [worker_tasks_completed] is used for reacting to user input, so its
+       latency is also important. [jobs_completed] and [yield] are where the
+       bulk of the work is done, so they are the lowest priority to avoid
+       starving other things. *)
     Event_source.
       [ shutdown
-      ; invalidation
       ; worker_tasks_completed
       ; (if Sys.win32 then jobs_completed else job_complete_ready)
       ; yield
@@ -244,32 +186,11 @@ module Queue = struct
     ev
   ;;
 
-  let send_worker_task_completed q event =
-    add_event q (fun q -> Queue.push q.worker_tasks_completed event)
-  ;;
-
   let send_worker_tasks_completed q events =
     match events with
     | [] -> ()
     | _ :: _ ->
       add_event q (fun q -> List.iter events ~f:(Queue.push q.worker_tasks_completed))
-  ;;
-
-  let send_invalidation_events q events =
-    add_event q (fun q -> q.invalidation_events <- q.invalidation_events @ events)
-  ;;
-
-  let send_file_watcher_events q files =
-    match files with
-    | [] -> ()
-    | _ :: _ ->
-      send_invalidation_events
-        q
-        (List.map files ~f:(fun file : Invalidation_event.t -> Filesystem_event file))
-  ;;
-
-  let send_invalidation_event q invalidation =
-    send_invalidation_events q [ Invalidation invalidation ]
   ;;
 
   let send_job_completed q job proc_info =

--- a/src/dune_scheduler/event.mli
+++ b/src/dune_scheduler/event.mli
@@ -24,32 +24,13 @@ module Fs_memo_event : sig
   val to_dyn : t -> Dyn.t
 end
 
-module Sync_id : sig
-  type t
-
-  val equal : t -> t -> bool
-  val hash : t -> int
-  val gen : unit -> t
-  val to_int : t -> int
-  val to_dyn : t -> Dyn.t
-end
-
 module File_watcher_event : sig
   type t =
     | Fs_memo_event of Fs_memo_event.t
     | Queue_overflow
-    | Sync of Sync_id.t
-    | Watcher_terminated
 end
 
-type build_input_change =
-  | Fs_event of Fs_memo_event.t
-  | Invalidation of Memo.Invalidation.t
-
 type t =
-  | Build_inputs_changed of build_input_change Nonempty_list.t
-  | File_system_sync of Sync_id.t
-  | File_system_watcher_terminated
   | Shutdown of Shutdown.Reason.t
   | Fiber_fill_ivar of Fiber.fill
   | Job_complete_ready
@@ -61,14 +42,10 @@ module Queue : sig
   val to_dyn : t -> Dyn.t
   val create : unit -> t
 
-  (** Return the next event. File changes event are always flattened and
-      returned first. *)
+  (** Return the next event. *)
   val next : t -> event
 
-  val send_worker_task_completed : t -> Fiber.fill -> unit
   val send_worker_tasks_completed : t -> Fiber.fill list -> unit
-  val send_file_watcher_events : t -> File_watcher_event.t list -> unit
-  val send_invalidation_event : t -> Memo.Invalidation.t -> unit
   val send_job_completed : t -> job -> Proc.Process_info.t -> unit
   val send_job_completed_ready : t -> unit
   val send_shutdown : t -> Shutdown.Reason.t -> unit

--- a/src/dune_scheduler/file_watcher.ml
+++ b/src/dune_scheduler/file_watcher.ml
@@ -1,8 +1,84 @@
 open Import
 module Scheduler_event = Event
 module Fs_memo_event = Scheduler_event.Fs_memo_event
-module Sync_id = Scheduler_event.Sync_id
 module Event = Scheduler_event.File_watcher_event
+
+module Sync = struct
+  module Id = Id.Make ()
+
+  type t =
+    { id : Id.t
+    ; ivar : unit Fiber.Ivar.t
+    }
+
+  module Table = struct
+    type nonrec t =
+      { table : (string, t) Table.t
+      ; mutex : Mutex.t
+      }
+
+    let create () = { table = Table.create (module String) 64; mutex = Mutex.create () }
+
+    let create_sync_file t ~fn ~sync ~path =
+      Mutex.protect t.mutex (fun () ->
+        Table.set t.table fn sync;
+        match
+          Unix.close (Unix.openfile path [ O_WRONLY; O_CREAT; O_TRUNC; O_CLOEXEC ] 0o666)
+        with
+        | () -> ()
+        | exception exn ->
+          Table.remove t.table fn;
+          Exn.reraise exn)
+    ;;
+
+    let consume_event t path =
+      Mutex.protect t.mutex (fun () ->
+        let basename = Filename.basename path in
+        match Table.find t.table basename with
+        | None -> None
+        | Some sync ->
+          Fpath.unlink_no_err path;
+          Table.remove t.table basename;
+          Some sync)
+    ;;
+  end
+
+  let special_dir_path = lazy (Path.Build.relative Path.Build.root ".sync")
+  let special_dir = lazy (Lazy.force special_dir_path |> Path.Build.to_string)
+
+  let flush sync_table =
+    let ivar = Fiber.Ivar.create () in
+    let id = Id.gen () in
+    let sync = { id; ivar } in
+    let fn = Id.to_int id |> string_of_int in
+    let path = Filename.concat (Lazy.force special_dir) fn in
+    Table.create_sync_file sync_table ~fn ~sync ~path;
+    Fiber.Ivar.read ivar
+  ;;
+
+  let is_special_file ~path_as_reported_by_file_watcher =
+    (* We use string matching here and that's fine because we match on the path
+       reported by the file watcher backend which will always report the same
+       string that was used to setup the watch. *)
+    Filename.dirname path_as_reported_by_file_watcher = Lazy.force special_dir
+  ;;
+
+  (* fsevents always reports absolute paths. therefore, we need callers to make
+     an effort to determine if an absolute path is in fact in the build dir *)
+  let is_special_file_fsevents (path : Path.t) =
+    match path with
+    | In_source_tree _ | External _ -> false
+    | In_build_dir build_path ->
+      (match Path.Build.parent build_path with
+       | None -> false
+       | Some dir -> Path.Build.equal dir (Lazy.force special_dir_path))
+  ;;
+end
+
+type backend_event =
+  | Filesystem_event of Event.t
+  | Sync of Sync.t
+  | Watcher_terminated
 
 module Watch_trie : sig
   (** Specialized trie for fsevent watches *)
@@ -184,28 +260,19 @@ type kind =
   | Fsevents of
       { mutable external_ : Fsevents.t Watch_trie.t
       ; dispatch_queue : Fsevents.Dispatch_queue.t
-      ; event_queue : Scheduler_event.Queue.t
       ; source : Fsevents.t
       ; sync : Fsevents.t
       ; latency : Time.Span.t
-      ; on_event : Fsevents.Event.t -> Path.t -> Event.t option
+      ; on_event : Fsevents.Event.t -> Path.t -> backend_event option
       }
   | Inotify of Inotify.t
   | Fswatch_win of { t : Fswatch_win.t }
 
-type sync_table =
-  { table : (string, Sync_id.t) Table.t
-  ; mutex : Mutex.t
-  }
-
-let create_sync_table () =
-  { table = Table.create (module String) 64; mutex = Mutex.create () }
-;;
-
 type t =
   { kind : kind
-  ; sync_table : sync_table
+  ; sync_table : Sync.Table.t
     (* Pending fs sync operations indexed by the special sync filename. *)
+  ; events : Event.t list Thread_safe_channel.t
   }
 
 let create_should_exclude_predicate ~watch_exclusions =
@@ -214,20 +281,16 @@ let create_should_exclude_predicate ~watch_exclusions =
   Re.execp (Re.compile (Re.alt (List.map watch_exclusions ~f:Re.Posix.re)))
 ;;
 
-module For_tests = struct
-  let should_exclude = create_should_exclude_predicate
-end
-
-let process_inotify_event (event : Inotify.Event.t) should_exclude : Event.t list =
+let process_inotify_event (event : Inotify.Event.t) should_exclude : backend_event list =
   let create_event_unless_excluded ~kind ~path =
     if should_exclude path
     then []
     else (
       let path = Path.of_string path in
-      [ Event.Fs_memo_event (Fs_memo_event.create ~kind ~path) ])
+      [ Filesystem_event (Event.Fs_memo_event (Fs_memo_event.create ~kind ~path)) ])
   in
   match event with
-  | Queue_overflow -> [ Queue_overflow ]
+  | Queue_overflow -> [ Filesystem_event Queue_overflow ]
   | Created path -> create_event_unless_excluded ~kind:Created ~path
   | Unlinked path -> create_event_unless_excluded ~kind:Deleted ~path
   | Modified path -> create_event_unless_excluded ~kind:File_changed ~path
@@ -240,33 +303,83 @@ let process_inotify_event (event : Inotify.Event.t) should_exclude : Event.t lis
        @ create_event_unless_excluded ~kind:Created ~path:dst)
 ;;
 
-let trace_and_send_events send_events events =
-  Dune_trace.emit_all ~buffered:true File_watcher (fun () ->
-    List.map events ~f:(fun (event : Event.t) ->
-      Dune_trace.Event.file_watcher
-        (match event with
-         | Queue_overflow -> `Queue_overflow
-         | Sync sync -> `Sync (Sync_id.to_int sync)
-         | Watcher_terminated -> `Watcher_terminated
-         | Fs_memo_event { path; kind } ->
-           let kind =
-             match kind with
-             | Created -> `Created
-             | Deleted -> `Deleted
-             | File_changed -> `File_changed
-             | Unknown -> `Unknown
-           in
-           `File (path, kind))));
-  send_events events
+let event_to_trace_event = function
+  | Sync { id; _ } -> `Sync (Sync.Id.to_int id)
+  | Watcher_terminated -> `Watcher_terminated
+  | Filesystem_event Queue_overflow -> `Queue_overflow
+  | Filesystem_event (Fs_memo_event { path; kind }) ->
+    `File
+      ( path
+      , match kind with
+        | Created -> `Created
+        | Deleted -> `Deleted
+        | File_changed -> `File_changed
+        | Unknown -> `Unknown )
 ;;
 
-let send_events event_queue events =
-  trace_and_send_events
-    (Scheduler_event.Queue.send_file_watcher_events event_queue)
-    events
+let trace_event_to_dyn = function
+  | `Sync id -> Dyn.variant "Sync" [ Dyn.int id ]
+  | `Queue_overflow -> Dyn.variant "Queue_overflow" []
+  | `Watcher_terminated -> Dyn.variant "Watcher_terminated" []
+  | `File (path, kind) ->
+    let kind =
+      match kind with
+      | `Created -> "Created"
+      | `Deleted -> "Deleted"
+      | `File_changed -> "File_changed"
+      | `Unknown -> "Unknown"
+    in
+    Dyn.variant "File" [ Path.to_dyn path; Dyn.string kind ]
 ;;
+
+let emit_events events =
+  Dune_trace.emit_all ~buffered:true File_watcher (fun () ->
+    List.map events ~f:(fun event ->
+      Dune_trace.Event.file_watcher (event_to_trace_event event)))
+;;
+
+let log_dropped_events events =
+  Log.info
+    "file watcher events dropped: channel closed"
+    [ "events", Dyn.list trace_event_to_dyn (List.map events ~f:event_to_trace_event) ]
+;;
+
+let dispatch_backend_events events backend_events =
+  let send_file_events file_events =
+    match List.rev file_events with
+    | [] -> ()
+    | file_events ->
+      let backend_events =
+        List.map file_events ~f:(fun event -> Filesystem_event event)
+      in
+      (match Thread_safe_channel.write events file_events with
+       | `Ok -> emit_events backend_events
+       | `Closed -> log_dropped_events backend_events)
+  in
+  let rec loop file_events = function
+    | [] -> send_file_events file_events
+    | Filesystem_event event :: backend_events ->
+      loop (event :: file_events) backend_events
+    | Sync ({ ivar; _ } as sync) :: backend_events ->
+      send_file_events file_events;
+      let backend_event = Sync sync in
+      (match Thread_safe_channel.write_fill events (Fiber.Fill (ivar, ())) with
+       | `Ok -> emit_events [ backend_event ]
+       | `Closed -> log_dropped_events [ backend_event ]);
+      loop [] backend_events
+    | Watcher_terminated :: _ ->
+      send_file_events file_events;
+      Thread_safe_channel.close events;
+      emit_events [ Watcher_terminated ]
+  in
+  loop [] backend_events
+;;
+
+let close t = Thread_safe_channel.close t.events
+let read t = Thread_safe_channel.read t.events
 
 let shutdown t =
+  close t;
   match t.kind with
   | Fswatch { pid; _ } -> `Kill pid
   | Inotify _ -> `No_op
@@ -280,67 +393,8 @@ let shutdown t =
   | Fswatch_win { t } -> `Thunk (fun () -> Fswatch_win.shutdown t)
 ;;
 
-module Fs_sync : sig
-  val special_dir_path : Path.Build.t Lazy.t
-  val special_dir : string Lazy.t
-  val emit : sync_table -> Sync_id.t
-  val is_special_file : path_as_reported_by_file_watcher:string -> bool
-
-  (** fsevents always reports absolute paths. therefore, we need callers to make
-      an effort to determine if an absolute path is in fact in the build dir *)
-  val is_special_file_fsevents : Path.t -> bool
-
-  val consume_event : sync_table -> string -> Sync_id.t option
-end = struct
-  let special_dir_path = lazy (Path.Build.relative Path.Build.root ".sync")
-  let special_dir = lazy (Lazy.force special_dir_path |> Path.Build.to_string)
-
-  let emit sync_table =
-    let id = Sync_id.gen () in
-    let fn = id |> Sync_id.to_int |> string_of_int in
-    let path = Filename.concat (Lazy.force special_dir) fn in
-    Mutex.protect sync_table.mutex (fun () ->
-      Table.set sync_table.table fn id;
-      match
-        Unix.close (Unix.openfile path [ O_WRONLY; O_CREAT; O_TRUNC; O_CLOEXEC ] 0o666)
-      with
-      | () -> ()
-      | exception exn ->
-        Table.remove sync_table.table fn;
-        Exn.reraise exn);
-    id
-  ;;
-
-  let is_special_file ~path_as_reported_by_file_watcher =
-    (* We use string matching here and that's fine because we match on the path
-       reported by the file watcher backend which will always report the same
-       string that was used to setup the watch. *)
-    Filename.dirname path_as_reported_by_file_watcher = Lazy.force special_dir
-  ;;
-
-  let consume_event sync_table path =
-    Mutex.protect sync_table.mutex (fun () ->
-      let basename = Filename.basename path in
-      match Table.find sync_table.table basename with
-      | None -> None
-      | Some id ->
-        Fpath.unlink_no_err path;
-        Table.remove sync_table.table basename;
-        Some id)
-  ;;
-
-  let is_special_file_fsevents (path : Path.t) =
-    match path with
-    | In_source_tree _ | External _ -> false
-    | In_build_dir build_path ->
-      (match Path.Build.parent build_path with
-       | None -> false
-       | Some dir -> Path.Build.equal dir (Lazy.force special_dir_path))
-  ;;
-end
-
 let command ~backend ~watch_exclusions =
-  let inotify_special_path = Lazy.force Fs_sync.special_dir in
+  let inotify_special_path = Lazy.force Sync.special_dir in
   match backend with
   | `Fswatch fswatch ->
     (* On all other platforms, try to use fswatch. fswatch's event filtering is
@@ -422,7 +476,7 @@ let select_watcher_backend () =
 ;;
 
 let prepare_sync () =
-  let dir = Lazy.force Fs_sync.special_dir in
+  let dir = Lazy.force Sync.special_dir in
   match Fpath.clear_dir dir with
   | Cleared -> ()
   | Directory_does_not_exist ->
@@ -444,9 +498,10 @@ let spawn_external_watcher ~backend ~watch_exclusions =
   Unix.in_channel_of_descr r_stdout, pid
 ;;
 
-let create_inotifylib_watcher ~sync_table ~event_queue should_exclude =
+let create_inotifylib_watcher ~sync_table ~event_channel should_exclude =
+  let { Sync.Table.mutex; _ } = sync_table in
   Inotify.create
-    ~mutex:sync_table.mutex
+    ~mutex
     ~modify_event_selector:`Closed_writable_fd
     ~emit_events:(fun events ->
       let events =
@@ -455,97 +510,94 @@ let create_inotifylib_watcher ~sync_table ~event_queue should_exclude =
             match (event : Inotify.Event.t) with
             | Modified path | Created path | Unlinked path ->
               Option.some_if
-                (Fs_sync.is_special_file ~path_as_reported_by_file_watcher:path)
+                (Sync.is_special_file ~path_as_reported_by_file_watcher:path)
                 path
             | Moved _ | Queue_overflow -> None
           in
           match is_fs_sync_event_generated_by_dune with
           | None -> process_inotify_event event should_exclude
           | Some path ->
-            (match Fs_sync.consume_event sync_table path with
+            (match Sync.Table.consume_event sync_table path with
              | None -> []
-             | Some id -> [ Event.Sync id ]))
+             | Some sync -> [ Sync sync ]))
       in
-      send_events event_queue events)
+      dispatch_backend_events event_channel events)
 ;;
 
-let create_external_fswatch ~event_queue ~backend ~watch_exclusions =
+let create_external_fswatch ~sync_table ~event_channel ~backend ~watch_exclusions =
   let debounce_interval = Time.Span.of_secs 0.5 in
-  let jobs = ref [] in
+  let pending_events = ref [] in
   let event_mtx = Mutex.create () in
   let event_cv = Condition.create () in
-  let res =
-    let sync_table = create_sync_table () in
-    let pipe, pid = spawn_external_watcher ~backend ~watch_exclusions in
-    let (_ : Thread.t) =
-      Thread0.spawn ~name:"file-watcher" (fun () ->
-        let enqueue events =
-          Mutex.protect event_mtx (fun () ->
-            jobs := events :: !jobs;
-            Condition.signal event_cv)
-        in
-        let rec loop () =
-          match input_line pipe with
-          | exception End_of_file -> enqueue [ Event.Watcher_terminated ]
-          | path_s ->
-            let events =
-              if Fs_sync.is_special_file ~path_as_reported_by_file_watcher:path_s
-              then (
-                match Fs_sync.consume_event sync_table path_s with
-                | None -> []
-                | Some id -> [ Event.Sync id ])
-              else (
-                let path = Path.Expert.try_localize_external (Path.of_string path_s) in
-                [ Fs_memo_event (Fs_memo_event.create ~kind:File_changed ~path) ])
-            in
-            enqueue events;
-            loop ()
-        in
-        loop ())
-    in
-    { kind = Fswatch { pid }; sync_table }
+  let pipe, pid = spawn_external_watcher ~backend ~watch_exclusions in
+  let (_ : Thread.t) =
+    Thread0.spawn ~name:"file-watcher" (fun () ->
+      let enqueue events =
+        Mutex.protect event_mtx (fun () ->
+          pending_events := events :: !pending_events;
+          Condition.signal event_cv)
+      in
+      let rec loop () =
+        match input_line pipe with
+        | exception End_of_file -> enqueue [ Watcher_terminated ]
+        | path_s ->
+          let events =
+            if Sync.is_special_file ~path_as_reported_by_file_watcher:path_s
+            then (
+              match Sync.Table.consume_event sync_table path_s with
+              | None -> []
+              | Some sync -> [ Sync sync ])
+            else (
+              let path = Path.Expert.try_localize_external (Path.of_string path_s) in
+              [ Filesystem_event
+                  (Fs_memo_event (Fs_memo_event.create ~kind:File_changed ~path))
+              ])
+          in
+          enqueue events;
+          loop ()
+      in
+      loop ())
   in
   let (_ : Thread.t) =
     (* The buffer thread is used to avoid flooding the main thread with file
-     changes events when a lot of file changes are reported at once. In
-     particular, this avoids restarting the build over and over in a short
-     period of time when many events are reported at once.
+       changes events when a lot of file changes are reported at once. In
+       particular, this avoids restarting the build over and over in a short
+       period of time when many events are reported at once.
 
-     It works as follow:
+       It works as follow:
 
-     - when the first event is received, send it to the main thread immediately
-       so that we get a fast response time
+       - when the first event is received, send it to the main thread immediately
+         so that we get a fast response time
 
-     - after the first event is received, buffer subsequent events for
-       [debounce_interval] *)
+       - after the first event is received, buffer subsequent events for
+         [debounce_interval] *)
     let rec buffer_thread () =
-      let jobs_batch =
+      let events =
         Mutex.protect event_mtx (fun () ->
-          while List.is_empty !jobs do
+          while List.is_empty !pending_events do
             Condition.wait event_cv event_mtx
           done;
-          let jobs_batch = List.rev !jobs in
-          jobs := [];
-          jobs_batch)
+          let events = List.rev !pending_events |> List.concat in
+          pending_events := [];
+          events)
       in
-      send_events event_queue (List.concat jobs_batch);
+      dispatch_backend_events event_channel events;
       Thread.delay (Time.Span.to_secs debounce_interval);
       buffer_thread ()
     in
     Thread0.spawn ~name:"file-watcher-buffer" buffer_thread
   in
-  res
+  Fswatch { pid }
 ;;
 
-let create_inotifylib ~event_queue ~should_exclude =
+let create_inotifylib ~sync_table ~event_channel ~should_exclude =
   prepare_sync ();
-  let sync_table = create_sync_table () in
-  let inotify = create_inotifylib_watcher ~sync_table ~event_queue should_exclude in
-  Inotify.add inotify (Lazy.force Fs_sync.special_dir);
-  { kind = Inotify inotify; sync_table }
+  let inotify = create_inotifylib_watcher ~sync_table ~event_channel should_exclude in
+  Inotify.add inotify (Lazy.force Sync.special_dir);
+  Inotify inotify
 ;;
 
-let fsevents_callback ?exclusion_paths event_queue ~f events =
+let fsevents_callback ?exclusion_paths event_channel ~f events =
   let skip_path =
     (* excluding a [path] will exclude children under [path] but not [path]
        itself. Hence we need to skip [path] manually *)
@@ -560,13 +612,16 @@ let fsevents_callback ?exclusion_paths event_queue ~f events =
       in
       if skip_path path then None else f event path)
   in
-  send_events event_queue events
+  dispatch_backend_events event_channel events
 ;;
 
-let fsevents ?exclusion_paths ~latency ~paths event_queue f =
+let fsevents ?exclusion_paths ~latency ~paths event_channel f =
   let fsevents =
     let paths = List.map paths ~f:Path.to_absolute_filename in
-    Fsevents.create ~latency ~paths ~f:(fsevents_callback ?exclusion_paths event_queue ~f)
+    Fsevents.create
+      ~latency
+      ~paths
+      ~f:(fsevents_callback ?exclusion_paths event_channel ~f)
   in
   Option.iter exclusion_paths ~f:(fun paths ->
     let paths = List.rev_map paths ~f:Path.to_absolute_filename in
@@ -584,17 +639,17 @@ let fsevents_standard_event_impl
   then None
   else (
     let fs_memo_event kind =
-      Some (Event.Fs_memo_event (Fs_memo_event.create ~kind ~path))
+      Some (Filesystem_event (Event.Fs_memo_event (Fs_memo_event.create ~kind ~path)))
     in
     match kind with
-    | Dir_and_descendants -> Some Event.Queue_overflow
+    | Dir_and_descendants -> Some (Filesystem_event Event.Queue_overflow)
     | Dir ->
       (match action with
        | Remove | Rename | Unknown ->
          (* FSEvents can report directory-wide or ambiguous changes without
             listing all affected descendants. Until Fs_memo supports subtree
             invalidation, over-invalidate by clearing the filesystem caches. *)
-         Some Event.Queue_overflow
+         Some (Filesystem_event Event.Queue_overflow)
        | Create -> fs_memo_event Created
        | Modify -> fs_memo_event Unknown)
     | File ->
@@ -614,10 +669,10 @@ let%expect_test "fsevents standard event handling" =
     =
     match fsevents_standard_event_impl ~should_exclude ~action ~kind path with
     | None -> print_endline "None"
-    | Some Event.Queue_overflow -> print_endline "Queue_overflow"
-    | Some (Event.Fs_memo_event event) ->
+    | Some (Filesystem_event Event.Queue_overflow) -> print_endline "Queue_overflow"
+    | Some (Filesystem_event (Event.Fs_memo_event event)) ->
       Fs_memo_event.to_dyn event |> Dyn.to_string |> print_endline
-    | Some (Event.Sync _ | Watcher_terminated) ->
+    | Some (Sync _ | Watcher_terminated) ->
       Code_error.raise "unexpected fsevents standard event" []
   in
   print Modify File;
@@ -639,26 +694,31 @@ let%expect_test "fsevents standard event handling" =
     |}]
 ;;
 
-let create_fsevents ?(latency = Time.Span.of_secs 0.2) ~event_queue ~should_exclude () =
+let create_fsevents
+      ~sync_table
+      ~event_channel
+      ?(latency = Time.Span.of_secs 0.2)
+      ~should_exclude
+      ()
+  =
   prepare_sync ();
-  let sync_table = create_sync_table () in
   let sync =
     (* Keep the original event path for consuming the sync file; use the
        localized path only to check whether the event is in the build directory. *)
     fsevents
       ~latency
-      ~paths:[ Path.build (Lazy.force Fs_sync.special_dir_path) ]
-      event_queue
+      ~paths:[ Path.build (Lazy.force Sync.special_dir_path) ]
+      event_channel
       (fun event localized_path ->
          let path = Fsevents.Event.path event in
-         if not (Fs_sync.is_special_file_fsevents localized_path)
-         then None
-         else (
-           match Fsevents.Event.action event with
-           | Remove -> None
-           | Rename | Unknown | Create | Modify ->
-             Fs_sync.consume_event sync_table path
-             |> Option.map ~f:(fun id -> Event.Sync id)))
+         match Sync.is_special_file_fsevents localized_path with
+         | false -> None
+         | true ->
+           (match Fsevents.Event.action event with
+            | Remove -> None
+            | Rename | Unknown | Create | Modify ->
+              Sync.Table.consume_event sync_table path
+              |> Option.map ~f:(fun sync -> Sync sync)))
   in
   let on_event event path =
     fsevents_standard_event_impl
@@ -674,7 +734,7 @@ let create_fsevents ?(latency = Time.Span.of_secs 0.2) ~event_queue ~should_excl
       :: ([ "_esy"; "_opam"; ".git"; ".hg" ]
           |> List.rev_map ~f:(Path.relative (Path.source Path.Source.root)))
     in
-    fsevents ~latency event_queue ~exclusion_paths ~paths on_event
+    fsevents ~latency event_channel ~exclusion_paths ~paths on_event
   in
   let cv = Condition.create () in
   let dispatch_queue_ref = ref None in
@@ -705,7 +765,7 @@ let create_fsevents ?(latency = Time.Span.of_secs 0.2) ~event_queue ~should_excl
          | Ok () -> ()
          | Error exn ->
            Log.warn "FSEvents watcher error" [ "exn", Exn.to_dyn exn ];
-           send_events event_queue [ Event.Watcher_terminated ]))
+           dispatch_backend_events event_channel [ Watcher_terminated ]))
   in
   let dispatch_queue =
     match
@@ -718,21 +778,11 @@ let create_fsevents ?(latency = Time.Span.of_secs 0.2) ~event_queue ~should_excl
     | Ok dispatch_queue -> dispatch_queue
     | Error exn -> Exn_with_backtrace.reraise exn
   in
-  { kind =
-      Fsevents
-        { latency
-        ; event_queue
-        ; sync
-        ; source
-        ; external_ = Watch_trie.empty
-        ; dispatch_queue
-        ; on_event
-        }
-  ; sync_table
-  }
+  Fsevents
+    { latency; sync; source; external_ = Watch_trie.empty; dispatch_queue; on_event }
 ;;
 
-let fswatch_win_callback ~event_queue ~sync_table ~should_exclude event =
+let fswatch_win_event ~sync_table ~should_exclude event =
   let filename =
     let dir = Fswatch_win.Event.directory event in
     Filename.concat dir (Fswatch_win.Event.path event)
@@ -740,62 +790,88 @@ let fswatch_win_callback ~event_queue ~sync_table ~should_exclude event =
   let localized_path = Path.Expert.try_localize_external (Path.of_string filename) in
   match localized_path with
   | In_build_dir _ ->
-    if Fs_sync.is_special_file_fsevents localized_path
+    if Sync.is_special_file_fsevents localized_path
     then (
       match Fswatch_win.Event.action event with
       | Added | Modified ->
-        (match Fs_sync.consume_event sync_table filename with
-         | None -> ()
-         | Some id -> send_events event_queue [ Event.Sync id ])
-      | Removed | Renamed_new | Renamed_old -> ())
+        Sync.Table.consume_event sync_table filename
+        |> Option.map ~f:(fun sync -> Sync sync)
+      | Removed | Renamed_new | Renamed_old -> None)
+    else None
   | path ->
     let normalized_filename =
       String.concat
         ~sep:"/"
         (String.split_on_char ~sep:'\\' (String.lowercase_ascii filename))
     in
-    if not (should_exclude normalized_filename)
-    then (
-      let kind =
-        match Fswatch_win.Event.action event with
-        | Added | Renamed_new -> Fs_memo_event.Created
-        | Removed | Renamed_old -> Deleted
-        | Modified -> File_changed
-      in
-      send_events event_queue [ Event.Fs_memo_event (Fs_memo_event.create ~kind ~path) ])
+    if should_exclude normalized_filename
+    then None
+    else
+      Some
+        (let kind =
+           match Fswatch_win.Event.action event with
+           | Added | Renamed_new -> Fs_memo_event.Created
+           | Removed | Renamed_old -> Deleted
+           | Modified -> File_changed
+         in
+         Filesystem_event (Event.Fs_memo_event (Fs_memo_event.create ~kind ~path)))
 ;;
 
-let create_fswatch_win ~event_queue ~debounce_interval:sleep ~should_exclude =
+let create_fswatch_win ~sync_table ~event_channel ~debounce_interval:sleep ~should_exclude
+  =
   prepare_sync ();
-  let sync_table = create_sync_table () in
   let t = Fswatch_win.create () in
   Fswatch_win.add t (Path.to_absolute_filename Path.root);
   let (_ : Thread.t) =
     Thread0.spawn ~name:"file-watcher" (fun () ->
       while true do
         let events = Fswatch_win.wait t ~sleep in
-        List.iter
-          ~f:(fswatch_win_callback ~event_queue ~sync_table ~should_exclude)
-          events
+        let events =
+          List.filter_map events ~f:(fswatch_win_event ~sync_table ~should_exclude)
+        in
+        dispatch_backend_events event_channel events
       done)
   in
-  { kind = Fswatch_win { t }; sync_table }
+  Fswatch_win { t }
 ;;
 
-let create_default ?fsevents_debounce ~watch_exclusions ~event_queue () =
+let create ?fsevents_debounce ~watch_exclusions ~event_queue () =
+  let events = Thread_safe_channel.create event_queue in
+  let sync_table = Sync.Table.create () in
   let should_exclude = create_should_exclude_predicate ~watch_exclusions in
-  match select_watcher_backend () with
-  | `Fswatch _ as backend ->
-    create_external_fswatch ~event_queue ~backend ~watch_exclusions
-  | `Fsevents ->
-    create_fsevents ?latency:fsevents_debounce ~event_queue ~should_exclude ()
-  | `Inotify_lib -> create_inotifylib ~event_queue ~should_exclude
-  | `Fswatch_win ->
-    create_fswatch_win
-      ~event_queue
-      ~should_exclude
-      ~debounce_interval:500 (* milliseconds *)
+  { kind =
+      (match select_watcher_backend () with
+       | `Fswatch _ as backend ->
+         create_external_fswatch
+           ~sync_table
+           ~event_channel:events
+           ~backend
+           ~watch_exclusions
+       | `Fsevents ->
+         create_fsevents
+           ~sync_table
+           ~event_channel:events
+           ?latency:fsevents_debounce
+           ~should_exclude
+           ()
+       | `Inotify_lib ->
+         create_inotifylib ~sync_table ~event_channel:events ~should_exclude
+       | `Fswatch_win ->
+         create_fswatch_win
+           ~sync_table
+           ~event_channel:events
+           ~should_exclude
+           ~debounce_interval:500)
+  ; sync_table
+  ; events
+  }
 ;;
+
+module For_tests = struct
+  let should_exclude = create_should_exclude_predicate
+end
+
+let flush t = Sync.flush t.sync_table
 
 (* Return the parent directory of [ext] if [ext] denotes a file. *)
 let parent_directory ext =
@@ -852,7 +928,7 @@ let add_watch t path =
             lazy
               (fsevents
                  ~latency:f.latency
-                 f.event_queue
+                 t.events
                  ~paths:[ Path.external_ ext ]
                  f.on_event)
           in
@@ -883,5 +959,3 @@ let add_watch t path =
           Fswatch_win.add fswatch.t (Path.External.to_string ext);
           Ok ()))
 ;;
-
-let emit_sync t = Fs_sync.emit t.sync_table

--- a/src/dune_scheduler/file_watcher.mli
+++ b/src/dune_scheduler/file_watcher.mli
@@ -2,21 +2,20 @@ open Stdune
 
 type t
 
-(** Create a new file watcher with default settings. *)
-val create_default
+(** Create a new file watcher. *)
+val create
   :  ?fsevents_debounce:Time.Span.t
   -> watch_exclusions:string list
   -> event_queue:Event.Queue.t
   -> unit
   -> t
 
+val close : t -> unit
+val read : t -> Event.File_watcher_event.t list option Fiber.t
+val flush : t -> unit Fiber.t
+
 (** The action that needs to be taken to shutdown the watcher. *)
 val shutdown : t -> [ `Kill of Pid.t | `No_op | `Thunk of unit -> unit ]
-
-(** Cause a sync event to be propagated through the notification subsystem to
-    attempt to make sure that we've processed all the events that happened so
-    far. *)
-val emit_sync : t -> Event.Sync_id.t
 
 val add_watch : t -> Path.t -> (unit, [ `Does_not_exist ]) result
 

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -1,21 +1,6 @@
 open Import
 open Fiber.O
 
-module Fs_memo = struct
-  let handle_fs_event = Fdecl.create Dyn.opaque
-  let init = Fdecl.create Dyn.opaque
-  let initialized = ref false
-
-  let set_impl ~handle_fs_event:handle_fs_event' ~init:init' =
-    Fdecl.set handle_fs_event handle_fs_event';
-    Fdecl.set init init';
-    initialized := true
-  ;;
-
-  let handle_fs_event event = Fdecl.get handle_fs_event event
-  let init ~dune_file_watcher = Fdecl.get init ~dune_file_watcher
-end
-
 module Config = struct
   type t =
     { concurrency : int
@@ -33,7 +18,24 @@ let running_jobs_count (t : t) = Process_watcher.running_count t.process_watcher
 exception Build_cancelled
 
 let cancelled () = raise (Memo.Non_reproducible Build_cancelled)
-let check_cancelled t = if Fiber.Cancel.fired t.build_loop.cancel then cancelled ()
+
+let check_cancelled t =
+  match t.current_build_cancel with
+  | Some cancel when Fiber.Cancel.fired cancel -> cancelled ()
+  | None | Some _ -> ()
+;;
+
+let with_current_build_cancellation cancel f =
+  let* () = Fiber.return () in
+  let t = t () in
+  match t.current_build_cancel with
+  | Some _ -> f ()
+  | None ->
+    t.current_build_cancel <- Some cancel;
+    Fiber.finalize f ~finally:(fun () ->
+      t.current_build_cancel <- None;
+      Fiber.return ())
+;;
 
 let check_point =
   let* () = Fiber.return () in
@@ -76,33 +78,40 @@ type termination_reason =
    scheduler explicitly *)
 let wait_for_build_process t ~is_process_group_leader pid =
   let sigkill_alarm = ref None in
-  let+ res, outcome =
-    Fiber.Cancel.with_handler
-      t.build_loop.cancel
-      ~on_cancel:(fun () ->
-        if not Sys.win32 then Process_watcher.killall t.process_watcher Sys.sigterm;
-        let sleep = Async_io.sleep t.async_io sigterm_grace_period in
-        sigkill_alarm := Some sleep;
-        Async_io.Task.await sleep
-        >>| function
-        | Error `Cancelled -> ()
-        | Ok () -> Process_watcher.killall t.process_watcher Sys.sigkill
-        | Error (`Exn _) -> assert false)
-      (fun () ->
-         let* r = wait_for_process t ~is_process_group_leader pid in
-         if not Sys.win32
-         then Process_watcher.kill_process_group pid Sys.sigterm ~is_process_group_leader;
-         let+ () =
-           match !sigkill_alarm with
-           | None -> Fiber.return ()
-           | Some alarm -> Async_io.Task.cancel alarm
-         in
-         r)
+  let wait () =
+    let* r = wait_for_process t ~is_process_group_leader pid in
+    if not Sys.win32
+    then Process_watcher.kill_process_group pid Sys.sigterm ~is_process_group_leader;
+    let+ () =
+      match !sigkill_alarm with
+      | None -> Fiber.return ()
+      | Some alarm -> Async_io.Task.cancel alarm
+    in
+    r
   in
-  ( res
-  , match outcome with
-    | Cancelled () -> Cancel
-    | Not_cancelled -> Normal )
+  match t.current_build_cancel with
+  | None ->
+    let+ res = wait () in
+    res, Normal
+  | Some cancel ->
+    let+ res, outcome =
+      Fiber.Cancel.with_handler
+        cancel
+        ~on_cancel:(fun () ->
+          if not Sys.win32 then Process_watcher.killall t.process_watcher Sys.sigterm;
+          let sleep = Async_io.sleep t.async_io sigterm_grace_period in
+          sigkill_alarm := Some sleep;
+          Async_io.Task.await sleep
+          >>| function
+          | Error `Cancelled -> ()
+          | Ok () -> Process_watcher.killall t.process_watcher Sys.sigkill
+          | Error (`Exn _) -> assert false)
+        wait
+    in
+    ( res
+    , (match outcome with
+       | Cancelled () -> Cancel
+       | Not_cancelled -> Normal) )
 ;;
 
 let got_shutdown reason =
@@ -113,10 +122,6 @@ let got_shutdown reason =
     | Requested -> Log.info "Shutdown" [ "reason", Dyn.variant "Requested" [] ]
     | Signal signal ->
       Log.info "Shutdown" [ "reason", Dyn.variant "Signal" [ Signal.to_dyn signal ] ])
-;;
-
-let filesystem_watcher_terminated () =
-  Log.info "Shutdown" [ "reason", Dyn.string "Filesystem watcher terminated" ]
 ;;
 
 type saw_shutdown =
@@ -185,46 +190,30 @@ let () =
     | Some s -> to_dyn s)
 ;;
 
-let prepare (config : Config.t) ~(handler : Handler.t) ~events ~file_watcher =
+let prepare (config : Config.t) ~events ~file_watcher =
   (* The signal watcher must be initialized first so that signals are
      blocked in all threads. *)
   let signal_watcher =
     Signal_watcher.init ~print_ctrl_c_warning:config.print_ctrl_c_warning events
   in
-  let cancel = Fiber.Cancel.create () in
   let process_watcher = Process_watcher.init events in
   let async_io = Async_io.create events in
-  let build_loop =
-    { Types.Scheduler.Build_loop.status =
-        (* Slightly weird initialization happening here: for polling mode we
-           initialize in "Building" state, immediately switch to Standing_by
-           and then back to "Building". It would make more sense to start in
-           "Stand_by" from the start. We can't "just" switch the initial value
-           here because then the non-polling mode would run in "Standing_by"
-           mode, which is even weirder. *)
-        Building cancel
-    ; invalidation = Memo.Invalidation.empty
-    ; watch_restart_started_at = None
-    ; handler
-    ; build_inputs_changed = Fiber.Trigger.create ()
-    ; cancel
-    }
-  in
   let t =
-    { build_loop
-    ; job_throttle = Fiber.Throttle.create config.concurrency
+    { job_throttle = Fiber.Throttle.create config.concurrency
     ; process_watcher
     ; events
     ; file_watcher
-    ; fs_syncs = Table.create (module Event.Sync_id) 64
     ; thread_pool = lazy (Thread_pool.create ~min_workers:4 ~max_workers:50)
     ; signal_watcher
     ; async_io
+    ; current_build_cancel = None
     }
   in
   current := Some t;
   t
 ;;
+
+let file_watcher () = (t ()).file_watcher
 
 module Run_once = struct
   type run_error =
@@ -233,18 +222,6 @@ module Run_once = struct
     | Exn of Exn_with_backtrace.t
 
   exception Abort of run_error
-
-  let handle_invalidation_events =
-    let handle_event event =
-      match (event : Event.build_input_change) with
-      | Invalidation invalidation -> invalidation
-      | Fs_event event -> Fs_memo.handle_fs_event event
-    in
-    fun events ->
-      let events = Nonempty_list.to_list events in
-      List.fold_left events ~init:Memo.Invalidation.empty ~f:(fun acc event ->
-        Memo.Invalidation.combine acc (handle_event event))
-  ;;
 
   (** This function is the heart of the scheduler. It makes progress in
       executing fibers by doing the following:
@@ -255,16 +232,6 @@ module Run_once = struct
   let rec iter (t : t) : Fiber.fill list =
     Console.Status_line.refresh ();
     match Event.Queue.next t.events with
-    | File_system_sync id ->
-      (match Table.find t.fs_syncs id with
-       | None -> iter t
-       | Some ivar ->
-         Table.remove t.fs_syncs id;
-         [ Fill (ivar, ()) ])
-    | Build_inputs_changed events -> build_input_change t events
-    | File_system_watcher_terminated ->
-      filesystem_watcher_terminated ();
-      raise (Abort Already_reported)
     | Job_complete_ready ->
       (match Process_watcher.wait_unix t.process_watcher with
        | [] -> iter t
@@ -273,30 +240,6 @@ module Run_once = struct
     | Shutdown reason ->
       got_shutdown reason;
       raise @@ Abort (Shutdown_requested reason)
-
-  and build_input_change (t : t) events =
-    let invalidation = handle_invalidation_events events in
-    if Memo.Invalidation.is_empty invalidation
-    then iter t
-    else (
-      let now = Time.now () in
-      let build_loop = t.build_loop in
-      if Option.is_none build_loop.watch_restart_started_at
-      then build_loop.watch_restart_started_at <- Some now;
-      build_loop.invalidation
-      <- Memo.Invalidation.combine build_loop.invalidation invalidation;
-      let fills =
-        match build_loop.status with
-        | Restarting_build | Standing_by -> []
-        | Building cancellation ->
-          build_loop.handler Build_interrupted;
-          build_loop.status <- Restarting_build;
-          Fiber.Cancel.fire' cancellation
-      in
-      let fills = Fiber.Trigger.trigger' build_loop.build_inputs_changed @ fills in
-      match fills with
-      | [] -> iter t
-      | fills -> fills)
   ;;
 
   let run t f : _ result =
@@ -349,7 +292,7 @@ let async f =
   let ivar = Fiber.Ivar.create () in
   let f () =
     let res = Exn_with_backtrace.try_with f in
-    Event.Queue.send_worker_task_completed t.events (Fiber.Fill (ivar, res))
+    Event.Queue.send_worker_tasks_completed t.events [ Fiber.Fill (ivar, res) ]
   in
   Thread_pool.task (Lazy.force t.thread_pool) ~f;
   Fiber.Ivar.read ivar
@@ -362,88 +305,11 @@ let async_exn f =
   | Ok e -> e
 ;;
 
-let flush_file_watcher_impl t =
-  match t.file_watcher with
+let flush_file_watcher () =
+  match (t ()).file_watcher with
   | None -> Fiber.return ()
-  | Some file_watcher ->
-    let ivar = Fiber.Ivar.create () in
-    let id = File_watcher.emit_sync file_watcher in
-    Table.set t.fs_syncs id ivar;
-    Fiber.Ivar.read ivar
+  | Some file_watcher -> File_watcher.flush file_watcher
 ;;
-
-let flush_file_watcher () = flush_file_watcher_impl (t ())
-
-module Build_loop = struct
-  open Types.Scheduler.Build_loop
-
-  type nonrec t = t
-
-  type build_finish =
-    | Finished of { restart_duration : Time.Span.t option }
-    | Restarting
-
-  let start_build () =
-    let build_loop = (t ()).build_loop in
-    let restart = Option.is_some build_loop.watch_restart_started_at in
-    `Restart restart
-  ;;
-
-  let finish_build ~stop =
-    let build_loop = (t ()).build_loop in
-    let finish () =
-      let restart_duration =
-        Option.map build_loop.watch_restart_started_at ~f:(fun restart_started_at ->
-          Time.diff stop restart_started_at)
-      in
-      build_loop.watch_restart_started_at <- None;
-      Finished { restart_duration }
-    in
-    match build_loop.status with
-    | Restarting_build -> Restarting
-    | Standing_by -> finish ()
-    | Building _ ->
-      build_loop.status <- Standing_by;
-      finish ()
-  ;;
-
-  let init () =
-    let+ () = Fiber.return () in
-    let scheduler = t () in
-    let t = scheduler.build_loop in
-    assert (
-      match t.status with
-      | Building _ -> true
-      | _ -> false);
-    t.status <- Standing_by;
-    t
-  ;;
-
-  let pending_invalidation t = t.invalidation
-
-  let start_iteration t =
-    t.invalidation <- Memo.Invalidation.empty;
-    t.build_inputs_changed <- Fiber.Trigger.create ();
-    (match t.status with
-     | Building _ -> assert false
-     | Standing_by | Restarting_build -> ());
-    let cancel = Fiber.Cancel.create () in
-    t.status <- Building cancel;
-    t.cancel <- cancel
-  ;;
-
-  let finish_iteration t =
-    match t.status with
-    | Standing_by -> `Done
-    | Restarting_build -> `Restart
-    | Building _ ->
-      t.status <- Standing_by;
-      t.watch_restart_started_at <- None;
-      `Done
-  ;;
-
-  let wait_for_build_input_change t = Fiber.Trigger.wait t.build_inputs_changed
-end
 
 module Run = struct
   exception Build_cancelled = Build_cancelled
@@ -460,38 +326,22 @@ module Run = struct
     | _, _ -> false
   ;;
 
-  module Event_queue = Event.Queue
-  module Event = Handler.Event
-
-  let go
-        (config : Config.t)
-        ?timeout
-        ?(file_watcher = No_watcher)
-        ~(on_event : Handler.Event.t -> unit)
-        run
-    =
-    let events = Event_queue.create () in
-    let file_watcher =
-      match file_watcher with
-      | No_watcher -> None
-      | Automatic ->
-        Some
-          (File_watcher.create_default
-             ~event_queue:events
-             ~watch_exclusions:config.watch_exclusions
-             ())
+  let go (config : Config.t) ?timeout ?(file_watcher = No_watcher) run =
+    let events = Event.Queue.create () in
+    let t =
+      let file_watcher =
+        match file_watcher with
+        | No_watcher -> None
+        | Automatic ->
+          Some
+            (File_watcher.create
+               ~event_queue:events
+               ~watch_exclusions:config.watch_exclusions
+               ())
+      in
+      prepare config ~events ~file_watcher
     in
-    let t = prepare config ~handler:on_event ~events ~file_watcher in
-    (match file_watcher with
-     | None ->
-       if !Fs_memo.initialized
-       then ignore (Fs_memo.init ~dune_file_watcher:None : Memo.Invalidation.t)
-     | Some dune_file_watcher ->
-       let initial_invalidation =
-         Fs_memo.init ~dune_file_watcher:(Some dune_file_watcher)
-       in
-       Memo.reset initial_invalidation);
-    let result =
+    match
       let run =
         match timeout with
         | None -> run
@@ -502,7 +352,7 @@ module Run = struct
               (fun () ->
                  let+ res = Async_io.Task.await sleep in
                  match res with
-                 | Ok () -> Event_queue.send_shutdown t.events Timeout
+                 | Ok () -> Event.Queue.send_shutdown t.events Timeout
                  | Error `Cancelled -> ()
                  | Error (`Exn _) -> assert false)
               (fun () ->
@@ -513,8 +363,7 @@ module Run = struct
       | Error (Shutdown_requested reason) -> Error (Shutdown.E reason, None)
       | Error Already_reported -> Error (Dune_util.Report_error.Already_reported, None)
       | Error (Exn exn_with_bt) -> Error (exn_with_bt.exn, Some exn_with_bt.backtrace)
-    in
-    match result with
+    with
     | Ok a -> a
     | Error (exn, None) -> Exn.raise exn
     | Error (exn, Some bt) -> Exn.raise_with_backtrace exn bt
@@ -528,13 +377,9 @@ let shutdown () =
 
 let cancel_current_build () =
   let* () = Fiber.return () in
-  let build_loop = (t ()).build_loop in
-  match build_loop.status with
-  | Restarting_build | Standing_by -> Fiber.return ()
-  | Building cancellation ->
-    build_loop.handler Build_interrupted;
-    build_loop.status <- Standing_by;
-    Fiber.Cancel.fire cancellation
+  match (t ()).current_build_cancel with
+  | None -> Fiber.return ()
+  | Some cancel -> Fiber.Cancel.fire cancel
 ;;
 
 let wait_for_process_with_timeout t pid waiter ~timeout ~is_process_group_leader =
@@ -592,20 +437,3 @@ let sleep dur =
     assert false
   | Error (`Exn _) -> assert false
 ;;
-
-let set_fs_memo_impl = Fs_memo.set_impl
-
-module For_tests = struct
-  let wait_for_build_input_change () =
-    let* () = Fiber.return () in
-    let build_loop = (t ()).build_loop in
-    Fiber.Trigger.wait build_loop.build_inputs_changed
-  ;;
-
-  let inject_memo_invalidation invalidation =
-    let* () = Fiber.return () in
-    let t = t () in
-    Event.Queue.send_invalidation_event t.events invalidation;
-    Fiber.return ()
-  ;;
-end

--- a/src/dune_scheduler/scheduler.mli
+++ b/src/dune_scheduler/scheduler.mli
@@ -11,10 +11,6 @@ module Config : sig
 end
 
 module Run : sig
-  module Event : sig
-    type t = Build_interrupted
-  end
-
   type file_watcher =
     | Automatic
     | No_watcher
@@ -27,7 +23,6 @@ module Run : sig
     :  Config.t
     -> ?timeout:Time.Span.t
     -> ?file_watcher:file_watcher
-    -> on_event:(Event.t -> unit)
     -> (unit -> 'a Fiber.t)
     -> 'a
 end
@@ -86,11 +81,11 @@ val running_jobs_count : t -> int
     do a bit cleanup, such as killing with [SIGKILL] all running external
     processes and will then raise [Run.Shutdown_requested].
 
-    Fibers that are suspended on a call such as [wait_for_process] or
-    [wait_for_build_input_change] by the time [shutdown] is called will
-    effectively never restart. If a fiber calls [wait_for_process] or any other
-    function from this module that needs an external event to make progress, it
-    will get suspended and will never restart. *)
+    Fibers that are suspended on a call such as [wait_for_process] by the time
+    [shutdown] is called will effectively never restart. If a fiber calls
+    [wait_for_process] or any other function from this module that needs an
+    external event to make progress, it will get suspended and will never
+    restart. *)
 val shutdown : unit -> unit
 
 (** Cancel the current build. Superficially, this function is like [shutdown]
@@ -104,39 +99,5 @@ val sleep : Time.Span.t -> unit Fiber.t
 
 val spawn_thread : name:string -> (unit -> unit) -> Thread.t
 val flush_file_watcher : unit -> unit Fiber.t
-
-module Build_loop : sig
-  type t
-
-  type build_finish =
-    | Finished of { restart_duration : Time.Span.t option }
-    | Restarting
-
-  val start_build : unit -> [ `Restart of bool ]
-  val finish_build : stop:Time.t -> build_finish
-  val init : unit -> t Fiber.t
-  val pending_invalidation : t -> Memo.Invalidation.t
-  val start_iteration : t -> unit
-  val finish_iteration : t -> [ `Done | `Restart ]
-  val wait_for_build_input_change : t -> unit Fiber.t
-end
-
-(** [set_fs_memo_impl] registers the file system memoization callbacks.
-    This must be called by dune_engine at initialization before starting
-    the scheduler to enable proper file system event handling. *)
-val set_fs_memo_impl
-  :  handle_fs_event:(Event.Fs_memo_event.t -> Memo.Invalidation.t)
-  -> init:(dune_file_watcher:File_watcher.t option -> Memo.Invalidation.t)
-  -> unit
-
-module For_tests : sig
-  (** Wait for a build input to change. If a build input change was seen but
-      hasn't been handled yet, return immediately.
-
-      Return even for build input change that are not significant, so that RPC
-      clients may observe that Dune reacted to a file change. This is needed
-      for benchmarking the watch mode of Dune. *)
-  val wait_for_build_input_change : unit -> unit Fiber.t
-
-  val inject_memo_invalidation : Memo.Invalidation.t -> unit Fiber.t
-end
+val file_watcher : unit -> File_watcher.t option
+val with_current_build_cancellation : Fiber.Cancel.t -> (unit -> 'a Fiber.t) -> 'a Fiber.t

--- a/src/dune_scheduler/thread_safe_channel.ml
+++ b/src/dune_scheduler/thread_safe_channel.ml
@@ -1,0 +1,92 @@
+open Import
+open Fiber.O
+
+type 'a item =
+  | Value of 'a
+  | Fill of Fiber.fill
+
+type 'a t =
+  { events : Event.Queue.t
+  ; items : 'a item Queue.t
+  ; readers : 'a option Fiber.Ivar.t Queue.t
+  ; mutex : Mutex.t
+  ; mutable closed : bool
+  }
+
+let create events =
+  { events
+  ; items = Queue.create ()
+  ; readers = Queue.create ()
+  ; mutex = Mutex.create ()
+  ; closed = false
+  }
+;;
+
+let write t value =
+  let status, fill =
+    Mutex.protect t.mutex (fun () ->
+      if t.closed
+      then `Closed, None
+      else (
+        match Queue.pop t.readers with
+        | Some ivar -> `Ok, Some (Fiber.Fill (ivar, Some value))
+        | None ->
+          Queue.push t.items (Value value);
+          `Ok, None))
+  in
+  Option.iter fill ~f:(fun fill ->
+    Event.Queue.send_worker_tasks_completed t.events [ fill ]);
+  status
+;;
+
+let write_fill t fill =
+  let status, fills =
+    Mutex.protect t.mutex (fun () ->
+      if t.closed
+      then `Closed, []
+      else if Queue.is_empty t.readers
+      then (
+        Queue.push t.items (Fill fill);
+        `Ok, [])
+      else `Ok, [ fill ])
+  in
+  Event.Queue.send_worker_tasks_completed t.events fills;
+  status
+;;
+
+let rec read t =
+  let* () = Fiber.return () in
+  match
+    Mutex.protect t.mutex (fun () ->
+      match Queue.pop t.items with
+      | Some (Value value) -> `Ready (Some value)
+      | Some (Fill fill) -> `Fill fill
+      | None when t.closed -> `Ready None
+      | None ->
+        let ivar = Fiber.Ivar.create () in
+        Queue.push t.readers ivar;
+        `Wait ivar)
+  with
+  | `Ready value -> Fiber.return value
+  | `Fill fill ->
+    Event.Queue.send_worker_tasks_completed t.events [ fill ];
+    read t
+  | `Wait ivar -> Fiber.Ivar.read ivar
+;;
+
+let close t =
+  let fills =
+    Mutex.protect t.mutex (fun () ->
+      if t.closed
+      then []
+      else (
+        t.closed <- true;
+        let rec drain acc =
+          match Queue.pop t.readers with
+          | None -> List.rev acc
+          | Some ivar -> drain (Fiber.Fill (ivar, None) :: acc)
+        in
+        drain []))
+  in
+  Event.Queue.send_worker_tasks_completed t.events fills
+;;

--- a/src/dune_scheduler/thread_safe_channel.mli
+++ b/src/dune_scheduler/thread_safe_channel.mli
@@ -1,0 +1,21 @@
+(** A FIFO channel that can be written to from any thread and read from
+    fibers running in the scheduler that created it. *)
+type 'a t
+
+val create : Event.Queue.t -> 'a t
+
+(** [write t x] makes [x] available to the next reader and wakes the scheduler
+    if needed. This function is thread-safe. *)
+val write : 'a t -> 'a -> [ `Closed | `Ok ]
+
+(** [write_fill t fill] schedules [fill] after all values already written to
+    [t] have been read. This function is thread-safe. *)
+val write_fill : _ t -> Fiber.fill -> [ `Closed | `Ok ]
+
+(** [read t] waits for the next value written to [t]. It returns [None] once
+    [t] is closed and all previously written values have been read. *)
+val read : 'a t -> 'a option Fiber.t
+
+(** Close [t] and wake any readers that are waiting. This function is
+    thread-safe and idempotent. *)
+val close : _ t -> unit

--- a/src/dune_scheduler/types.ml
+++ b/src/dune_scheduler/types.ml
@@ -52,45 +52,15 @@ module Async_io = struct
 end
 
 module Scheduler = struct
-  module Handler = struct
-    module Event = struct
-      type t = Build_interrupted
-    end
-
-    type t = Event.t -> unit
-  end
-
-  module Build_loop = struct
-    type status =
-      | (* We are not doing a build. Just accumulating invalidations until the next
-         build starts. *)
-        Standing_by
-      | (* Running a build *)
-        Building of Fiber.Cancel.t
-      | (* Cancellation requested. Build jobs are immediately rejected in this
-         state *)
-        Restarting_build
-
-    type t =
-      { mutable status : status
-      ; mutable invalidation : Memo.Invalidation.t
-      ; mutable watch_restart_started_at : Time.t option
-      ; handler : Handler.t
-      ; mutable build_inputs_changed : Fiber.Trigger.t
-      ; mutable cancel : Fiber.Cancel.t
-      }
-  end
-
   type t =
-    { build_loop : Build_loop.t
-    ; job_throttle : Fiber.Throttle.t
+    { job_throttle : Fiber.Throttle.t
     ; events : Event.Queue.t
     ; process_watcher : Process_watcher.t
     ; file_watcher : File_watcher.t option
-    ; fs_syncs : (Event.Sync_id.t, unit Fiber.Ivar.t) Table.t
     ; thread_pool : Thread_pool.t Lazy.t
     ; signal_watcher : Thread.t
     ; async_io : Async_io.t
+    ; mutable current_build_cancel : Fiber.Cancel.t option
     }
 
   let current : t option ref = ref None

--- a/test/blackbox-tests/test-cases/trace/interrupted-watch-build-events.t
+++ b/test/blackbox-tests/test-cases/trace/interrupted-watch-build-events.t
@@ -45,7 +45,7 @@ own source invalidation.
   $ stop_dune > /dev/null
 
   $ dune trace cat | jq_dune -s '
-  > [ .[] | buildEvents | del(.args.rusage) ] | .[-4:]'
+  > [ .[] | buildEvents | del(.args.rusage) ] | .[-5:]'
   [
     {
       "args": {
@@ -56,12 +56,20 @@ own source invalidation.
     },
     {
       "args": {
-        "run_id": 3,
+        "run_id": 2,
         "reasons": [
           "x changed"
         ]
       },
       "name": "build-restart"
+    },
+    {
+      "args": {
+        "run_id": 2,
+        "outcome": "failure",
+        "restart_duration": "number"
+      },
+      "name": "build-finish"
     },
     {
       "args": {

--- a/test/blackbox-tests/test-cases/trace/watch-build-events.t
+++ b/test/blackbox-tests/test-cases/trace/watch-build-events.t
@@ -71,11 +71,12 @@ build trace events.
 
   $ stop_dune > /dev/null
 
-File watcher backends may batch file changes differently. Normalize contiguous
-restart events so the test checks the run id and reasons, not the batching.
+File changes observed while the build is idle are reflected by the next
+build-start event's restart flag. A build-restart event is only emitted when an
+active build is interrupted.
 
   $ dune trace cat | jq_dune -s '
-  > [ .[] | buildEvents ] | normalizeBuildRestartEvents'
+  > .[] | buildEvents'
   {
     "args": {
       "run_id": 1,
@@ -111,16 +112,6 @@ restart events so the test checks the run id and reasons, not the batching.
       ]
     },
     "name": "build-finish"
-  }
-  {
-    "args": {
-      "run_id": 2,
-      "reasons": [
-        "x changed",
-        "z changed"
-      ]
-    },
-    "name": "build-restart"
   }
   {
     "args": {

--- a/test/blackbox-tests/test-cases/watching/rpc-build-during-eager-build.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-during-eager-build.t
@@ -31,19 +31,12 @@ The eager loop still reacts to filesystem changes after the RPC build has run.
   $ dune trace cat | jq_dune -s '
   > [ [ .[] | buildEvents ] | normalizeBuildRestartEvents ]
   > | map(select(
-  >     (.name == "build-restart" and (.args.reasons | index("dune changed")))
-  >     or (.name == "build-start" and .args.restart == true)
+  >     (.name == "build-start" and .args.restart == true)
   >     or (.name == "build-finish" and .args.outcome == "success")))
-  > | .[-3:]
-  > | map({ name, restart: .args.restart, outcome: .args.outcome, reasons: .args.reasons }
+  > | .[-2:]
+  > | map({ name, restart: .args.restart, outcome: .args.outcome }
   >       | del(.. | nulls))'
   [
-    {
-      "name": "build-restart",
-      "reasons": [
-        "dune changed"
-      ]
-    },
     {
       "name": "build-start",
       "restart": true

--- a/test/expect-tests/build_loop_tests.ml
+++ b/test/expect-tests/build_loop_tests.ml
@@ -1,0 +1,82 @@
+open Stdune
+include Dune_scheduler
+open Dune_tests_common
+open Dune_engine
+open Fiber.O
+
+let () = init ()
+
+let default =
+  Clflags.display := Short;
+  { Scheduler.Config.concurrency = 1
+  ; print_ctrl_c_warning = false
+  ; watch_exclusions = []
+  }
+;;
+
+let go ?(timeout = Time.Span.of_secs 0.3) ?(config = default) f =
+  try Scheduler.Run.go ~timeout config ~file_watcher:No_watcher f with
+  | Shutdown.E Requested -> ()
+;;
+
+let cell = Memo.lazy_cell Memo.return
+
+let%expect_test "cancelling a build" =
+  let build_started = Fiber.Ivar.create () in
+  let build_cancelled = Fiber.Ivar.create () in
+  go (fun () ->
+    Build_loop.run (fun build_loop ->
+      Fiber.fork_and_join_unit
+        (fun () ->
+           Build_loop.poll build_loop (fun ~run_id:_ ~restart_started_at:_ ->
+             let* () = Fiber.Ivar.fill build_started () in
+             let* () = Fiber.Ivar.read build_cancelled in
+             let* res =
+               Fiber.collect_errors (fun () -> Scheduler.with_job_slot Fiber.return)
+             in
+             print_endline
+               (match res with
+                | Ok () -> "FAIL: build wasn't cancelled"
+                | Error _ -> "PASS: build was cancelled");
+             let () = Scheduler.shutdown () in
+             Fiber.never))
+        (fun () ->
+           let* () = Fiber.Ivar.read build_started in
+           let* () =
+             Build_loop.For_tests.inject_memo_invalidation
+               build_loop
+               (Memo.Cell.invalidate cell ~reason:Unknown)
+           in
+           (* Wait for the scheduler to acknowledge the change *)
+           let* () = Build_loop.For_tests.wait_for_build_input_change build_loop in
+           Fiber.Ivar.fill build_cancelled ())));
+  [%expect {| PASS: build was cancelled |}]
+;;
+
+(* CR-soon jeremiedimino: currently cancelling a build cancels not only this
+   build but also all running fibers, including ones that are unrelated. *)
+let%expect_test "cancelling a build: effect on other fibers" =
+  let build_started = Fiber.Ivar.create () in
+  go (fun () ->
+    Build_loop.run (fun build_loop ->
+      Fiber.fork_and_join_unit
+        (fun () ->
+           Build_loop.poll build_loop (fun ~run_id:_ ~restart_started_at:_ ->
+             let* () = Fiber.Ivar.fill build_started () in
+             Fiber.never))
+        (fun () ->
+           let* () = Fiber.Ivar.read build_started in
+           let* () =
+             Build_loop.For_tests.inject_memo_invalidation
+               build_loop
+               (Memo.Cell.invalidate cell ~reason:Unknown)
+           in
+           let* () = Build_loop.For_tests.wait_for_build_input_change build_loop in
+           let+ res = Fiber.collect_errors (fun () -> Fiber.return ()) in
+           print_endline
+             (match res with
+              | Ok () -> "PASS: we can still run things outside the build"
+              | Error _ -> "FAIL: other fiber got cancelled");
+           Scheduler.shutdown ())));
+  [%expect {| PASS: we can still run things outside the build |}]
+;;

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -61,7 +61,7 @@ let scheduler_config =
 
 let run_scheduler ?timeout f =
   Dune_engine.Clflags.display := Quiet;
-  Scheduler.Run.go scheduler_config ?timeout f ~on_event:(fun _ -> ())
+  Scheduler.Run.go scheduler_config ?timeout f
 ;;
 
 let stop_server server = run_scheduler (fun () -> Server.stop server)

--- a/test/expect-tests/dune
+++ b/test/expect-tests/dune
@@ -14,6 +14,7 @@
   dune_lang
   memo
   unix
+  threads.posix
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project
   ppx_expect.config

--- a/test/expect-tests/dune_file_watcher/dune
+++ b/test/expect-tests/dune_file_watcher/dune
@@ -1,7 +1,7 @@
 (library
  (name dune_file_watcher_tests_lib)
  (modules dune_file_watcher_tests_lib)
- (libraries dune_scheduler base stdune threads.posix stdio unix))
+ (libraries dune_scheduler base stdune fiber threads.posix stdio unix))
 
 (library
  (name dune_file_watcher_tests_macos)

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_lib.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_lib.ml
@@ -14,13 +14,9 @@ let init () =
   Path.Build.set_build_dir (Path.Outside_build_dir.of_string "_build")
 ;;
 
-let create_event_queue () =
-  let event_queue = Dune_scheduler.Event.Queue.create () in
+let create_watcher ?fsevents_debounce ~watch_exclusions () =
   let mutex = Mutex.create () in
   let events_buffer = ref [] in
-  let add_events events =
-    Mutex.protect mutex (fun () -> events_buffer := !events_buffer @ events)
-  in
   let try_to_get_events () =
     Mutex.protect mutex (fun () ->
       match !events_buffer with
@@ -29,26 +25,37 @@ let create_event_queue () =
         events_buffer := [];
         Some events)
   in
-  let (_ : Thread.t) =
-    Thread.create
-      (fun () ->
-         while true do
-           match Dune_scheduler.Event.Queue.next event_queue with
-           | Build_inputs_changed events ->
-             Nonempty_list.to_list events
-             |> List.filter_map ~f:(function
-               | Dune_scheduler.Event.Fs_event event -> Some event
-               | Dune_scheduler.Event.Invalidation _ -> assert false)
-             |> add_events
-           | File_system_sync _ -> ()
-           | File_system_watcher_terminated
-           | Shutdown _
-           | Fiber_fill_ivar _
-           | Job_complete_ready -> assert false
-         done)
+  let event_queue = Dune_scheduler.Event.Queue.create () in
+  let watcher =
+    Dune_scheduler.File_watcher.create
+      ?fsevents_debounce
+      ~watch_exclusions
+      ~event_queue
       ()
   in
-  event_queue, try_to_get_events
+  let rec read_events () =
+    let open Fiber.O in
+    Dune_scheduler.File_watcher.read watcher
+    >>= function
+    | None -> Fiber.return ()
+    | Some events ->
+      let events =
+        List.map events ~f:(function
+          | Dune_scheduler.Event.File_watcher_event.Fs_memo_event event -> event
+          | Queue_overflow -> assert false)
+      in
+      Mutex.protect mutex (fun () -> events_buffer := !events_buffer @ events);
+      read_events ()
+  in
+  let (_ : Thread.t) =
+    let iter () =
+      match Dune_scheduler.Event.Queue.next event_queue with
+      | Fiber_fill_ivar fill -> [ fill ]
+      | Shutdown _ | Job_complete_ready -> assert false
+    in
+    Thread.create (fun () -> Fiber.run (read_events ()) ~iter) ()
+  in
+  watcher, try_to_get_events
 ;;
 
 let retry_loop (type a) ~period ~timeout ~(f : unit -> a option) : a option =

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_lib.mli
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_lib.mli
@@ -1,8 +1,12 @@
+open Stdune
+
 val init : unit -> unit
 
-val create_event_queue
-  :  unit
-  -> Dune_scheduler.Event.Queue.t
+val create_watcher
+  :  ?fsevents_debounce:Time.Span.t
+  -> watch_exclusions:string list
+  -> unit
+  -> Dune_scheduler.File_watcher.t
      * (unit -> Dune_scheduler.Event.Fs_memo_event.t list option)
 
 val print_events

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
@@ -4,10 +4,7 @@ open Dune_file_watcher_tests_lib
 let%expect_test _ = init ()
 
 let%expect_test _ =
-  let event_queue, try_to_get_events = create_event_queue () in
-  let watcher =
-    Dune_scheduler.File_watcher.create_default ~event_queue ~watch_exclusions:[] ()
-  in
+  let watcher, try_to_get_events = create_watcher ~watch_exclusions:[] () in
   let print_events n = print_events ~try_to_get_events ~expected:n in
   (match Dune_scheduler.File_watcher.add_watch watcher (Path.of_string ".") with
    | Error _ -> assert false

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_macos.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_macos.ml
@@ -4,13 +4,8 @@ open Dune_file_watcher_tests_lib
 let%expect_test _ = init ()
 
 let%expect_test _ =
-  let event_queue, try_to_get_events = create_event_queue () in
-  let (_ : Dune_scheduler.File_watcher.t) =
-    Dune_scheduler.File_watcher.create_default
-      ~fsevents_debounce:(Time.Span.of_secs 0.)
-      ~event_queue
-      ~watch_exclusions:[]
-      ()
+  let (_ : Dune_scheduler.File_watcher.t), try_to_get_events =
+    create_watcher ~fsevents_debounce:(Time.Span.of_secs 0.) ~watch_exclusions:[] ()
   in
   let print_events n = print_events ~try_to_get_events ~expected:n in
   Stdio.Out_channel.write_all "x" ~data:"x";

--- a/test/expect-tests/dune_patch/patch_action_tests.ml
+++ b/test/expect-tests/dune_patch/patch_action_tests.ml
@@ -27,11 +27,7 @@ let test files (patch, patch_contents) =
     ; watch_exclusions = []
     }
   in
-  Scheduler.Run.go
-    config
-    ~timeout:(Time.Span.of_secs 5.0)
-    ~file_watcher:No_watcher
-    ~on_event:(fun _ -> ())
+  Scheduler.Run.go config ~timeout:(Time.Span.of_secs 5.0) ~file_watcher:No_watcher
   @@ fun () ->
   let open Fiber.O in
   let* () = Fiber.return @@ create_files ((patch, patch_contents) :: files) in

--- a/test/expect-tests/dune_pkg/common/git_test_utils.ml
+++ b/test/expect-tests/dune_pkg/common/git_test_utils.ml
@@ -6,11 +6,10 @@ module Display = Dune_engine.Display
 module Vcs = Dune_vcs.Vcs
 
 let run thunk =
-  let on_event _event = () in
   let config : Scheduler.Config.t =
     { concurrency = 1; print_ctrl_c_warning = false; watch_exclusions = [] }
   in
-  Scheduler.Run.go config ~on_event thunk
+  Scheduler.Run.go config thunk
 ;;
 
 let display = Display.Quiet

--- a/test/expect-tests/dune_pkg/encode_decode_tests.ml
+++ b/test/expect-tests/dune_pkg/encode_decode_tests.ml
@@ -94,11 +94,10 @@ let lock_dir_encode_decode_round_trip_test ?commit ~lock_dir_path ~lock_dir () =
 ;;
 
 let run thunk =
-  let on_event _event = () in
   let config : Scheduler.Config.t =
     { concurrency = 1; print_ctrl_c_warning = false; watch_exclusions = [] }
   in
-  Scheduler.Run.go config ~on_event thunk
+  Scheduler.Run.go config thunk
 ;;
 
 let%expect_test "encode/decode round trip test for lockdir with no deps" =

--- a/test/expect-tests/dune_pkg/fetch_tests.ml
+++ b/test/expect-tests/dune_pkg/fetch_tests.ml
@@ -67,11 +67,10 @@ let download ?(reproducible = true) ~unpack ~port ~filename ~target ?checksum ()
 ;;
 
 let run thunk =
-  let on_event _event = () in
   let config : Scheduler.Config.t =
     { concurrency = 1; print_ctrl_c_warning = false; watch_exclusions = [] }
   in
-  Scheduler.Run.go config ~on_event (fun () ->
+  Scheduler.Run.go config (fun () ->
     let open Fiber.O in
     Git_test_utils.git_init_and_config_user (Path.of_string ".") >>> thunk ())
 ;;

--- a/test/expect-tests/dune_pkg/rev_store_fetch_depth/rev_store_fetch_depth_test.ml
+++ b/test/expect-tests/dune_pkg/rev_store_fetch_depth/rev_store_fetch_depth_test.ml
@@ -33,7 +33,6 @@ let%expect_test "second fetch uses refs for efficient negotiation (fix #13323)" 
   in
   (Dune_scheduler.Scheduler.Run.go
      { concurrency = 2; print_ctrl_c_warning = false; watch_exclusions = [] }
-     ~on_event:(fun _ -> ())
    @@ fun () ->
    let* rev_store = Rev_store.get in
    let git = git ~dir:repo_dir in

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -198,5 +198,5 @@ let run run =
     ~finally:(fun () -> Sys.chdir cwd)
     ~f:(fun () ->
       Sys.chdir (Path.to_string dir);
-      Scheduler.Run.go config run ~timeout:(Time.Span.of_secs 5.0) ~on_event:(fun _ -> ()))
+      Scheduler.Run.go config run ~timeout:(Time.Span.of_secs 5.0))
 ;;

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
@@ -41,8 +41,7 @@ let run =
       ~finally:(fun () -> Sys.chdir cwd)
       ~f:(fun () ->
         Sys.chdir (Path.to_string dir);
-        Scheduler.Run.go config run ~timeout:(Time.Span.of_secs 5.0) ~on_event:(fun _ ->
-          ()))
+        Scheduler.Run.go config run ~timeout:(Time.Span.of_secs 5.0))
 ;;
 
 let%expect_test "turn on dune watch and wait until the connection is listed" =

--- a/test/expect-tests/dune_scheduler/async_io_tests.ml
+++ b/test/expect-tests/dune_scheduler/async_io_tests.ml
@@ -51,7 +51,7 @@ let read_one fd =
 ;;
 
 let%expect_test "read readiness" =
-  (Scheduler.Run.go config ~on_event:(fun _ -> ())
+  (Scheduler.Run.go config
    @@ fun () ->
    let r, w = pipe () in
    if not Sys.win32 then set_nonblock r;
@@ -69,7 +69,7 @@ let%expect_test "read readiness" =
 ;;
 
 let%expect_test "write readiness" =
-  (Scheduler.Run.go config ~on_event:(fun _ -> ())
+  (Scheduler.Run.go config
    @@ fun () ->
    let r, w = pipe () in
    if not Sys.win32 then set_nonblock w;
@@ -86,7 +86,7 @@ let%expect_test "write readiness" =
 ;;
 
 let%expect_test "first ready" =
-  (Scheduler.Run.go config ~on_event:(fun _ -> ())
+  (Scheduler.Run.go config
    @@ fun () ->
    let r1, w1 = pipe () in
    let r2, w2 = pipe () in
@@ -110,7 +110,7 @@ let%expect_test "first ready" =
 ;;
 
 let%expect_test "cancel task" =
-  (Scheduler.Run.go config ~on_event:(fun _ -> ())
+  (Scheduler.Run.go config
    @@ fun () ->
    let r, w = pipe () in
    if not Sys.win32 then set_nonblock r;
@@ -129,7 +129,7 @@ let%expect_test "cancel task" =
 ;;
 
 let%expect_test "close cancels pending readiness" =
-  (Scheduler.Run.go config ~on_event:(fun _ -> ())
+  (Scheduler.Run.go config
    @@ fun () ->
    let r, w = pipe () in
    if not Sys.win32 then set_nonblock r;
@@ -147,7 +147,7 @@ let%expect_test "close cancels pending readiness" =
 ;;
 
 let%expect_test "close cancels unawaited task" =
-  (Scheduler.Run.go config ~on_event:(fun _ -> ())
+  (Scheduler.Run.go config
    @@ fun () ->
    let r, w = pipe () in
    if not Sys.win32 then set_nonblock r;
@@ -159,7 +159,7 @@ let%expect_test "close cancels unawaited task" =
 ;;
 
 let%expect_test "close waits for the loop thread to close the fd" =
-  (Scheduler.Run.go config ~on_event:(fun _ -> ())
+  (Scheduler.Run.go config
    @@ fun () ->
    let is_closed fd =
      let buf = Bytes.make 1 '0' in
@@ -178,7 +178,7 @@ let%expect_test "close waits for the loop thread to close the fd" =
 ;;
 
 let%expect_test "re-arm when watched mask changes" =
-  (Scheduler.Run.go config ~on_event:(fun _ -> ())
+  (Scheduler.Run.go config
    @@ fun () ->
    let a, b = socketpair () in
    set_nonblock a;
@@ -214,7 +214,7 @@ let%expect_test "re-arm when watched mask changes" =
 ;;
 
 let%expect_test "mask switch on same fd" =
-  (Scheduler.Run.go config ~on_event:(fun _ -> ())
+  (Scheduler.Run.go config
    @@ fun () ->
    let client, server = connected_sockets () in
    set_nonblock client;
@@ -237,7 +237,7 @@ let%expect_test "mask switch on same fd" =
 ;;
 
 let%expect_test "close cancels ready_one task" =
-  (Scheduler.Run.go config ~on_event:(fun _ -> ())
+  (Scheduler.Run.go config
    @@ fun () ->
    let r1, w1 = pipe () in
    let r2, w2 = pipe () in

--- a/test/expect-tests/process_tests.ml
+++ b/test/expect-tests/process_tests.ml
@@ -10,7 +10,7 @@ let go =
     ; watch_exclusions = []
     }
   in
-  Scheduler.Run.go config ~file_watcher:No_watcher ~on_event:(fun _ -> ())
+  Scheduler.Run.go config ~file_watcher:No_watcher
 ;;
 
 let true_ = Bin.which "true" ~path:(Env_path.path Env.initial) |> Option.value_exn

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -1,13 +1,11 @@
 open Stdune
 include Dune_scheduler
 open Dune_tests_common
-open Dune_engine
-open Fiber.O
 
 let () = init ()
 
 let default =
-  Clflags.display := Short;
+  Dune_engine.Clflags.display := Short;
   { Scheduler.Config.concurrency = 1
   ; print_ctrl_c_warning = false
   ; watch_exclusions = []
@@ -15,69 +13,8 @@ let default =
 ;;
 
 let go ?(timeout = Time.Span.of_secs 0.3) ?(config = default) f =
-  try
-    Scheduler.Run.go ~timeout config ~file_watcher:No_watcher ~on_event:(fun _ -> ()) f
-  with
+  try Scheduler.Run.go ~timeout config ~file_watcher:No_watcher f with
   | Shutdown.E Requested -> ()
-;;
-
-let true_ = Bin.which "true" ~path:(Env_path.path Env.initial) |> Option.value_exn
-let cell = Memo.lazy_cell Memo.return
-
-let%expect_test "cancelling a build" =
-  let build_started = Fiber.Ivar.create () in
-  let build_cancelled = Fiber.Ivar.create () in
-  go (fun () ->
-    Fiber.fork_and_join_unit
-      (fun () ->
-         Build_loop.poll (fun ~run_id:_ ->
-           let* () = Fiber.Ivar.fill build_started () in
-           let* () = Fiber.Ivar.read build_cancelled in
-           let* res =
-             Fiber.collect_errors (fun () -> Scheduler.with_job_slot Fiber.return)
-           in
-           print_endline
-             (match res with
-              | Ok () -> "FAIL: build wasn't cancelled"
-              | Error _ -> "PASS: build was cancelled");
-           let () = Scheduler.shutdown () in
-           Fiber.never))
-      (fun () ->
-         let* () = Fiber.Ivar.read build_started in
-         let* () =
-           Scheduler.For_tests.inject_memo_invalidation
-             (Memo.Cell.invalidate cell ~reason:Unknown)
-         in
-         (* Wait for the scheduler to acknowledge the change *)
-         let* () = Scheduler.For_tests.wait_for_build_input_change () in
-         Fiber.Ivar.fill build_cancelled ()));
-  [%expect {| PASS: build was cancelled |}]
-;;
-
-(* CR-soon jeremiedimino: currently cancelling a build cancels not only this
-   build but also all running fibers, including ones that are unrelated. *)
-let%expect_test "cancelling a build: effect on other fibers" =
-  let build_started = Fiber.Ivar.create () in
-  go (fun () ->
-    Fiber.fork_and_join_unit
-      (fun () ->
-         Build_loop.poll (fun ~run_id:_ ->
-           let* () = Fiber.Ivar.fill build_started () in
-           Fiber.never))
-      (fun () ->
-         let* () = Fiber.Ivar.read build_started in
-         let* () =
-           Scheduler.For_tests.inject_memo_invalidation
-             (Memo.Cell.invalidate cell ~reason:Unknown)
-         in
-         let* () = Scheduler.For_tests.wait_for_build_input_change () in
-         let+ res = Fiber.collect_errors (fun () -> Fiber.return ()) in
-         print_endline
-           (match res with
-            | Ok () -> "PASS: we can still run things outside the build"
-            | Error _ -> "FAIL: other fiber got cancelled");
-         Scheduler.shutdown ()));
-  [%expect {| PASS: we can still run things outside the build |}]
 ;;
 
 let%expect_test "raise inside Scheduler.Run.go" =

--- a/test/expect-tests/thread_safe_channel_tests.ml
+++ b/test/expect-tests/thread_safe_channel_tests.ml
@@ -1,0 +1,185 @@
+open Stdune
+include Dune_scheduler
+open Dune_tests_common
+open Fiber.O
+module Thread_safe_channel = Dune_scheduler.For_tests.Thread_safe_channel
+
+let () = init ()
+
+let next_fills event_queue =
+  match Event.Queue.next event_queue with
+  | Fiber_fill_ivar fill -> [ fill ]
+  | Shutdown _ | Job_complete_ready -> assert false
+;;
+
+let create_channel () =
+  let event_queue = Event.Queue.create () in
+  let channel = Thread_safe_channel.create event_queue in
+  event_queue, channel
+;;
+
+let run event_queue fiber = Fiber.run fiber ~iter:(fun () -> next_fills event_queue)
+
+let run_with_first_iter_action event_queue fiber ~f =
+  let did_run = ref false in
+  let iter () =
+    if not !did_run
+    then (
+      did_run := true;
+      f ());
+    next_fills event_queue
+  in
+  Fiber.run fiber ~iter
+;;
+
+let rec read_all channel acc =
+  Thread_safe_channel.read channel
+  >>= function
+  | None -> Fiber.return (List.rev acc)
+  | Some value -> read_all channel (value :: acc)
+;;
+
+let require_ok = function
+  | `Ok -> ()
+  | `Closed -> Code_error.raise "channel unexpectedly closed" []
+;;
+
+let write_values channel values =
+  List.iter values ~f:(fun value -> require_ok (Thread_safe_channel.write channel value))
+;;
+
+let write_fill channel ivar =
+  Thread_safe_channel.write_fill channel (Fiber.Fill (ivar, ()))
+;;
+
+let write_fill_ok channel ivar = require_ok (write_fill channel ivar)
+
+let print_write_status label = function
+  | `Ok -> printfn "%s: Ok" label
+  | `Closed -> printfn "%s: Closed" label
+;;
+
+let print_read_result label = function
+  | None -> printfn "%s: closed" label
+  | Some value -> printfn "%s: %d" label value
+;;
+
+let read_and_print channel label =
+  Thread_safe_channel.read channel >>| print_read_result label
+;;
+
+let close_after_fill channel ivar =
+  let+ () = Fiber.Ivar.read ivar in
+  print_endline "fill";
+  Thread_safe_channel.close channel
+;;
+
+let%expect_test "reads queued values before reporting closed" =
+  let event_queue, channel = create_channel () in
+  write_values channel [ 1; 2; 3 ];
+  Thread_safe_channel.close channel;
+  run event_queue (read_all channel []) |> Dyn.list Dyn.int |> print_dyn;
+  [%expect {| [ 1; 2; 3 ] |}]
+;;
+
+let%expect_test "write wakes waiting reader" =
+  let event_queue, channel = create_channel () in
+  run_with_first_iter_action event_queue (read_and_print channel "reader") ~f:(fun () ->
+    Thread_safe_channel.write channel 42 |> print_write_status "write");
+  [%expect
+    {|
+    write: Ok
+    reader: 42 |}]
+;;
+
+let%expect_test "close wakes waiting readers" =
+  let event_queue, channel = create_channel () in
+  run_with_first_iter_action
+    event_queue
+    (Fiber.fork_and_join_unit
+       (fun () -> read_and_print channel "first")
+       (fun () -> read_and_print channel "second"))
+    ~f:(fun () ->
+      print_endline "close";
+      Thread_safe_channel.close channel);
+  [%expect
+    {|
+    close
+    first: closed
+    second: closed |}]
+;;
+
+let%expect_test "close is idempotent and writes after close fail" =
+  let event_queue, channel = create_channel () in
+  Thread_safe_channel.close channel;
+  Thread_safe_channel.close channel;
+  print_write_status "write" (Thread_safe_channel.write channel 1);
+  print_write_status "write_fill" (write_fill channel (Fiber.Ivar.create ()));
+  run event_queue (Thread_safe_channel.read channel) |> Dyn.option Dyn.int |> print_dyn;
+  [%expect
+    {|
+    write: Closed
+    write_fill: Closed
+    None |}]
+;;
+
+let%expect_test "write_fill is ordered after queued values" =
+  let event_queue, channel = create_channel () in
+  write_values channel [ 1; 2 ];
+  let flushed = Fiber.Ivar.create () in
+  write_fill_ok channel flushed;
+  let reader () =
+    let rec loop () =
+      let* value = Thread_safe_channel.read channel in
+      match value with
+      | None ->
+        print_endline "closed";
+        Fiber.return ()
+      | Some value ->
+        printfn "value: %d" value;
+        loop ()
+    in
+    loop ()
+  in
+  run
+    event_queue
+    (Fiber.fork_and_join_unit reader (fun () -> close_after_fill channel flushed));
+  [%expect
+    {|
+    value: 1
+    value: 2
+    fill
+    closed |}]
+;;
+
+let%expect_test "write_fill wakes scheduler when readers are waiting" =
+  let event_queue, channel = create_channel () in
+  let flushed = Fiber.Ivar.create () in
+  run_with_first_iter_action
+    event_queue
+    (Fiber.fork_and_join_unit
+       (fun () -> read_and_print channel "reader")
+       (fun () -> close_after_fill channel flushed))
+    ~f:(fun () -> write_fill channel flushed |> print_write_status "write_fill");
+  [%expect
+    {|
+    write_fill: Ok
+    fill
+    reader: closed |}]
+;;
+
+let%expect_test "wakes fibers from side threads" =
+  let event_queue, channel = create_channel () in
+  ignore
+    (Thread.create
+       (fun () ->
+          for i = 1 to 3 do
+            match Thread_safe_channel.write channel i with
+            | `Ok -> ()
+            | `Closed -> print_endline "channel closed"
+          done;
+          Thread_safe_channel.close channel)
+       ());
+  run event_queue (read_all channel []) |> Dyn.list Dyn.int |> print_dyn;
+  [%expect {| [ 1; 2; 3 ] |}]
+;;

--- a/test/expect-tests/timer_tests.ml
+++ b/test/expect-tests/timer_tests.ml
@@ -10,10 +10,8 @@ let config =
   }
 ;;
 
-let on_event (_ : Scheduler.Run.Event.t) = ()
-
 let%expect_test "create and wait for timer" =
-  Scheduler.Run.go ~on_event config (fun () ->
+  Scheduler.Run.go config (fun () ->
     let now () = Time.now () in
     let start = now () in
     let duration = Time.Span.of_secs 0.2 in
@@ -24,17 +22,14 @@ let%expect_test "create and wait for timer" =
 ;;
 
 let%expect_test "multiple timers" =
-  Scheduler.Run.go
-    ~on_event:(fun _ -> ())
-    config
-    (fun () ->
-       [ 0.3; 0.2; 0.1 ]
-       |> Fiber.parallel_iter ~f:(fun duration ->
-         let+ () =
-           let duration = Time.Span.of_secs duration in
-           Scheduler.sleep duration
-         in
-         printfn "finished %0.2f" duration));
+  Scheduler.Run.go config (fun () ->
+    [ 0.3; 0.2; 0.1 ]
+    |> Fiber.parallel_iter ~f:(fun duration ->
+      let+ () =
+        let duration = Time.Span.of_secs duration in
+        Scheduler.sleep duration
+      in
+      printfn "finished %0.2f" duration));
   [%expect
     {|
     finished 0.10
@@ -43,7 +38,7 @@ let%expect_test "multiple timers" =
 ;;
 
 let%expect_test "simultaneous timers are deterministic" =
-  Scheduler.Run.go ~on_event config (fun () ->
+  Scheduler.Run.go config (fun () ->
     [ "first"; "second"; "third" ]
     |> Fiber.parallel_iter ~f:(fun name ->
       let+ () = Scheduler.sleep Time.Span.zero in
@@ -56,24 +51,21 @@ let%expect_test "simultaneous timers are deterministic" =
 ;;
 
 let%expect_test "run process with timeout" =
-  Scheduler.Run.go
-    ~on_event:(fun _ -> ())
-    config
-    (fun () ->
-       let pid =
-         let prog =
-           let path = Env.get Env.initial "PATH" |> Option.value_exn |> Bin.parse_path in
-           Bin.which ~path "sleep" |> Option.value_exn |> Path.to_string
-         in
-         Spawn.spawn ~prog ~argv:[ prog; "100000" ] () |> Pid.of_int
-       in
-       let+ (_ : Proc.Process_info.t) =
-         Scheduler.wait_for_process
-           ~timeout:(Time.Span.of_secs 0.1)
-           ~is_process_group_leader:false
-           pid
-       in
-       print_endline "sleep timed out");
+  Scheduler.Run.go config (fun () ->
+    let pid =
+      let prog =
+        let path = Env.get Env.initial "PATH" |> Option.value_exn |> Bin.parse_path in
+        Bin.which ~path "sleep" |> Option.value_exn |> Path.to_string
+      in
+      Spawn.spawn ~prog ~argv:[ prog; "100000" ] () |> Pid.of_int
+    in
+    let+ (_ : Proc.Process_info.t) =
+      Scheduler.wait_for_process
+        ~timeout:(Time.Span.of_secs 0.1)
+        ~is_process_group_leader:false
+        pid
+    in
+    print_endline "sleep timed out");
   [%expect
     {|
     sleep timed out |}]

--- a/test/expect-tests/vcs/vcs_tests.ml
+++ b/test/expect-tests/vcs/vcs_tests.ml
@@ -129,10 +129,7 @@ let run kind script =
     ; watch_exclusions = []
     }
   in
-  Scheduler.Run.go
-    ~on_event:(fun _ -> ())
-    config
-    (fun () -> Fiber.sequential_iter script ~f:(run_action vcs))
+  Scheduler.Run.go config (fun () -> Fiber.sequential_iter script ~f:(run_action vcs))
 ;;
 
 let script =


### PR DESCRIPTION
Add a thread-safe channel for delivering values from watcher threads to fibers, and use it to make File_watcher expose read, flush, and close operations instead of pushing raw filesystem events through Scheduler.Event.Queue.

Move filesystem-event handling and Fs_memo initialization into the build loop, so the scheduler event queue only needs to handle memo invalidations, worker/job notifications, and shutdown.

Add expect coverage for the thread-safe channel and update file watcher tests to use a test event sink.



scheduler: simplify file watcher invalidation plumbing

Combine queued build-input invalidations before delivering them to the scheduler, so Build_inputs_changed carries one invalidation.

Keep sync ids private to File_watcher and store pending flush ivars directly in the sync table, removing the separate pending-sync table.

Remove duplicated build-loop file-watcher state and narrow Fs_memo watcher hooks under a build-loop-facing submodule.