### PR TITLE
test: factor shared cache mode setup

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -15,6 +15,36 @@ setup_xdg_runtime_dir () {
     chmod 700 "$XDG_RUNTIME_DIR"
 }
 
+setup_basic_shared_cache_project () {
+    local mode="$1"
+
+    cat > config <<EOF
+(lang dune 3.0)
+(cache enabled)
+EOF
+    if [ "$mode" != "default" ]; then
+        cat >> config <<EOF
+(cache-storage-mode $mode)
+EOF
+    fi
+    cat > dune-project <<EOF
+(lang dune 3.5)
+EOF
+    cat > dune <<'EOF'
+(rule
+ (deps source)
+ (targets target1 target2)
+ (action
+  (progn
+   (no-infer (with-stdout-to beacon (echo "")))
+   (with-stdout-to target1 (cat source))
+   (with-stdout-to target2 (cat source source)))))
+EOF
+    cat > source <<'EOF'
+\_o< COIN
+EOF
+}
+
 init_oxcaml_project() {
   cat > "dune-project" <<- EOF
 	(lang dune 3.20)

--- a/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
@@ -6,30 +6,7 @@ variable, and via the [DUNE_CACHE_ROOT] variable. Here we test the former.
   $ export XDG_CACHE_HOME=$PWD/.xdg-cache
   $ setup_xdg_runtime_dir
 
-  $ cat > config <<EOF
-  > (lang dune 3.0)
-  > (cache enabled)
-  > (cache-storage-mode copy)
-  > EOF
-  $ cat > dune-project <<EOF
-  > (lang dune 3.5)
-  > EOF
-  $ cat > dune <<EOF
-  > (rule
-  >  (deps source)
-  >  (targets target1 target2)
-  >  (action
-  >   (progn
-  >    (no-infer (with-stdout-to beacon (echo "")))
-  >    (with-stdout-to target1 (cat source))
-  >    (with-stdout-to target2 (cat source source)))))
-  > EOF
-
-It's a duck. It quacks. (Yes, the author of this comment didn't get it.)
-
-  $ cat > source <<EOF
-  > \_o< COIN
-  > EOF
+  $ setup_basic_shared_cache_project copy
 
 Test that after the build, the files in the build directory have the hard link
 count of 1, because they are not shared with the corresponding cache entries.

--- a/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
@@ -6,25 +6,7 @@ variable, and via the [DUNE_CACHE_ROOT] variable. Here we test the former.
   $ export XDG_CACHE_HOME=$(dune_cmd native-path $PWD/.xdg-cache)
   $ setup_xdg_runtime_dir
 
-  $ cat > config <<EOF
-  > (lang dune 2.1)
-  > (cache enabled)
-  > EOF
-  $ cat > dune-project <<EOF
-  > (lang dune 2.1)
-  > EOF
-  $ cat > dune <<EOF
-  > (rule
-  >   (deps source)
-  >   (targets target1 target2)
-  >   (action (bash "touch beacon; cat source > target1; cat source source > target2")))
-  > EOF
-
-It's a duck. It quacks. (Yes, the author of this comment didn't get it.)
-
-  $ cat > source <<EOF
-  > \_o< COIN
-  > EOF
+  $ setup_basic_shared_cache_project default
 
 Test that after the build, the files in the build directory have the hard link
 counts greater than 1, because they are shared with the corresponding cache entries.


### PR DESCRIPTION
Add a setup_basic_shared_cache_project helper for the shared cache fixture and use it in the copy and default hardlink cache mode tests, removing duplicated inline setup while keeping the storage mode configurable.