### PR TITLE
Cover Watch_trie root watch handling

### DIFF
--- a/src/dune_scheduler/file_watcher.ml
+++ b/src/dune_scheduler/file_watcher.ml
@@ -162,6 +162,21 @@ end = struct
       ;;
     end)
   ;;
+
+  let%expect_test "root watch covers descendants" =
+    let p = Path.External.of_string in
+    let t =
+      match add empty (p "/") (lazy "root") with
+      | Under_existing_node -> Code_error.raise "unexpected existing node" []
+      | Inserted { new_t; removed = [] } -> new_t
+      | Inserted { removed = _ :: _; _ } ->
+        Code_error.raise "unexpected removed watches" []
+    in
+    (match add t (p "/tmp") (lazy "tmp") with
+     | Under_existing_node -> Printf.printf "covered by root\n"
+     | Inserted _ -> Printf.printf "inserted separate watch\n");
+    [%expect {| inserted separate watch |}]
+  ;;
 end
 
 type kind =


### PR DESCRIPTION
Add an expect test that inserts a watch for "/" and then tries to insert "/tmp", documenting that the descendant currently becomes a separate watch instead of being covered by the root watch.