### PR TITLE
Use anonymous actions for pkg-config queries

### DIFF
--- a/src/dune_rules/ctypes/ctypes_rules.ml
+++ b/src/dune_rules/ctypes/ctypes_rules.ml
@@ -306,20 +306,12 @@ let gen_rules ~cctx ~(buildable : Buildable.t) ~loc ~scope ~dir ~sctx =
       Foreign_rules.foreign_flags sctx ~dir ~expander ~flags:c_flags ~language:C
       |> Memo.return
     | Pkg_config ->
-      let+ () =
-        let setup query =
-          Pkg_config.gen_rule sctx ~dir ~loc query
-          >>| function
-          | Ok () | Error `Not_found -> ()
-        in
-        let lib = External_lib_name.to_string external_library_name in
-        let* () = setup (Libs lib) in
-        setup (Cflags lib)
-      in
-      Pkg_config.Query.read
-        ~dir
-        (Cflags (External_lib_name.to_string external_library_name))
-        sctx
+      Memo.return
+        (Pkg_config.Query.read
+           ~loc
+           ~dir
+           (Cflags (External_lib_name.to_string external_library_name))
+           sctx)
   in
   let generated_entry_module = ctypes.generated_entry_point in
   let headers =
@@ -485,7 +477,7 @@ let ctypes_cclib_flags sctx ~expander ~(buildable : Buildable.t) =
     (match ctypes.build_flags_resolver with
      | Pkg_config ->
        let dir = Expander.dir expander in
-       Pkg_config.Query.read (Libs external_library_name) sctx ~dir
+       Pkg_config.Query.read ~loc:Loc.none (Libs external_library_name) sctx ~dir
      | Vendored { c_library_flags; c_flags = _ } ->
        Expander.expand_and_eval_set expander c_library_flags ~standard)
 ;;

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -241,6 +241,7 @@ let compilation_flags ~sctx ~dir ~expander ~(src : Foreign.Source.t) =
          let+ default_flags = default_foreign_flags ~dir ~language:C
          and+ pkg_config_flags =
            Pkg_config.Query.read
+             ~loc:Loc.none
              ~dir
              (Cflags (External_lib_name.to_string field.external_library_name))
              sctx

--- a/src/dune_rules/pkg_config.ml
+++ b/src/dune_rules/pkg_config.ml
@@ -13,15 +13,6 @@ module Query = struct
     | Libs of string
     | Cflags of string
 
-  let file t ~dir =
-    let dir = Path.Build.relative dir ".pkg-config" in
-    Path.Build.relative dir
-    @@
-    match t with
-    | Libs s -> sprintf "%s.libs" s
-    | Cflags s -> sprintf "%s.cflags" s
-  ;;
-
   let to_args t ~env : _ Command.Args.t list =
     let env_args : _ Command.Args.t =
       match Env.get env "PKG_CONFIG_ARGN" with
@@ -41,50 +32,40 @@ module Query = struct
     | Cflags _ -> [ "-I/usr/include" ]
   ;;
 
-  let read t sctx ~dir =
+  let read ~loc t sctx ~dir =
     let open Action_builder.O in
     let* bin =
-      let open Action_builder.O in
       let* pkg_config = Action_builder.of_memo @@ pkg_config_binary sctx ~dir in
       Super_context.resolve_program sctx ~loc:None ~dir pkg_config
     in
     match bin with
     | Error _ -> Action_builder.return (default t)
-    | Ok _ ->
-      let file = file t ~dir in
-      let+ contents = Action_builder.contents (Path.build file) in
-      String.split_lines contents |> List.hd |> String.extract_blank_separated_words
+    | Ok _ as bin ->
+      let external_env =
+        let open Memo.O in
+        Super_context.env_node sctx ~dir >>= Env_node.external_env
+      in
+      let action =
+        let+ action =
+          let* env =
+            Action_builder.of_memo
+              (let open Memo.O in
+               let* dune_version =
+                 Dune_load.find_project ~dir >>| Dune_project.dune_version
+               in
+               if dune_version >= (3, 8) then external_env else Memo.return Env.empty)
+          in
+          Command.run'
+            ~dir:(Path.build dir)
+            ~env:(Action_builder.of_memo external_env)
+            bin
+            (to_args t ~env)
+        in
+        { Rule.Anonymous_action.action; loc; dir; alias = None }
+      in
+      Build_system.execute_action_stdout action
+      |> Memo.map ~f:(fun contents ->
+        String.split_lines contents |> List.hd |> String.extract_blank_separated_words)
+      |> Action_builder.of_memo
   ;;
 end
-
-let gen_rule sctx ~loc ~dir query =
-  let* bin =
-    let* pkg_config = pkg_config_binary sctx ~dir in
-    Super_context.resolve_program_memo sctx ~loc:(Some loc) ~dir pkg_config
-  in
-  match bin with
-  | Error _ -> Memo.return @@ Error `Not_found
-  | Ok _ as bin ->
-    let* command =
-      let+ env =
-        let* dune_version = Dune_load.find_project ~dir >>| Dune_project.dune_version in
-        let* env_node = Super_context.env_node sctx ~dir in
-        if dune_version >= (3, 8)
-        then Env_node.external_env env_node
-        else Memo.return Env.empty
-      in
-      Command.run
-        ~dir:(Path.build dir)
-        ~stdout_to:(Query.file ~dir query)
-        bin
-        (Query.to_args ~env query)
-    in
-    let+ () = Super_context.add_rule sctx ~loc ~dir command in
-    Ok ()
-;;
-
-let read_flags ~file =
-  let open Action_builder.O in
-  let+ contents = Action_builder.contents (Path.build file) in
-  String.split_lines contents |> List.hd |> String.extract_blank_separated_words
-;;

--- a/src/dune_rules/pkg_config.mli
+++ b/src/dune_rules/pkg_config.mli
@@ -5,15 +5,10 @@ module Query : sig
     | Libs of string
     | Cflags of string
 
-  val file : t -> dir:Path.Build.t -> Path.Build.t
-  val read : t -> Super_context.t -> dir:Path.Build.t -> string list Action_builder.t
+  val read
+    :  loc:Loc.t
+    -> t
+    -> Super_context.t
+    -> dir:Path.Build.t
+    -> string list Action_builder.t
 end
-
-val gen_rule
-  :  Super_context.t
-  -> loc:Loc.t
-  -> dir:Path.Build.t
-  -> Query.t
-  -> (unit, [ `Not_found ]) result Memo.t
-
-val read_flags : file:Path.Build.t -> string list Action_builder.t


### PR DESCRIPTION
Stop materializing .pkg-config/*.cflags and *.libs files. Run pkg-config through Build_system.execute_action_stdout from Query.read and remove the now-unused rule/file API.