### PR TITLE
dune_trace: ignore writes after close

### DIFF
--- a/otherlibs/stdune/src/fd.ml
+++ b/otherlibs/stdune/src/fd.ml
@@ -9,6 +9,7 @@ let hash_raw_fd fd = Int.hash (unsafe_to_int fd)
 let raw_fd_repr = Repr.view Repr.int ~to_:unsafe_to_int
 let unsafe_to_unix_file_descr t = t.fd
 let unsafe_of_unix_file_descr fd = { fd; closed = false }
+let is_closed t = t.closed
 
 let set_nonblock t =
   assert (not t.closed);

--- a/otherlibs/stdune/src/fd.mli
+++ b/otherlibs/stdune/src/fd.mli
@@ -5,6 +5,7 @@ val equal : t -> t -> bool
 val hash : t -> int
 val to_dyn : t -> Dyn.t
 val close : t -> unit
+val is_closed : t -> bool
 val set_nonblock : t -> unit
 
 (** Unsafe casts to bridge callers that still use [Unix.file_descr]. *)

--- a/src/dune_trace/out.ml
+++ b/src/dune_trace/out.ml
@@ -65,8 +65,10 @@ let flush =
 
 let close t =
   Mutex.protect t.mutex (fun () ->
-    flush t;
-    Fd.close t.fd)
+    if not (Fd.is_closed t.fd)
+    then (
+      flush t;
+      Fd.close t.fd))
 ;;
 
 let create cats path =
@@ -108,11 +110,13 @@ let emit_buffered t event =
 
 let emit ?(buffered = false) t event =
   Mutex.protect t.mutex (fun () ->
-    emit_buffered t event;
-    if not buffered then flush t)
+    if not (Fd.is_closed t.fd)
+    then (
+      emit_buffered t event;
+      if not buffered then flush t))
 ;;
 
-let flush t = Mutex.protect t.mutex (fun () -> flush t)
+let flush t = Mutex.protect t.mutex (fun () -> if not (Fd.is_closed t.fd) then flush t)
 
 let start t k : Event.Async.t option =
   match t with


### PR DESCRIPTION
Track whether the trace output has been closed and make emit and flush no-ops after close. This makes close idempotent and avoids writing to a closed trace fd from late worker threads.