### PR TITLE
Use locations for pkg-config query actions

### DIFF
--- a/src/dune_rules/compile_commands.ml
+++ b/src/dune_rules/compile_commands.ml
@@ -17,14 +17,22 @@ let entry_to_json { directory; file; arguments } : Json.t =
     ]
 ;;
 
-let build_c_command ~sctx ~dir ~expander ~include_flags (src : Foreign.Source.t) ~ext_obj =
+let build_c_command
+      ~sctx
+      ~dir
+      ~expander
+      ~include_flags
+      ~loc
+      (src : Foreign.Source.t)
+      ~ext_obj
+  =
   let open Action_builder.O in
   let+ ocaml = Action_builder.of_memo (Context.ocaml (Super_context.context sctx))
   and+ args =
     (* Expand the command args to strings, discarding file-level deps (header
        files, include directories). Flag values flow through Memo, so changes
        to dune files or compiler config still invalidate this rule. *)
-    Foreign_rules.c_compile_args ~sctx ~dir ~expander ~src ~include_flags
+    Foreign_rules.c_compile_args ~sctx ~dir ~expander ~loc ~src ~include_flags
     |> Command.expand_no_targets ~dir:(Path.build dir)
     |> Action_builder.evaluate_and_collect_deps
     |> Action_builder.of_memo
@@ -70,11 +78,11 @@ let collect_from_foreign_sources
     let+ ocaml = Action_builder.of_memo (Context.ocaml (Super_context.context sctx)) in
     ocaml.lib_config.ext_obj
   in
-  Foreign.Sources.to_list_map foreign_sources ~f:(fun _ (_, src) ->
+  Foreign.Sources.to_list_map foreign_sources ~f:(fun _ (loc, src) ->
     let include_flags =
       Foreign_rules.build_include_flags ~sctx ~dir ~expander ~dir_contents ~requires ~src
     in
-    build_c_command ~sctx ~dir ~expander ~include_flags src ~ext_obj)
+    build_c_command ~sctx ~dir ~expander ~include_flags ~loc src ~ext_obj)
   |> Action_builder.all
 ;;
 

--- a/src/dune_rules/ctypes/ctypes_rules.ml
+++ b/src/dune_rules/ctypes/ctypes_rules.ml
@@ -477,7 +477,7 @@ let ctypes_cclib_flags sctx ~expander ~(buildable : Buildable.t) =
     (match ctypes.build_flags_resolver with
      | Pkg_config ->
        let dir = Expander.dir expander in
-       Pkg_config.Query.read ~loc:Loc.none (Libs external_library_name) sctx ~dir
+       Pkg_config.Query.read ~loc:buildable.loc (Libs external_library_name) sctx ~dir
      | Vendored { c_library_flags; c_flags = _ } ->
        Expander.expand_and_eval_set expander c_library_flags ~standard)
 ;;

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -225,7 +225,7 @@ let base_flags ~(kind : Foreign_language.t) ~use_standard_flags ~ctx ~ocaml_conf
          ])
 ;;
 
-let compilation_flags ~sctx ~dir ~expander ~(src : Foreign.Source.t) =
+let compilation_flags ~sctx ~dir ~expander ~loc ~(src : Foreign.Source.t) =
   let open Action_builder.O in
   let kind = Foreign.Source.language src in
   let ctx = Super_context.context sctx in
@@ -241,7 +241,7 @@ let compilation_flags ~sctx ~dir ~expander ~(src : Foreign.Source.t) =
          let+ default_flags = default_foreign_flags ~dir ~language:C
          and+ pkg_config_flags =
            Pkg_config.Query.read
-             ~loc:Loc.none
+             ~loc
              ~dir
              (Cflags (External_lib_name.to_string field.external_library_name))
              sctx
@@ -258,11 +258,12 @@ let compilation_flags ~sctx ~dir ~expander ~(src : Foreign.Source.t) =
   @ user_flags
 ;;
 
-let c_compile_args ~sctx ~dir ~expander ~src ~include_flags =
+let c_compile_args ~sctx ~dir ~expander ~loc ~src ~include_flags =
   Command.Args.S
     [ Dyn
-        (Action_builder.map (compilation_flags ~sctx ~dir ~expander ~src) ~f:(fun flags ->
-           Command.Args.As flags))
+        (Action_builder.map
+           (compilation_flags ~sctx ~dir ~expander ~loc ~src)
+           ~f:(fun flags -> Command.Args.As flags))
     ; Dyn
         (let open Action_builder.O in
          let+ ocaml =
@@ -355,7 +356,7 @@ let build_c ~sctx ~dir ~expander ~include_flags (loc, (src : Foreign.Source.t), 
             errors happen only when compiling c files.) *)
        ~sandbox:Sandbox_config.no_sandboxing
        c_compiler
-       [ c_compile_args ~sctx ~dir ~expander ~src ~include_flags
+       [ c_compile_args ~sctx ~dir ~expander ~loc ~src ~include_flags
        ; Hidden_deps (Dep.Set.singleton (Dep.file_selector caml_headers))
        ; S output_param
        ; A "-c"

--- a/src/dune_rules/foreign_rules.mli
+++ b/src/dune_rules/foreign_rules.mli
@@ -39,6 +39,7 @@ val c_compile_args
   :  sctx:Super_context.t
   -> dir:Path.Build.t
   -> expander:Expander.t
+  -> loc:Loc.t
   -> src:Foreign.Source.t
   -> include_flags:Command.Args.without_targets Command.Args.t
   -> Command.Args.without_targets Command.Args.t


### PR DESCRIPTION
Thread stanza/source locations to the remaining pkg-config query call sites so anonymous action failures can report a useful location.