### PR TITLE
Use anonymous actions for mdx dependency queries

### DIFF
--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -13,7 +13,6 @@ let color_always : _ Command.Args.t Lazy.t =
 module Files = struct
   type t =
     { src : Path.Build.t
-    ; deps : Path.Build.t
     ; corrected : Path.Build.t
     }
 
@@ -21,21 +20,16 @@ module Files = struct
     Path.Build.extend_basename ~suffix:Filename.corrected build_path
   ;;
 
-  let deps_file build_path =
-    Path.Build.extend_basename ~suffix:Filename.mdx_deps build_path
-  ;;
-
   let from_source_file ~mdx_dir src =
     let dot_mdx_path =
       let basename = Path.Build.basename src |> Filename.to_string in
       Path.Build.relative mdx_dir basename
     in
-    let deps = deps_file dot_mdx_path in
     let corrected = corrected_file dot_mdx_path in
-    { src; deps; corrected }
+    { src; corrected }
   ;;
 
-  let diff_action { src; corrected; deps = _ } =
+  let diff_action { src; corrected } =
     let src = Path.build src in
     let open Action_builder.O in
     let+ () = Action_builder.path src
@@ -63,13 +57,26 @@ module Deps = struct
     | Error (_, msg) -> Error msg
   ;;
 
-  let read (files : Files.t) =
+  let read ~sctx ~dir ~loc ~mdx_prog (files : Files.t) =
     let open Action_builder.O in
-    let+ content =
-      let path = Path.build files.deps in
-      Action_builder.contents path
-    in
-    match parse content with
+    (let+ action =
+       let* prog = mdx_prog in
+       let env =
+         Super_context.env_node sctx ~dir
+         |> Memo.bind ~f:Env_node.external_env
+         |> Action_builder.of_memo
+       in
+       Command.run'
+         ~dir:(Path.build dir)
+         ~env
+         prog
+         [ Command.Args.A "deps"; Lazy.force color_always; Dep (Path.build files.src) ]
+     in
+     { Rule.Anonymous_action.action; loc; dir; alias = None })
+    |> Build_system.execute_action_stdout
+    |> Action_builder.of_memo
+    >>| parse
+    >>| function
     | Ok deps -> deps
     | Error msg ->
       User_error.raise
@@ -79,14 +86,6 @@ module Deps = struct
         ; Pp.text msg
         ; Pp.textf "Please make sure you are using mdx.%s or higher" mdx_version_required
         ]
-  ;;
-
-  let rule ~dir ~mdx_prog (files : Files.t) =
-    Command.run_dyn_prog
-      ~dir:(Path.build dir)
-      mdx_prog
-      ~stdout_to:files.deps
-      [ Command.Args.A "deps"; Lazy.force color_always; Dep (Path.build files.Files.src) ]
   ;;
 
   let path_escapes_dir str =
@@ -314,15 +313,13 @@ let gen_rules_for_single_file stanza ~sctx ~dir ~expander ~mdx_prog ~mdx_prog_ge
     let mdx_dir = Path.Build.relative dir ".mdx" in
     Files.from_source_file ~mdx_dir src
   in
-  (* Add the rule for generating the .mdx.deps file with ocaml-mdx deps *)
-  let* () = Super_context.add_rule sctx ~loc ~dir (Deps.rule ~dir ~mdx_prog files)
-  and* () =
-    (* Add the rule for generating the .corrected file using ocaml-mdx test *)
+  (* Add the rule for generating the .corrected file using ocaml-mdx test *)
+  let* () =
     let mdx_action =
       let open Action_builder.With_targets.O in
       let mdx_input_dependencies =
         let open Action_builder.O in
-        let* dep_set = Deps.read files in
+        let* dep_set = Deps.read ~sctx ~dir ~loc ~mdx_prog files in
         Action_builder.of_memo
           (let open Memo.O in
            let src_path_msg =


### PR DESCRIPTION
Run `ocaml-mdx deps` as an anonymous stdout action when computing mdx dynamic dependencies, instead of materializing and rereading `.mdx.deps` files.