### PR TITLE
Use anonymous actions for inline-test partitions

### DIFF
--- a/src/dune_lang/stanzas/mode_conf.ml
+++ b/src/dune_lang/stanzas/mode_conf.ml
@@ -8,20 +8,30 @@ module T = struct
     | Best
 
   let all = [ Byte; Native; Best ]
-
-  let compare x y =
-    match x, y with
-    | Byte, Byte -> Eq
-    | Byte, _ -> Lt
-    | _, Byte -> Gt
-    | Native, Native -> Eq
-    | Native, _ -> Lt
-    | _, Native -> Gt
-    | Best, Best -> Eq
-  ;;
 end
 
 include T
+
+let repr =
+  Repr.variant
+    "mode-conf"
+    [ Repr.case0 "byte" ~test:(function
+        | Byte -> true
+        | Native | Best -> false)
+    ; Repr.case0 "native" ~test:(function
+        | Native -> true
+        | Byte | Best -> false)
+    ; Repr.case0 "best" ~test:(function
+        | Best -> true
+        | Byte | Native -> false)
+    ]
+;;
+
+include Repr.Poly (struct
+    type nonrec t = t
+
+    let repr = repr
+  end)
 
 let decode = enum [ "byte", Byte; "native", Native; "best", Best ]
 
@@ -31,7 +41,7 @@ let to_string = function
   | Best -> "best"
 ;;
 
-let to_dyn t = Dyn.variant (to_string t) []
+let to_dyn = Repr.to_dyn repr
 let encode t = Dune_sexp.atom (to_string t)
 
 module Kind = struct
@@ -126,6 +136,30 @@ module Lib = struct
     | Ocaml of mode_conf
     | Melange
 
+  let repr =
+    Repr.variant
+      "mode-conf-lib"
+      [ Repr.case0 "byte" ~test:(function
+          | Ocaml Byte -> true
+          | Ocaml (Native | Best) | Melange -> false)
+      ; Repr.case0 "native" ~test:(function
+          | Ocaml Native -> true
+          | Ocaml (Byte | Best) | Melange -> false)
+      ; Repr.case0 "best" ~test:(function
+          | Ocaml Best -> true
+          | Ocaml (Byte | Native) | Melange -> false)
+      ; Repr.case0 "melange" ~test:(function
+          | Melange -> true
+          | Ocaml _ -> false)
+      ]
+  ;;
+
+  include Repr.Poly (struct
+      type nonrec t = t
+
+      let repr = repr
+    end)
+
   let decode =
     enum'
       [ "byte", return @@ Ocaml Byte
@@ -135,24 +169,7 @@ module Lib = struct
       ]
   ;;
 
-  let to_string = function
-    | Ocaml Byte -> "byte"
-    | Ocaml Native -> "native"
-    | Ocaml Best -> "best"
-    | Melange -> "melange"
-  ;;
-
-  let to_dyn t = Dyn.variant (to_string t) []
-
-  let equal x y =
-    match x, y with
-    | Ocaml o1, Ocaml o2 ->
-      (match compare o1 o2 with
-       | Eq -> true
-       | _ -> false)
-    | Ocaml _, _ | _, Ocaml _ -> false
-    | Melange, Melange -> true
-  ;;
+  let to_dyn = Repr.to_dyn repr
 
   module Map = struct
     type nonrec 'a t =

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -387,22 +387,28 @@ include Sub_system.Register_end_point (struct
         in
         Dep_conf_eval.unnamed sandbox info.deps ~expander
       in
-      let action = action sctx ~loc ~dir ~inline_test_dir ~runner_name in
+      let test_action = action sctx ~loc ~dir ~inline_test_dir ~runner_name in
+      let list_partitions mode partitions_flags =
+        let open Action_builder.O in
+        let action =
+          let+ action = test_action mode partitions_flags
+          and+ env in
+          Action.Full.make ~sandbox action |> Action.Full.add_env env
+        in
+        let+ partitions =
+          Super_context.execute_action_stdout sctx ~loc ~dir action
+          |> Action_builder.of_memo
+          >>| String.split_lines
+        in
+        Log.info
+          "inline-test partitions"
+          [ "library", Lib_name.Local.to_dyn lib_name
+          ; "mode", Mode_conf.to_dyn mode
+          ; "partitions", Dyn.list Dyn.string partitions
+          ];
+        partitions
+      in
       Memo.parallel_iter modes ~f:(fun (mode : Mode_conf.t) ->
-        let partition_file =
-          Path.Build.relative inline_test_dir ("partitions-" ^ Mode_conf.to_string mode)
-        in
-        let* () =
-          match partitions_flags with
-          | None -> Memo.return ()
-          | Some partitions_flags ->
-            let open Action_builder.O in
-            (let+ action = action mode partitions_flags
-             and+ env in
-             Action.Full.make ~sandbox action |> Action.Full.add_env env)
-            |> Action_builder.with_stdout_to partition_file
-            |> Super_context.add_rule sctx ~dir ~loc
-        in
         let* runtest_alias =
           match mode with
           | Native | Best | Byte -> Memo.return Alias0.runtest
@@ -426,25 +432,23 @@ include Sub_system.Register_end_point (struct
           ~loc:info.loc
           alias
           (let open Action_builder.O in
-           let runner_inputs =
-             List.concat_map source_modules ~f:(fun module_ ->
-               Module.ml_source module_ |> Module.sources)
-           in
            let promotion_targets =
              List.concat_map source_modules ~f:Module.sources_without_pp
            in
            let+ actions =
-             (match partitions_flags with
-              | None -> Action_builder.return [ None ]
-              | Some _ ->
-                Path.build partition_file
-                |> Action_builder.lines_of
-                >>| List.map ~f:(fun x -> Some x))
-             >>| List.map ~f:(fun partition ->
-               flags ~info ~expander ~backends ~lib_name:(snd lib.name) ~partition
-               |> action mode)
-             >>= Action_builder.all
-           and+ () = Action_builder.paths runner_inputs
+             let action_for_partition partition =
+               flags ~info ~expander ~backends ~lib_name ~partition |> test_action mode
+             in
+             match partitions_flags with
+             | None -> action_for_partition None >>| List.singleton
+             | Some partitions_flags ->
+               list_partitions mode partitions_flags
+               >>= Action_builder.List.map ~f:(fun partition ->
+                 action_for_partition (Some partition))
+           and+ () =
+             List.concat_map source_modules ~f:(fun module_ ->
+               Module.ml_source module_ |> Module.sources)
+             |> Action_builder.paths
            and+ () = Action_builder.paths promotion_targets
            and+ env in
            match actions with

--- a/src/dune_rules/inline_tests_info.ml
+++ b/src/dune_rules/inline_tests_info.ml
@@ -72,26 +72,40 @@ module Mode_conf = struct
       | Jsoo of Js_of_ocaml.Mode.t
       | Native
       | Best
-
-    let compare x y =
-      match x, y with
-      | Byte, Byte -> Eq
-      | Byte, _ -> Lt
-      | _, Byte -> Gt
-      | Jsoo m, Jsoo m' -> Js_of_ocaml.Mode.compare m m'
-      | Jsoo _, _ -> Lt
-      | _, Jsoo _ -> Gt
-      | Native, Native -> Eq
-      | Native, _ -> Lt
-      | _, Native -> Gt
-      | Best, Best -> Eq
-    ;;
-
-    let to_dyn = Dyn.opaque
   end
 
   include T
+
+  let repr =
+    Repr.variant
+      "inline-tests-mode-conf"
+      [ Repr.case0 "byte" ~test:(function
+          | Byte -> true
+          | Jsoo _ | Native | Best -> false)
+      ; Repr.case0 "js" ~test:(function
+          | Jsoo JS -> true
+          | Byte | Jsoo Wasm | Native | Best -> false)
+      ; Repr.case0 "wasm" ~test:(function
+          | Jsoo Wasm -> true
+          | Byte | Jsoo JS | Native | Best -> false)
+      ; Repr.case0 "native" ~test:(function
+          | Native -> true
+          | Byte | Jsoo _ | Best -> false)
+      ; Repr.case0 "best" ~test:(function
+          | Best -> true
+          | Byte | Jsoo _ | Native -> false)
+      ]
+  ;;
+
+  include Repr.Poly (struct
+      type nonrec t = t
+
+      let repr = repr
+    end)
+
   open Dune_lang.Decoder
+
+  let to_dyn = Repr.to_dyn repr
 
   let to_string = function
     | Byte -> "byte"
@@ -111,7 +125,13 @@ module Mode_conf = struct
       ]
   ;;
 
-  module O = Comparable.Make (T)
+  module O = Comparable.Make (struct
+      type nonrec t = T.t
+
+      let compare = compare
+      let to_dyn = Repr.to_dyn repr
+    end)
+
   module Map = O.Map
 
   module Set = struct

--- a/test/blackbox-tests/dune.jq
+++ b/test/blackbox-tests/dune.jq
@@ -1,6 +1,9 @@
 def logs($m):
   select(.cat == "log" and (.args.message | contains($m))) | .args;
 
+def inlineTestPartitions:
+  logs("inline-test partitions") | {library, mode, partitions};
+
 def redactCommandTimes:
   walk(if type == "object" then
     with_entries(

--- a/test/blackbox-tests/test-cases/inline-tests/parallel.t/run.t
+++ b/test/blackbox-tests/test-cases/inline-tests/parallel.t/run.t
@@ -14,17 +14,16 @@ See that `test2/runtest`, which uses `fake_backend_2`, runs one inline test runn
   inline-test-runner alias test2/runtest-test_lib2
   inline-test-runner alias test2/runtest-test_lib2
 
-See that we indeed have 3 partitions
+See that the trace reports 3 partitions
 
-  $ cat _build/default/test2/.test_lib2.inline-tests/partitions-best
-  p1
-  p2
-  p3
+  $ dune trace cat | jq -c 'include "dune"; inlineTestPartitions'
+  {"library":"test_lib2","mode":"best","partitions":["p1","p2","p3"]}
 
 
   $ dune build --display short @test3/runtest 2>&1 | grep alias
   [1]
 
-See that we have no partition.
+See that the trace reports no partition.
 
-  $ cat _build/default/test3/.test_lib3.inline-tests/partitions-best
+  $ dune trace cat | jq -c 'include "dune"; inlineTestPartitions'
+  {"library":"test_lib3","mode":"best","partitions":[]}


### PR DESCRIPTION
Capture partition-listing stdout directly from the inline-test runner instead of writing and rereading `partitions-<mode>` files before building per-partition runtest actions.