### PR TITLE
Add Super_context.execute_action_stdout

### DIFF
--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -59,21 +59,12 @@ module Deps = struct
 
   let read ~sctx ~dir ~loc ~mdx_prog (files : Files.t) =
     let open Action_builder.O in
-    (let+ action =
-       let* prog = mdx_prog in
-       let env =
-         Super_context.env_node sctx ~dir
-         |> Memo.bind ~f:Env_node.external_env
-         |> Action_builder.of_memo
-       in
-       Command.run'
-         ~dir:(Path.build dir)
-         ~env
-         prog
-         [ Command.Args.A "deps"; Lazy.force color_always; Dep (Path.build files.src) ]
-     in
-     { Rule.Anonymous_action.action; loc; dir; alias = None })
-    |> Build_system.execute_action_stdout
+    (let* prog = mdx_prog in
+     Command.run'
+       ~dir:(Path.build dir)
+       prog
+       [ Command.Args.A "deps"; Lazy.force color_always; Dep (Path.build files.src) ])
+    |> Super_context.execute_action_stdout sctx ~loc ~dir
     |> Action_builder.of_memo
     >>| parse
     >>| function

--- a/src/dune_rules/ocamldep.ml
+++ b/src/dune_rules/ocamldep.ml
@@ -46,7 +46,7 @@ let parse_deps_exn ~file lines =
        String.extract_blank_separated_words deps)
 ;;
 
-let ocamldep_action ~sandbox ~sctx ~dir ~ml_kind unit =
+let ocamldep_action ~sandbox ~sctx ~ml_kind unit =
   let context = Super_context.context sctx in
   let flags, sandbox =
     Module.pp_flags unit |> Option.value ~default:(Action_builder.return [], sandbox)
@@ -56,26 +56,16 @@ let ocamldep_action ~sandbox ~sctx ~dir ~ml_kind unit =
     let+ ocaml = Action_builder.of_memo (Context.ocaml context) in
     ocaml.ocamldep
   in
-  let+ action =
-    let source = Option.value_exn (Module.source unit ~ml_kind) in
-    let env =
-      (* CR-someday rgrinberg: consider getting rid of this *)
-      Action_builder.of_memo
-        (let open Memo.O in
-         Super_context.env_node sctx ~dir >>= Env_node.external_env)
-    in
-    Command.run'
-      ~dir:(Path.build (Context.build_dir context))
-      ~sandbox
-      ~env
-      ocamldep
-      [ A "-modules"
-      ; Command.Args.dyn flags
-      ; Command.Ml_kind.flag ml_kind
-      ; Dep (Module.File.path source)
-      ]
-  in
-  { Rule.Anonymous_action.action; loc = Loc.none; dir; alias = None }
+  let source = Option.value_exn (Module.source unit ~ml_kind) in
+  Command.run'
+    ~dir:(Path.build (Context.build_dir context))
+    ~sandbox
+    ocamldep
+    [ A "-modules"
+    ; Command.Args.dyn flags
+    ; Command.Ml_kind.flag ml_kind
+    ; Dep (Module.File.path source)
+    ]
 ;;
 
 (* Top-level cache per (source path, ml_kind). Without it, each caller's
@@ -115,8 +105,8 @@ let read_immediate_deps_words =
        | None ->
          let dir = Obj_dir.dir obj_dir in
          let builder =
-           ocamldep_action ~sandbox ~sctx ~dir ~ml_kind unit
-           |> Build_system.execute_action_stdout
+           ocamldep_action ~sandbox ~sctx ~ml_kind unit
+           |> Super_context.execute_action_stdout sctx ~loc:Loc.none ~dir
            |> Memo.map ~f:(fun output ->
              Some (String.split_lines output |> parse_deps_exn ~file:source_path))
            |> Action_builder.of_memo

--- a/src/dune_rules/pkg_config.ml
+++ b/src/dune_rules/pkg_config.ml
@@ -46,24 +46,17 @@ module Query = struct
         Super_context.env_node sctx ~dir >>= Env_node.external_env
       in
       let action =
-        let+ action =
-          let* env =
-            Action_builder.of_memo
-              (let open Memo.O in
-               let* dune_version =
-                 Dune_load.find_project ~dir >>| Dune_project.dune_version
-               in
-               if dune_version >= (3, 8) then external_env else Memo.return Env.empty)
-          in
-          Command.run'
-            ~dir:(Path.build dir)
-            ~env:(Action_builder.of_memo external_env)
-            bin
-            (to_args t ~env)
+        let* env =
+          Action_builder.of_memo
+            (let open Memo.O in
+             let* dune_version =
+               Dune_load.find_project ~dir >>| Dune_project.dune_version
+             in
+             if dune_version >= (3, 8) then external_env else Memo.return Env.empty)
         in
-        { Rule.Anonymous_action.action; loc; dir; alias = None }
+        Command.run' ~dir:(Path.build dir) bin (to_args t ~env)
       in
-      Build_system.execute_action_stdout action
+      Super_context.execute_action_stdout sctx ~loc ~dir action
       |> Memo.map ~f:(fun contents ->
         String.split_lines contents |> List.hd |> String.extract_blank_separated_words)
       |> Action_builder.of_memo

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -142,7 +142,7 @@ let create ~context ~host_env_tree ~default_env ~root_expander ~artifacts ~conte
   Non_rec.Rec.env_tree ()
 ;;
 
-let extend_action t ~dir action =
+let extend_action_env t ~dir action =
   let open Action_builder.O in
   let+ (action : Action.Full.t) = action
   and+ env =
@@ -155,9 +155,21 @@ let extend_action t ~dir action =
      entries remain visible. Other vars from action.env overwrite dir env. *)
   let env = Install.Roots.extend_env_concat_path_vars env action.env in
   Action.Full.add_env env action
-  |> Action.Full.map ~f:(function
-    | Chdir _ as a -> a
-    | a -> Chdir (Path.build (Context.build_dir t.context), a))
+;;
+
+let execute_action_stdout t ?alias ~loc ~dir action =
+  let open Action_builder.O in
+  (let+ action = extend_action_env t ~dir action in
+   { Rule.Anonymous_action.action; loc; dir; alias })
+  |> Build_system.execute_action_stdout
+;;
+
+let extend_action t ~dir action =
+  extend_action_env t ~dir action
+  |> Action_builder.map ~f:(fun action ->
+    Action.Full.map action ~f:(function
+      | Chdir _ as a -> a
+      | a -> Chdir (Path.build (Context.build_dir t.context), a)))
 ;;
 
 let make_rule t ?mode ?loc ~dir { Action_builder.With_targets.build; targets } =

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -59,6 +59,16 @@ val add_alias_action
   -> Action.Full.t Action_builder.t
   -> unit Memo.t
 
+(** Execute an anonymous action after adding the directory's external
+    environment, as [add_rule] and [add_alias_action] do for regular rules. *)
+val execute_action_stdout
+  :  t
+  -> ?alias:Alias.Name.t
+  -> loc:Loc.t
+  -> dir:Path.Build.t
+  -> Action.Full.t Action_builder.t
+  -> string Memo.t
+
 (** [resolve_program t ?hint name] resolves a program. [name] is looked up in
     the workspace, if it is not found in the tree is is looked up in the PATH.
     If it is not found at all, the resulting [Action.Prog.t] will either return


### PR DESCRIPTION
Centralize stdout execution for anonymous actions that should inherit the directory external environment, matching the environment handling used for regular rules. Use the helper for mdx dependency queries, pkg-config queries, and ocamldep.