### PR TITLE
feat(single-context): Add (melange.ppx_runtime_libraries ..)

### DIFF
--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -70,6 +70,13 @@ module Lib = struct
     let name = Lib_info.name info in
     let kind = Lib_info.kind info in
     let modes = Lib_info.modes info in
+    let melange_libs name encode equal ~ocaml ~melange =
+      match ocaml, melange with
+      | [], [] -> field_b name false
+      | _ :: _, [] -> field_b name true
+      | _, _ when List.equal equal ocaml melange -> field_b name false
+      | _, _ :: _ -> field_l name encode melange
+    in
     let synopsis = Lib_info.synopsis info in
     let obj_dir = Lib_info.obj_dir info in
     let additional_paths (paths : _ Lib_info.File_deps.t) =
@@ -164,9 +171,12 @@ module Lib = struct
            (if modes.melange then requires.melange else [])
            ~name:"melange_requires"
        ; libs "ppx_runtime_deps" ppx_runtime_deps.ocaml
-       ; libs
+       ; melange_libs
            "melange_ppx_runtime_deps"
-           (if modes.melange then ppx_runtime_deps.melange else [])
+           (no_loc Lib_name.encode)
+           (fun (_, x) (_, y) -> Lib_name.equal x y)
+           ~ocaml:ppx_runtime_deps.ocaml
+           ~melange:ppx_runtime_deps.melange
        ; field_o "implements" (no_loc Lib_name.encode) implements
        ; field_o "default_implementation" (no_loc Lib_name.encode) default_implementation
        ; field_o "main_module_name" Module_name.encode main_module_name
@@ -346,10 +356,8 @@ module Lib = struct
            { Compilation_mode.By_mode.ocaml = ppx_runtime_deps
            ; melange =
                (match modes.melange, melange_ppx_runtime_deps with
-                | true, Some melange_ppx_runtime_deps -> melange_ppx_runtime_deps
-                | true, None -> ppx_runtime_deps
-                | false, None -> []
-                | false, Some _ -> assert false)
+                | _, Some melange_ppx_runtime_deps -> melange_ppx_runtime_deps
+                | _, None -> ppx_runtime_deps)
            }
          in
          Lib_info.create

--- a/src/dune_rules/stanzas/library.ml
+++ b/src/dune_rules/stanzas/library.ml
@@ -62,6 +62,7 @@ type t =
   ; install_c_headers : (Loc.t * string) list
   ; public_headers : Loc.t * Dep_conf.t list
   ; ppx_runtime_libraries : (Loc.t * Lib_name.t) list
+  ; melange_ppx_runtime_libraries : (Loc.t * Lib_name.t) list option
   ; modes : Mode_conf.Lib.Set.t
   ; kind : Lib_kind.t
   ; library_flags : Ordered_set_lang.Unexpanded.t
@@ -110,6 +111,11 @@ let decode =
          ~default:(stanza_loc, [])
      and+ ppx_runtime_libraries =
        field "ppx_runtime_libraries" (repeat (located Lib_name.decode)) ~default:[]
+     and+ melange_ppx_runtime_libraries =
+       field_o
+         "melange.ppx_runtime_libraries"
+         (Dune_lang.Syntax.since Stanza.syntax (3, 24)
+          >>> repeat (located Lib_name.decode))
      and+ library_flags = Ordered_set_lang.Unexpanded.field "library_flags"
      and+ c_library_flags = Ordered_set_lang.Unexpanded.field "c_library_flags"
      and+ virtual_deps =
@@ -289,6 +295,7 @@ let decode =
      ; install_c_headers
      ; public_headers
      ; ppx_runtime_libraries
+     ; melange_ppx_runtime_libraries
      ; modes
      ; kind
      ; library_flags
@@ -605,9 +612,10 @@ let to_lib_info
   let synopsis = conf.synopsis in
   let sub_systems = conf.sub_systems in
   let ppx_runtime_deps =
-    { Compilation_mode.By_mode.ocaml = conf.ppx_runtime_libraries
-    ; melange = conf.ppx_runtime_libraries
-    }
+    let melange =
+      Option.value conf.melange_ppx_runtime_libraries ~default:conf.ppx_runtime_libraries
+    in
+    { Compilation_mode.By_mode.ocaml = conf.ppx_runtime_libraries; melange }
   in
   let preprocess =
     { Compilation_mode.By_mode.ocaml = conf.buildable.preprocess.config

--- a/src/dune_rules/stanzas/library.mli
+++ b/src/dune_rules/stanzas/library.mli
@@ -11,6 +11,7 @@ type t =
   ; install_c_headers : (Loc.t * string) list
   ; public_headers : Loc.t * Dep_conf.t list
   ; ppx_runtime_libraries : (Loc.t * Lib_name.t) list
+  ; melange_ppx_runtime_libraries : (Loc.t * Lib_name.t) list option
   ; modes : Mode_conf.Lib.Set.t
   ; kind : Lib_kind.t
     (* TODO: It may be worth remaming [c_library_flags] to

--- a/src/dune_rules/stanzas/parameter.ml
+++ b/src/dune_rules/stanzas/parameter.ml
@@ -45,6 +45,7 @@ let to_library t =
   ; enabled_if = t.enabled_if
   ; instrumentation_backend = None
   ; melange_runtime_deps = loc, []
+  ; melange_ppx_runtime_libraries = None
   ; optional = t.optional
   }
 ;;

--- a/test/blackbox-tests/test-cases/melange/conditional-ppx-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/conditional-ppx-runtime-deps.t
@@ -104,3 +104,34 @@ Define a PPX rewriter that has different runtime libs (native / melange)
 
   $ dune exec bin/app.exe
   native runtime
+
+The same ppx runtime dependency information is preserved after installation.
+This exercises decoding [melange_ppx_runtime_deps] from the installed
+[dune-package] file of a native-only ppx rewriter.
+
+  $ dune build @install
+  $ dune install --prefix $PWD/prefix > /dev/null
+
+  $ mkdir installed-consumer
+  $ cat > installed-consumer/dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name installed-consumer))
+  > (using melange 0.1)
+  > EOF
+  $ cat > installed-consumer/dune <<EOF
+  > (melange.emit
+  >  (package installed-consumer)
+  >  (target js-out)
+  >  (preprocess (pps my-ppx))
+  >  (emit_stdlib false))
+  > EOF
+  $ cat > installed-consumer/app.ml <<EOF
+  > let () = Js.log Runtime.msg
+  > EOF
+
+  $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root installed-consumer @melange --display=quiet
+  $ find installed-consumer/_build/default/js-out -type f | sort
+  installed-consumer/_build/default/js-out/app.js
+  installed-consumer/_build/default/js-out/node_modules/my-ppx.runtime/runtime.js
+  $ node installed-consumer/_build/default/js-out/app.js
+  melange runtime

--- a/test/blackbox-tests/test-cases/melange/conditional-ppx-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/conditional-ppx-runtime-deps.t
@@ -1,0 +1,106 @@
+This test checks that ppx rewriters can declare different runtime libraries for
+native and Melange compilation.
+
+The field is available starting in Dune 3.24.
+
+  $ mkdir old-lang
+  $ cat > old-lang/dune-project <<EOF
+  > (lang dune 3.23)
+  > (using melange 0.1)
+  > EOF
+  $ cat > old-lang/dune <<EOF
+  > (library
+  >  (name ppx)
+  >  (kind ppx_rewriter)
+  >  (melange.ppx_runtime_libraries runtime))
+  > EOF
+  $ dune build --root old-lang
+  Entering directory 'old-lang'
+  File "dune", line 4, characters 1-40:
+  4 |  (melange.ppx_runtime_libraries runtime))
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: 'melange.ppx_runtime_libraries' is only available since version 3.24
+  of the dune language. Please update your dune-project file to have (lang dune
+  3.24).
+  Leaving directory 'old-lang'
+  [1]
+  $ rm -r old-lang
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name my-ppx))
+  > (package (name foo))
+  > (package (name mel-foo) (allow_empty))
+  > (using melange 0.1)
+  > EOF
+
+Define a runtime library that the ppx will depend on via `(ppx_runtime_libraries)`
+
+  $ mkdir runtime
+  $ cat > runtime/dune <<EOF
+  > (library
+  >  (name runtime)
+  >  (public_name my-ppx.runtime)
+  >  (modules runtime)
+  >  (modes melange))
+  > (library
+  >  (name native)
+  >  (public_name my-ppx.native-runtime)
+  >  (modules native))
+  > EOF
+  $ cat > runtime/runtime.ml <<EOF
+  > let msg = "melange runtime"
+  > EOF
+  $ cat > runtime/native.ml <<EOF
+  > let msg = "native runtime"
+  > EOF
+
+Define a PPX rewriter that has different runtime libs (native / melange)
+
+  $ mkdir ppx
+  $ cat > ppx/dune <<EOF
+  > (library
+  >  (name my_ppx)
+  >  (public_name my-ppx)
+  >  (kind ppx_rewriter)
+  >  (libraries ppxlib)
+  >  (ppx_runtime_libraries my-ppx.native-runtime)
+  >  (melange.ppx_runtime_libraries my-ppx.runtime))
+  > EOF
+  $ cat > ppx/my_ppx.ml <<EOF
+  > open Ppxlib
+  > let () = Driver.register_transformation "my_ppx"
+  > EOF
+
+  $ mkdir src
+  $ cat > src/dune <<EOF
+  > (melange.emit
+  >  (package mel-foo)
+  >  (target js-out)
+  >  (preprocess (pps my-ppx))
+  >  (emit_stdlib false))
+  > EOF
+  $ cat > src/app.ml <<EOF
+  > let () = Js.log Runtime.msg
+  > EOF
+
+  $ dune build @src/melange
+  $ find _build/default/src/js-out -type f | sort
+  _build/default/src/js-out/node_modules/my-ppx.runtime/runtime.js
+  _build/default/src/js-out/src/app.js
+  $ node _build/default/src/js-out/src/app.js
+  melange runtime
+
+  $ mkdir bin
+  $ cat > bin/dune <<EOF
+  > (executable
+  >  (public_name app)
+  >  (package foo)
+  >  (preprocess (pps my-ppx)))
+  > EOF
+  $ cat > bin/app.ml <<EOF
+  > let () = Format.eprintf "%s" Native.msg
+  > EOF
+
+  $ dune exec bin/app.exe
+  native runtime


### PR DESCRIPTION
Add `melange.ppx_runtime_libraries` for ppx rewriters that need different native and Melange runtime libraries.

Extracted from `anmonteiro/single-context-universal`.