### PR TITLE
action: use Filename.t for missing program names

### DIFF
--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -71,7 +71,7 @@ module Prog = struct
   module Not_found = struct
     type t =
       { context : Context_name.t
-      ; program : string
+      ; program : Filename.t
       ; hint : string option
       ; loc : Loc.t option
       }
@@ -79,14 +79,14 @@ module Prog = struct
     let create ?hint ~context ~program ~loc () = { hint; context; program; loc }
 
     let raise { context; program; hint; loc } =
-      Utils.program_not_found ?hint ~loc ~context program
+      Utils.program_not_found ?hint ~loc ~context (Filename.to_string program)
     ;;
 
     let to_dyn { context; program; hint; loc = _ } =
       let open Dyn in
       record
         [ "context", Context_name.to_dyn context
-        ; "program", string program
+        ; "program", Filename.to_dyn program
         ; "hint", option string hint
         ]
     ;;
@@ -180,7 +180,7 @@ let for_shell t =
     ~f_program:(fun ~dir x ->
       match x with
       | Ok p -> Path.reach p ~from:dir
-      | Error e -> e.program)
+      | Error e -> Filename.to_string e.program)
 ;;
 
 let digest =
@@ -192,7 +192,7 @@ let digest =
   let digest_program d ~dir (program : Prog.t) =
     match program with
     | Ok p -> string d (Path.reach p ~from:dir)
-    | Error e -> string d e.program
+    | Error e -> string d (Filename.to_string e.program)
   in
   let digest_path d ~dir path = string d (Path.reach path ~from:dir) in
   let digest_target d ~dir target = string d (Path.reach (Path.build target) ~from:dir) in

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -55,7 +55,7 @@ module Prog : sig
   module Not_found : sig
     type t = private
       { context : Context_name.t
-      ; program : string
+      ; program : Filename.t
       ; hint : string option
       ; loc : Loc.t option
       }
@@ -63,7 +63,7 @@ module Prog : sig
     val create
       :  ?hint:string
       -> context:Context_name.t
-      -> program:string
+      -> program:Filename.t
       -> loc:Loc.t option
       -> unit
       -> t

--- a/src/dune_rules/artifacts.ml
+++ b/src/dune_rules/artifacts.ml
@@ -102,7 +102,13 @@ let binary t ?hint ?(where = Original_path) ~dir ~loc name =
   | `None ->
     let context = Context.name t.context in
     Memo.return
-    @@ Error (Action.Prog.Not_found.create ~program:name ?hint ~context ~loc ())
+    @@ Error
+         (Action.Prog.Not_found.create
+            ~program:(Filename.of_string_exn name)
+            ?hint
+            ~context
+            ~loc
+            ())
   | `Origin { dir; binding; dst; enabled_if = _; package = _ } ->
     (match where with
      | Install_dir ->

--- a/src/dune_rules/ocaml_toolchain.ml
+++ b/src/dune_rules/ocaml_toolchain.ml
@@ -60,7 +60,12 @@ let best_mode t : Mode.t =
 
 let make name ~which ~env ~get_ocaml_tool =
   let not_found ?hint program =
-    Action.Prog.Not_found.create ?hint ~context:name ~loc:None ~program ()
+    Action.Prog.Not_found.create
+      ?hint
+      ~context:name
+      ~loc:None
+      ~program:(Filename.of_string_exn program)
+      ()
   in
   let* ocamlc =
     let program = "ocamlc" in

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -998,7 +998,7 @@ module Action_expander = struct
                       Error
                         (Action.Prog.Not_found.create
                            ?hint
-                           ~program:(Filename.to_string program)
+                           ~program
                            ~context:t.context
                            ~loc:(Some loc)
                            ())))))
@@ -1225,7 +1225,8 @@ module Action_expander = struct
     Which.which ~path:(Env_path.path Env.initial) Filename.dune
     >>| function
     | Some s -> Ok s
-    | None -> Error (Action.Prog.Not_found.create ~loc:None ~context ~program:"dune" ())
+    | None ->
+      Error (Action.Prog.Not_found.create ~loc:None ~context ~program:Filename.dune ())
   ;;
 
   let build_command context (pkg : Pkg.t) =

--- a/src/dune_rules/run_with_path.ml
+++ b/src/dune_rules/run_with_path.ml
@@ -198,7 +198,7 @@ module Spec = struct
     let prog : Sexp.t =
       match prog with
       | Ok p -> path p
-      | Error e -> Atom e.program
+      | Error e -> Atom (Filename.to_string e.program)
     in
     let args =
       Array.Immutable.to_list_map args ~f:(fun x ->


### PR DESCRIPTION
Change Action.Prog.Not_found.program from string to Filename.t and convert to strings only at reporting/serialization boundaries. Update callers that construct missing-program errors accordingly.