### PR TITLE
Run mdx corrections as anonymous actions

### DIFF
--- a/doc/explanation/tour/rule-generation.rst
+++ b/doc/explanation/tour/rule-generation.rst
@@ -40,129 +40,128 @@ other arguments), and returning ``unit Memo.t``.
     input changes. This is a mini in-memory build system that works like a
     spreadsheet. It is essential to the watch mode.
 
-An example of rule is the :doc:`/reference/dune/mdx` stanza, implemented in
-:file:`src/dune_rules/mdx.ml`. There are several steps in setting up rules for
-a ``(mdx)`` stanza:
+An example rule is the :doc:`/reference/dune/mdx` stanza, implemented in
+:file:`src/dune_rules/mdx.ml`. There are several steps in setting up rules and
+alias actions for a ``(mdx)`` stanza:
 
-- How to run ``ocaml-mdx deps`` on the input file to produce a ``.mdx.deps``
-- Run ``ocaml-mdx dune-gen`` to produce a ``mdx_gen.ml-gen`` OCaml source file
-- Compile this executable
-- Run this executable to produce a ``.corrected`` file
-- Register a :doc:`/reference/actions/diff` action between the ``.corrected`` file
-  and the original file
+- Run ``ocaml-mdx deps`` on the input file to discover extra dependencies.
+- Run ``ocaml-mdx dune-gen`` to produce a ``mdx_gen.ml-gen`` OCaml source file.
+- Compile this generated executable.
+- Attach an action to :doc:`/reference/aliases/runtest` that creates the
+  ``.corrected`` file and immediately compares it with the original file using
+  :doc:`/reference/actions/diff`.
 
-Let's walk through these rules.
+Let's walk through these pieces.
 
-The first one is about producing a ``.mdx.deps`` file. It is a simple call to
-``Super_context.add_rule``.
-
-.. code-block:: ocaml
-  :linenos:
-  :lineno-start: 312
-
-  let* () = Super_context.add_rule sctx ~loc ~dir (Deps.rule ~dir ~mdx_prog files)
-
-``Deps.rule`` is defined in a helper function:
-
-.. code-block:: ocaml
-  :linenos:
-  :lineno-start: 77
-
-  let rule ~dir ~mdx_prog (files : Files.t) =
-    Command.run_dyn_prog
-      ~dir:(Path.build dir)
-      mdx_prog
-      ~stdout_to:files.deps
-      [ Command.Args.A "deps"; Lazy.force color_always; Dep (Path.build files.Files.src) ]
-
-This is a rule made by just running a command, here ``mdx_prog`` (a resolved
-path to ``ocaml-mdx``, meaning it can point to a binary in ``PATH`` or a built
-version in the current workspace). Its arguments are a domain-specific language
-defined in :file:`src/dune_rules/command.mli` where ``A`` refers to a plain
-string, and ``Dep`` refers to a string that should be interpreted as a dependency.
-Between that, and the ``~stdout_to`` parameter, it is enough for Dune to know
-about the rule's dependencies (what it will read) and its target (what it will
-produce).
-
-The second rule, which generates ``mdx_gen.ml-gen``, is similar. It is also done
-by calling ``Command.run_dyn_prog``.
-
-The third rule, to build the executable, calls ``Exe.build_and_link`` that is a
-helper function.
-
-Let's observe how the fourth rule (that calls the generated executable) is set
-up.
+The rule that generates ``mdx_gen.ml-gen`` is a regular rule made by running a
+command:
 
 .. code-block:: ocaml
 
-    let mdx_action ~loc:_ =
-      let open Action_builder.With_targets.O in
-      let mdx_input_dependencies = (* ... *) in
-      let executable, command_line = (* ... *) in
-      let deps, sandbox = (* ... *) in
-      let+ action =
-        Action_builder.with_no_targets deps
-        >>> Action_builder.with_no_targets
-              (Action_builder.env_var "MDX_RUN_NON_DETERMINISTIC")
-        >>> Action_builder.with_no_targets
-              (Action_builder.map mdx_input_dependencies ~f:(fun d -> (), d)
-               |> Action_builder.dyn_deps)
-        >>> Command.run_dyn_prog
-              ~dir:(Path.build dir)
-              ~stdout_to:files.corrected
-              executable
-              command_line
-      and+ locks =
-        Expander.expand_locks expander stanza.locks |> Action_builder.with_no_targets
-      in
-      Action.Full.add_locks locks action |> Action.Full.add_sandbox sandbox
+  Command.run_dyn_prog
+    ~dir:(Path.build dir)
+    mdx_prog
+    ~stdout_to
+    [ A "dune-gen"
+    ; prelude_args
+    ; Resolve.Memo.args directory_args
+    ; Lazy.force color_always
+    ]
+
+Here ``mdx_prog`` is the resolved path to ``ocaml-mdx``. It can point to a
+binary in ``PATH`` or to a binary built in the current workspace. The command
+arguments are written in a domain-specific language defined in
+:file:`src/dune_rules/command.mli`. For example, ``A`` is a plain string, and
+``Path`` or ``Dep`` arguments let Dune track paths used by the command. The
+``~stdout_to`` parameter tells Dune which target this rule produces.
+
+The generated executable is then built with ``Exe.build_and_link``.
+
+The dependencies reported by ``ocaml-mdx deps`` are not stored in a separate
+``.mdx.deps`` target. Instead, Dune runs that command as an anonymous action and
+reads its standard output:
+
+.. code-block:: ocaml
+
+  let read ~sctx ~dir ~loc ~mdx_prog (files : Files.t) =
+    let open Action_builder.O in
+    (let* prog = mdx_prog in
+     Command.run'
+       ~dir:(Path.build dir)
+       prog
+       [ Command.Args.A "deps"
+       ; Lazy.force color_always
+       ; Dep (Path.build files.src)
+       ])
+    |> Super_context.execute_action_stdout sctx ~loc ~dir
+    |> Action_builder.of_memo
+    >>| parse
+
+``Super_context.execute_action_stdout`` executes the command as an anonymous
+action and returns its captured standard output to the rule generator. The
+result is parsed into the dynamic dependencies of the mdx test action.
+
+Finally, Dune attaches one anonymous action to the ``@runtest`` alias. This
+action runs mdx to produce the ``.corrected`` file and then runs the diff action
+that compares it with the source file:
+
+.. code-block:: ocaml
+
+  let mdx_action =
+    let mdx_input_dependencies = (* Deps.read ... *) in
+    let executable, command_line, redirect_stdout = (* ... *) in
+    let env, sandbox = (* ... *) in
+    let open Action_builder.O in
+    let action =
+      Action_builder.env_var "MDX_RUN_NON_DETERMINISTIC"
+      >>> (Action_builder.map mdx_input_dependencies ~f:(fun d -> (), d)
+           |> Action_builder.dyn_deps)
+      >>> let* executable = executable in
+          Command.run'
+            ~dir:(Path.build dir)
+            ~env
+            ~sandbox
+            executable
+            command_line
     in
-    Super_context.add_rule sctx ~loc ~dir (mdx_action ~loc)
+    let action =
+      if redirect_stdout
+      then
+        Action_builder.map
+          action
+          ~f:(Action.Full.map ~f:(Action.with_stdout_to files.corrected))
+      else action
+    in
+    let+ action
+    and+ locks = Expander.expand_locks expander stanza.locks in
+    let mkdir_corrected_dir =
+      Action.mkdir (Path.Build.parent_exn files.corrected) |> Action.Full.make
+    in
+    let diff =
+      Action.diff ~optional:false (Path.build files.src) files.corrected
+      |> Action.Full.make
+    in
+    Action.Full.reduce
+      [ mkdir_corrected_dir; Action.Full.add_locks locks action; diff ]
+  in
+  Super_context.add_alias_action
+    sctx
+    (Alias.make Alias0.runtest ~dir)
+    mdx_action
+    ~loc
+    ~dir
 
-Here, the ``mdx_action`` that is set up is not just a single
-``Command.run_dyn_prog`` call. It is assembled using combinators from
-``Action_builder.With_targets``. This is another monad used in Dune. It
-corresponds to what can happen at build time, like running commands or creating
-files, or more complex actions such as reading a file that needs to be built by
-another rule. It is also used to track dependencies and targets. The "thing"
-that we register to the Dune engine using ``Super_context.add_rule`` has type
-``Action.Full.t Action_builder.With_targets.t``.
+Here, ``Action_builder.dyn_deps`` makes the dependencies discovered by
+``ocaml-mdx deps`` part of the anonymous action. The ``.corrected`` file is an
+intermediate file used by the same alias action, not a target with its own
+standalone build rule. If the diff finds a mismatch, it registers the usual
+promotion from the corrected file back to the source file.
 
 .. note::
 
-  This is different from ``Memo``, which corresponds to what happens within
-  Dune itself. But it is also possible to use ``Memo`` from an
+  ``Action_builder`` is different from ``Memo``, which corresponds to what
+  happens within Dune itself. But it is also possible to use ``Memo`` from an
   ``Action_builder`` context. In that sense, ``Action_builder`` is more
   powerful: at execution time, ``Action_builder`` will manage what happens in
   the ``_build`` directory, while ``Memo`` is only concerned with what happens
   in memory.
-
-Finally, to register the correction, the technique is to attach the
-:doc:`/reference/actions/diff` action to the :doc:`/reference/aliases/runtest`
-alias (a collection of rules) using this call:
-
-.. code-block:: ocaml
-  :linenos:
-  :lineno-start: 405
-
-  (* Attach the diff action to the @runtest for the src and corrected files *)
-  Files.diff_action files
-  |> Super_context.add_alias_action sctx (Alias.make Alias0.runtest ~dir) ~loc ~dir
-
-Where ``Files.diff_action`` is defined as:
-
-.. code-block:: ocaml
-  :linenos:
-  :lineno-start: 33
-
-  let diff_action { src; corrected; deps = _ } =
-    let src = Path.build src in
-    let open Action_builder.O in
-    let+ () = Action_builder.path src
-    and+ () = Action_builder.path (Path.build corrected) in
-    Action.Full.make (Action.diff ~optional:false src corrected)
-  ;;
-
-As explained above, ``Action_builder`` keeps tracks of dependencies, so using
-``let+ () = Action_builder.path src`` is a way to declare ``src`` as a
-dependency of the current action.

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -28,14 +28,6 @@ module Files = struct
     let corrected = corrected_file dot_mdx_path in
     { src; corrected }
   ;;
-
-  let diff_action { src; corrected } =
-    let src = Path.build src in
-    let open Action_builder.O in
-    let+ () = Action_builder.path src
-    and+ () = Action_builder.path (Path.build corrected) in
-    Action.Full.make (Action.diff ~optional:false src corrected)
-  ;;
 end
 
 module Deps = struct
@@ -304,107 +296,115 @@ let gen_rules_for_single_file stanza ~sctx ~dir ~expander ~mdx_prog ~mdx_prog_ge
     let mdx_dir = Path.Build.relative dir ".mdx" in
     Files.from_source_file ~mdx_dir src
   in
-  (* Add the rule for generating the .corrected file using ocaml-mdx test *)
-  let* () =
-    let mdx_action =
-      let open Action_builder.With_targets.O in
-      let mdx_input_dependencies =
-        let open Action_builder.O in
-        let* dep_set = Deps.read ~sctx ~dir ~loc ~mdx_prog files in
-        Action_builder.of_memo
-          (let open Memo.O in
-           let src_path_msg =
-             Pp.seq (Pp.text "Source path: ") (Path.pp (Path.build src))
-           in
-           Deps.to_dep_set dep_set ~version ~dir
-           >>| function
-           | Result.Ok r -> r
-           | Error (`Absolute str) ->
-             User_error.raise
-               ~loc
-               [ Pp.text
-                   "Paths referenced in mdx files must be relative. This stanza refers \
-                    to the following absolute path:"
-               ; src_path_msg
-               ; Pp.seq (Pp.text "Included path: ") (Pp.text str)
-               ]
-           | Error (`Escapes_workspace str) ->
-             User_error.raise
-               ~loc
-               [ Pp.text
-                   "Paths referenced in mdx files must stay within the workspace. This \
-                    stanza refers to the following path which escapes:"
-               ; src_path_msg
-               ; Pp.seq (Pp.text "Included path: ") (Pp.text str)
-               ]
-           | Error (`Escapes_dir str) ->
-             User_error.raise
-               ~loc
-               [ Pp.text
-                   "Paths referenced in mdx files cannot escape the directory. This \
-                    stanza refers to the following path which escapes:"
-               ; src_path_msg
-               ; Pp.seq (Pp.text "Included path: ") (Pp.text str)
-               ])
-      in
-      let executable, command_line =
-        (* The old mdx stanza calls the [ocaml-mdx] executable, new ones the
-           generated executable *)
-        let open Command.Args in
-        match mdx_prog_gen with
-        | Some prog ->
-          ( Action_builder.return @@ Ok (Path.build prog)
-          , [ Dep (Path.build files.src)
-            ; S (List.map ~f:(Prelude.runtime_deps ~dir) stanza.preludes)
-            ] )
-        | None ->
-          let prelude_args = List.concat_map stanza.preludes ~f:(Prelude.to_args ~dir) in
-          ( mdx_prog
-          , [ A "test"
-            ; S prelude_args
-            ; Lazy.force color_always
-            ; A "-o"
-            ; Target files.corrected
-            ; Dep (Path.build files.src)
-            ] )
-      in
-      let env, sandbox =
-        let mdx_generic_deps = Bindings.to_list stanza.deps in
-        let mdx_package_deps =
-          stanza.packages
-          |> List.map ~f:(fun (loc, pkg) ->
-            Dep_conf.Package (Package.Name.to_string pkg |> String_with_vars.make_text loc))
-        in
-        Dep_conf_eval.unnamed
-          (if version < (0, 5)
-           then Sandbox_config.no_special_requirements
-           else Sandbox_config.needs_sandboxing)
-          ~expander
-          (mdx_package_deps @ mdx_generic_deps)
-      in
-      let+ action =
-        Action_builder.with_no_targets
-          (Action_builder.env_var "MDX_RUN_NON_DETERMINISTIC")
-        >>> Action_builder.with_no_targets
-              (Action_builder.map mdx_input_dependencies ~f:(fun d -> (), d)
-               |> Action_builder.dyn_deps)
-        >>> Command.run_dyn_prog
-              ~dir:(Path.build dir)
-              ~stdout_to:files.corrected
-              ~env
-              ~sandbox
-              executable
-              command_line
-      and+ locks =
-        Expander.expand_locks expander stanza.locks |> Action_builder.with_no_targets
-      in
-      Action.Full.add_locks locks action
+  (* Attach the mdx correction action to the @runtest alias. *)
+  let mdx_action =
+    let mdx_input_dependencies =
+      let open Action_builder.O in
+      let* dep_set = Deps.read ~sctx ~dir ~loc ~mdx_prog files in
+      Action_builder.of_memo
+        (let open Memo.O in
+         let src_path_msg = Pp.seq (Pp.text "Source path: ") (Path.pp (Path.build src)) in
+         Deps.to_dep_set dep_set ~version ~dir
+         >>| function
+         | Result.Ok r -> r
+         | Error (`Absolute str) ->
+           User_error.raise
+             ~loc
+             [ Pp.text
+                 "Paths referenced in mdx files must be relative. This stanza refers to \
+                  the following absolute path:"
+             ; src_path_msg
+             ; Pp.seq (Pp.text "Included path: ") (Pp.text str)
+             ]
+         | Error (`Escapes_workspace str) ->
+           User_error.raise
+             ~loc
+             [ Pp.text
+                 "Paths referenced in mdx files must stay within the workspace. This \
+                  stanza refers to the following path which escapes:"
+             ; src_path_msg
+             ; Pp.seq (Pp.text "Included path: ") (Pp.text str)
+             ]
+         | Error (`Escapes_dir str) ->
+           User_error.raise
+             ~loc
+             [ Pp.text
+                 "Paths referenced in mdx files cannot escape the directory. This stanza \
+                  refers to the following path which escapes:"
+             ; src_path_msg
+             ; Pp.seq (Pp.text "Included path: ") (Pp.text str)
+             ])
     in
-    Super_context.add_rule sctx ~loc ~dir mdx_action
+    let executable, command_line, redirect_stdout =
+      (* The old mdx stanza calls the [ocaml-mdx] executable, new ones the
+         generated executable *)
+      let open Command.Args in
+      match mdx_prog_gen with
+      | Some prog ->
+        ( Action_builder.return @@ Ok (Path.build prog)
+        , [ Dep (Path.build files.src)
+          ; S (List.map ~f:(Prelude.runtime_deps ~dir) stanza.preludes)
+          ]
+        , true )
+      | None ->
+        let prelude_args = List.concat_map stanza.preludes ~f:(Prelude.to_args ~dir) in
+        ( mdx_prog
+        , [ A "test"
+          ; S prelude_args
+          ; Lazy.force color_always
+          ; A "-o"
+          ; Path (Path.build files.corrected)
+          ; Dep (Path.build files.src)
+          ]
+        , false )
+    in
+    let env, sandbox =
+      let mdx_generic_deps = Bindings.to_list stanza.deps in
+      let mdx_package_deps =
+        stanza.packages
+        |> List.map ~f:(fun (loc, pkg) ->
+          Dep_conf.Package (Package.Name.to_string pkg |> String_with_vars.make_text loc))
+      in
+      Dep_conf_eval.unnamed
+        (if version < (0, 5)
+         then Sandbox_config.no_special_requirements
+         else Sandbox_config.needs_sandboxing)
+        ~expander
+        (mdx_package_deps @ mdx_generic_deps)
+    in
+    let open Action_builder.O in
+    let action =
+      Action_builder.env_var "MDX_RUN_NON_DETERMINISTIC"
+      >>> (Action_builder.map mdx_input_dependencies ~f:(fun d -> (), d)
+           |> Action_builder.dyn_deps)
+      >>> let* executable = executable in
+          Command.run' ~dir:(Path.build dir) ~env ~sandbox executable command_line
+    in
+    let action =
+      if redirect_stdout
+      then
+        Action_builder.map
+          action
+          ~f:(Action.Full.map ~f:(Action.with_stdout_to files.corrected))
+      else action
+    in
+    let+ action
+    and+ locks = Expander.expand_locks expander stanza.locks in
+    let mkdir_corrected_dir =
+      Action.mkdir (Path.Build.parent_exn files.corrected) |> Action.Full.make
+    in
+    let diff =
+      Action.diff ~optional:false (Path.build files.src) files.corrected
+      |> Action.Full.make
+    in
+    Action.Full.reduce [ mkdir_corrected_dir; Action.Full.add_locks locks action; diff ]
   in
-  (* Attach the diff action to the @runtest for the src and corrected files *)
-  Files.diff_action files
-  |> Super_context.add_alias_action sctx (Alias.make Alias0.runtest ~dir) ~loc ~dir
+  Super_context.add_alias_action
+    sctx
+    (Alias.make Alias0.runtest ~dir)
+    mdx_action
+    ~loc
+    ~dir
 ;;
 
 let name = "mdx_gen"


### PR DESCRIPTION
Attach mdx correction generation directly to the runtest alias and run the follow-up diff in the same anonymous alias action. This removes the standalone rule for `.mdx/*.corrected` targets.