### PR TITLE
Add git-sha to rule variables, add test for the variable.

### DIFF
--- a/doc/changes/added/14810.md
+++ b/doc/changes/added/14810.md
@@ -1,0 +1,3 @@
+- Add ``%{git-sha}`` variable that expands to the short git SHA of the current
+  HEAD commit, or the empty string when git is unavailable or the workspace is
+  not inside a git repository (#14810, @toots).

--- a/doc/concepts/variables.rst
+++ b/doc/concepts/variables.rst
@@ -78,6 +78,9 @@ Dune supports the following variables:
   stricter warning set. The old behaviour of Dune can be recovered by using the
   following stanza in a top-level ``dune`` file: ``(env (dev (flags :standard
   %{dune-warnings})))``.
+- ``git-sha`` expands to the short git SHA of the HEAD commit of the workspace's
+  git repository (equivalent to ``git rev-parse --short HEAD``). Expands to the
+  empty string when no commit sha was found. Available since Dune 3.24.
 - ``<ext>:<path>`` where ``<ext>`` is one of ``cmo``, ``cmi``, ``cma``,
   ``cmx``, or ``cmxa``. See :ref:`variables-for-artifacts`.
 - ``env:<var>=<default`` expands to the value of the environment

--- a/src/dune_lang/pform.ml
+++ b/src/dune_lang/pform.ml
@@ -138,6 +138,7 @@ module Var = struct
     | Pkg of Pkg.t
     | Oxcaml_supported
     | Dune_warnings
+    | Git_sha
 
   let compare : t -> t -> Ordering.t = Poly.compare
 
@@ -193,7 +194,8 @@ module Var = struct
        | Os os -> Os.to_dyn os
        | Pkg pkg -> Pkg.to_dyn pkg
        | Oxcaml_supported -> variant "Oxcaml_supported" []
-       | Dune_warnings -> variant "Dune_warnings" [])
+       | Dune_warnings -> variant "Dune_warnings" []
+       | Git_sha -> variant "Git_sha" [])
   ;;
 
   let of_opam_global_variable_name name =
@@ -541,6 +543,7 @@ let encode_to_latest_dune_lang_version t =
        | Pkg pkg -> Some (Var.Pkg.encode_to_latest_dune_lang_version pkg)
        | Oxcaml_supported -> Some "oxcaml_supported"
        | Dune_warnings -> Some "dune-warnings"
+       | Git_sha -> Some "git-sha"
      with
      | None -> Pform_was_deleted
      | Some name -> Success { name; payload = None })
@@ -762,6 +765,7 @@ module Env = struct
         ; ( "oxcaml_supported"
           , since ~what:Oxcaml.syntax ~version:(0, 1) Var.Oxcaml_supported )
         ; "dune-warnings", since ~version:(3, 21) Var.Dune_warnings
+        ; "git-sha", since ~version:(3, 24) Var.Git_sha
         ]
       in
       String.Map.of_list_exn

--- a/src/dune_lang/pform.mli
+++ b/src/dune_lang/pform.mli
@@ -92,6 +92,7 @@ module Var : sig
     | Pkg of Pkg.t
     | Oxcaml_supported
     | Dune_warnings
+    | Git_sha
 
   val compare : t -> t -> Ordering.t
   val to_dyn : t -> Dyn.t

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -599,6 +599,16 @@ let expand_pform_var (context : Context.t) ~dir ~source (var : Pform.Var.t) =
            let+ scope = scope in
            let dune_version = Dune_project.dune_version (Scope.project scope) in
            Value.L.strings (Ocaml_flags.dune_warnings ~dune_version ~profile:Dev)))
+  | Git_sha ->
+    (let open Memo.O in
+     let+ sha =
+       Source_tree.nearest_vcs Path.Source.root
+       >>= function
+       | None -> Memo.return None
+       | Some vcs -> Vcs.git_sha_short vcs
+     in
+     string (Option.value sha ~default:""))
+    |> static
 ;;
 
 let ocaml_config_macro source macro_invocation context =

--- a/src/dune_vcs/vcs.ml
+++ b/src/dune_vcs/vcs.ml
@@ -169,6 +169,17 @@ let commit_id =
          Some res)
 ;;
 
+let git_sha_short =
+  Staged.unstage
+  @@ make_fun
+       "vcs-git-sha-short"
+       ~git:(fun t ->
+         match run_git t [ "rev-parse"; "--short"; "HEAD" ] with
+         | exception _ -> Fiber.return None
+         | fiber -> fiber)
+       ~hg:(fun _ -> Fiber.return None)
+;;
+
 let files =
   let run_zero_separated_hg t args =
     Process.run_capture_zero_separated

--- a/src/dune_vcs/vcs.mli
+++ b/src/dune_vcs/vcs.mli
@@ -29,6 +29,9 @@ val describe : t -> string option Memo.t
 (** String uniquely identifying the current head commit *)
 val commit_id : t -> string option Memo.t
 
+(** Short git SHA of the current head commit, or [None] if unavailable *)
+val git_sha_short : t -> string option Memo.t
+
 (** List of files committed in the repo *)
 val files : t -> Path.Source.t list Memo.t
 

--- a/test/blackbox-tests/test-cases/git-sha.t
+++ b/test/blackbox-tests/test-cases/git-sha.t
@@ -1,0 +1,43 @@
+Test the %{git-sha} variable.
+
+Without a git repository, %{git-sha} expands to the empty string.
+
+  $ make_dune_project 3.24
+  $ cat > dune << EOF
+  > (rule
+  >  (target sha.txt)
+  >  (action (with-stdout-to sha.txt (echo "%{git-sha}"))))
+  > EOF
+  $ dune build sha.txt
+  $ cat _build/default/sha.txt
+
+In a git repository with a commit, %{git-sha} expands to the short git SHA.
+
+  $ git init --quiet
+  $ git config user.email "test@test.com"
+  $ git config user.name "Test"
+  $ git add .
+  $ git commit -q -m "initial"
+  $ rm -f _build/default/sha.txt
+  $ dune build sha.txt
+  $ [ "$(cat _build/default/sha.txt)" = "$(git rev-parse --short HEAD)" ] && echo "sha matches"
+  sha matches
+
+In a git repository with no commits, %{git-sha} expands to the empty string.
+
+  $ rm -rf .git
+  $ git init --quiet
+  $ rm -f _build/default/sha.txt
+  $ dune build sha.txt
+  $ cat _build/default/sha.txt
+
+Version check: %{git-sha} requires dune >= 3.24.
+
+  $ make_dune_project 3.23
+  $ dune build sha.txt
+  File "dune", line 3, characters 40-50:
+  3 |  (action (with-stdout-to sha.txt (echo "%{git-sha}"))))
+                                              ^^^^^^^^^^
+  Error: %{git-sha} is only available since version 3.24 of the dune language.
+  Please update your dune-project file to have (lang dune 3.24).
+  [1]


### PR DESCRIPTION
This follows the discussion at: https://github.com/ocaml/dune/issues/14723

My suggestion is that since this value is used to track the exact commit being used for builds, CI run etc, it's better to be specific about what it is, i.e. a `git` commit SHA rather than wrapping it up in any higher level semantics i.e. `vcs-commit-id` etc. so that the user knows exactly what they're dealing with and can use it with confidence.