### PR TITLE
test(single-context): generate mode-aware Merlin configs

### DIFF
--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -361,6 +361,7 @@ let executables_rules
       ~dialects:(Dune_project.dialects (Scope.project scope))
       ~ident:(Merlin_ident.for_exes ~names:(Nonempty_list.map ~f:snd exes.names))
       ~for_
+      ~is_default:true
       ~parameters:(Resolve.return [])
   in
   cctx, merlin

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -46,7 +46,7 @@ module For_stanza : sig
     -> scope:Scope.t
     -> dir_contents:Dir_contents.t
     -> expander:Expander.t
-    -> ( Merlin.t list
+    -> ( Merlin.group list
          , Compilation_context.t option Compilation_mode.Per_mode.t Loc.Map.t
          , Path.Build.t list
          , Path.Source.t list )
@@ -60,12 +60,11 @@ end = struct
     ; source_dirs : 'source_dirs
     }
 
-  let empty_none = { merlin = None; cctx = None; js = None; source_dirs = None }
+  let empty_none = { merlin = []; cctx = []; js = None; source_dirs = None }
   let empty_list = { merlin = []; cctx = Loc.Map.empty; js = []; source_dirs = [] }
 
-  let add_map_maybe hd_o tl =
-    match hd_o with
-    | Some (loc, hd) ->
+  let add_map hds tl =
+    List.fold_left hds ~init:tl ~f:(fun tl (loc, hd) ->
       Loc.Map.update tl loc ~f:(function
         | None ->
           Some
@@ -78,20 +77,16 @@ end = struct
             (Compilation_mode.Per_mode.of_list
                ~init:None
                ((Compilation_context.for_ hd, Some hd)
-                :: List.map current ~f:(fun (k, v) -> k, Some v))))
-    | None -> tl
-  ;;
-
-  let cons_maybe hd_o tl =
-    match hd_o with
-    | Some hd -> hd :: tl
-    | None -> tl
+                :: List.map current ~f:(fun (k, v) -> k, Some v)))))
   ;;
 
   let cons acc x =
-    { merlin = cons_maybe x.merlin acc.merlin
-    ; cctx = add_map_maybe x.cctx acc.cctx
-    ; source_dirs = cons_maybe x.source_dirs acc.source_dirs
+    { merlin = List.rev_append x.merlin acc.merlin
+    ; cctx = add_map x.cctx acc.cctx
+    ; source_dirs =
+        (match x.source_dirs with
+         | None -> acc.source_dirs
+         | Some source_dir -> source_dir :: acc.source_dirs)
     ; js =
         (match x.js with
          | None -> acc.js
@@ -107,7 +102,7 @@ end = struct
   ;;
 
   let with_cctx_merlin ~loc (cctx, merlin) =
-    { empty_none with merlin = Some merlin; cctx = Some (loc, cctx) }
+    { empty_none with merlin = [ Merlin.group [ merlin ] ]; cctx = [ loc, cctx ] }
   ;;
 
   let if_available_buildable ~loc f = function
@@ -129,12 +124,19 @@ end = struct
           (Scope.libs scope)
           (Local (Library.to_lib_id ~src_dir lib))
       in
-      if_available_buildable
-        ~loc:lib.buildable.loc
+      if_available
         (fun () ->
-           Lib_rules.rules lib ~sctx ~scope ~dir_contents ~expander
-           >>| Compilation_mode.Per_mode.choose
-           >>| Option.value_exn)
+           let+ cctx_merlins = Lib_rules.rules lib ~sctx ~scope ~dir_contents ~expander in
+           let cctx_merlins =
+             Compilation_mode.Per_mode.to_list cctx_merlins |> List.map ~f:snd
+           in
+           let cctx =
+             List.map cctx_merlins ~f:(fun (cctx, _) -> lib.buildable.loc, cctx)
+           in
+           match List.map cctx_merlins ~f:snd with
+           | [] -> { empty_none with cctx }
+           | merlin :: merlins ->
+             { empty_none with merlin = [ Merlin.group (merlin :: merlins) ]; cctx })
         enabled_if
     | Foreign_library.T lib ->
       Expander.eval_blang expander lib.enabled_if

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -561,6 +561,7 @@ let library_rules
       ~compile_info
       ~ctx_dir
       ~for_merlin
+      ~merlin_ident
   =
   let modules = Compilation_context.modules cctx in
   let obj_dir = Compilation_context.obj_dir cctx in
@@ -665,8 +666,9 @@ let library_rules
       ~libname:(Some (snd lib.name))
       ~obj_dir
       ~dialects:(Dune_project.dialects (Scope.project scope))
-      ~ident:(Merlin_ident.for_lib (Library.best_name lib))
+      ~ident:merlin_ident
       ~for_
+      ~is_default:for_merlin
       ~parameters
   in
   merlin
@@ -715,7 +717,7 @@ let compile_context (lib : Library.t) ~sctx ~dir_contents ~expander ~scope ~for_
 let rules (lib : Library.t) ~sctx ~dir_contents ~expander ~scope =
   let dir = Dir_contents.dir dir_contents in
   let buildable = lib.buildable in
-  let f ~for_ ~for_merlin =
+  let f ~for_ ~for_merlin ~merlin_ident =
     let* local_lib, compile_info, source_modules, parameters =
       compile_context_data lib ~dir_contents ~scope ~for_
     in
@@ -749,6 +751,7 @@ let rules (lib : Library.t) ~sctx ~dir_contents ~expander ~scope =
         ~compile_info
         ~ctx_dir:dir
         ~for_merlin
+        ~merlin_ident
     in
     cctx, merlin
   in
@@ -765,7 +768,6 @@ let rules (lib : Library.t) ~sctx ~dir_contents ~expander ~scope =
         ~dir
         ~lib_config
     in
-    let merlin_ident = Merlin_ident.for_lib (Library.best_name lib) in
     let* modes =
       let+ effective_modes =
         Lib_info.effective_modes
@@ -789,6 +791,7 @@ let rules (lib : Library.t) ~sctx ~dir_contents ~expander ~scope =
           ~allow_overlaps:buildable.allow_overlapping_dependencies
       in
       let* () = Buildable_rules.gen_select_rules sctx compile_info ~dir ~for_ in
+      let merlin_ident = Merlin_ident.for_lib (Library.best_name lib) in
       let+ r =
         Buildable_rules.with_lib_deps
           (Super_context.context sctx)
@@ -796,7 +799,7 @@ let rules (lib : Library.t) ~sctx ~dir_contents ~expander ~scope =
           ~dir
           ~f:(fun () ->
             let for_merlin = Compilation_mode.equal for_ for_merlin in
-            f ~for_ ~for_merlin)
+            f ~for_ ~for_merlin ~merlin_ident)
       in
       for_, Some r)
   in

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -614,6 +614,7 @@ let setup_emit_cmj_rules
         ~ident:merlin_ident
         ~dialects:(Dune_project.dialects (Scope.project scope))
         ~for_
+        ~is_default:true
         ~parameters:(Resolve.return []) )
   in
   let* () = Buildable_rules.gen_select_rules sctx compile_info ~dir ~for_ in

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -60,7 +60,8 @@ module Processed = struct
 
   (* Most of the configuration is shared across a same lib/exe... *)
   type config =
-    { stdlib_dir : Path.t option
+    { for_ : Compilation_mode.t
+    ; stdlib_dir : Path.t option
     ; source_root : Path.t
     ; obj_dirs : Path.Set.t
     ; src_dirs : Path.Set.t
@@ -85,7 +86,8 @@ module Processed = struct
   let config_repr =
     Repr.record
       "merlin-config"
-      [ Repr.field "stdlib_dir" (Repr.option Path.repr) ~get:(fun t -> t.stdlib_dir)
+      [ Repr.field "for_" Compilation_mode.repr ~get:(fun t -> t.for_)
+      ; Repr.field "stdlib_dir" (Repr.option Path.repr) ~get:(fun t -> t.stdlib_dir)
       ; Repr.field "source_root" Path.repr ~get:(fun t -> t.source_root)
       ; Repr.field "obj_dirs" path_set_repr ~get:(fun t -> t.obj_dirs)
       ; Repr.field "src_dirs" path_set_repr ~get:(fun t -> t.src_dirs)
@@ -117,11 +119,14 @@ module Processed = struct
   ;;
 
   (* ...but modules can have different preprocessing specifications*)
-  type t =
+  type configuration =
     { config : config
     ; per_file_config : module_config Path.Build.Map.t
     ; pp_config : pp_flag option Module_name.Per_item.t
+    ; is_default : bool
     }
+
+  type t = configuration list
 
   type output_format =
     [ `Text
@@ -154,9 +159,9 @@ module Processed = struct
     ;;
   end
 
-  let repr =
+  let configuration_repr =
     Repr.record
-      "merlin-processed"
+      "merlin-processed-configuration"
       [ Repr.field "config" config_repr ~get:(fun t -> t.config)
       ; Repr.field
           "per_file_config"
@@ -166,9 +171,11 @@ module Processed = struct
           "pp_config"
           (Module_name.Per_item.repr (Repr.option pp_flag_repr))
           ~get:(fun t -> t.pp_config)
+      ; Repr.field "is_default" Repr.bool ~get:(fun t -> t.is_default)
       ]
   ;;
 
+  let repr = Repr.list configuration_repr
   let to_dyn = Repr.to_dyn repr
 
   module D = struct
@@ -176,7 +183,7 @@ module Processed = struct
 
     let name = "merlin-conf"
     let sharing = false
-    let version = 8
+    let version = 9
 
     let repr =
       Repr.view Repr.string ~to_:(fun _ -> "Use [dune ocaml dump-dot-merlin] instead")
@@ -213,7 +220,8 @@ module Processed = struct
         ~opens
         ~pp
         ~reader
-        { stdlib_dir
+        { for_ = _
+        ; stdlib_dir
         ; source_root
         ; obj_dirs
         ; src_dirs
@@ -376,7 +384,7 @@ module Processed = struct
     Buffer.contents b
   ;;
 
-  let get { per_file_config; pp_config; config } ~file =
+  let get_configuration { per_file_config; pp_config; config; is_default = _ } ~file =
     let open Option.O in
     let+ { module_; opens; reader } =
       let find file = Path.Build.Map.find per_file_config file in
@@ -401,7 +409,23 @@ module Processed = struct
     to_sexp ~unit_name ~opens ~pp ~reader config
   ;;
 
-  let dump_entries { per_file_config; pp_config; config } : Dump_entry.t list =
+  let get configurations ~file =
+    let rec loop fallback = function
+      | [] -> fallback
+      | configuration :: configurations ->
+        (match get_configuration configuration ~file with
+         | None -> loop fallback configurations
+         | Some directives ->
+           if configuration.is_default
+           then Some directives
+           else loop (Option.first_some fallback (Some directives)) configurations)
+    in
+    loop None configurations
+  ;;
+
+  let dump_entries { per_file_config; pp_config; config; is_default = _ }
+    : Dump_entry.t list
+    =
     Path.Build.Map.to_list per_file_config
     |> List.map ~f:(fun (source_path, { module_; opens; reader }) ->
       let module_name = Module.name module_ in
@@ -428,7 +452,8 @@ module Processed = struct
   let print_file path =
     match load_file path with
     | Error msg -> Printf.eprintf "%s\n" msg
-    | Ok t -> dump_entries t |> List.iter ~f:print_entry
+    | Ok configurations ->
+      List.concat_map configurations ~f:dump_entries |> List.iter ~f:print_entry
   ;;
 
   let print_files format paths =
@@ -439,7 +464,7 @@ module Processed = struct
          Result.List.map paths ~f:(fun path ->
            match load_file path with
            | Error msg -> Error msg
-           | Ok t -> Ok (dump_entries t))
+           | Ok configurations -> Ok (List.concat_map configurations ~f:dump_entries))
        with
        | Error msg -> Printf.eprintf "%s\n" msg
        | Ok entries ->
@@ -452,78 +477,88 @@ module Processed = struct
   let print_generic_dot_merlin paths =
     match Result.List.map paths ~f:load_file with
     | Error msg -> Printf.eprintf "%s\n" msg
-    | Ok [] -> Printf.eprintf "No merlin configuration found.\n"
-    | Ok (init :: tl) ->
-      let ( pp_configs
-          , obj_dirs
-          , src_dirs
-          , hidden_obj_dirs
-          , hidden_src_dirs
-          , flags
-          , extensions
-          , indexes )
-        =
-        (* We merge what is easy to merge and ignore the rest *)
-        List.fold_left
-          tl
-          ~init:
-            ( [ init.pp_config ]
-            , init.config.obj_dirs
-            , init.config.src_dirs
-            , init.config.hidden_obj_dirs
-            , init.config.hidden_src_dirs
-            , [ init.config.flags ]
-            , init.config.extensions
-            , init.config.indexes )
-          ~f:
-            (fun
-              ( acc_pp
-              , acc_obj
-              , acc_src
-              , acc_hidden_obj
-              , acc_hidden_src
-              , acc_flags
-              , acc_ext
-              , acc_indexes )
-              { per_file_config = _
-              ; pp_config
-              ; config =
-                  { stdlib_dir = _
-                  ; source_root = _
-                  ; obj_dirs
-                  ; src_dirs
-                  ; hidden_obj_dirs
-                  ; hidden_src_dirs
-                  ; flags
-                  ; extensions
-                  ; indexes
-                  ; parameters = _
-                  }
-              }
-            ->
-            ( pp_config :: acc_pp
-            , Path.Set.union acc_obj obj_dirs
-            , Path.Set.union acc_src src_dirs
-            , Path.Set.union acc_hidden_obj hidden_obj_dirs
-            , Path.Set.union acc_hidden_src hidden_src_dirs
-            , flags :: acc_flags
-            , extensions @ acc_ext
-            , indexes @ acc_indexes ))
+    | Ok containers ->
+      let configurations =
+        List.filter_map containers ~f:(fun configurations ->
+          Option.first_some
+            (List.find configurations ~f:(fun configuration -> configuration.is_default))
+            (List.hd_opt configurations))
       in
-      Printf.printf
-        "%s\n"
-        (to_dot_merlin
-           init.config.stdlib_dir
-           init.config.source_root
-           pp_configs
-           flags
-           obj_dirs
-           src_dirs
-           hidden_obj_dirs
-           hidden_src_dirs
-           extensions
-           indexes
-           init.config.parameters)
+      (match configurations with
+       | [] -> Printf.eprintf "No merlin configuration found.\n"
+       | init :: tl ->
+         let ( pp_configs
+             , obj_dirs
+             , src_dirs
+             , hidden_obj_dirs
+             , hidden_src_dirs
+             , flags
+             , extensions
+             , indexes )
+           =
+           (* We merge what is easy to merge and ignore the rest *)
+           List.fold_left
+             tl
+             ~init:
+               ( [ init.pp_config ]
+               , init.config.obj_dirs
+               , init.config.src_dirs
+               , init.config.hidden_obj_dirs
+               , init.config.hidden_src_dirs
+               , [ init.config.flags ]
+               , init.config.extensions
+               , init.config.indexes )
+             ~f:
+               (fun
+                 ( acc_pp
+                 , acc_obj
+                 , acc_src
+                 , acc_hidden_obj
+                 , acc_hidden_src
+                 , acc_flags
+                 , acc_ext
+                 , acc_indexes )
+                 { per_file_config = _
+                 ; pp_config
+                 ; is_default = _
+                 ; config =
+                     { for_ = _
+                     ; stdlib_dir = _
+                     ; source_root = _
+                     ; obj_dirs
+                     ; src_dirs
+                     ; hidden_obj_dirs
+                     ; hidden_src_dirs
+                     ; flags
+                     ; extensions
+                     ; indexes
+                     ; parameters = _
+                     }
+                 }
+               ->
+               ( pp_config :: acc_pp
+               , Path.Set.union acc_obj obj_dirs
+               , Path.Set.union acc_src src_dirs
+               , Path.Set.union acc_hidden_obj hidden_obj_dirs
+               , Path.Set.union acc_hidden_src hidden_src_dirs
+               , flags :: acc_flags
+               , extensions @ acc_ext
+               , indexes @ acc_indexes ))
+         in
+         Printf.printf
+           "%s\n"
+           (to_dot_merlin
+              init.config.stdlib_dir
+              init.config.source_root
+              pp_configs
+              flags
+              obj_dirs
+              src_dirs
+              hidden_obj_dirs
+              hidden_src_dirs
+              extensions
+              indexes
+              init.config.parameters))
   ;;
 end
 
@@ -558,6 +593,7 @@ module Unprocessed = struct
 
   type t =
     { ident : Merlin_ident.t
+    ; is_default : bool
     ; config : config
     ; modules : Modules.With_vlib.t
     }
@@ -574,6 +610,7 @@ module Unprocessed = struct
         ~dialects
         ~ident
         ~for_
+        ~is_default
         ~parameters
     =
     (* Merlin shouldn't cause the build to fail, so we just ignore errors *)
@@ -602,7 +639,7 @@ module Unprocessed = struct
       ; parameters
       }
     in
-    { ident; config; modules }
+    { ident; is_default; config; modules }
   ;;
 
   let encode_command =
@@ -720,6 +757,7 @@ module Unprocessed = struct
   let process
         ({ modules
          ; ident = _
+         ; is_default
          ; config =
              { stdlib_dir
              ; extensions
@@ -798,7 +836,8 @@ module Unprocessed = struct
       in
       let obj_dirs = Path.Set.union deps_obj_dirs objs_dirs in
       let source_root = Path.Source.root |> Path.source in
-      { Processed.stdlib_dir
+      { Processed.for_ = t.config.for_
+      ; stdlib_dir
       ; source_root
       ; src_dirs
       ; obj_dirs
@@ -833,19 +872,26 @@ module Unprocessed = struct
           (src, config) :: (src_without_extension, config) :: acc))
       |> Path.Build.Map.of_list_reduce ~f:(fun existing _ -> existing)
     in
-    { Processed.pp_config; config; per_file_config }
+    { Processed.pp_config; config; per_file_config; is_default }
   ;;
 end
 
-let dot_merlin sctx ~dir ~more_src_dirs ~expander (t : Unprocessed.t) =
-  let merlin_file = Merlin_ident.merlin_file_path dir t.ident in
+type group = Unprocessed.t Nonempty_list.t
+
+let group configurations = configurations
+
+let dot_merlin sctx ~dir ~more_src_dirs ~expander (first :: _ as configurations : group) =
+  let merlin_file = Merlin_ident.merlin_file_path dir first.ident in
   let* () =
     Rules.Produce.Alias.add_deps
       (Alias.make Alias0.check ~dir)
       (Action_builder.path (Path.build merlin_file))
   in
   let action =
-    Unprocessed.process t sctx ~dir ~more_src_dirs ~expander
+    Nonempty_list.to_list configurations
+    |> List.map ~f:(fun configuration ->
+      Unprocessed.process configuration sctx ~dir ~more_src_dirs ~expander)
+    |> Action_builder.all
     |> Action_builder.map ~f:Processed.Persist.to_string
     |> Action_builder.with_no_targets
     |> Action_builder.With_targets.write_file_dyn merlin_file
@@ -853,10 +899,10 @@ let dot_merlin sctx ~dir ~more_src_dirs ~expander (t : Unprocessed.t) =
   Super_context.add_rule sctx ~dir action
 ;;
 
-let add_rules sctx ~dir ~more_src_dirs ~expander merlin =
+let add_rules sctx ~dir ~more_src_dirs ~expander group =
   Memo.when_
     (Context.merlin (Super_context.context sctx))
-    (fun () -> dot_merlin sctx ~more_src_dirs ~expander ~dir merlin)
+    (fun () -> dot_merlin sctx ~more_src_dirs ~expander ~dir group)
 ;;
 
 let more_src_dirs dir_contents ~source_dirs =

--- a/src/dune_rules/merlin/merlin.mli
+++ b/src/dune_rules/merlin/merlin.mli
@@ -59,12 +59,16 @@ val make
   -> dialects:Dialect.DB.t
   -> ident:Merlin_ident.t
   -> for_:Compilation_mode.t
+  -> is_default:bool
   -> parameters:Module_name.t list Resolve.t
        (** The `parameters` argument takes the list of parameters from the
        compilation context and stores it in the form of `["-parameter"; "P1";
        "-parameter"; "P2"]` where P1 and P2 are the parameters. *)
   -> t
 
+type group
+
+val group : t Nonempty_list.t -> group
 val more_src_dirs : Dir_contents.t -> source_dirs:Path.Source.t list -> Path.Source.t list
 
 (** Add rules for generating the merlin configuration of a specific stanza
@@ -74,7 +78,7 @@ val add_rules
   -> dir:Path.Build.t
   -> more_src_dirs:Path.Source.t list
   -> expander:Expander.t
-  -> t
+  -> group
   -> unit Memo.t
 
 val pp_config

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -529,9 +529,9 @@ Melange-only Merlin configurations use Melange preprocessing.
   > | select(.[0] == "FLG" and .[1][0] == "-pp")
   > | .[1][1]
   > | if contains("pp_melange") then "melange" else "ocaml" end' | sort -u
-  ocaml
+  melange
 
-Mixed OCaml/Melange libraries generate separate Merlin configuration files.
+Mixed OCaml/Melange libraries store both configurations in one stanza file.
 
   $ mkdir mixed
   $ cat > mixed/dune-project <<EOF
@@ -558,13 +558,20 @@ Mixed OCaml/Melange libraries generate separate Merlin configuration files.
   >  (melange.preprocess
   >   (action
   >    (run sh %{dep:pp_melange.sh} %{input-file}))))
+  > (library
+  >  (name aaa)
+  >  (modules aaa))
   > EOF
   $ cat > mixed/foo.ml <<EOF
   > let x = "foo"
   > EOF
+  $ cat > mixed/aaa.ml <<EOF
+  > let x = "aaa"
+  > EOF
 
   $ dune build --root mixed @check
   $ find mixed/_build/default/.merlin-conf -type f | sort
+  mixed/_build/default/.merlin-conf/lib-aaa
   mixed/_build/default/.merlin-conf/lib-mixed
 
 The old `File` query still returns the default OCaml Merlin configuration.
@@ -574,6 +581,11 @@ The old `File` query still returns the default OCaml Merlin configuration.
    (B $TESTCASE_ROOT/mixed/_build/default/.mixed.objs/byte)
   $ query_ocaml_merlin_pp "$PWD/mixed/foo.ml" --root mixed | grep -E 'MELC_STDLIB|\.objs/melange|pp_melange'
   [1]
+
+Dump-dot-merlin also uses the default OCaml configuration.
+
+  $ dune ocaml dump-dot-merlin --root mixed "$PWD/mixed" | grep -E '\.mixed\.objs/(byte|melange)'
+  B $TESTCASE_ROOT/mixed/_build/default/.mixed.objs/byte
 
 Both generated configurations remain available to debug tooling.
 
@@ -597,5 +609,10 @@ Both generated configurations remain available to debug tooling.
       "mode": "ocaml",
       "obj_dir": "_build/default/.mixed.objs/byte",
       "preprocess": "ocaml"
+    },
+    {
+      "mode": "melange",
+      "obj_dir": "_build/default/.mixed.objs/melange",
+      "preprocess": "melange"
     }
   ]


### PR DESCRIPTION
Store all effective Merlin configurations for a stanza in one `.merlin-conf` file while preserving the existing default `File` query behavior.