### PR TITLE
feat(pkg): allow lock-dir pkgs to dep on workspace pkgs (in&out)

### DIFF
--- a/bin/describe/describe_pkg.ml
+++ b/bin/describe/describe_pkg.ml
@@ -5,14 +5,18 @@ module Local_package = Dune_pkg.Local_package
 module Show_lock = struct
   let print_lock lock_dir_arg () =
     let open Fiber.O in
-    let* lock_dir_paths =
-      Memo.run (Workspace.workspace ())
-      >>| Pkg.Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dir_arg
+    let* lock_dir_paths, external_packages =
+      Memo.run
+        (let open Memo.O in
+         let* workspace = Workspace.workspace () in
+         let+ local_packages = Pkg.Pkg_common.find_local_packages in
+         ( Pkg.Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dir_arg workspace
+         , Package_name.Set.of_keys local_packages ))
     in
     Fiber.parallel_map lock_dir_paths ~f:(fun lock_dir_path ->
       let lock_dir_path = Path.source lock_dir_path in
       let+ platform = Pkg.Pkg_common.solver_env_from_system_and_context ~lock_dir_path in
-      let lock_dir = Lock_dir.read_disk_exn lock_dir_path in
+      let lock_dir = Lock_dir.read_disk_exn lock_dir_path ~external_packages in
       let packages =
         Lock_dir.Packages.pkgs_on_platform_by_name lock_dir.packages ~platform
         |> Package_name.Map.values
@@ -121,14 +125,14 @@ module List_locked_dependencies = struct
     |> Pp.vbox
   ;;
 
-  let enumerate_lock_dirs_by_path workspace ~lock_dirs =
+  let enumerate_lock_dirs_by_path workspace ~lock_dirs ~external_packages =
     let lock_dirs =
       Pkg.Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dirs workspace
     in
     List.filter_map lock_dirs ~f:(fun lock_dir_path ->
       if Fpath.exists (Path.Source.to_string lock_dir_path)
       then (
-        match Lock_dir.read_disk_exn (Path.source lock_dir_path) with
+        match Lock_dir.read_disk_exn (Path.source lock_dir_path) ~external_packages with
         | lock_dir -> Some (lock_dir_path, lock_dir)
         | exception User_error.E e ->
           User_warning.emit
@@ -144,11 +148,15 @@ module List_locked_dependencies = struct
   let list_locked_dependencies ~transitive ~lock_dirs () =
     let open Fiber.O in
     let* lock_dirs_by_path, local_packages =
-      let open Memo.O in
-      Memo.both
-        (Workspace.workspace () >>| enumerate_lock_dirs_by_path ~lock_dirs)
-        Pkg.Pkg_common.find_local_packages
-      |> Memo.run
+      Memo.run
+        (let open Memo.O in
+         let* local_packages = Pkg.Pkg_common.find_local_packages in
+         let external_packages = Package_name.Set.of_keys local_packages in
+         let+ lock_dirs_by_path =
+           Workspace.workspace ()
+           >>| enumerate_lock_dirs_by_path ~lock_dirs ~external_packages
+         in
+         lock_dirs_by_path, local_packages)
     in
     let+ pp =
       Fiber.parallel_map lock_dirs_by_path ~f:(fun (lock_dir_path, lock_dir) ->

--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -169,7 +169,11 @@ let lockdir_status dev_tool =
   | false -> Memo.return `No_lockdir
   | true ->
     let dev_tool_lock_dir = Path.external_ dev_tool_lock_dir in
-    (match Lock_dir.read_disk dev_tool_lock_dir with
+    (* Dev tool lockdirs are produced by the solver running over a single
+       package and never reference workspace packages, so validate strictly. *)
+    (match
+       Lock_dir.read_disk dev_tool_lock_dir ~external_packages:Package_name.Set.empty
+     with
      | Error _ -> Memo.return `No_lockdir
      | Ok { packages; _ } ->
        let* platform =

--- a/bin/pkg/outdated.ml
+++ b/bin/pkg/outdated.ml
@@ -15,7 +15,8 @@ let find_outdated_packages ~transitive ~lock_dirs_arg () =
           ~repositories:(repositories_of_lock_dir workspace ~lock_dir_path)
       and+ local_packages = Memo.run find_local_packages
       and+ platform = solver_env_from_system_and_context ~lock_dir_path in
-      let lock_dir = Dune_pkg.Lock_dir.read_disk_exn lock_dir_path in
+      let external_packages = Package_name.Set.of_keys local_packages in
+      let lock_dir = Dune_pkg.Lock_dir.read_disk_exn lock_dir_path ~external_packages in
       let packages =
         Dune_pkg.Lock_dir.Packages.pkgs_on_platform_by_name lock_dir.packages ~platform
       in

--- a/bin/pkg/validate_lock_dir.ml
+++ b/bin/pkg/validate_lock_dir.ml
@@ -15,7 +15,7 @@ let info =
 (* CR-someday alizter: The logic here is a little more complicated than it needs
    to be and can be simplified. *)
 
-let enumerate_lock_dirs_by_path ~lock_dirs () =
+let enumerate_lock_dirs_by_path ~lock_dirs ~external_packages () =
   let open Memo.O in
   let+ per_contexts =
     Workspace.workspace () >>| Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dirs
@@ -23,7 +23,7 @@ let enumerate_lock_dirs_by_path ~lock_dirs () =
   List.filter_map per_contexts ~f:(fun lock_dir_path ->
     if Fpath.exists (Path.Source.to_string lock_dir_path)
     then (
-      match Lock_dir.read_disk_exn (Path.source lock_dir_path) with
+      match Lock_dir.read_disk_exn (Path.source lock_dir_path) ~external_packages with
       | lock_dir -> Some (Ok (lock_dir_path, lock_dir))
       | exception User_error.E e -> Some (Error (lock_dir_path, `Parse_error e)))
     else None)
@@ -32,8 +32,14 @@ let enumerate_lock_dirs_by_path ~lock_dirs () =
 let validate_lock_dirs ~lock_dirs () =
   let open Fiber.O in
   let* lock_dirs_by_path, local_packages =
-    Memo.both (enumerate_lock_dirs_by_path ~lock_dirs ()) Pkg_common.find_local_packages
-    |> Memo.run
+    Memo.run
+      (let open Memo.O in
+       let* local_packages = Pkg_common.find_local_packages in
+       let external_packages = Package_name.Set.of_keys local_packages in
+       let+ lock_dirs_by_path =
+         enumerate_lock_dirs_by_path ~lock_dirs ~external_packages ()
+       in
+       lock_dirs_by_path, local_packages)
   in
   if List.is_empty lock_dirs_by_path
   then

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -1019,6 +1019,8 @@ module Packages = struct
     Package_name.Map.values t |> List.concat_map ~f:Package_version.Map.values
   ;;
 
+  let mem = Package_name.Map.mem
+
   let of_pkg_list pkgs =
     List.map pkgs ~f:(fun (pkg : Pkg.t) -> pkg.info.name, (pkg.info.version, pkg))
     |> Package_name.Map.of_list_multi
@@ -1142,17 +1144,35 @@ let to_dyn
    consolidated with non-portable lock directories. *)
 let uses_versioned_paths t = not (List.is_empty (snd t.solved_for_platforms))
 
-type missing_dependency =
+type invalid_dependency =
   { dependant_package : Pkg.t
   ; dependency : Package_name.t
   ; loc : Loc.t
   }
 
-(* [validate_packages packages] returns
+(* [validate_packages packages ~external_packages] returns
    [Error (`Missing_dependencies missing_dependencies)] where
    [missing_dependencies] is a non-empty list with an element for each package
-   dependency which doesn't have a corresponding entry in [packages]. *)
-let validate_packages packages =
+   dependency which doesn't have a corresponding entry in [packages] and is
+   not in [external_packages]. The [external_packages] set names dependency
+   targets that callers vouch for outside the lockdir (e.g. workspace
+   packages whose install entries are materialised by the build path). *)
+let validate_packages packages ~external_packages =
+  (* Use the full lockdir package table here rather than a platform-filtered
+     subset. Portable lockdirs may contain packages that are inactive on the
+     current platform, but a workspace package with the same name would still
+     make the dependency ambiguous across platforms. *)
+  let ambiguous_dependencies =
+    Packages.to_pkg_list packages
+    |> List.concat_map ~f:(fun (dependant_package : Pkg.t) ->
+      List.concat_map dependant_package.depends ~f:(fun conditional_depends ->
+        List.filter_map conditional_depends.value ~f:(fun depend ->
+          if
+            Package_name.Map.mem packages depend.name
+            && Package_name.Set.mem external_packages depend.name
+          then Some { dependant_package; dependency = depend.name; loc = depend.loc }
+          else None)))
+  in
   let missing_dependencies =
     Packages.to_pkg_list packages
     |> List.concat_map ~f:(fun (dependant_package : Pkg.t) ->
@@ -1163,12 +1183,14 @@ let validate_packages packages =
           if
             Package_name.Map.mem packages depend.name
             || Package_name.equal depend.name Dune_dep.name
+            || Package_name.Set.mem external_packages depend.name
           then None
           else Some { dependant_package; dependency = depend.name; loc = depend.loc })))
   in
-  if List.is_empty missing_dependencies
-  then Ok ()
-  else Error (`Missing_dependencies missing_dependencies)
+  match ambiguous_dependencies, missing_dependencies with
+  | _ :: _, _ -> Error (`Ambiguous_dependencies ambiguous_dependencies)
+  | [], _ :: _ -> Error (`Missing_dependencies missing_dependencies)
+  | [], [] -> Ok ()
 ;;
 
 let create_latest_version
@@ -1184,8 +1206,21 @@ let create_latest_version
     Package_name.Map.map packages ~f:(fun (pkg : Pkg.t) ->
       Package_version.Map.singleton pkg.info.version pkg)
   in
-  (match validate_packages packages with
+  (* The solver rejects workspace dependencies, so a well-formed solver
+     output should never contain references to packages outside the
+     lockdir. We pass [external_packages:empty] here so this assert catches
+     any solver bug that lets such a reference slip through. *)
+  (match validate_packages packages ~external_packages:Package_name.Set.empty with
    | Ok () -> ()
+   | Error (`Ambiguous_dependencies ambiguous_dependencies) ->
+     List.map ambiguous_dependencies ~f:(fun { dependant_package; dependency; loc = _ } ->
+       ( "ambiguous dependency"
+       , Dyn.record
+           [ "dependency", Package_name.to_dyn dependency
+           ; "dependency of", Package_name.to_dyn dependant_package.info.name
+           ] ))
+     @ [ "packages", Packages.to_dyn packages ]
+     |> Code_error.raise "Invalid package table"
    | Error (`Missing_dependencies missing_dependencies) ->
      List.map missing_dependencies ~f:(fun { dependant_package; dependency; loc = _ } ->
        ( "missing dependency"
@@ -1658,40 +1693,6 @@ struct
       package_name
   ;;
 
-  let check_packages packages ~lock_dir_path =
-    match validate_packages packages with
-    | Ok () -> Ok ()
-    | Error (`Missing_dependencies missing_dependencies) ->
-      List.iter missing_dependencies ~f:(fun { dependant_package; dependency; loc } ->
-        User_message.prerr
-          (User_message.make
-             ~loc
-             [ Pp.textf
-                 "The package %S depends on the package %S, but %S does not appear in \
-                  the lockdir %s."
-                 (Package_name.to_string dependant_package.info.name)
-                 (Package_name.to_string dependency)
-                 (Package_name.to_string dependency)
-                 (Path.to_string_maybe_quoted lock_dir_path)
-             ]));
-      Error
-        (User_error.make
-           ~hints:
-             [ Pp.concat
-                 ~sep:Pp.space
-                 [ Pp.text
-                     "This could indicate that the lockdir is corrupted. Delete it and \
-                      then regenerate it by running:"
-                 ; User_message.command "dune pkg lock"
-                 ]
-             ]
-           [ Pp.textf
-               "At least one package dependency is itself not present as a package in \
-                the lockdir %s."
-               (Path.to_string_maybe_quoted lock_dir_path)
-           ])
-  ;;
-
   let load lock_dir_path =
     let event =
       Dune_trace.(
@@ -1735,25 +1736,15 @@ struct
         pkg)
       >>| Packages.of_pkg_list
     in
-    let result =
-      check_packages packages ~lock_dir_path
-      |> Result.map ~f:(fun () ->
-        { version
-        ; dependency_hash
-        ; packages
-        ; ocaml
-        ; repos
-        ; expanded_solver_variable_bindings
-        ; solved_for_platforms
-        })
-    in
     Option.iter (Dune_trace.global ()) ~f:(fun trace -> Dune_trace.Out.finish trace event);
-    result
-  ;;
-
-  let load_exn lock_dir_path =
-    let open Io.O in
-    load lock_dir_path >>| User_error.ok_exn
+    { version
+    ; dependency_hash
+    ; packages
+    ; ocaml
+    ; repos
+    ; expanded_solver_variable_bindings
+    ; solved_for_platforms
+    }
   ;;
 end
 
@@ -1771,8 +1762,72 @@ module Load_immediate = Make_load (struct
     let with_lexbuf_from_file = Io.with_lexbuf_from_file
   end)
 
-let read_disk = Load_immediate.load
-let read_disk_exn = Load_immediate.load_exn
+(* Verify every dependency edge in [packages] resolves to a known target:
+   either another package in the lockdir, dune itself, or a name in
+   [external_packages] (typically workspace packages whose install entries
+   are materialised outside the lockdir). *)
+let check_packages packages ~lock_dir_path ~external_packages =
+  match validate_packages packages ~external_packages with
+  | Ok () -> Ok ()
+  | Error (`Ambiguous_dependencies ambiguous_dependencies) ->
+    List.iter ambiguous_dependencies ~f:(fun { dependant_package; dependency; loc } ->
+      User_message.prerr
+        (User_message.make
+           ~loc
+           [ Pp.textf
+               "The package %S depends on the package %S, but %S appears both in the \
+                lockdir %s and in the workspace."
+               (Package_name.to_string dependant_package.info.name)
+               (Package_name.to_string dependency)
+               (Package_name.to_string dependency)
+               (Path.to_string_maybe_quoted lock_dir_path)
+           ]));
+    Error
+      (User_error.make
+         [ Pp.text
+             "A package dependency cannot be resolved unambiguously because the same \
+              package name exists in both the lockdir and the workspace."
+         ])
+  | Error (`Missing_dependencies missing_dependencies) ->
+    List.iter missing_dependencies ~f:(fun { dependant_package; dependency; loc } ->
+      User_message.prerr
+        (User_message.make
+           ~loc
+           [ Pp.textf
+               "The package %S depends on the package %S, but %S does not appear in the \
+                lockdir %s."
+               (Package_name.to_string dependant_package.info.name)
+               (Package_name.to_string dependency)
+               (Package_name.to_string dependency)
+               (Path.to_string_maybe_quoted lock_dir_path)
+           ]));
+    Error
+      (User_error.make
+         ~hints:
+           [ Pp.concat
+               ~sep:Pp.space
+               [ Pp.text
+                   "This could indicate that the lockdir is corrupted. Delete it and \
+                    then regenerate it by running:"
+               ; User_message.command "dune pkg lock"
+               ]
+           ]
+         [ Pp.textf
+             "At least one package dependency is itself not present as a package in the \
+              lockdir %s."
+             (Path.to_string_maybe_quoted lock_dir_path)
+         ])
+;;
+
+let read_disk lock_dir_path ~external_packages =
+  let t = Load_immediate.load lock_dir_path in
+  check_packages t.packages ~lock_dir_path ~external_packages
+  |> Result.map ~f:(fun () -> t)
+;;
+
+let read_disk_exn lock_dir_path ~external_packages =
+  read_disk lock_dir_path ~external_packages |> User_error.ok_exn
+;;
 
 let transitive_dependency_closure t ~platform start =
   let missing_packages =

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -91,6 +91,7 @@ module Packages : sig
   type t
 
   val to_pkg_list : t -> Pkg.t list
+  val mem : t -> Package_name.t -> bool
   val pkgs_on_platform_by_name : t -> platform:Solver_env.t -> Pkg.t Package_name.Map.t
 
   (** All the packages grouped by the platforms where they are enabled. *)
@@ -157,8 +158,28 @@ module Write_disk : sig
   val commit : t -> unit
 end
 
-val read_disk : Path.t -> (t, User_message.t) result
-val read_disk_exn : Path.t -> t
+(** Read a lockdir from disk and verify that every dependency edge resolves
+    to either another package in the lockdir, dune itself, or a name in
+    [external_packages]. Pass [external_packages:Package_name.Set.empty]
+    to require the lockdir to be self-contained; pass workspace package
+    names to permit hand-written lockdirs that reference them. *)
+val read_disk
+  :  Path.t
+  -> external_packages:Package_name.Set.t
+  -> (t, User_message.t) result
+
+val read_disk_exn : Path.t -> external_packages:Package_name.Set.t -> t
+
+(** Verify the dependency graph of a loaded lockdir against an
+    [external_packages] set. Reports each missing or ambiguous edge with its
+    source location and returns a single [User_message.t] describing the
+    overall failure. An edge is ambiguous when its target appears both in the
+    lockdir and in [external_packages]. *)
+val check_packages
+  :  Packages.t
+  -> lock_dir_path:Path.t
+  -> external_packages:Package_name.Set.t
+  -> (unit, User_message.t) result
 
 module Make_load (Io : sig
     include Monad.S
@@ -167,8 +188,10 @@ module Make_load (Io : sig
     val readdir_with_kinds : Path.t -> (Filename.t * Unix.file_kind) list t
     val with_lexbuf_from_file : Path.t -> f:(Lexing.lexbuf -> 'a) -> 'a t
   end) : sig
-  val load : Path.t -> (t, User_message.t) result Io.t
-  val load_exn : Path.t -> t Io.t
+  (** Load a lockdir from disk without validating its dependency graph.
+      Callers are responsible for running {!check_packages} with the
+      appropriate [external_packages] set. *)
+  val load : Path.t -> t Io.t
 end
 
 (** [transitive_dependency_closure t ~platform names] returns the set of package names

--- a/src/dune_pkg/package_universe.ml
+++ b/src/dune_pkg/package_universe.ml
@@ -4,6 +4,7 @@ type t =
   { local_packages : Local_package.t Package_name.Map.t
   ; lock_dir : Lock_dir.t
   ; platform : Solver_env.t
+  ; lock_packages : Lock_dir.Pkg.t Package_name.Map.t
   ; version_by_package_name : Package_version.t Package_name.Map.t
   }
 
@@ -18,22 +19,30 @@ let lockdir_regenerate_hints =
   ]
 ;;
 
-let version_by_package_name ~platform local_packages (lock_dir : Lock_dir.t) =
+let version_by_package_name local_packages lock_packages =
   let from_local_packages =
     Package_name.Map.map local_packages ~f:(fun (local_package : Local_package.t) ->
       local_package.version)
   in
   let from_lock_dir =
-    Lock_dir.Packages.pkgs_on_platform_by_name ~platform lock_dir.packages
-    |> Package_name.Map.map ~f:(fun (pkg : Lock_dir.Pkg.t) -> pkg.info.version)
+    Package_name.Map.map lock_packages ~f:(fun (pkg : Lock_dir.Pkg.t) -> pkg.info.version)
   in
   let exception Duplicate_package of Package_name.t in
   try
-    Package_name.Map.union
-      from_local_packages
-      from_lock_dir
-      ~f:(fun duplicate_package_name _ _ ->
-        raise (Duplicate_package duplicate_package_name))
+    let versions =
+      Package_name.Map.union
+        from_local_packages
+        from_lock_dir
+        ~f:(fun duplicate_package_name _ _ ->
+          raise (Duplicate_package duplicate_package_name))
+    in
+    if Package_name.Map.mem versions Dune_dep.name
+    then versions
+    else
+      Package_name.Map.set
+        versions
+        Dune_dep.name
+        (Package_version.of_opam_package_version Dune_dep.version)
   with
   | Duplicate_package duplicate_package_name ->
     let local_package = Package_name.Map.find_exn local_packages duplicate_package_name in
@@ -54,8 +63,10 @@ let concrete_dependencies_of_local_package t local_package_name ~with_test =
     |> Resolve_opam_formula.filtered_formula_to_package_names
          ~with_test
          ~env:
-           (Solver_stats.Expanded_variable_bindings.to_solver_env
-              t.lock_dir.expanded_solver_variable_bindings
+           (Solver_env.extend
+              (Solver_stats.Expanded_variable_bindings.to_solver_env
+                 t.lock_dir.expanded_solver_variable_bindings)
+              t.platform
             |> Solver_env.to_env)
          ~packages:t.version_by_package_name
   with
@@ -232,79 +243,55 @@ let validate t =
   |> check_for_unnecessary_packges_in_lock_dir ~platform:t.platform t.lock_dir
 ;;
 
+let create_for_build ~platform local_packages lock_dir =
+  let lock_packages = Lock_dir.packages_on_platform lock_dir ~platform in
+  let version_by_package_name = version_by_package_name local_packages lock_packages in
+  { local_packages; lock_dir; platform; lock_packages; version_by_package_name }
+;;
+
 let create ~platform local_packages lock_dir =
   try
-    let version_by_package_name =
-      version_by_package_name ~platform local_packages lock_dir
-    in
-    let t = { local_packages; lock_dir; platform; version_by_package_name } in
+    let t = create_for_build ~platform local_packages lock_dir in
     validate t;
     Ok t
   with
   | User_error.E e -> Error e
 ;;
 
-let local_transitive_dependency_closure_without_test =
+let immediate_build_dependencies t package_name =
+  match Package_name.Map.find t.local_packages package_name with
+  | Some _ -> concrete_dependencies_of_local_package t package_name ~with_test:false
+  | None ->
+    (match Package_name.Map.find t.lock_packages package_name with
+     | None -> []
+     | Some package ->
+       Lock_dir.Conditional_choice.choose_for_platform
+         package.depends
+         ~platform:t.platform
+       |> Option.value ~default:[]
+       |> List.map ~f:(fun (dependency : Lock_dir.Dependency.t) -> dependency.name))
+;;
+
+let transitive_dependency_closure_without_test =
   let module Top_closure = Top_closure.Make (Package_name.Set) (Monad.Id) in
   fun t start ->
     match
       Top_closure.top_closure
-        ~deps:(fun a ->
-          concrete_dependencies_of_local_package t a ~with_test:false
-          |> List.filter ~f:(Package_name.Map.mem t.local_packages))
+        ~deps:(immediate_build_dependencies t)
         ~key:Fun.id
-        start
+        (Package_name.Set.to_list start)
     with
-    | Ok s -> Package_name.Set.of_list s
-    | Error _ -> Code_error.raise "cycles aren't allowed because we forbid post deps" []
-;;
-
-let transitive_dependency_closure_without_test t start =
-  let local_package_names = Package_name.Set.of_keys t.local_packages in
-  let local_transitive_dependency_closure =
-    local_transitive_dependency_closure_without_test
-      t
-      (Package_name.Set.inter local_package_names start |> Package_name.Set.to_list)
-  in
-  let non_local_transitive_dependency_closure =
-    let non_local_immediate_dependencies_of_local_transitive_dependency_closure =
-      local_transitive_dependency_closure
-      |> Package_name.Set.to_list
-      |> Package_name.Set.union_map ~f:(fun name ->
-        let all_deps =
-          concrete_dependencies_of_local_package t name ~with_test:false
-          |> Package_name.Set.of_list
-        in
-        Package_name.Set.diff all_deps local_package_names)
-    in
-    match
-      Lock_dir.transitive_dependency_closure
-        t.lock_dir
-        ~platform:t.platform
-        Package_name.Set.(
-          union
-            non_local_immediate_dependencies_of_local_transitive_dependency_closure
-            (diff start local_package_names))
-    with
-    | Ok x -> x
-    | Error (`Missing_packages missing_packages) ->
-      Code_error.raise
-        "Attempted to find non-existent packages in lockdir after validation which \
-         should not be possible"
-        (Package_name.Set.to_list missing_packages
-         |> List.map ~f:(fun p -> "missing package", Package_name.to_dyn p))
-  in
-  Package_name.Set.union
-    local_transitive_dependency_closure
-    non_local_transitive_dependency_closure
+    | Ok closure -> Package_name.Set.of_list closure
+    | Error cycle ->
+      User_error.raise
+        [ Pp.text "Dependency cycle between packages:"
+        ; Pp.chain cycle ~f:(fun package -> Pp.text (Package_name.to_string package))
+        ]
 ;;
 
 let contains_package t package_name =
   let in_local_packages = Package_name.Map.mem t.local_packages package_name in
-  let lock_dir_packages =
-    Lock_dir.Packages.pkgs_on_platform_by_name ~platform:t.platform t.lock_dir.packages
-  in
-  let in_lock_dir = Package_name.Map.mem lock_dir_packages package_name in
+  let in_lock_dir = Package_name.Map.mem t.lock_packages package_name in
   in_local_packages || in_lock_dir
 ;;
 
@@ -316,6 +303,14 @@ let check_contains_package t package_name =
           "Package %S is neither a local package nor present in the lockdir."
           (Package_name.to_string package_name)
       ]
+;;
+
+let build_dependency_closure t package =
+  check_contains_package t package;
+  let closure =
+    transitive_dependency_closure_without_test t (Package_name.Set.singleton package)
+  in
+  Package_name.Set.remove closure package
 ;;
 
 let all_dependencies t package ~traverse =
@@ -341,11 +336,7 @@ let non_test_dependencies t package ~traverse =
   | `Immediate ->
     concrete_dependencies_of_local_package t package ~with_test:false
     |> Package_name.Set.of_list
-  | `Transitive ->
-    let closure =
-      transitive_dependency_closure_without_test t (Package_name.Set.singleton package)
-    in
-    Package_name.Set.remove closure package
+  | `Transitive -> build_dependency_closure t package
 ;;
 
 let test_only_dependencies t package ~traverse =

--- a/src/dune_pkg/package_universe.mli
+++ b/src/dune_pkg/package_universe.mli
@@ -14,6 +14,19 @@ val create
   -> Lock_dir.t
   -> (t, User_message.t) result
 
+(** Create the package graph used to construct build rules. Unlike {!create},
+    this does not validate dependency hashes or reject unreachable packages in
+    hand-written lock directories. *)
+val create_for_build
+  :  platform:Solver_env.t
+  -> Local_package.t Package_name.Map.t
+  -> Lock_dir.t
+  -> t
+
+(** The packages needed to build the given package, across both workspace and
+    lock-directory dependency edges. *)
+val build_dependency_closure : t -> Package_name.t -> Package_name.Set.t
+
 val dependency_digest
   :  Local_package.t Package_name.Map.t
   -> Local_package.Dependency_hash.t option

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -727,10 +727,58 @@ let analyze_private_context_path components =
         | false -> `Invalid_context))
 ;;
 
+let is_private_pkg_path = function
+  | ".pkg" :: _ -> true
+  | _ -> false
+;;
+
+let raise_on_lock_dir_out_of_sync =
+  Per_context.create_by_name ~name:"check-lock-dir" (fun ctx ->
+    Memo.lazy_ (fun () ->
+      let* lock_dir_available = Lock_dir.lock_dir_active ctx in
+      if lock_dir_available
+      then (
+        let* path, lock_dir = Lock_dir.get_with_path ctx >>| User_error.ok_exn in
+        let* packages = Dune_load.packages () in
+        let local_packages =
+          Dune_lang.Package.Name.Map.map packages ~f:Dune_pkg.Local_package.of_package
+        in
+        (match
+           Dune_pkg.Package_universe.up_to_date
+             local_packages
+             ~dependency_hash:(Option.map ~f:snd lock_dir.dependency_hash)
+         with
+         | `Valid -> ()
+         | `Invalid ->
+           let source_path = Dune_pkg.Lock_dir.in_source_tree path in
+           let loc_path = Path.source source_path in
+           let loc = Loc.in_file (Path.relative loc_path "lock.dune") in
+           let hints = Pp.[ text "run dune pkg lock" ] in
+           User_error.raise
+             ~loc
+             ~hints
+             [ Pp.text "The lock dir is not sync with your dune-project" ]);
+        let external_packages = Dune_lang.Package.Name.Set.of_keys packages in
+        Memo.return
+          (Dune_pkg.Lock_dir.check_packages
+             lock_dir.packages
+             ~lock_dir_path:path
+             ~external_packages
+           |> User_error.ok_exn))
+      else Memo.return ())
+    |> Memo.Lazy.force)
+  |> Staged.unstage
+;;
+
 let private_context ~dir components _ctx =
   analyze_private_context_path components
   >>= function
   | `Invalid_context -> Memo.return Gen_rules.unknown_context
+  | `Valid (ctx, components) when is_private_pkg_path components ->
+    let* () = raise_on_lock_dir_out_of_sync ctx in
+    let+ lock_rules = Lock_rules.setup_rules ~dir ~components
+    and+ pkg_rules = Pkg_rules.setup_rules ctx ~dir ~components in
+    Gen_rules.combine lock_rules pkg_rules
   | `Valid (ctx, components) ->
     let+ lock_rules = Lock_rules.setup_rules ~dir ~components
     and+ pkg_rules = Pkg_rules.setup_rules ctx ~dir ~components in
@@ -745,37 +793,6 @@ let private_context ~dir components _ctx =
               Filename.of_string_exn (Context_name.to_string context_name))))
     in
     Gen_rules.make ~build_dir_only_sub_dirs (Memo.return Rules.empty)
-;;
-
-let raise_on_lock_dir_out_of_sync =
-  Per_context.create_by_name ~name:"check-lock-dir" (fun ctx ->
-    Memo.lazy_ (fun () ->
-      let* lock_dir_available = Lock_dir.lock_dir_active ctx in
-      if lock_dir_available
-      then
-        let* path, lock_dir = Lock_dir.get_with_path ctx >>| User_error.ok_exn in
-        let+ local_packages =
-          Dune_load.packages ()
-          >>| Dune_lang.Package.Name.Map.map ~f:Dune_pkg.Local_package.of_package
-        in
-        match
-          Dune_pkg.Package_universe.up_to_date
-            local_packages
-            ~dependency_hash:(Option.map ~f:snd lock_dir.dependency_hash)
-        with
-        | `Valid -> ()
-        | `Invalid ->
-          let source_path = Dune_pkg.Lock_dir.in_source_tree path in
-          let loc_path = Path.source source_path in
-          let loc = Loc.in_file (Path.relative loc_path "lock.dune") in
-          let hints = Pp.[ text "run dune pkg lock" ] in
-          User_error.raise
-            ~loc
-            ~hints
-            [ Pp.text "The lock dir is not sync with your dune-project" ]
-      else Memo.return ())
-    |> Memo.Lazy.force)
-  |> Staged.unstage
 ;;
 
 let gen_rules ctx ~dir components =
@@ -817,6 +834,17 @@ let gen_rules ctx ~dir components =
     let gen_pkg_alias_rule = Pkg_rules.setup_pkg_install_alias ~dir ctx in
     let+ sctx_rules = gen_rules ctx (Super_context.find_exn ctx) ~dir components in
     Gen_rules.combine sctx_rules gen_pkg_alias_rule
+;;
+
+let () =
+  Pkg_rules.set_project_package_universe (fun context_name ->
+    let* lock_dir = Lock_dir.get_exn context_name
+    and* platform = Lock_dir.Sys_vars.solver_env
+    and* local_packages =
+      Dune_load.packages () >>| Package.Name.Map.map ~f:Dune_pkg.Local_package.of_package
+    in
+    Dune_pkg.Package_universe.create_for_build ~platform local_packages lock_dir
+    |> Memo.return)
 ;;
 
 let () =

--- a/src/dune_rules/install_layout.ml
+++ b/src/dune_rules/install_layout.ml
@@ -40,6 +40,21 @@ let entry_resolver_fdecl
 
 let set_entry_resolver f = Fdecl.set entry_resolver_fdecl f
 
+let package_variable_resolver_fdecl
+  : (Context_name.t
+     -> Package.Name.t
+     -> OpamVariable.variable_contents Package_variable_name.Map.t Memo.t)
+      Fdecl.t
+  =
+  Fdecl.create Dyn.opaque
+;;
+
+let set_package_variable_resolver f = Fdecl.set package_variable_resolver_fdecl f
+
+let package_variables context package =
+  Fdecl.get package_variable_resolver_fdecl context package
+;;
+
 let dir ~context ~key =
   Path.Build.L.relative (Install.Context.dir ~context) [ ".packages"; key ]
 ;;

--- a/src/dune_rules/install_layout.mli
+++ b/src/dune_rules/install_layout.mli
@@ -4,6 +4,27 @@ val set_entry_resolver
   :  (Context_name.t -> Package.Name.t -> Install.Entry.Sourced.Unexpanded.t list Memo.t)
   -> unit
 
+val set_package_variable_resolver
+  :  (Context_name.t
+      -> Package.Name.t
+      -> OpamVariable.variable_contents Package_variable_name.Map.t Memo.t)
+  -> unit
+
+(* Resolved install-layout entries, keyed by their materialised destination
+   under {!root}. *)
+val entries
+  :  Context_name.t
+  -> Package.Name.Set.t
+  -> Path.t Install.Entry.Expanded.t Path.Build.Map.t Memo.t
+
+val package_variables
+  :  Context_name.t
+  -> Package.Name.t
+  -> OpamVariable.variable_contents Package_variable_name.Map.t Memo.t
+
+(** The materialised root for the install layout of the package set. *)
+val root : Context_name.t -> Package.Name.Set.t -> Path.Build.t
+
 (** Env extension for an action depending on a package set. Returns an env
     with PATH, OCAMLPATH, etc. prepended for the layout root, and registers
     the action's dependency on every install entry the layout produces for

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -1208,6 +1208,28 @@ let () =
     install_entries sctx package)
 ;;
 
+let package_variables package =
+  let module Variable = OpamVariable in
+  let+ packages = Dune_load.packages () in
+  match Package.Name.Map.find packages package with
+  | None -> Package_variable_name.Map.empty
+  | Some package ->
+    let version = Package.version package in
+    let dev = Option.is_none version in
+    let version = Option.value version ~default:Dune_pkg.Package_version.dev in
+    Package_variable_name.Map.of_list_exn
+      [ ( Package_variable_name.name
+        , Variable.S (Package.Name.to_string (Package.name package)) )
+      ; Package_variable_name.version, S (Package_version.to_string version)
+      ; Package_variable_name.dev, B dev
+      ]
+;;
+
+let () =
+  Install_layout.set_package_variable_resolver (fun _context_name package ->
+    package_variables package)
+;;
+
 let packages =
   let f sctx =
     let* packages = Dune_load.packages () in

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -235,18 +235,15 @@ let get_with_path =
             "No lock dir path for context available"
             [ "context", Context_name.to_dyn ctx ]
       in
-      read_lockdir path
-      >>= function
-      | Error e -> Memo.return (Error e)
-      | Ok lock_dir ->
-        let+ workspace_lock_dir = get_workspace_lock_dir ctx in
-        (match workspace_lock_dir with
-         | None -> ()
-         | Some workspace_lock_dir ->
-           Solver_stats.Expanded_variable_bindings.validate_against_solver_env
-             lock_dir.expanded_solver_variable_bindings
-             (workspace_lock_dir.solver_env |> Option.value ~default:Solver_env.empty));
-        Ok (path, lock_dir))
+      let* lock_dir = read_lockdir path in
+      let+ workspace_lock_dir = get_workspace_lock_dir ctx in
+      (match workspace_lock_dir with
+       | None -> ()
+       | Some workspace_lock_dir ->
+         Solver_stats.Expanded_variable_bindings.validate_against_solver_env
+           lock_dir.expanded_solver_variable_bindings
+           (workspace_lock_dir.solver_env |> Option.value ~default:Solver_env.empty));
+      Ok (path, lock_dir))
     |> Memo.Lazy.force)
   |> Staged.unstage
 ;;
@@ -254,11 +251,24 @@ let get_with_path =
 let get ctx = get_with_path ctx >>| Result.map ~f:snd
 let get_exn ctx = get ctx >>| User_error.ok_exn
 
+(* Dev-tool lockdirs are produced by the solver running over a
+   single-package universe (the tool itself), so they never reference
+   workspace packages. Validate strictly. *)
+let check_dev_tool_lock_dir ~path lock_dir =
+  Dune_pkg.Lock_dir.check_packages
+    lock_dir.packages
+    ~lock_dir_path:path
+    ~external_packages:Package.Name.Set.empty
+  |> User_error.ok_exn
+;;
+
 let of_dev_tool dev_tool =
   let path = dev_tool |> dev_tool_external_lock_dir |> Path.external_ in
   (* Ensure the internal lock dir is built so copy rules run *)
   let* () = Build_system.build_dir (dev_tool_lock_dir dev_tool) in
-  Load.load_exn path
+  let+ lock_dir = Load.load path in
+  check_dev_tool_lock_dir ~path lock_dir;
+  lock_dir
 ;;
 
 let of_dev_tool_if_lock_dir_exists dev_tool =
@@ -269,9 +279,10 @@ let of_dev_tool_if_lock_dir_exists dev_tool =
     Fpath.exists (Path.to_string path)
   in
   if exists
-  then
-    let+ t = Load.load_exn path in
-    Some t
+  then (
+    let+ t = Load.load path in
+    check_dev_tool_lock_dir ~path t;
+    Some t)
   else Memo.return None
 ;;
 

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -14,6 +14,24 @@ include struct
   module Dune_dep = Dune_dep
 end
 
+let project_package_universe_fdecl
+  : (Context_name.t -> Dune_pkg.Package_universe.t Memo.t) Fdecl.t
+  =
+  Fdecl.create Dyn.opaque
+;;
+
+let set_project_package_universe f = Fdecl.set project_package_universe_fdecl f
+
+let project_package_universe =
+  let memo =
+    Memo.create
+      "project-package-universe"
+      ~input:(module Context_name)
+      (fun context -> Fdecl.get project_package_universe_fdecl context)
+  in
+  Memo.exec memo
+;;
+
 module Variable = struct
   type value = OpamVariable.variable_contents =
     | B of bool
@@ -242,6 +260,19 @@ module Paths = struct
     }
   ;;
 
+  let of_install_layout name ~root ~relative =
+    let install_roots = lazy (install_roots ~target_dir:root ~relative) in
+    let install_paths = lazy (install_paths (Lazy.force install_roots) name ~relative) in
+    { source_dir = root
+    ; target_dir = root
+    ; extra_sources = root
+    ; name
+    ; install_paths
+    ; install_roots
+    ; prefix = root
+    }
+  ;;
+
   let extra_source t extra_source = Path.append_local t.extra_sources extra_source
 
   let extra_source_build t extra_source =
@@ -450,6 +481,10 @@ module Pkg = struct
     ; build_command : Build_command.t option
     ; install_command : Dune_lang.Action.t option
     ; depends : t list
+    ; workspace_deps : Package.Name.Set.t
+      (* Names of workspace packages this package depends on. Their install
+         entries are materialised through the install layout rather than
+         resolved against the lockdir. *)
     ; depends_on_dune : bool
       (* whether the package declares a dependency on Dune, even if Dune is stripped from [depends] *)
     ; depexts : Depexts.t list
@@ -477,6 +512,23 @@ module Pkg = struct
   ;;
 
   let deps_closure t = top_closure t.depends
+
+  let workspace_deps_closure t =
+    t :: deps_closure t
+    |> List.fold_left ~init:Package.Name.Set.empty ~f:(fun acc (pkg : t) ->
+      Package.Name.Set.union acc pkg.workspace_deps)
+  ;;
+
+  let deps_for_project_context deps =
+    (* [deps] is dependency-first, while [build_env_of_deps] reverses its input
+       by prepending paths. Mixed graphs need dependencies to stay first so a
+       workspace lookup cannot probe a downstream lock-directory package. *)
+    if
+      List.exists deps ~f:(fun pkg ->
+        not (Package.Name.Set.is_empty (workspace_deps_closure pkg)))
+    then List.rev deps
+    else deps
+  ;;
 
   let source_files t ~loc =
     let skip_dir = function
@@ -1173,6 +1225,53 @@ module Action_expander = struct
             in
             { binaries; dep_info }))
     ;;
+
+    let of_workspace_deps context workspace_deps =
+      if Package.Name.Set.is_empty workspace_deps
+      then Memo.return empty
+      else (
+        let root = Install_layout.root context workspace_deps in
+        let paths name =
+          Paths.of_install_layout name ~root ~relative:Path.Build.relative
+          |> Paths.map_path ~f:Path.build
+        in
+        let+ entries = Install_layout.entries context workspace_deps
+        and+ variables =
+          Memo.parallel_map (Package.Name.Set.to_list workspace_deps) ~f:(fun package ->
+            let+ variables = Install_layout.package_variables context package in
+            package, variables)
+        in
+        let variables = Package.Name.Map.of_list_exn variables in
+        let binaries =
+          Seq.fold_left
+            (Path.Build.Map.to_seq entries)
+            ~init:Filename.Map.empty
+            ~f:(fun acc (dst, (entry : Path.t Install.Entry.Expanded.t)) ->
+              match entry.section, entry.kind with
+              | Bin, File ->
+                Filename.Map.set
+                  acc
+                  (Filename.of_string_exn
+                     (Bin.strip_exe (Path.Build.basename dst |> Filename.to_string)))
+                  (Path.build dst)
+              | _ -> acc)
+        in
+        let dep_info =
+          Package.Name.Set.fold
+            workspace_deps
+            ~init:Package.Name.Map.empty
+            ~f:(fun name acc ->
+              let variables = Package.Name.Map.find_exn variables name in
+              Package.Name.Map.add_exn acc name (variables, paths name))
+        in
+        { binaries; dep_info })
+    ;;
+
+    let union a b =
+      { binaries = Filename.Map.union a.binaries b.binaries ~f:(fun _ _ b -> Some b)
+      ; dep_info = Package.Name.Map.union a.dep_info b.dep_info ~f:(fun _ _ b -> Some b)
+      }
+    ;;
   end
 
   let expander context (pkg : Pkg.t) =
@@ -1182,7 +1281,13 @@ module Action_expander = struct
           Pp.textf
             "Computing closure for package %S"
             (Package.Name.to_string pkg.info.name))
-        (fun () -> Pkg.deps_closure pkg |> Artifacts_and_deps.of_closure)
+        (fun () ->
+           let+ lockdir_deps = Pkg.deps_closure pkg |> Artifacts_and_deps.of_closure
+           and+ workspace_deps =
+             Pkg.workspace_deps_closure pkg
+             |> Artifacts_and_deps.of_workspace_deps context
+           in
+           Artifacts_and_deps.union lockdir_deps workspace_deps)
     in
     let env = Pkg.exported_value_env pkg in
     let depends =
@@ -1270,19 +1375,52 @@ module DB = struct
     type entry =
       { pkg : Pkg.t
       ; deps : dep list
+      ; workspace_deps : Package.Name.Set.t
       ; has_dune_dep : bool
       ; pkg_digest : Pkg_digest.t
       }
+
+    type resolved_dep =
+      | Lockdir of Pkg.t
+      | Workspace
+      | Dune
+      | System
+      | Unavailable_lockdir
 
     let entries_by_name_of_lock_dir
           (lock_dir : Dune_pkg.Lock_dir.t)
           ~platform
           ~system_provided
+          ~project_package_universe
       =
       let pkgs_by_name = Dune_pkg.Lock_dir.packages_on_platform lock_dir ~platform in
+      let resolve_dep name : resolved_dep =
+        if Dune_lang.Package_name.equal name Dune_dep.name
+        then Dune
+        else if Package.Name.Set.mem system_provided name
+        then System
+        else (
+          match Package.Name.Map.find pkgs_by_name name with
+          | Some pkg -> Lockdir pkg
+          | None ->
+            if Dune_pkg.Lock_dir.Packages.mem lock_dir.packages name
+            then Unavailable_lockdir
+            else Workspace)
+      in
       let cache =
         (* Cache so that the digest of each package is only computed once *)
         Package.Name.Table.create 10
+      in
+      let unavailable_dependency ~dependent ~dependency loc =
+        User_error.raise
+          ~loc
+          [ Pp.textf
+              "The package %S depends on the package %S, but %S is not available on the \
+               current platform."
+              (Package.Name.to_string dependent)
+              (Package.Name.to_string dependency)
+              (Package.Name.to_string dependency)
+          ]
       in
       let rec compute_entry (pkg : Pkg.t) ~seen_set ~seen_list =
         if Package.Name.Set.mem seen_set pkg.info.name
@@ -1300,35 +1438,73 @@ module DB = struct
         Package.Name.Table.find_or_add cache pkg.info.name ~f:(fun name ->
           let seen_set = Package.Name.Set.add seen_set name in
           let seen_list = pkg :: seen_list in
-          let has_dune_dep, deps =
+          let has_dune_dep, deps, workspace_deps =
             Dune_pkg.Lock_dir.Conditional_choice.choose_for_platform pkg.depends ~platform
             |> Option.value ~default:[]
             |> List.fold_right
-                 ~init:(false, [])
+                 ~init:(false, [], Package.Name.Set.empty)
                  ~f:
                    (fun
                      { Dune_pkg.Lock_dir.Dependency.name; loc = dep_loc }
-                     (has_dune_dep, acc)
+                     (has_dune_dep, deps, ws_deps)
                    ->
-                   match
-                     ( Dune_lang.Package_name.equal name Dune_dep.name
-                     , Package.Name.Set.mem system_provided name )
-                   with
-                   | true, _ -> true, acc
-                   | false, true -> has_dune_dep, acc
-                   | _, false ->
-                     let dep_pkg = Package.Name.Map.find_exn pkgs_by_name name in
-                     let dep_entry = compute_entry dep_pkg ~seen_set ~seen_list in
+                   match resolve_dep name with
+                   | Dune -> true, deps, ws_deps
+                   | System -> has_dune_dep, deps, ws_deps
+                   | Unavailable_lockdir ->
+                     unavailable_dependency
+                       ~dependent:pkg.info.name
+                       ~dependency:name
+                       dep_loc
+                   | Lockdir dep_pkg ->
                      ( has_dune_dep
-                     , { dep_pkg; dep_loc; dep_pkg_digest = dep_entry.pkg_digest } :: acc
-                     ))
+                     , add_lockdir_dep dep_pkg ~dep_loc ~seen_set ~seen_list deps
+                     , ws_deps )
+                   | Workspace ->
+                     let closure =
+                       match project_package_universe with
+                       | None -> Package.Name.Set.singleton name
+                       | Some package_universe ->
+                         let closure =
+                           Dune_pkg.Package_universe.build_dependency_closure
+                             package_universe
+                             name
+                         in
+                         Package.Name.Set.add closure name
+                     in
+                     let deps, ws_deps =
+                       Package.Name.Set.fold
+                         closure
+                         ~init:(deps, ws_deps)
+                         ~f:(fun name (deps, ws_deps) ->
+                           match resolve_dep name with
+                           | Dune | System -> deps, ws_deps
+                           | Workspace -> deps, Package.Name.Set.add ws_deps name
+                           | Unavailable_lockdir ->
+                             unavailable_dependency
+                               ~dependent:pkg.info.name
+                               ~dependency:name
+                               dep_loc
+                           | Lockdir dep_pkg ->
+                             ( add_lockdir_dep dep_pkg ~dep_loc ~seen_set ~seen_list deps
+                             , ws_deps ))
+                     in
+                     has_dune_dep, deps, ws_deps)
           in
           let pkg_digest =
             Pkg_digest.create
               pkg
               (List.map deps ~f:(fun { dep_pkg_digest; _ } -> dep_pkg_digest))
           in
-          { pkg; deps; has_dune_dep; pkg_digest })
+          { pkg; deps; workspace_deps; has_dune_dep; pkg_digest })
+      and add_lockdir_dep dep_pkg ~dep_loc ~seen_set ~seen_list deps =
+        if
+          List.exists deps ~f:(fun dep ->
+            Package.Name.equal dep.dep_pkg.info.name dep_pkg.info.name)
+        then deps
+        else (
+          let dep_entry = compute_entry dep_pkg ~seen_set ~seen_list in
+          { dep_pkg; dep_loc; dep_pkg_digest = dep_entry.pkg_digest } :: deps)
       in
       Package.Name.Map.map
         pkgs_by_name
@@ -1338,21 +1514,34 @@ module DB = struct
     (* Associate each package's digest with the package and its dependencies. *)
     type t = entry Pkg_digest.Map.t
 
-    let of_lock_dir lock_dir ~platform ~system_provided =
-      entries_by_name_of_lock_dir lock_dir ~platform ~system_provided
+    let of_lock_dir lock_dir ~platform ~system_provided ~project_package_universe =
+      entries_by_name_of_lock_dir
+        lock_dir
+        ~platform
+        ~system_provided
+        ~project_package_universe
       |> Package.Name.Map.values
       |> Pkg_digest.Map.of_list_map_exn ~f:(fun entry -> entry.pkg_digest, entry)
     ;;
 
-    (* Helper which is called when both tables have an entry with the same
-       digest. This happens when two lock directories have a package in common
-       and the transitive dependency closure of the package is identical in both
-       lock directories. Here we assert that the packages and their immediate
-       dependencies are identical as a sanity check. *)
+    (* Helper which is called when two lock directories contain the same
+       package and locked dependency closure. Project tables are only combined
+       with strictly validated dev-tool tables, which cannot contain workspace
+       dependencies. *)
     let union_check
           pkg_digest
-          ({ pkg = pkg_a; deps = deps_a; has_dune_dep = _; pkg_digest = _ } as entry)
-          { pkg = pkg_b; deps = deps_b; has_dune_dep = _; pkg_digest = _ }
+          ({ pkg = pkg_a
+           ; deps = deps_a
+           ; workspace_deps = _
+           ; has_dune_dep = _
+           ; pkg_digest = _
+           } as entry)
+          { pkg = pkg_b
+          ; deps = deps_b
+          ; workspace_deps = _
+          ; has_dune_dep = _
+          ; pkg_digest = _
+          }
       =
       if not (Pkg.equal (Pkg.remove_locs pkg_a) (Pkg.remove_locs pkg_b))
       then
@@ -1383,7 +1572,8 @@ module DB = struct
 
     let of_dev_tool_deps_if_lock_dir_exists dev_tool ~platform ~system_provided =
       let+ lock_dir_opt = Lock_dir.of_dev_tool_if_lock_dir_exists dev_tool in
-      Option.map lock_dir_opt ~f:(of_lock_dir ~platform ~system_provided)
+      Option.map lock_dir_opt ~f:(fun lock_dir ->
+        of_lock_dir lock_dir ~platform ~system_provided ~project_package_universe:None)
     ;;
 
     let all_existing_dev_tools =
@@ -1415,9 +1605,19 @@ module DB = struct
     { id = Id.gen (); pkg_digest_table; system_provided }
   ;;
 
-  let pkg_digest_of_name lock_dir platform pkg_name ~system_provided =
+  let pkg_digest_of_name
+        lock_dir
+        platform
+        pkg_name
+        ~system_provided
+        ~project_package_universe
+    =
     let entries_by_name =
-      Pkg_table.entries_by_name_of_lock_dir lock_dir ~platform ~system_provided
+      Pkg_table.entries_by_name_of_lock_dir
+        lock_dir
+        ~platform
+        ~system_provided
+        ~project_package_universe
     in
     let entry = Package.Name.Map.find_exn entries_by_name pkg_name in
     entry.pkg_digest
@@ -1449,12 +1649,17 @@ module DB = struct
              let system_provided = default_system_provided in
              let+ pkg_digest_table =
                let* lock_dir = Lock_dir.get_exn ctx
-               and* platform = Lock_dir.Sys_vars.solver_env in
+               and* platform = Lock_dir.Sys_vars.solver_env
+               and* project_package_universe = project_package_universe ctx in
                (if allow_sharing
                 then Memo.Lazy.force Pkg_table.all_existing_dev_tools
                 else Memo.return Pkg_table.empty)
                >>| Pkg_table.union
-                     (Pkg_table.of_lock_dir lock_dir ~platform ~system_provided)
+                     (Pkg_table.of_lock_dir
+                        lock_dir
+                        ~platform
+                        ~system_provided
+                        ~project_package_universe:(Some project_package_universe))
              in
              create ~pkg_digest_table ~system_provided)
     in
@@ -1465,9 +1670,16 @@ module DB = struct
      within that context. *)
   let of_project_pkg ctx pkg_name =
     let* lock_dir = Lock_dir.get_exn ctx
-    and* platform = Lock_dir.Sys_vars.solver_env in
+    and* platform = Lock_dir.Sys_vars.solver_env
+    and* project_package_universe = project_package_universe ctx in
     let+ t = of_ctx ctx ~allow_sharing:true in
-    t, pkg_digest_of_name lock_dir platform pkg_name ~system_provided:t.system_provided
+    ( t
+    , pkg_digest_of_name
+        lock_dir
+        platform
+        pkg_name
+        ~system_provided:t.system_provided
+        ~project_package_universe:(Some project_package_universe) )
   ;;
 
   (* Returns the db for all dev tools combined with the default context, and
@@ -1489,6 +1701,7 @@ module DB = struct
         platform
         (Pkg_dev_tool.package_name dev_tool)
         ~system_provided
+        ~project_package_universe:None
     in
     fun dev_tool ->
       let+ db =
@@ -1576,6 +1789,7 @@ end = struct
             ; enabled_on_platforms = _
             } as pkg
         ; deps
+        ; workspace_deps
         ; has_dune_dep
         ; pkg_digest = _
         } ->
@@ -1591,9 +1805,9 @@ end = struct
             let package_universe =
               match package_universe with
               | Dev_tool _ ->
-                (* The dependencies of dev tools are installed into the default
-                 context so they may be shared with the project's
-                 dependencies. *)
+                (* The dependencies of dev tools are installed into the
+                   default context so they may be shared with the
+                   project's dependencies. *)
                 Package_universe.Dependencies Context_name.default
               | _ -> package_universe
             in
@@ -1651,6 +1865,7 @@ end = struct
         ; build_command
         ; install_command
         ; depends
+        ; workspace_deps
         ; depends_on_dune = has_dune_dep
         ; depexts
         ; paths
@@ -2132,6 +2347,23 @@ let add_env env action =
   Action_builder.With_targets.map action ~f:(Action.Full.add_env env)
 ;;
 
+(* Extend the action's env with PATH, OCAMLPATH, etc. for the install
+   layout of [pkg]'s workspace deps. Uses concat semantics (the action's
+   existing values for path-like vars are preserved, with the layout's
+   prepended) and registers a dep on every install entry the layout
+   produces. *)
+let add_workspace_env context_name (pkg : Pkg.t) action =
+  let workspace_deps = Pkg.workspace_deps_closure pkg in
+  if Package.Name.Set.is_empty workspace_deps
+  then action
+  else
+    Action_builder.With_targets.map_build action ~f:(fun build ->
+      let open Action_builder.O in
+      let+ (a : Action.Full.t) = build
+      and+ ws_env = Install_layout.env context_name workspace_deps in
+      Action.Full.add_env (Install.Roots.extend_env_concat_path_vars a.env ws_env) a)
+;;
+
 let rule ?loc { Action_builder.With_targets.build; targets } =
   (* TODO this ignores the workspace file *)
   Rule.make ~info:(Rule.Info.of_loc_opt loc) ~targets build |> Rules.Produce.rule
@@ -2366,6 +2598,7 @@ let build_rule context_name ~source_deps (pkg : Pkg.t) =
    Action_builder.deps deps |> Action_builder.with_no_targets)
   (* TODO should we add env deps on these? *)
   >>> add_env (Pkg.exported_env pkg) build_action
+  |> add_workspace_env context_name pkg
   |> Action_builder.With_targets.add_directories
        ~directory_targets:[ pkg.write_paths.target_dir ]
 ;;
@@ -2588,9 +2821,8 @@ let which context =
     Filename.Map.find artifacts program)
 ;;
 
-let ocamlpath universe =
-  let+ all_project_deps = all_deps universe in
-  let env = Pkg.build_env_of_deps all_project_deps in
+let ocamlpath_of_deps deps =
+  let env = Pkg.build_env_of_deps deps in
   Env.Map.find env Dune_findlib.Config.ocamlpath_var
   |> Option.value ~default:[]
   |> List.map ~f:(function
@@ -2598,7 +2830,16 @@ let ocamlpath universe =
     | String s -> Path.of_filename_relative_to_initial_cwd s)
 ;;
 
-let project_ocamlpath context = ocamlpath (Dependencies context)
+let ocamlpath universe =
+  let+ deps = all_deps universe in
+  ocamlpath_of_deps deps
+;;
+
+let project_ocamlpath context =
+  let+ deps = all_project_deps context in
+  Pkg.deps_for_project_context deps |> ocamlpath_of_deps
+;;
+
 let dev_tool_ocamlpath dev_tool = ocamlpath (Dev_tool dev_tool)
 let lock_dir_active = Lock_dir.lock_dir_active
 let lock_dir_path = Lock_dir.get_path

--- a/src/dune_rules/pkg_rules.mli
+++ b/src/dune_rules/pkg_rules.mli
@@ -20,6 +20,11 @@ val setup_rules
 
 val lock_dir_path : Context_name.t -> Path.t option Memo.t
 val lock_dir_active : Context_name.t -> bool Memo.t
+
+val set_project_package_universe
+  :  (Context_name.t -> Dune_pkg.Package_universe.t Memo.t)
+  -> unit
+
 val ocaml_toolchain : Context_name.t -> Ocaml_toolchain.t Action_builder.t option Memo.t
 val which : Context_name.t -> (Filename.t -> Path.t option Memo.t) Staged.t
 val exported_env : Context_name.t -> Env.t Memo.t

--- a/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/basic.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/basic.t
@@ -16,17 +16,29 @@ A rule depends on the lock-dir package:
 
   $ write_lockdir_consumer_rule
 
-Lock-dir validation does not currently recognise workspace packages as
-valid dependency targets:
+The build succeeds. The rule depends on consumer's cookie; the
+workspace install layout is materialized as part of consumer's build:
 
-  $ dune build out 2>&1
-  File "_build/_private/default/.lock/dune.lock/consumer.pkg", line 2,
-  characters 9-22:
-  The package "consumer" depends on the package "workspace-lib", but
-  "workspace-lib" does not appear in the lockdir
-  _build/_private/default/.lock/dune.lock.
-  Error: At least one package dependency is itself not present as a package in
-  the lockdir _build/_private/default/.lock/dune.lock.
-  Hint: This could indicate that the lockdir is corrupted. Delete it and then
-  regenerate it by running: 'dune pkg lock'
-  [1]
+  $ dune build out
+  building consumer
+
+  $ dune rules --format=json _build/default/out | jq 'include "dune"; .[] | ruleDepFilePaths' | censor | sort
+  "_build/_private/default/.pkg/consumer.0.0.1-$DIGEST/target/cookie"
+
+  $ find _build/install/default/.packages -name '*.cmi' -o -name 'META' | censor | sort
+  _build/install/default/.packages/$DIGEST/lib/workspace-lib/META
+  _build/install/default/.packages/$DIGEST/lib/workspace-lib/workspace_lib.cmi
+
+Editing the workspace library and rebuilding incrementally still works:
+
+  $ cat > src/workspace_lib.ml <<EOF
+  > let greeting = "Updated!"
+  > let version = 2
+  > EOF
+
+  $ dune build out
+  building consumer
+
+The full build including the lock-dir consumer also succeeds:
+
+  $ dune build @install

--- a/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/compile-against-workspace-lib.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/compile-against-workspace-lib.t
@@ -1,38 +1,83 @@
-A lock-dir package depends on a workspace library and its build
-action inspects [OCAMLPATH].
+A lock-dir package depends on a workspace library that itself depends on
+another lock-dir package. This is the full in-and-out graph:
 
-  $ make_workspace_lib_package
+consumer (lock dir) -> workspace-lib (workspace) -> lock-base (lock dir)
 
-The lock dir contains one package "consumer" whose build action
-writes [OCAMLPATH] to a file and installs it. The intent is that the
-file should later be inspectable to confirm the workspace install
-layout was prepended.
+First create the library installed by lock-base. It only needs bytecode
+artifacts for this test.
+
+  $ mkdir lock-base-src
+  $ cat > lock-base-src/lock_base.ml <<EOF
+  > let greeting = "Hello through lock-base!"
+  > EOF
+  $ (cd lock-base-src && \
+  >   ocamlc -c lock_base.ml && \
+  >   ocamlc -a -o lock_base.cma lock_base.cmo)
+  $ cat > lock-base-src/META <<EOF
+  > version = "0.0.1"
+  > description = ""
+  > archive(byte) = "lock_base.cma"
+  > EOF
+  $ cat > lock-base-src/lock-base.install <<EOF
+  > lib: [
+  >  "META"
+  >  "lock_base.cma"
+  >  "lock_base.cmi"
+  > ]
+  > EOF
+
+The workspace package depends on lock-base both in its package metadata and
+in the library stanza. Its installed META therefore requires lock-base.
+
+  $ make_dune_project 3.24
+  $ cat >> dune-project <<EOF
+  > (package
+  >  (name workspace-lib)
+  >  (depends lock-base))
+  > EOF
+  $ mkdir src
+  $ cat > src/dune <<EOF
+  > (library
+  >  (name workspace_lib)
+  >  (public_name workspace-lib)
+  >  (libraries lock-base)
+  >  (modes byte))
+  > EOF
+  $ cat > src/workspace_lib.ml <<EOF
+  > let greeting = Lock_base.greeting
+  > EOF
+
+The lock dir contains lock-base and consumer. Consumer declares only its
+immediate dependency on workspace-lib, as it would in an opam package.
 
   $ make_lockdir
-  $ make_lockpkg consumer <<EOF
+  $ make_lockpkg lock-base <<EOF
+  > (version 0.0.1)
+  > (source (copy $PWD/lock-base-src))
+  > EOF
+  $ make_lockpkg consumer <<'EOF'
   > (version 0.0.1)
   > (depends workspace-lib)
   > (build
-  >  (system "echo \$OCAMLPATH > ocamlpath.txt"))
-  > (install
-  >  (system "mkdir -p %{lib}/consumer && cp ocamlpath.txt %{lib}/consumer/"))
+  >  (progn
+  >   (system "echo 'let () = print_endline' > consumer.ml")
+  >   (system "echo '  Workspace_lib.greeting' >> consumer.ml")
+  >   (run
+  >    ocamlfind
+  >    ocamlc
+  >    -package
+  >    workspace-lib
+  >    -linkpkg
+  >    consumer.ml
+  >    -o
+  >    consumer.exe)
+  >   (run ./consumer.exe)))
   > EOF
-
-A rule depends on the lock-dir package:
 
   $ write_lockdir_consumer_rule
 
-Lock-dir validation does not currently recognise workspace packages as
-valid dependency targets, so the consumer's build action never runs:
+The mixed dependency closure makes both workspace-lib and lock-base visible to
+consumer without making consumer visible while workspace-lib is built.
 
-  $ dune build out 2>&1
-  File "_build/_private/default/.lock/dune.lock/consumer.pkg", line 2,
-  characters 9-22:
-  The package "consumer" depends on the package "workspace-lib", but
-  "workspace-lib" does not appear in the lockdir
-  _build/_private/default/.lock/dune.lock.
-  Error: At least one package dependency is itself not present as a package in
-  the lockdir _build/_private/default/.lock/dune.lock.
-  Hint: This could indicate that the lockdir is corrupted. Delete it and then
-  regenerate it by running: 'dune pkg lock'
-  [1]
+  $ dune build out 2>&1 | censor
+  Hello through lock-base!

--- a/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/empty-package.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/empty-package.t
@@ -20,16 +20,12 @@ A rule depends on the lock-dir package:
 
   $ write_lockdir_consumer_rule
 
-Lock-dir validation does not currently recognise workspace packages as
-valid dependency targets:
+The build succeeds even when the workspace package is empty:
 
-  $ dune build out 2>&1
-  File "_build/_private/default/.lock/dune.lock/consumer.pkg", line 2,
-  characters 9-17:
-  The package "consumer" depends on the package "ws-empty", but "ws-empty" does
-  not appear in the lockdir _build/_private/default/.lock/dune.lock.
-  Error: At least one package dependency is itself not present as a package in
-  the lockdir _build/_private/default/.lock/dune.lock.
-  Hint: This could indicate that the lockdir is corrupted. Delete it and then
-  regenerate it by running: 'dune pkg lock'
-  [1]
+  $ dune build out
+  building consumer
+
+  $ find _build/install/default/.packages -type f -o -type l | censor | sort
+  _build/install/default/.packages/$DIGEST/lib/ws-empty/META
+  _build/install/default/.packages/$DIGEST/lib/ws-empty/dune-package
+

--- a/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/env-precedence.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/env-precedence.t
@@ -1,0 +1,48 @@
+A workspace package and a lock-dir package both install a binary
+named "foo". A consumer lock-dir package depends on both; the
+workspace install layout is prepended to consumer's PATH, so when
+consumer's build action runs "foo" it picks up the workspace binary,
+not the lock-dir one. This pins the layout-vs-lockdir precedence
+on path-like env vars.
+
+  $ make_dune_project 3.24
+  $ cat >> dune-project <<EOF
+  > (package (name ws-tool))
+  > EOF
+
+  $ mkdir src
+  $ cat > src/dune <<EOF
+  > (executable
+  >  (name main)
+  >  (package ws-tool)
+  >  (public_name foo))
+  > EOF
+  $ cat > src/main.ml <<EOF
+  > let () = print_endline "from-workspace"
+  > EOF
+
+The lock dir contains lock-tool, which installs its own "foo" binary,
+and consumer, which depends on both:
+
+  $ make_lockdir
+  $ make_lockpkg lock-tool <<EOF
+  > (version 0.0.1)
+  > (install
+  >  (system "mkdir -p %{bin} && printf '#!/bin/sh\necho from-lockdir\n' > %{bin}/foo && chmod +x %{bin}/foo"))
+  > EOF
+  $ make_lockpkg consumer <<EOF
+  > (version 0.0.1)
+  > (depends lock-tool ws-tool)
+  > (build (system "foo > which.txt"))
+  > (install
+  >  (system "mkdir -p %{share}/consumer && cp which.txt %{share}/consumer/"))
+  > EOF
+
+  $ write_lockdir_consumer_rule
+
+  $ dune build out
+
+The workspace binary wins:
+
+  $ find _build -name 'which.txt' -exec cat {} \;
+  from-workspace

--- a/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/executable.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/executable.t
@@ -31,16 +31,13 @@ A rule depends on the lock-dir package:
 
   $ write_lockdir_consumer_rule
 
-Lock-dir validation does not currently recognise workspace packages as
-valid dependency targets:
+The build succeeds. The workspace executable appears under the layout's
+bin/ section:
 
-  $ dune build out 2>&1
-  File "_build/_private/default/.lock/dune.lock/consumer.pkg", line 2,
-  characters 9-16:
-  The package "consumer" depends on the package "ws-tool", but "ws-tool" does
-  not appear in the lockdir _build/_private/default/.lock/dune.lock.
-  Error: At least one package dependency is itself not present as a package in
-  the lockdir _build/_private/default/.lock/dune.lock.
-  Hint: This could indicate that the lockdir is corrupted. Delete it and then
-  regenerate it by running: 'dune pkg lock'
-  [1]
+  $ dune build out
+  building consumer
+
+  $ find _build/install/default/.packages -type f -o -type l | censor | sort
+  _build/install/default/.packages/$DIGEST/bin/ws-tool
+  _build/install/default/.packages/$DIGEST/lib/ws-tool/META
+  _build/install/default/.packages/$DIGEST/lib/ws-tool/dune-package

--- a/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/multiple-workspace-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/multiple-workspace-deps.t
@@ -39,20 +39,30 @@ A rule depends on the lock-dir package:
 
   $ write_lockdir_consumer_rule
 
-Lock-dir validation does not currently recognise workspace packages as
-valid dependency targets. Both missing workspace deps are reported:
+The build succeeds. Both workspace libraries appear in the same layout
+digest under .packages:
 
-  $ dune build out 2>&1
-  File "_build/_private/default/.lock/dune.lock/consumer.pkg", line 2,
-  characters 9-17:
-  The package "consumer" depends on the package "ws-lib-a", but "ws-lib-a" does
-  not appear in the lockdir _build/_private/default/.lock/dune.lock.
-  File "_build/_private/default/.lock/dune.lock/consumer.pkg", line 2,
-  characters 18-26:
-  The package "consumer" depends on the package "ws-lib-b", but "ws-lib-b" does
-  not appear in the lockdir _build/_private/default/.lock/dune.lock.
-  Error: At least one package dependency is itself not present as a package in
-  the lockdir _build/_private/default/.lock/dune.lock.
-  Hint: This could indicate that the lockdir is corrupted. Delete it and then
-  regenerate it by running: 'dune pkg lock'
-  [1]
+  $ dune build out
+  building consumer
+
+  $ find _build/install/default/.packages -type f -o -type l | censor | sort
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-a/META
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-a/dune-package
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-a/ws_lib_a.a
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-a/ws_lib_a.cma
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-a/ws_lib_a.cmi
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-a/ws_lib_a.cmt
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-a/ws_lib_a.cmx
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-a/ws_lib_a.cmxa
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-a/ws_lib_a.cmxs
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-a/ws_lib_a.ml
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-b/META
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-b/dune-package
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-b/ws_lib_b.a
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-b/ws_lib_b.cma
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-b/ws_lib_b.cmi
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-b/ws_lib_b.cmt
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-b/ws_lib_b.cmx
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-b/ws_lib_b.cmxa
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-b/ws_lib_b.cmxs
+  _build/install/default/.packages/$DIGEST/lib/ws-lib-b/ws_lib_b.ml

--- a/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/name-collision.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/name-collision.t
@@ -1,0 +1,45 @@
+When a package name appears in both the lockdir and the workspace,
+dependency resolution would otherwise be ambiguous. Dune rejects the edge
+rather than silently choosing the lockdir package or the workspace package.
+
+A workspace package "shared" defines a library:
+
+  $ make_dune_project_with_package 3.24 shared
+  $ mkdir src
+  $ cat > src/dune <<EOF
+  > (library (name shared) (public_name shared))
+  > EOF
+  $ cat > src/shared.ml <<EOF
+  > let from_workspace = "ws"
+  > EOF
+
+The lock dir contains a package also called "shared":
+
+  $ make_lockdir
+  $ make_lockpkg shared <<EOF
+  > (version 0.0.1)
+  > (build (run echo "building shared from lockdir"))
+  > EOF
+
+A consumer lock-dir package depends on "shared":
+
+  $ make_lockpkg consumer <<EOF
+  > (version 0.0.1)
+  > (depends shared)
+  > (build (run echo "building consumer"))
+  > EOF
+
+  $ write_lockdir_consumer_rule
+
+The dependency is rejected before the lockdir build of "shared" can shadow the
+workspace package:
+
+  $ dune build out
+  File "_build/_private/default/.lock/dune.lock/consumer.pkg", line 2,
+  characters 9-15:
+  The package "consumer" depends on the package "shared", but "shared" appears
+  both in the lockdir _build/_private/default/.lock/dune.lock and in the
+  workspace.
+  Error: A package dependency cannot be resolved unambiguously because the same
+  package name exists in both the lockdir and the workspace.
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/platform-disabled-lockdir-dep.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/platform-disabled-lockdir-dep.t
@@ -1,0 +1,44 @@
+A lock-dir package can depend on a package that is present in the
+lockdir but unavailable for the current platform. Validation accepts
+the edge because the name exists somewhere in the lockdir, but rule
+generation resolves against the current platform subset and
+misclassifies the unavailable lockdir package as a workspace
+dependency.
+
+  $ export DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled
+
+  $ make_dune_project 3.24
+
+  $ mkdir -p dune.lock
+  $ cat > dune.lock/lock.dune <<EOF
+  > (lang package 0.1)
+  > (repositories (complete true))
+  > (solved_for_platforms ((os linux) (arch x86_64)))
+  > EOF
+
+The current test platform is linux/x86_64. Package "inactive" exists
+in the lockdir, but is enabled only on macos, while "consumer" depends
+on it on all solved platforms.
+
+  $ make_lockpkg inactive <<EOF
+  > (version 0.0.1)
+  > (enabled_on_platforms (only ((os macos) (arch x86_64))))
+  > EOF
+  $ make_lockpkg consumer <<'EOF'
+  > (version 0.0.1)
+  > (depends (all_platforms (inactive)))
+  > (build (all_platforms ((action (run echo building-consumer)))))
+  > EOF
+
+  $ write_lockdir_consumer_rule
+
+The dependency is rejected as an unavailable lockdir dependency rather
+than being treated as a workspace package with an empty install layout.
+
+  $ dune build out
+  File "_build/_private/default/.lock/dune.lock/consumer.pkg", line 2, characters 25-33:
+  2 | (depends (all_platforms (inactive)))
+                               ^^^^^^^^
+  Error: The package "consumer" depends on the package "inactive", but
+  "inactive" is not available on the current platform.
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/run-workspace-executable.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/run-workspace-executable.t
@@ -1,0 +1,52 @@
+A lock-dir package depends on another lock-dir package that depends on a
+workspace package installing an executable. The workspace executable is
+materialised into the package install layout and action expansion can resolve
+`(run foo)` from that transitive dependency.
+
+  $ make_dune_project 3.24
+  $ cat >> dune-project <<EOF
+  > (package
+  >  (name ws-tool)
+  >  (version 1.2.3))
+  > EOF
+
+  $ mkdir src
+  $ cat > src/dune <<EOF
+  > (executable
+  >  (name main)
+  >  (package ws-tool)
+  >  (public_name foo))
+  > EOF
+  $ cat > src/main.ml <<EOF
+  > let () = print_endline "from-workspace"
+  > EOF
+
+  $ make_lockdir
+  $ make_lockpkg provider <<EOF
+  > (version 0.0.1)
+  > (depends ws-tool)
+  > EOF
+  $ make_lockpkg consumer <<EOF
+  > (version 0.0.1)
+  > (depends provider)
+  > (build
+  >  (progn
+  >   (run foo)
+  >   (system "test -x %{pkg:ws-tool:bin}/foo && echo bin-var-ok")
+  >   (run echo %{pkg:ws-tool:name})
+  >   (run echo %{pkg:ws-tool:version})
+  >   (run echo %{pkg:ws-tool:dev})))
+  > EOF
+
+  $ write_lockdir_consumer_rule
+
+The build succeeds. The package action expander resolves `foo`, package section
+variables, and standard package metadata through the transitive workspace
+dependency.
+
+  $ dune build out
+  from-workspace
+  bin-var-ok
+  ws-tool
+  1.2.3
+  false

--- a/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/unknown-dep.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/unknown-dep.t
@@ -1,0 +1,33 @@
+A lock-dir package declares a dependency on a name that does not exist
+anywhere: not in the lockdir, not in the workspace, not dune, not a
+system-provided package. Lockdir validation rejects this at load time
+with a located error rather than letting the build silently produce an
+empty install layout.
+
+  $ make_dune_project 3.24
+
+The lock dir contains one package "consumer" that declares a dep on
+"does-not-exist":
+
+  $ make_lockdir
+  $ make_lockpkg consumer <<EOF
+  > (version 0.0.1)
+  > (depends does-not-exist)
+  > (build (run echo "building consumer"))
+  > EOF
+
+A rule depends on the lock-dir package:
+
+  $ write_lockdir_consumer_rule
+
+  $ dune build out
+  File "_build/_private/default/.lock/dune.lock/consumer.pkg", line 2,
+  characters 9-23:
+  The package "consumer" depends on the package "does-not-exist", but
+  "does-not-exist" does not appear in the lockdir
+  _build/_private/default/.lock/dune.lock.
+  Error: At least one package dependency is itself not present as a package in
+  the lockdir _build/_private/default/.lock/dune.lock.
+  Hint: This could indicate that the lockdir is corrupted. Delete it and then
+  regenerate it by running: 'dune pkg lock'
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/workspace-deps/depends-on-workspace-package.t
+++ b/test/blackbox-tests/test-cases/pkg/workspace-deps/depends-on-workspace-package.t
@@ -32,17 +32,10 @@ A rule depends on the lock-dir package:
   >  (action (with-stdout-to out (echo "done"))))
   > EOF
 
-Building rejects the lock dir because "myws" is a dependency of "mylock" but is
-not itself a package in the lock dir. Lock-dir validation does not currently
-recognise workspace packages as valid dependency targets.
+The build accepts the workspace dependency and runs [mylock]'s build
+action. Whether the workspace package's artifacts are actually made
+available to that action is exercised by other tests in this
+directory.
 
   $ dune build @check 2>&1
-  File "_build/_private/default/.lock/dune.lock/mylock.pkg", line 2, characters
-  9-13:
-  The package "mylock" depends on the package "myws", but "myws" does not
-  appear in the lockdir _build/_private/default/.lock/dune.lock.
-  Error: At least one package dependency is itself not present as a package in
-  the lockdir _build/_private/default/.lock/dune.lock.
-  Hint: This could indicate that the lockdir is corrupted. Delete it and then
-  regenerate it by running: 'dune pkg lock'
-  [1]
+  building mylock

--- a/test/expect-tests/dune_pkg/encode_decode_tests.ml
+++ b/test/expect-tests/dune_pkg/encode_decode_tests.ml
@@ -67,7 +67,9 @@ let lock_dir_encode_decode_round_trip_test ?commit ~lock_dir_path ~lock_dir () =
     prepare ~portable_lock_dir:false ~lock_dir_path ~files:Package_name.Map.empty lock_dir
     |> commit);
   let lock_dir_round_tripped =
-    try Lock_dir.read_disk_exn lock_dir_path with
+    try
+      Lock_dir.read_disk_exn lock_dir_path ~external_packages:Package_name.Set.empty
+    with
     | User_error.E _ as exn ->
       let metadata_path = Path.relative_fname lock_dir_path Lock_dir.metadata_filename in
       let metadata_file_contents = Io.read_file metadata_path in


### PR DESCRIPTION
A package in `dune.lock` can now name a workspace package in its `(depends ...)` field. The workspace package's install entries are materialised via the scoped install layout (#14373) and consed onto the lock-dir package's build env, so the build action sees the workspace package the same way it sees any other declared dep. Previously such an edge was rejected at validation time.

This is the first step of the "in-and-out" case from #8652.

`Lock_dir.read_disk{,_exn}` now take `~external_packages : Package_name.Set.t` and `validate_packages` accepts an edge whose target is in the lockdir, is dune, or is in `external_packages`. Workspace-driven callers populate the set from local package names; dev-tool lockdirs and the solver's own output check pass `empty`, preserving strict validation. `check_packages` becomes a public helper so callers can stage parsing and validation separately (used by dev-tool loading in `src/dune_rules/lock_dir.ml`), and `Make_load.load` no longer validates — the removed `load_exn` was equivalent to `load |> ok_exn`.

`Pkg.t` and `DB.Pkg_table.entry` carry `workspace_deps : Package.Name.Set.t` next to the lock-dir-only `depends`. A new `Resolved_dep` variant classifies each declared edge as `Lockdir | Workspace | Dune | System`; anything not found in the lockdir, dune, or the system-provided set falls to `Workspace`. `add_workspace_env` builds an `Install_layout` for the lock-dir package's `workspace_deps` and conses its env onto the build action.

Related:

- #8652
- Builds on #14373
- [ ] changelog
- [ ] documentation (`doc/dev/install-layouts.md` — promote the "Lock-dir build layouts" future-work entry into the design body)

## Follow-up

- [ ] let the solver itself pick workspace packages (stacked PR)
- [ ] mixed lock-dir + workspace deps on the same consumer