### PR TITLE
test: use make_dune_project in blackbox tests

### DIFF
--- a/test/blackbox-tests/test-cases/absolute-switch-context-name-gh10721.t
+++ b/test/blackbox-tests/test-cases/absolute-switch-context-name-gh10721.t
@@ -1,8 +1,6 @@
 Rejects switch-derived context names that come from absolute paths.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ cat > dune-workspace << EOF
   > (lang dune 3.0)

--- a/test/blackbox-tests/test-cases/action-stdin-not-inherited-gh3672.t
+++ b/test/blackbox-tests/test-cases/action-stdin-not-inherited-gh3672.t
@@ -1,6 +1,6 @@
 Tests that actions do not inherit stdin by default.
 
-  $ echo "(lang dune 2.7)" > dune-project
+  $ make_dune_project 2.7
   $ cat >dune <<EOF
   > (rule (with-stdout-to file.txt (run cat)))
   > EOF

--- a/test/blackbox-tests/test-cases/actions/cat-multiple.t
+++ b/test/blackbox-tests/test-cases/actions/cat-multiple.t
@@ -1,6 +1,4 @@
-  $ cat > dune-project << EOF
-  > (lang dune 3.4)
-  > EOF
+  $ make_dune_project 3.4
 
 It is an error to pass an empty list:
 
@@ -46,9 +44,7 @@ The cat action supports several files.
 
 This requires 3.4.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.3)
-  > EOF
+  $ make_dune_project 3.3
 
   $ dune runtest
   File "dune", line 8, characters 2-13:

--- a/test/blackbox-tests/test-cases/actions/concurrent.t
+++ b/test/blackbox-tests/test-cases/actions/concurrent.t
@@ -1,8 +1,6 @@
 Specification of the concurrency action:
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.7)
-  > EOF
+  $ make_dune_project 3.7
 
   $ cat > dune << EOF
   > (rule
@@ -20,9 +18,7 @@ Specification of the concurrency action:
 
 Requires Dune 3.8.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.8)
-  > EOF
+  $ make_dune_project 3.8
 
 (concurrent ...) runs actions concurrently. Here we mock up an example where two
 subactions rely on eachother to also be running in order to terminate.

--- a/test/blackbox-tests/test-cases/actions/with-stdin-from.t
+++ b/test/blackbox-tests/test-cases/actions/with-stdin-from.t
@@ -1,8 +1,6 @@
 Feeds an action's stdin from a file with `with-stdin-from`.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 2.0)
-  > EOF
+  $ make_dune_project 2.0
 
   $ cat > dune << EOF
   > (rule (with-stdin-from input (with-stdout-to output (run cat))))

--- a/test/blackbox-tests/test-cases/alias-rule-without-targets-gh2681.t
+++ b/test/blackbox-tests/test-cases/alias-rule-without-targets-gh2681.t
@@ -1,9 +1,7 @@
 A rule may have an alias field. This denotes that the action of the rule is a
 dependency of the alias.
   $ mkdir simple && cd simple
-  $ cat > dune-project <<EOF
-  > (lang dune 2.0)
-  > EOF
+  $ make_dune_project 2.0
   $ cat > dune <<EOF
   > (rule
   >  (action (with-stdout-to foo (echo "hello world")))
@@ -16,9 +14,7 @@ dependency of the alias.
 
 A rule may now have an empty set of targets if it has an alias field
   $ mkdir no-targets && cd no-targets
-  $ cat > dune-project <<EOF
-  > (lang dune 2.0)
-  > EOF
+  $ make_dune_project 2.0
   $ cat > dune <<EOF
   > (rule
   >  (action (echo "hello world"))

--- a/test/blackbox-tests/test-cases/alias/alias-candidates.t
+++ b/test/blackbox-tests/test-cases/alias/alias-candidates.t
@@ -1,8 +1,6 @@
 Dune should suggest similar aliases when it cannot find one. 
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.7)
-  > EOF
+  $ make_dune_project 3.7
   $ cat > dune << EOF
   > (rule
   >  (alias foo)

--- a/test/blackbox-tests/test-cases/alias/alias-empty.t
+++ b/test/blackbox-tests/test-cases/alias/alias-empty.t
@@ -1,8 +1,6 @@
 Testing the empty alias
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.17)
-  > EOF
+  $ make_dune_project 3.17
 
 Building the empty alias does nothing
   $ dune build @empty
@@ -31,9 +29,7 @@ Also creating an alias called empty is allowed prior to 3.20:
 
 For versions 3.20 and after these should fail:
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.20)
-  > EOF
+  $ make_dune_project 3.20
 
   $ cat > dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/alias/alias-multiple.t
+++ b/test/blackbox-tests/test-cases/alias/alias-multiple.t
@@ -1,9 +1,7 @@
 Testing multiple aliases in rules stanza
 
 First we start with a dune-project before alias was introduced:
-  $ cat > dune-project << EOF
-  > (lang dune 1.9)
-  > EOF
+  $ make_dune_project 1.9
 
   $ cat > dune << EOF
   > (rule
@@ -20,9 +18,7 @@ First we start with a dune-project before alias was introduced:
   [1]
 
 Next we update the dune-project file to use dune 2.0:
-  $ cat > dune-project << EOF
-  > (lang dune 2.0)
-  > EOF
+  $ make_dune_project 2.0
 
   $ dune build @a
   I have run
@@ -57,9 +53,7 @@ That doesn't work so we use the aliases field
   [1]
 
 Updating the dune-project file to use dune 3.5 allows the build to succeed:
-  $ cat > dune-project << EOF
-  > (lang dune 3.5)
-  > EOF
+  $ make_dune_project 3.5
 
   $ dune build @a
   I have run

--- a/test/blackbox-tests/test-cases/alias/all-alias/source-file-copies.t
+++ b/test/blackbox-tests/test-cases/alias/all-alias/source-file-copies.t
@@ -1,8 +1,6 @@
 @all does not depend directly on file copies from the source tree
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
 Add two files
 

--- a/test/blackbox-tests/test-cases/bin-pform/env-binaries.t
+++ b/test/blackbox-tests/test-cases/bin-pform/env-binaries.t
@@ -1,8 +1,6 @@
 %{bin:...} for a binary added via (env (binaries ...)).
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.24)
-  > EOF
+  $ make_dune_project 3.24
   $ cat >dune <<'EOF'
   > (executable (name mybin))
   > (env (_ (binaries (mybin.exe as myothername))))

--- a/test/blackbox-tests/test-cases/bin-pform/missing-bin.t
+++ b/test/blackbox-tests/test-cases/bin-pform/missing-bin.t
@@ -3,9 +3,7 @@ where the name doesn't resolve all fail with "Program ... not found".
 Three different code paths converge on the same error, and each is
 exercised so any one can regress independently.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.24)
-  > EOF
+  $ make_dune_project 3.24
 
 In an action:
 

--- a/test/blackbox-tests/test-cases/bin-pform/system.t
+++ b/test/blackbox-tests/test-cases/bin-pform/system.t
@@ -1,8 +1,6 @@
 %{bin:...} for a system binary found via PATH.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.24)
-  > EOF
+  $ make_dune_project 3.24
   $ cat >dune <<'EOF'
   > (rule
   >  (with-stdout-to bin-path

--- a/test/blackbox-tests/test-cases/build-info-no-head-commit-gh4429.t
+++ b/test/blackbox-tests/test-cases/build-info-no-head-commit-gh4429.t
@@ -6,7 +6,7 @@ Create a repository with no HEAD commit:
 
 ... and an executable that links `dune-build-info':
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ touch main.ml
   $ cat >dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/builtin-support-override.t
+++ b/test/blackbox-tests/test-cases/builtin-support-override.t
@@ -24,9 +24,7 @@ Create a library called `findlib.dynload`
   > EOF
   $ touch findlib/fl_dynload.ml
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.7)
-  > EOF
+  $ make_dune_project 3.7
 
   $ mkdir lib
   $ cat > lib/dune <<EOF

--- a/test/blackbox-tests/test-cases/copy-files-parent-dir-no-cycle-gh4345.t
+++ b/test/blackbox-tests/test-cases/copy-files-parent-dir-no-cycle-gh4345.t
@@ -5,7 +5,7 @@ bug is now fixed, so this project should build without error.
 
   $ DIR="gh4345"
   $ mkdir $DIR && cd $DIR
-  $ echo "(lang dune 2.8)" > dune-project
+  $ make_dune_project 2.8
   $ mkdir lib
   $ touch lib.opam file lib/lib.ml
   $ cat >lib/dune <<EOF

--- a/test/blackbox-tests/test-cases/copy-files-self-copy-errors-gh2848.t
+++ b/test/blackbox-tests/test-cases/copy-files-self-copy-errors-gh2848.t
@@ -12,7 +12,7 @@ is <dir>/<glob> where <dir> is not the current directory.
 ----------------------------------------------------------------------------------
 * Good error message when <dir> is the current directory
 
-  $ echo "(lang dune 2.2)" > dune-project
+  $ make_dune_project 2.2
 
   $ cat >dune <<EOF
   > (executable (name foo))
@@ -40,7 +40,7 @@ is <dir>/<glob> where <dir> is not the current directory.
 ----------------------------------------------------------------------------------
 * Good error message when <dir> is missing
 
-  $ echo "(lang dune 2.2)" > dune-project
+  $ make_dune_project 2.2
 
   $ cat >dune <<EOF
   > (executable (name foo))

--- a/test/blackbox-tests/test-cases/corrupt-persistent.t
+++ b/test/blackbox-tests/test-cases/corrupt-persistent.t
@@ -1,6 +1,4 @@
-  $ cat > dune-project <<EOF
-  > (lang dune 2.0)
-  > EOF
+  $ make_dune_project 2.0
 
   $ cat > dune << EOF
   > (rule (target a) (deps) (action (bash "echo a > a")))

--- a/test/blackbox-tests/test-cases/cram/bash-shell.t
+++ b/test/blackbox-tests/test-cases/cram/bash-shell.t
@@ -1,8 +1,6 @@
 Demonstrate the shell field in the cram stanza
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ printShell() {
   > dune trace cat | jq 'include "dune"; processes | select(.args.categories | index("cram")) | .args | .prog | split("/") | last'

--- a/test/blackbox-tests/test-cases/cram/cram-setting-in-dune-project.t
+++ b/test/blackbox-tests/test-cases/cram/cram-setting-in-dune-project.t
@@ -6,9 +6,7 @@ file and we enter a loop:
   $ mkdir test
   $ cd test
 
-  $ cat >dune-project<<EOF
-  > (lang dune 2.8)
-  > EOF
+  $ make_dune_project 2.8
 
   $ cat >dune<<EOF
   > (cram)
@@ -45,9 +43,7 @@ executed:
 With Dune 3.0 and later, we don't get an error since cram tests are enabled by
 default:
 
-  $ cat >dune-project<<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ dune runtest
   File "run.t", line 1, characters 0-0:

--- a/test/blackbox-tests/test-cases/cram/cram-setup-scripts/basic.t
+++ b/test/blackbox-tests/test-cases/cram/cram-setup-scripts/basic.t
@@ -2,9 +2,7 @@ Test setup_scripts feature for cram tests
 
 Create a project with a helper script:
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
   $ cat > helpers.sh << 'EOF'
   > #!/bin/sh

--- a/test/blackbox-tests/test-cases/cram/cram-setup-scripts/check-visibility.t
+++ b/test/blackbox-tests/test-cases/cram/cram-setup-scripts/check-visibility.t
@@ -1,8 +1,6 @@
 Test if setup scripts are visible in test directory
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ cat > secret.sh << 'EOF'
   > MY_SECRET="should_not_be_visible"

--- a/test/blackbox-tests/test-cases/cram/cram-setup-scripts/duplicate-setup-scripts.t
+++ b/test/blackbox-tests/test-cases/cram/cram-setup-scripts/duplicate-setup-scripts.t
@@ -1,8 +1,6 @@
 Applying the same setup script twice:
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
   $ cat >helpers.sh <<EOF
   > if [ -n "${x:-}" ]; then

--- a/test/blackbox-tests/test-cases/cram/cram-setup-scripts/external-scripts.t
+++ b/test/blackbox-tests/test-cases/cram/cram-setup-scripts/external-scripts.t
@@ -14,9 +14,7 @@ First, create an external script in /tmp:
 
 Create a project that uses the external script:
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
   $ cat > dune << EOF
   > (cram

--- a/test/blackbox-tests/test-cases/cram/cram-setup-scripts/multiple-stanzas.t
+++ b/test/blackbox-tests/test-cases/cram/cram-setup-scripts/multiple-stanzas.t
@@ -1,8 +1,6 @@
 Test evaluation order when multiple cram stanzas introduce different setup scripts
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
 Create two different setup scripts:
 

--- a/test/blackbox-tests/test-cases/cram/cram-setup-scripts/stanza-accumulation.t
+++ b/test/blackbox-tests/test-cases/cram/cram-setup-scripts/stanza-accumulation.t
@@ -1,8 +1,6 @@
 Test that setup scripts accumulate when multiple stanzas match the same test
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
 Create three different setup scripts:
 

--- a/test/blackbox-tests/test-cases/cram/cram-setup-scripts/test-script-visibility.t
+++ b/test/blackbox-tests/test-cases/cram/cram-setup-scripts/test-script-visibility.t
@@ -2,9 +2,7 @@ Test that setup scripts are NOT visible in the test directory
 
 Create a project with a helper script:
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
   $ cat > helpers.sh << 'EOF'
   > #!/bin/sh

--- a/test/blackbox-tests/test-cases/cram/disabled-test.t
+++ b/test/blackbox-tests/test-cases/cram/disabled-test.t
@@ -3,9 +3,7 @@ Test that disabled cram tests can still be run explicitly.
 The enabled_if field controls whether a test is included in @runtest,
 but does not prevent the test from being run explicitly.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
   $ cat > dune <<EOF
   > (cram

--- a/test/blackbox-tests/test-cases/cram/double-run-promote.t
+++ b/test/blackbox-tests/test-cases/cram/double-run-promote.t
@@ -1,9 +1,7 @@
 This test demonstrates that we pointlessly re-run cram tests
 after they're promted
 
-  $ cat >dune-project<<EOF
-  > (lang dune 3.12)
-  > EOF
+  $ make_dune_project 3.12
 
   $ cat >foo.t <<EOF
   >   $ echo run >> $PWD/side-effect

--- a/test/blackbox-tests/test-cases/cram/git-diff-fail.t
+++ b/test/blackbox-tests/test-cases/cram/git-diff-fail.t
@@ -3,9 +3,7 @@ cram tests.
 
 First we make a cram test:
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.7)
-  > EOF
+  $ make_dune_project 3.7
 
   $ cat > mytest.t << EOF
   >   $ echo A

--- a/test/blackbox-tests/test-cases/cram/partial-promotion-on-error.t
+++ b/test/blackbox-tests/test-cases/cram/partial-promotion-on-error.t
@@ -1,9 +1,7 @@
 Test that cram tests with unreachable commands can still partially promote
 output from commands that executed successfully.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
 Create a test with some successful commands, then an exit, then unreachable
 commands:

--- a/test/blackbox-tests/test-cases/cram/subprocess.t
+++ b/test/blackbox-tests/test-cases/cram/subprocess.t
@@ -1,9 +1,7 @@
 Testing the termination of subprocesses in cram tests. We first create a dune
 project with a single cram test.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.19)
-  > EOF
+  $ make_dune_project 3.19
 
 We create a file for tracking the PID of a subprocess.
 

--- a/test/blackbox-tests/test-cases/cram/timeout-invalid.t
+++ b/test/blackbox-tests/test-cases/cram/timeout-invalid.t
@@ -2,9 +2,7 @@ Here we check the validation of the timeout field of the cram stanza.
 
 First we check the version guard.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.19)
-  > EOF
+  $ make_dune_project 3.19
 
   $ cat > dune <<EOF
   > (cram
@@ -21,9 +19,7 @@ First we check the version guard.
 
 Next we check some invalid values:
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.20)
-  > EOF
+  $ make_dune_project 3.20
 
   $ cat > test.t <<EOF
   >   $ echo hi

--- a/test/blackbox-tests/test-cases/cram/timeout-no-command.t
+++ b/test/blackbox-tests/test-cases/cram/timeout-no-command.t
@@ -3,9 +3,7 @@ Testing that timeout errors don't include the command that caused the timeout.
 This test demonstrates the current behavior where timeout error messages
 don't include information about which specific command caused the timeout.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.20)
-  > EOF
+  $ make_dune_project 3.20
 
   $ cat > dune <<EOF
   > (cram

--- a/test/blackbox-tests/test-cases/cram/timeout-redigest.t
+++ b/test/blackbox-tests/test-cases/cram/timeout-redigest.t
@@ -1,8 +1,6 @@
 Testing how timeout affects the digest:
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.20)
-  > EOF
+  $ make_dune_project 3.20
 
   $ cat > mytest.t
 

--- a/test/blackbox-tests/test-cases/cram/timeout.t
+++ b/test/blackbox-tests/test-cases/cram/timeout.t
@@ -3,9 +3,7 @@ Testing the timeout functionality of cram tests.
 First we create a cram test that will take less than our time budget. This will
 allow the test to fail. (Since "hi" needs to be promoted).
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.20)
-  > EOF
+  $ make_dune_project 3.20
 
   $ cat > dune <<EOF
   > (cram

--- a/test/blackbox-tests/test-cases/cram/trace-commands.t
+++ b/test/blackbox-tests/test-cases/cram/trace-commands.t
@@ -1,8 +1,6 @@
 Demonstrate command level trace events
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ cat > dune <<EOF
   > (cram

--- a/test/blackbox-tests/test-cases/cram/windows-path-rewriting.t
+++ b/test/blackbox-tests/test-cases/cram/windows-path-rewriting.t
@@ -10,9 +10,7 @@ Create a test that uses cygpath to get the native Windows path of the root
 (with a drive letter like C:\...), adds it to BUILD_PATH_PREFIX_MAP, and
 verifies the path gets rewritten in output.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ cat >t1.t <<'EOF'
   > Get a native Windows path with a drive letter colon:

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/target-exec.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/target-exec.t
@@ -7,9 +7,7 @@ Setup environment:
 
 Create a simple executable that prints a message:
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ cat > hello.ml <<EOF
   > let () =

--- a/test/blackbox-tests/test-cases/cycle-detection-symlinks-2863.t
+++ b/test/blackbox-tests/test-cases/cycle-detection-symlinks-2863.t
@@ -1,6 +1,6 @@
 Avoids false cycle detection when multiple symlinks point to the same tree.
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ mkdir src
   $ ln -s src src-clone
   $ dune build

--- a/test/blackbox-tests/test-cases/cyclic-dep-executable.t
+++ b/test/blackbox-tests/test-cases/cyclic-dep-executable.t
@@ -1,8 +1,6 @@
 Reports module dependency cycles inside executables.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.20)
-  > EOF
+  $ make_dune_project 3.20
 
   $ cat > dune <<EOF
   > (executable (name foo))

--- a/test/blackbox-tests/test-cases/default-implementation/package-mismatch1.t
+++ b/test/blackbox-tests/test-cases/default-implementation/package-mismatch1.t
@@ -1,6 +1,6 @@
 A default implementation of a library must belong to the same package
 
-  $ echo "(lang dune 2.6)" > dune-project
+  $ make_dune_project 2.6
   $ touch dummyfoo1.opam
   $ touch dummyfoo2.opam
   $ mkdir vlib impl

--- a/test/blackbox-tests/test-cases/default-implementation/package-mismatch2.t
+++ b/test/blackbox-tests/test-cases/default-implementation/package-mismatch2.t
@@ -1,6 +1,6 @@
 A default implementation of a library must belong to the same package
 
-  $ echo "(lang dune 2.6)" > dune-project
+  $ make_dune_project 2.6
   $ touch dummyfoo2.opam
   $ mkdir -p vlib impl
   $ touch vlib/vlib.mli impl/vlib.ml

--- a/test/blackbox-tests/test-cases/deps-conf-vars/alias-lib-file.t
+++ b/test/blackbox-tests/test-cases/deps-conf-vars/alias-lib-file.t
@@ -6,7 +6,7 @@ Expands library artifact variables in alias dependencies.
   >  (deps %{lib:foo:theories/a})
   >  (action (echo "deps: %{deps}\n")))
   > EOF
-  $ echo "(lang dune 1.6)" > dune-project
+  $ make_dune_project 1.6
   $ touch foo.opam
   $ mkdir foo && touch foo/a
   $ cat >foo/dune <<EOF

--- a/test/blackbox-tests/test-cases/deps-conf-vars/deps-diff.t
+++ b/test/blackbox-tests/test-cases/deps-conf-vars/deps-diff.t
@@ -7,7 +7,7 @@ Deps in diff position. Used to work in 2.9.x
   >  (alias foo)
   >  (action (diff? %{deps} %{deps}.diff)))
   > EOF
-  $ echo "(lang dune 2.9)" > dune-project
+  $ make_dune_project 2.9
   $ dune build @foo
   File "dune", line 4, characters 24-31:
   4 |  (action (diff? %{deps} %{deps}.diff)))

--- a/test/blackbox-tests/test-cases/deps-conf-vars/dynamic.t
+++ b/test/blackbox-tests/test-cases/deps-conf-vars/dynamic.t
@@ -5,7 +5,7 @@ to be discovered dynamically as we were trying to evaluate the dependencies,
 the new code simply doesn't detect it. We should add a proper version check for
 this feature.
 
-  $ echo "(lang dune 1.6)" > dune-project
+  $ make_dune_project 1.6
   $ cat >dune <<EOF
   > (rule (with-stdout-to foo (echo bar)))
   > (alias

--- a/test/blackbox-tests/test-cases/deps-conf-vars/static.t
+++ b/test/blackbox-tests/test-cases/deps-conf-vars/static.t
@@ -6,7 +6,7 @@ Expands static library artifact variables in dependencies.
   >  (deps %{lib:foo:foo.cma})
   >  (action (echo "deps: %{deps}\n")))
   > EOF
-  $ echo "(lang dune 1.6)" > dune-project
+  $ make_dune_project 1.6
   $ touch foo.opam
   $ mkdir foo && touch foo/foo.ml
   $ cat >foo/dune << EOF

--- a/test/blackbox-tests/test-cases/describe/missing-external-libraries-gh12997.t
+++ b/test/blackbox-tests/test-cases/describe/missing-external-libraries-gh12997.t
@@ -1,8 +1,6 @@
 `dune describe workspace` should not fail on missing external libraries.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ cat > dune << EOF
   > (library

--- a/test/blackbox-tests/test-cases/directory-targets/main.t
+++ b/test/blackbox-tests/test-cases/directory-targets/main.t
@@ -1,8 +1,6 @@
 Tests for directory targets.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
 Directory targets require an extension.
 
@@ -21,9 +19,7 @@ Directory targets require an extension.
 
 Starting from Dune 3.24, directory targets no longer require an extension.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.24)
-  > EOF
+  $ make_dune_project 3.24
 
   $ cat > dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/dirs-and-data-only-dirs-gh2584.t
+++ b/test/blackbox-tests/test-cases/dirs-and-data-only-dirs-gh2584.t
@@ -1,6 +1,6 @@
 Allows `dirs` and `data_only_dirs` to coexist.
 
-  $ echo "(lang dune 1.11)" > dune-project
+  $ make_dune_project 1.11
   $ cat >dune <<EOF
   > (dirs foo)
   > (data_only_dirs bar)

--- a/test/blackbox-tests/test-cases/dirs-ignored-subdirs-conflict-gh3772.t
+++ b/test/blackbox-tests/test-cases/dirs-ignored-subdirs-conflict-gh3772.t
@@ -2,9 +2,7 @@ Reproduction of https://github.com/ocaml/dune/issues/3773
 
 Mixing incompatible features should fail earlier with a proper message.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 2.0)
-  > EOF
+  $ make_dune_project 2.0
 
   $ cat > dune <<EOF
   > (ignored_subdirs (node_modules))

--- a/test/blackbox-tests/test-cases/disabled-public-library-gh4821.t
+++ b/test/blackbox-tests/test-cases/disabled-public-library-gh4821.t
@@ -1,8 +1,6 @@
 Ensure that a public, non-optional library can be disabled.
   $ touch foo.opam
-  $ cat > dune-project<<EOF
-  > (lang dune 2.0)
-  > EOF
+  $ make_dune_project 2.0
   $ cat > dune <<EOF
   > (library (name foo) (public_name foo) (enabled_if false))
   > EOF

--- a/test/blackbox-tests/test-cases/dune-cache/config.t
+++ b/test/blackbox-tests/test-cases/dune-cache/config.t
@@ -10,9 +10,7 @@ Check that old cache configuration format works fine with an old language
   > (cache-trim-period 1h)
   > (cache-trim-size 1GB)
   > EOF
-  $ cat > dune-project <<EOF
-  > (lang dune 2.1)
-  > EOF
+  $ make_dune_project 2.1
   $ cat > dune <<EOF
   > (rule
   >   (deps source)

--- a/test/blackbox-tests/test-cases/dune-cache/dedup.t
+++ b/test/blackbox-tests/test-cases/dune-cache/dedup.t
@@ -3,9 +3,7 @@ Test deduplication of build artifacts when using Dune cache with hard links.
   $ export DUNE_CACHE=enabled
   $ export DUNE_CACHE_ROOT=$(dune_cmd native-path $PWD/.cache)
 
-  $ cat > dune-project <<EOF
-  > (lang dune 2.1)
-  > EOF
+  $ make_dune_project 2.1
   $ cat > dune <<EOF
   > (rule
   >   (deps source)

--- a/test/blackbox-tests/test-cases/dune-cache/default-cache.t
+++ b/test/blackbox-tests/test-cases/dune-cache/default-cache.t
@@ -1,6 +1,6 @@
 The dune cache should be enabled by default
 
-  $ echo "(lang dune 3.17)" > dune-project
+  $ make_dune_project 3.17
 
   $ cat > dune << EOF
   > (library

--- a/test/blackbox-tests/test-cases/dune-cache/missing-cache-entries.t
+++ b/test/blackbox-tests/test-cases/dune-cache/missing-cache-entries.t
@@ -9,9 +9,7 @@ Check that Dune cache can cope with missing file/metadata entries.
   > (cache-duplication copy)
   > (cache-transport direct)
   > EOF
-  $ cat > dune-project <<EOF
-  > (lang dune 2.1)
-  > EOF
+  $ make_dune_project 2.1
   $ cat > dune <<EOF
   > (rule
   >   (deps source)

--- a/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
@@ -105,9 +105,7 @@ No cache misses should appear in the trace.
 
 Test that the cache stores all historical build results.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 2.1)
-  > EOF
+  $ make_dune_project 2.1
   $ cat > dune-v1 <<EOF
   > (rule
   >  (targets t1)

--- a/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
@@ -105,9 +105,7 @@ No cache misses should appear in the trace.
 
 Test that the cache stores all historical build results.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 2.1)
-  > EOF
+  $ make_dune_project 2.1
   $ cat > dune-v1 <<EOF
   > (rule
   >   (targets t1)

--- a/test/blackbox-tests/test-cases/dune-cache/possible-locations.t
+++ b/test/blackbox-tests/test-cases/dune-cache/possible-locations.t
@@ -1,6 +1,6 @@
 Showcase all possible locations of the cache.
 
-  $ echo "(lang dune 3.17)" > dune-project
+  $ make_dune_project 3.17
 
   $ cat > dune << EOF
   > (library

--- a/test/blackbox-tests/test-cases/dune-cache/promotion-in-source-tree.t
+++ b/test/blackbox-tests/test-cases/dune-cache/promotion-in-source-tree.t
@@ -9,9 +9,7 @@ Reproduction case for #3026
   > (cache enabled)
   > EOF
 
-  $ cat > dune-project <<EOF
-  > (lang dune 2.1)
-  > EOF
+  $ make_dune_project 2.1
 
   $ cat > dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/dune-cache/readonly-fs.t
+++ b/test/blackbox-tests/test-cases/dune-cache/readonly-fs.t
@@ -1,9 +1,7 @@
 The cache can't be written if the location to where it is supposed to be
 written can't be written to.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.17)
-  > EOF
+  $ make_dune_project 3.17
   $ cat >dune <<EOF
   > (rule (with-stdout-to foo (progn)))
   > EOF

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t
@@ -20,9 +20,7 @@ Test reproducibility check
   >   sed '/^Warning:/,/^action at dune:6/d; /^build /d' dune-build-output
   > }
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
   $ cat > dune <<EOF
   > (rule
   >   (deps dep)

--- a/test/blackbox-tests/test-cases/dune-cache/size.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/size.t/run.t
@@ -10,9 +10,7 @@ the cache.
   > (cache-storage-mode copy)
   > EOF
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.7)
-  > EOF
+  $ make_dune_project 3.7
 
   $ cat > dune << EOF
   > (rule

--- a/test/blackbox-tests/test-cases/dune-cache/symlink.t
+++ b/test/blackbox-tests/test-cases/dune-cache/symlink.t
@@ -4,9 +4,7 @@ produced symbolic links work correctly and are appropriately cached.
   $ export DUNE_CACHE=enabled
   $ export DUNE_CACHE_ROOT=$PWD/.cache
 
-  $ cat > dune-project <<EOF
-  > (lang dune 2.1)
-  > EOF
+  $ make_dune_project 2.1
   $ cat > dune <<EOF
   > (rule
   >   (deps source)

--- a/test/blackbox-tests/test-cases/dune-cache/trim-copy-mode.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim-copy-mode.t
@@ -5,9 +5,7 @@ Test that copy-mode cache trim keeps recently restored entries.
   $ export XDG_CACHE_HOME=$PWD/.xdg-cache
   $ setup_xdg_runtime_dir
 
-  $ cat > dune-project <<EOF
-  > (lang dune 2.1)
-  > EOF
+  $ make_dune_project 2.1
   $ cat > dune <<EOF
   > (rule
   >   (targets copy_a)

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -2,9 +2,7 @@
   $ export XDG_CACHE_HOME=$PWD/.xdg-cache
   $ setup_xdg_runtime_dir
 
-  $ cat > dune-project <<EOF
-  > (lang dune 2.1)
-  > EOF
+  $ make_dune_project 2.1
   $ cat > dune <<EOF
   > (rule
   >   (targets target_a)

--- a/test/blackbox-tests/test-cases/dune-rules-makefile-output-gh3440.t
+++ b/test/blackbox-tests/test-cases/dune-rules-makefile-output-gh3440.t
@@ -2,5 +2,5 @@ This test just makes sure that dune rules doesn't error out. In the past, we've
 had bugs where this subcommand would stop working and nobody would notice as
 it's not used very much.
 
-  $ echo "(lang dune 2.5)" > dune-project
+  $ make_dune_project 2.5
   $ dune rules --root . --format=json -o Makefile

--- a/test/blackbox-tests/test-cases/dynamic-dependencies.t
+++ b/test/blackbox-tests/test-cases/dynamic-dependencies.t
@@ -1,8 +1,6 @@
 Tests for dynamic dependencies computed from the `%{read:...}` family of macros
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.1)
-  > EOF
+  $ make_dune_project 3.1
 
 Define 2 rules and a file containing their paths
 
@@ -41,9 +39,7 @@ Building `./output` should now produce a file with contents "depA depB"
 
 Doesn't work in dune pre 3.0
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ dune build ./output
   File "dune", line 12, characters 7-23:
@@ -55,9 +51,7 @@ Doesn't work in dune pre 3.0
 
 Works with aliases and other dependency specifications
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.1)
-  > EOF
+  $ make_dune_project 3.1
 
   $ cat > deps.d <<EOF
   > ((alias depA) (universe) depB another_dep)

--- a/test/blackbox-tests/test-cases/dynamic-dependencies/read-macro-produces-dyn-deps.t
+++ b/test/blackbox-tests/test-cases/dynamic-dependencies/read-macro-produces-dyn-deps.t
@@ -1,8 +1,6 @@
 Tests for dynamic dependencies computed from the `%{read:...}` family of macros
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
 Define rules have dynamic file dependencies
 

--- a/test/blackbox-tests/test-cases/empty-meta-version-gh9176.t
+++ b/test/blackbox-tests/test-cases/empty-meta-version-gh9176.t
@@ -7,9 +7,7 @@ We check that `version = ""` in META files are correctly handled.
   > version=""
   > EOF
 
-  $ cat > dune-project << EOF
-  > (lang dune 1.0)
-  > EOF
+  $ make_dune_project 1.0
 
   $ cat > dune << EOF
   > (executable

--- a/test/blackbox-tests/test-cases/enabled_if/eif-arch_sixtyfour.t/run.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-arch_sixtyfour.t/run.t
@@ -1,17 +1,13 @@
 Testing %{arch_sixtyfour} in enabled_if
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.11)
-  > EOF
+  $ make_dune_project 3.11
 
   $ dune exec -- ./hello.exe
   Hello, World!
 
 Testing the version guard
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.10)
-  > EOF
+  $ make_dune_project 3.10
 
   $ dune exec -- ./hello.exe
   File "dune", line 4, characters 5-22:

--- a/test/blackbox-tests/test-cases/enabled_if/eif-exe-name-collision-same-folder.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-exe-name-collision-same-folder.t
@@ -1,9 +1,7 @@
 Using same executable name in two contexts, where the executables are defined
 in the same dune file
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.13)
-  > EOF
+  $ make_dune_project 3.13
 
   $ cat > dune-workspace << EOF
   > (lang dune 3.13)

--- a/test/blackbox-tests/test-cases/enabled_if/eif-exe-name-collision.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-exe-name-collision.t
@@ -1,9 +1,7 @@
 Using same executable name in two contexts
 
   $ mkdir -p a b
-  $ cat > dune-project << EOF
-  > (lang dune 3.13)
-  > EOF
+  $ make_dune_project 3.13
 
   $ cat > dune-workspace << EOF
   > (lang dune 3.13)

--- a/test/blackbox-tests/test-cases/enabled_if/eif-exec-forbidden_var.t/run.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-exec-forbidden_var.t/run.t
@@ -1,8 +1,6 @@
 The next ones use forbidden variables For dune 2.3 -> 2.5 it is a warning
 
-  $ cat > dune-project <<EOF
-  > (lang dune 2.3)
-  > EOF
+  $ make_dune_project 2.3
   $ dune exec ./foo.exe
   File "dune", line 3, characters 17-32:
   3 |  (enabled_if (<> %{project_root} "")))
@@ -13,9 +11,7 @@ The next ones use forbidden variables For dune 2.3 -> 2.5 it is a warning
   bar
 
 For dune >= 2.6 it is an error
-  $ cat > dune-project <<EOF
-  > (lang dune 2.6)
-  > EOF
+  $ make_dune_project 2.6
   $ dune exec ./foo.exe
   File "dune", line 3, characters 17-32:
   3 |  (enabled_if (<> %{project_root} "")))

--- a/test/blackbox-tests/test-cases/enabled_if/eif-library-cycle.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-library-cycle.t
@@ -1,8 +1,6 @@
 Test cycles in enabled_if field of libraries
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.15)
-  > EOF
+  $ make_dune_project 3.15
 
   $ cat > dune << EOF
   > (library

--- a/test/blackbox-tests/test-cases/enabled_if/eif-library-disabled-cmo-error.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-library-disabled-cmo-error.t
@@ -1,9 +1,7 @@
 Test behavior when targeting artifacts of a disabled library
 
   $ mkdir -p a b
-  $ cat > dune-project << EOF
-  > (lang dune 3.13)
-  > EOF
+  $ make_dune_project 3.13
 
   $ cat > dune << EOF
   > (library

--- a/test/blackbox-tests/test-cases/enabled_if/eif-var_context_name.t/run.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-var_context_name.t/run.t
@@ -1,7 +1,5 @@
 For dune < 2.7 context_name is not allowed
-  $ cat > dune-project <<EOF
-  > (lang dune 2.6)
-  > EOF
+  $ make_dune_project 2.6
   $ dune exec ./foo.exe
   File "dune", line 3, characters 16-31:
   3 |  (enabled_if (= %{context_name} "default")))
@@ -11,8 +9,6 @@ For dune < 2.7 context_name is not allowed
   [1]
 
 For dune >= 2.7 context_name allowed
-  $ cat > dune-project <<EOF
-  > (lang dune 2.7)
-  > EOF
+  $ make_dune_project 2.7
   $ dune exec ./foo.exe
   bar

--- a/test/blackbox-tests/test-cases/enabled_if/negated.t
+++ b/test/blackbox-tests/test-cases/enabled_if/negated.t
@@ -1,7 +1,5 @@
 For dune >= 3.2, negating expressions is allowed
-  $ cat > dune-project <<EOF
-  > (lang dune 3.2)
-  > EOF
+  $ make_dune_project 3.2
   $ cat > dune <<EOF
   > (executable
   >  (name foo)

--- a/test/blackbox-tests/test-cases/enabled_if/short-circuit.t
+++ b/test/blackbox-tests/test-cases/enabled_if/short-circuit.t
@@ -3,9 +3,7 @@ Test that `and` and `or` in enabled_if should short-circuit.
 When the first conjunct of `and` is false, the second should not be evaluated.
 Currently this is broken: both are evaluated eagerly, causing spurious errors.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ cat >dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/exec-watch/exec-signal.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-signal.t
@@ -7,9 +7,7 @@ since it shouldn't affect dune's other functions.
 
   $ DONE_FLAG=_build/done_flag
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.18)
-  > EOF
+  $ make_dune_project 3.18
 
   $ cat > dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/exec-watch/exec-stdin.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-stdin.t
@@ -3,9 +3,7 @@ Testing stdin for watch mode dune exec
 We use the done flag as a signal that the program has finished.
   $ DONE_FLAG=_build/done_flag
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.18)
-  > EOF
+  $ make_dune_project 3.18
 
   $ cat > dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-fail.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-fail.t
@@ -3,9 +3,7 @@ non-zero exit code.
 
   $ DONE_FLAG=_build/done_flag
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.18)
-  > EOF
+  $ make_dune_project 3.18
 
   $ cat > dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/exec/exec-abs.t
+++ b/test/blackbox-tests/test-cases/exec/exec-abs.t
@@ -1,8 +1,6 @@
 Testing interaction of dune exec and absolute directories.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.20)
-  > EOF
+  $ make_dune_project 3.20
 
   $ cat > dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/exec/exec-argv0-relative-path-github11527.t
+++ b/test/blackbox-tests/test-cases/exec/exec-argv0-relative-path-github11527.t
@@ -3,9 +3,7 @@ Reproducing github #11527
 When running dune exec on a binary `./bug.exe` we can expect that the working directory
 and argv.(0) can be concatenated to get a valid path.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.18)
-  > EOF
+  $ make_dune_project 3.18
 
   $ cat > dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/exec/exec-fail.t
+++ b/test/blackbox-tests/test-cases/exec/exec-fail.t
@@ -1,8 +1,6 @@
 Testing how dune exec handles errors in the program being run.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.18)
-  > EOF
+  $ make_dune_project 3.18
 
   $ cat > dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/external-lib-deps/simple.t/run.t
+++ b/test/blackbox-tests/test-cases/external-lib-deps/simple.t/run.t
@@ -1,6 +1,6 @@
 external library dependencies of a simple project
 
-  $ echo "(lang dune 2.3)" > dune-project
+  $ make_dune_project 2.3
   $ touch dummypkg.opam
   $ cat >dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/fallback-dune/fallback-partial.t
+++ b/test/blackbox-tests/test-cases/fallback-dune/fallback-partial.t
@@ -6,9 +6,7 @@ Fallback rules must either have:
 Here we me makes sure that having some targets in the source and some not is
 impossible.
 
-  $ cat>dune-project <<EOF
-  > (lang dune 3.10)
-  > EOF
+  $ make_dune_project 3.10
 
   $ cat >dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/file-available.t
+++ b/test/blackbox-tests/test-cases/file-available.t
@@ -7,9 +7,7 @@ Populate the current workspace with some files and test if they are available.
   $ touch bin/foo.ml
   $ touch bar.ml
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ cat > dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/foreign-stubs/available-version.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/available-version.t
@@ -1,7 +1,7 @@
 ----------------------------------------------------------------------------------
 * (foreign_library ...) is unavailable before Dune 2.0.
 
-  $ echo "(lang dune 1.0)" > dune-project
+  $ make_dune_project 1.0
   $ mkdir -p lib
 
   $ cat >lib/dune <<EOF
@@ -23,7 +23,7 @@
 * (foreign_library ...) is available in Dune 2.0.
 * "archive_name" is a required field.
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
 
   $ dune build
   File "lib/dune", lines 1-3, characters 0-44:

--- a/test/blackbox-tests/test-cases/foreign-stubs/c-library-flags.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/c-library-flags.t
@@ -1,7 +1,7 @@
 ----------------------------------------------------------------------------------
 Tests for the (c_library_flags ...) field in foreign code stanzas.
 
-  $ echo "(lang dune 3.23)" > dune-project
+  $ make_dune_project 3.23
 
 ----------------------------------------------------------------------------------
 * Build a library with (foreign_stubs ...) that uses (c_library_flags ...).

--- a/test/blackbox-tests/test-cases/foreign-stubs/cxx-extension.t/run.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/cxx-extension.t/run.t
@@ -21,7 +21,7 @@
   $ dune build
   n = 42
 
-  $ echo "(lang dune 1.11)" > dune-project
+  $ make_dune_project 1.11
 
 * Compilation succeeds when unused baz.cpp and baz.cxx exist
 
@@ -100,7 +100,7 @@ This works because the translation layer from pre-2.0 to 2.0 replaces
 
 * Compilation fails when using :standard in Dune 2.0
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
 
   $ cat >dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/foreign-stubs/extra-objects/extra-objects-compile-with-rule.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/extra-objects/extra-objects-compile-with-rule.t
@@ -1,7 +1,7 @@
 ----------------------------------------------------------------------------------
 Build an executable which depends on foreign object files compiled with a rule.
 
-  $ echo "(lang dune 3.5)" > dune-project
+  $ make_dune_project 3.5
 
   $ cat >dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/foreign-stubs/extra-objects/extra-objects-error-on-duplicate.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/extra-objects/extra-objects-error-on-duplicate.t
@@ -1,7 +1,7 @@
 ----------------------------------------------------------------------------------
 Test that duplicate foreign objects results in an error
 
-  $ echo "(lang dune 3.5)" > dune-project
+  $ make_dune_project 3.5
 
   $ cat >dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/foreign-stubs/extra-objects/extra-objects-exe.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/extra-objects/extra-objects-exe.t
@@ -4,7 +4,7 @@ Build an executable which depends on foreign object files.
 ----------------------------------------------------------------------------------
 * (extra_objects ...) is unavailable before Dune 3.5.
 
-  $ echo "(lang dune 3.4)" > dune-project
+  $ make_dune_project 3.4
   $ mkdir -p bin
 
   $ cat >bin/dune <<EOF
@@ -24,7 +24,7 @@ Build an executable which depends on foreign object files.
 ----------------------------------------------------------------------------------
 * Error for missing object file
 
-  $ echo "(lang dune 3.5)" > dune-project
+  $ make_dune_project 3.5
 
   $ cat >bin/calc.ml <<EOF
   > external add : int -> int -> int = "add"

--- a/test/blackbox-tests/test-cases/foreign-stubs/extra-objects/extra-objects-indirect.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/extra-objects/extra-objects-indirect.t
@@ -4,7 +4,7 @@ Build an library which indirectly depends on foreign object files.
 ----------------------------------------------------------------------------------
 * Building library with indirect dependency on object file
 
-  $ echo "(lang dune 3.5)" > dune-project
+  $ make_dune_project 3.5
 
   $ mkdir -p lib
 

--- a/test/blackbox-tests/test-cases/foreign-stubs/extra-objects/extra-objects-lib.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/extra-objects/extra-objects-lib.t
@@ -4,7 +4,7 @@ Build a library which depends on foreign object files.
 ----------------------------------------------------------------------------------
 * (extra_objects ...) is unavailable before Dune 3.5.
 
-  $ echo "(lang dune 3.4)" > dune-project
+  $ make_dune_project 3.4
   $ mkdir -p lib
 
   $ cat >lib/dune <<EOF
@@ -24,7 +24,7 @@ Build a library which depends on foreign object files.
 ----------------------------------------------------------------------------------
 * Error for missing object file
 
-  $ echo "(lang dune 3.5)" > dune-project
+  $ make_dune_project 3.5
 
   $ cat >lib/calc.ml <<EOF
   > external add : int -> int -> int = "add"

--- a/test/blackbox-tests/test-cases/foreign-stubs/foreign-library-enabled-if.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/foreign-library-enabled-if.t
@@ -1,8 +1,6 @@
 Interaction of the foreign_library stanza and the enabled_if field.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.18)
-  > EOF
+  $ make_dune_project 3.18
 
   $ cat > a.c <<EOF
   > int foo() {

--- a/test/blackbox-tests/test-cases/foreign-stubs/foreign-library-extra-objects.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/foreign-library-extra-objects.t
@@ -1,8 +1,6 @@
 Testing extra_objects in foreign libraries
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.19)
-  > EOF
+  $ make_dune_project 3.19
 
 First we create a foreign library that uses an extra object file containing our message.
 

--- a/test/blackbox-tests/test-cases/foreign-stubs/foreign-library.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/foreign-library.t
@@ -2,7 +2,7 @@
 Testsuite for the (foreign_library ...) stanza.
 
   $ export DUNE_SANDBOX=symlink
-  $ echo "(lang dune 3.0)" > dune-project
+  $ make_dune_project 3.0
 
 ----------------------------------------------------------------------------------
 * Multiple (foreign_library ...) declarations.

--- a/test/blackbox-tests/test-cases/foreign-stubs/foreign-stubs-archive-name.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/foreign-stubs-archive-name.t
@@ -1,6 +1,6 @@
 Error when specifying an (archive_name ...) in (foreign_stubs ...) stanza.
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ ./sandboxed.sh
 
   $ cat >dune <<EOF

--- a/test/blackbox-tests/test-cases/foreign-stubs/foreign-stubs-bytecode-executable.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/foreign-stubs-bytecode-executable.t
@@ -1,7 +1,7 @@
 ----------------------------------------------------------------------------------
 Testing the building of bytecode executables with foreign archives.
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ ./sandboxed.sh
 
 ----------------------------------------------------------------------------------

--- a/test/blackbox-tests/test-cases/foreign-stubs/foreign-stubs-caml-headers.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/foreign-stubs-caml-headers.t
@@ -1,8 +1,6 @@
 Check that C stub compilation rules are made to depend on the Caml header files.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
   $ cat >dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/foreign-stubs/foreign-stubs-dune-2.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/foreign-stubs-dune-2.t
@@ -6,7 +6,7 @@ Compatability testsuite for the (foreign_stubs ...) field.
 ----------------------------------------------------------------------------------
 * Error when using both (self_build_stubs_archive ...) and (c_names ...) before 2.0.
 
-  $ echo "(lang dune 1.0)" > dune-project
+  $ make_dune_project 1.0
 
   $ cat >dune <<EOF
   > (library
@@ -26,7 +26,7 @@ Compatability testsuite for the (foreign_stubs ...) field.
 ----------------------------------------------------------------------------------
 * Error when using (c_names ...) in (library ...) in Dune 2.0.
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
 
   $ dune build
   File "dune", line 3, characters 1-14:

--- a/test/blackbox-tests/test-cases/foreign-stubs/foreign-stubs-missing-c.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/foreign-stubs-missing-c.t
@@ -3,7 +3,7 @@
 * Error when a C source file is missing.
 
   $ ./sandboxed.sh
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
 
   $ cat >dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/foreign-stubs/foreign-stubs-multiple.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/foreign-stubs-multiple.t
@@ -1,6 +1,6 @@
 Testsuite for the (foreign_stubs ...) field.
 
-  $ echo "(lang dune 3.0)" > dune-project
+  $ make_dune_project 3.0
   $ ./sandboxed.sh
 
 ----------------------------------------------------------------------------------

--- a/test/blackbox-tests/test-cases/foreign-stubs/h-files-not-copied-without-stubs.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/h-files-not-copied-without-stubs.t
@@ -4,9 +4,7 @@ source tree should not appear as dependencies of any build rule.
 
 See https://github.com/ocaml/dune/issues/2370
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
 A library with no C stubs — .h files should not be a dependency of any rule:
 

--- a/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/include-dir-chain.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/include-dir-chain.t
@@ -2,7 +2,7 @@
 Include a file with an `(include ...)` statement, which iteslf contains an
 `(include ...`) statement.
 
-  $ echo "(lang dune 3.5)" > dune-project
+  $ make_dune_project 3.5
 
   $ cat >dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/include-dir-include-lib.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/include-dir-include-lib.t
@@ -1,7 +1,7 @@
 ----------------------------------------------------------------------------------
 Test use of `(lib ...)` statements inside a file included with `(include ...)`
 
-  $ echo "(lang dune 3.5)" > dune-project
+  $ make_dune_project 3.5
 
   $ cat >dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/include-dir-include-loop.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/include-dir-include-loop.t
@@ -1,7 +1,7 @@
 ----------------------------------------------------------------------------------
 Detect loops of `(include ...)` statements
 
-  $ echo "(lang dune 3.5)" > dune-project
+  $ make_dune_project 3.5
 
   $ cat >dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/multiple-include-dirs.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/multiple-include-dirs.t
@@ -1,7 +1,7 @@
 ----------------------------------------------------------------------------------
 Test where a multiple include directories are added via a `(include ...)` statement
 
-  $ echo "(lang dune 3.5)" > dune-project
+  $ make_dune_project 3.5
 
   $ cat >dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/single-include-dir.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/single-include-dir.t
@@ -4,7 +4,7 @@ Test where a single include directory is added via a `(include ...)` statement
 ----------------------------------------------------------------------------------
 * Versions of dune before 3.5 do not support this feature
 
-  $ echo "(lang dune 3.4)" > dune-project
+  $ make_dune_project 3.4
   $ cat >dune <<EOF
   > (library
   >  (name foo)
@@ -24,7 +24,7 @@ Test where a single include directory is added via a `(include ...)` statement
 ----------------------------------------------------------------------------------
 * Error if include file is missing
 
-  $ echo "(lang dune 3.5)" > dune-project
+  $ make_dune_project 3.5
 
   $ cat >bar.c <<EOF
   > #include <caml/mlvalues.h>

--- a/test/blackbox-tests/test-cases/foreign-stubs/same-executable-name-stubs-github10675.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/same-executable-name-stubs-github10675.t
@@ -13,9 +13,7 @@ stubs, dune should not crash. See #10675.
   >   (names startup)))
   > EOF
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ touch startup.c main.ml
 

--- a/test/blackbox-tests/test-cases/foreign-stubs/source-file-absence.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/source-file-absence.t
@@ -1,4 +1,4 @@
-  $ echo "(lang dune 3.0)" > dune-project
+  $ make_dune_project 3.0
 
 ----------------------------------------------------------------------------------
 * Error message for a missing source file.

--- a/test/blackbox-tests/test-cases/foreign-stubs/tests-stanza-with-c-stubs-github4936.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/tests-stanza-with-c-stubs-github4936.t
@@ -1,9 +1,7 @@
 C stubs and the tests stanza
 
   $ touch e.ml stubs.c
-  $ cat > dune-project << EOF
-  > (lang dune 2.0)
-  > EOF
+  $ make_dune_project 2.0
   $ cat > dune << EOF
   > (test
   >  (name e)

--- a/test/blackbox-tests/test-cases/formatting/disable-dune-file.t
+++ b/test/blackbox-tests/test-cases/formatting/disable-dune-file.t
@@ -2,9 +2,7 @@ This tests how it is possible to disable formatting for a particular dialect in
 a given subdirectory. This can be used to disable formatting of a particular
 dune file.
 
-  $ cat > dune-project << EOF
-  > (lang dune 2.8)
-  > EOF
+  $ make_dune_project 2.8
 
   $ cat > dune << EOF
   > ; this file should be formatted

--- a/test/blackbox-tests/test-cases/formatting/error-field.t
+++ b/test/blackbox-tests/test-cases/formatting/error-field.t
@@ -1,8 +1,6 @@
 Rejects unknown fields in `(formatting ...)`.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.5)
-  > EOF
+  $ make_dune_project 3.5
 
   $ cat > dune << EOF
   > (env

--- a/test/blackbox-tests/test-cases/formatting/fmt-no-promote.t
+++ b/test/blackbox-tests/test-cases/formatting/fmt-no-promote.t
@@ -1,6 +1,4 @@
-  $ cat > dune-project << EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
 Make a dune file that should be formatted.
   $ cat > dune << EOF

--- a/test/blackbox-tests/test-cases/generated-source-dir-overlap.t
+++ b/test/blackbox-tests/test-cases/generated-source-dir-overlap.t
@@ -8,9 +8,7 @@ If a generated directory is "overlaid" by a source dir, then things break.
   >  (action (echo foobar)))
   > EOF
 
-  $ cat > dune-project <<EOF
-  > (lang dune 2.2)
-  > EOF
+  $ make_dune_project 2.2
 
   $ cat > dune <<EOF
   > (dirs .dune)

--- a/test/blackbox-tests/test-cases/glob-deps-outside-directory.t
+++ b/test/blackbox-tests/test-cases/glob-deps-outside-directory.t
@@ -1,8 +1,6 @@
 Glob deps in a subdirectory that refer to a path outside that subdirectory
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.6)
-  > EOF
+  $ make_dune_project 3.6
 
   $ mkdir -p foo bar
 

--- a/test/blackbox-tests/test-cases/glob_files_rec.t
+++ b/test/blackbox-tests/test-cases/glob_files_rec.t
@@ -1,9 +1,7 @@
 Tests for (glob_files_rec <dir>/<glob>). This feature is not meat to
 be release as it. We plan to replace it by recursive globs for 3.0.0.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 2.9)
-  > EOF
+  $ make_dune_project 2.9
 
   $ cat > dune <<EOF
   > (rule
@@ -32,9 +30,7 @@ Leave a/b2/c empty to make sure we don't choke on empty dirs.
   language. Please update your dune-project file to have (lang dune 3.0).
   [1]
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ dune build @x
   foo/a/b1/c/x.txt

--- a/test/blackbox-tests/test-cases/graceful-shutdown.t
+++ b/test/blackbox-tests/test-cases/graceful-shutdown.t
@@ -3,9 +3,7 @@ actions should receive SIGTERM before SIGKILL so they can run cleanup handlers.
 
 See https://github.com/ocaml/dune/issues/2445
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.18)
-  > EOF
+  $ make_dune_project 3.18
 
   $ cat > dune <<EOF
   > (executable (name main) (libraries unix))

--- a/test/blackbox-tests/test-cases/hyphenated-module-name-gh3180.t
+++ b/test/blackbox-tests/test-cases/hyphenated-module-name-gh3180.t
@@ -1,6 +1,6 @@
 Tests hyphenated module name.
 
-  $ echo "(lang dune 2.3)" > dune-project
+  $ make_dune_project 2.3
   $ cat >dune <<EOF
   > (executable (name foo) (modules foo foo-bar))
   > EOF

--- a/test/blackbox-tests/test-cases/include-qualified/ambiguous-module-name.t
+++ b/test/blackbox-tests/test-cases/include-qualified/ambiguous-module-name.t
@@ -2,7 +2,7 @@ There is ambiguity between the two different foo modules.
 The behaviour is now correct both in the bootstrap process, and in dune.
 It picks up the closest one.
 
-  $ echo "(lang dune 3.21)" > dune-project
+  $ make_dune_project 3.21
   $ cat > dune << EOF
   > (include_subdirs qualified)
   > (executable

--- a/test/blackbox-tests/test-cases/include-qualified/build-with-sandbox.t
+++ b/test/blackbox-tests/test-cases/include-qualified/build-with-sandbox.t
@@ -1,9 +1,7 @@
 Test `(include_subdirs qualified)` with sandboxing
 
   $ mkdir lib
-  $ cat > dune-project <<EOF
-  > (lang dune 3.20)
-  > EOF
+  $ make_dune_project 3.20
 
   $ mkdir lib/sub
   $ cat > lib/dune <<EOF

--- a/test/blackbox-tests/test-cases/include-qualified/include-qualified-empty-dir.t
+++ b/test/blackbox-tests/test-cases/include-qualified/include-qualified-empty-dir.t
@@ -1,9 +1,7 @@
 Test `(include_subdirs qualified)` in the presence of invalid module name
 directories that don't contain source files
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ cat > dune <<EOF
   > (include_subdirs qualified)

--- a/test/blackbox-tests/test-cases/include-qualified/invalid-deps/group-interface-sub-module.t
+++ b/test/blackbox-tests/test-cases/include-qualified/invalid-deps/group-interface-sub-module.t
@@ -1,8 +1,6 @@
 We shouldn't allow foo/y/$x.ml to depend on foo/foo.ml
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.7)
-  > EOF
+  $ make_dune_project 3.7
 
   $ cat > dune << EOF
   > (include_subdirs qualified)

--- a/test/blackbox-tests/test-cases/include-qualified/invalid-deps/group-interface.t
+++ b/test/blackbox-tests/test-cases/include-qualified/invalid-deps/group-interface.t
@@ -1,8 +1,6 @@
 We shouldn't allow foo/$x.ml to depend on foo/foo.ml
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.7)
-  > EOF
+  $ make_dune_project 3.7
 
   $ cat > dune << EOF
   > (include_subdirs qualified)

--- a/test/blackbox-tests/test-cases/include-qualified/invalid-deps/toplevel-lib-interface.t
+++ b/test/blackbox-tests/test-cases/include-qualified/invalid-deps/toplevel-lib-interface.t
@@ -1,8 +1,6 @@
 We should forbid lib interfaces modules from depending on themselves:
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.7)
-  > EOF
+  $ make_dune_project 3.7
 
   $ cat > dune << EOF
   > (include_subdirs qualified)

--- a/test/blackbox-tests/test-cases/include-qualified/ocamldep-regression.t
+++ b/test/blackbox-tests/test-cases/include-qualified/ocamldep-regression.t
@@ -1,8 +1,6 @@
 We should forbid lib interfaces modules from depending on themselves:
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.7)
-  > EOF
+  $ make_dune_project 3.7
 
   $ cat > dune << EOF
   > (include_subdirs qualified)

--- a/test/blackbox-tests/test-cases/include-qualified/qualified-subdir-invalid-module-name-github7600.t
+++ b/test/blackbox-tests/test-cases/include-qualified/qualified-subdir-invalid-module-name-github7600.t
@@ -4,9 +4,7 @@ When using (include_subdirs qualified), valid module names should be checked for
 directories too.
 
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.8)
-  > EOF
+  $ make_dune_project 3.8
 
   $ mkdir src
 

--- a/test/blackbox-tests/test-cases/inline-tests/clicolor-force-inline-tests-github6607.t
+++ b/test/blackbox-tests/test-cases/inline-tests/clicolor-force-inline-tests-github6607.t
@@ -2,9 +2,7 @@ This shows that the test suite is impacted by CLICOLOR_FORCE=1 (#6607).
 This environment variable should only impact the output of dune, not behavior
 visible from within the test suite.
 
-  $ cat > dune-project << EOF
-  > (lang dune 1.0)
-  > EOF
+  $ make_dune_project 1.0
 
   $ cat > dune << EOF
   > (library

--- a/test/blackbox-tests/test-cases/inline-tests/generate-runner-sandboxing.t
+++ b/test/blackbox-tests/test-cases/inline-tests/generate-runner-sandboxing.t
@@ -23,9 +23,7 @@ The inline-tests runner generator becomes sandboxed starting with dune 3.23.
 
 At dune 3.22 the generator still runs outside the sandbox.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ dune test lib.ml
   File "dune", line 13, characters 1-38:
@@ -45,9 +43,7 @@ At dune 3.22 the generator still runs outside the sandbox.
 At dune 3.23 the generator is sandboxed and %{impl-files} still works.
 
   $ rm -rf _build
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ dune test lib.ml
   File "dune", line 13, characters 1-38:

--- a/test/blackbox-tests/test-cases/inline-tests/reason-expect.t/run.t
+++ b/test/blackbox-tests/test-cases/inline-tests/reason-expect.t/run.t
@@ -16,9 +16,7 @@ Testing the interaction of reason syntax and ppx expect
 In https://github.com/ocaml/dune/issues/7930 there is an issue where reason
 syntax and ppx_expect break at dune lang 3.3 due to the sandboxing of ppx.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.9)
-  > EOF
+  $ make_dune_project 3.9
   $ dune test 2>&1 | head -n 6
   File "test.re", line 1, characters 0-0:
   --- test.re

--- a/test/blackbox-tests/test-cases/install-command/install-does-not-write-build-dir-github3857.t
+++ b/test/blackbox-tests/test-cases/install-command/install-does-not-write-build-dir-github3857.t
@@ -1,5 +1,5 @@
 dune install should not write anything to _build/
-  $ echo "(lang dune 2.8)" > dune-project
+  $ make_dune_project 2.8
   $ dune install --prefix _install
   $ ls .
   dune-project

--- a/test/blackbox-tests/test-cases/install-dir/install-bindir.t
+++ b/test/blackbox-tests/test-cases/install-dir/install-bindir.t
@@ -1,6 +1,6 @@
 Honors `--bindir` and `--sbindir` during installation.
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ touch foo.opam user.ml admin.ml
   $ cat >dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/install-dir/install-datadir.t
+++ b/test/blackbox-tests/test-cases/install-dir/install-datadir.t
@@ -1,6 +1,6 @@
 Honors `--datadir` for installed shared files.
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ touch foo.opam datafile
   $ cat >dune <<EOF
   > (install

--- a/test/blackbox-tests/test-cases/install-dir/install-docdir.t
+++ b/test/blackbox-tests/test-cases/install-dir/install-docdir.t
@@ -1,6 +1,6 @@
 Honors `--docdir` for installed documentation files.
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ touch foo.opam docfile
   $ cat >dune <<EOF
   > (install

--- a/test/blackbox-tests/test-cases/install-dir/install-etcdir.t
+++ b/test/blackbox-tests/test-cases/install-dir/install-etcdir.t
@@ -1,6 +1,6 @@
 Honors `--etcdir` for installed configuration files.
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ touch foo.opam configfile
   $ cat >dune <<EOF
   > (install

--- a/test/blackbox-tests/test-cases/install-dir/install-mandir.t
+++ b/test/blackbox-tests/test-cases/install-dir/install-mandir.t
@@ -1,6 +1,6 @@
 Honors `--mandir` for installed manpages.
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ touch foo.opam manfile
   $ cat >dune <<EOF
   > (install

--- a/test/blackbox-tests/test-cases/install/install-no-prefix.t
+++ b/test/blackbox-tests/test-cases/install/install-no-prefix.t
@@ -1,8 +1,6 @@
 Here we specify the behaviour of dune install when no install prefix is given.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.9)
-  > EOF
+  $ make_dune_project 3.9
 
   $ cat > dune << EOF
   > (executable

--- a/test/blackbox-tests/test-cases/intf-only/excluded-by-modules-field.t
+++ b/test/blackbox-tests/test-cases/intf-only/excluded-by-modules-field.t
@@ -1,9 +1,7 @@
 Specifying a module without implementation that isn't inside the (modules ..)
 field
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.7)
-  > EOF
+  $ make_dune_project 3.7
 
   $ mkdir src
   $ cat > src/dune << EOF
@@ -37,9 +35,7 @@ X is warned about:
 
 In 3.11 onwards this warning becomes an error
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.11)
-  > EOF
+  $ make_dune_project 3.11
 
   $ dune build
   File "src/dune", line 4, characters 33-34:

--- a/test/blackbox-tests/test-cases/invalid-dune-package.t
+++ b/test/blackbox-tests/test-cases/invalid-dune-package.t
@@ -1,7 +1,7 @@
 This test demonstrates the handling of invalid dune-package files
   $ mkdir -p findlib/baz
   $ touch findlib/baz/dune-package
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ echo 'let () = print_endline "foo"' > foo.ml
   $ cat >dune <<EOF
   > (executable (name foo))

--- a/test/blackbox-tests/test-cases/invalid-module-name.t
+++ b/test/blackbox-tests/test-cases/invalid-module-name.t
@@ -1,5 +1,5 @@
 Dune does not report an invalid module name as an error
-  $ echo "(lang dune 2.2)" > dune-project
+  $ make_dune_project 2.2
   $ cat >dune <<EOF
   > (library (name foo))
   > EOF

--- a/test/blackbox-tests/test-cases/invalid-module.t
+++ b/test/blackbox-tests/test-cases/invalid-module.t
@@ -1,9 +1,7 @@
 Test `(include_subdirs qualified)` in the presence of invalid module names in
 the source tree
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
   $ cat > dune <<EOF
   > (library (name foo) (modules foo))
   > EOF
@@ -49,9 +47,7 @@ Invalid module may be used in executables
 
 Prior to Dune 3.0, executable names aren't validated as valid module names
 
-  $ cat > dune-project <<EOF
-  > (lang dune 2.9)
-  > EOF
+  $ make_dune_project 2.9
 
   $ dune exec ./invalid-module.exe
   hello from invalid-module.ml

--- a/test/blackbox-tests/test-cases/jsoo/build-info.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/build-info.t/run.t
@@ -1,6 +1,6 @@
 Jsoo and build-info
 
-  $ echo "(lang dune 3.0)" > dune-project
+  $ make_dune_project 3.0
   $ dune build
   Warning [missing-debug-event]: '--source-map' is enabled but the bytecode program was compiled with no debugging information.
   Consider passing '-g' option to ocamlc.

--- a/test/blackbox-tests/test-cases/jsoo/env.t
+++ b/test/blackbox-tests/test-cases/jsoo/env.t
@@ -1,8 +1,6 @@
 Tests env stanzas in JSOO contexts.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
   $ cat >dune <<EOF
   > (env (_ (js_of_ocaml (flags :standard "--no-inline"))))
   > (library (name test))

--- a/test/blackbox-tests/test-cases/jsoo/runtest-cmd-inline-tests.t
+++ b/test/blackbox-tests/test-cases/jsoo/runtest-cmd-inline-tests.t
@@ -1,8 +1,6 @@
 Test running js_of_ocaml inline tests by specifying ML source files directly.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
   $ cat > dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/jsoo/without_implem.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/without_implem.t/run.t
@@ -1,8 +1,6 @@
 Tests JSOO rules for modules without implementations.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
   $ cat > dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/lang-dune-warning.t
+++ b/test/blackbox-tests/test-cases/lang-dune-warning.t
@@ -1,9 +1,7 @@
 If (lang dune) does not use a valid format on a 2.x project, a warning is
 emitted:
 
-  $ cat > dune-project << EOF
-  > (lang dune 2.3.0)
-  > EOF
+  $ make_dune_project 2.3.0
 
   $ dune build
   File "dune-project", line 1, characters 11-16:
@@ -12,9 +10,7 @@ emitted:
   Warning: The ".0" part is ignored here.
   This version is parsed as just 2.3.
 
-  $ cat > dune-project << EOF
-  > (lang dune 2.4suffix)
-  > EOF
+  $ make_dune_project 2.4suffix
 
   $ dune build
   File "dune-project", line 1, characters 11-20:
@@ -25,17 +21,13 @@ emitted:
 
 If the version is valid, no warning is emitted:
 
-  $ cat > dune-project << EOF
-  > (lang dune 2.2)
-  > EOF
+  $ make_dune_project 2.2
 
   $ dune build
 
 Starting with lang 3.0, the warning turns into an error.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.0suffix)
-  > EOF
+  $ make_dune_project 3.0suffix
 
   $ dune build
   File "dune-project", line 1, characters 11-20:
@@ -47,8 +39,6 @@ Starting with lang 3.0, the warning turns into an error.
 
 And without suffix it is accepted.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ dune build

--- a/test/blackbox-tests/test-cases/lib-available-dynamic-modules.t
+++ b/test/blackbox-tests/test-cases/lib-available-dynamic-modules.t
@@ -1,9 +1,7 @@
 Demonstrate a dependency cycle between library modules field and a rule that
 generates them dynamically in the same directory
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.13)
-  > EOF
+  $ make_dune_project 3.13
 
   $ mkdir gen
   $ cat > gen/dune << EOF

--- a/test/blackbox-tests/test-cases/lib-collision/lib-collision-private-optional.t
+++ b/test/blackbox-tests/test-cases/lib-collision/lib-collision-private-optional.t
@@ -2,9 +2,7 @@ Private libraries using the same library name, in the same context, defined in
 the same folder. One of them is unavailable because it's `(optional)` and a
 dependency is missing.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.13)
-  > EOF
+  $ make_dune_project 3.13
 
   $ cat > dune << EOF
   > (library

--- a/test/blackbox-tests/test-cases/lib-collision/lib-collision-private-same-folder.t
+++ b/test/blackbox-tests/test-cases/lib-collision/lib-collision-private-same-folder.t
@@ -1,9 +1,7 @@
 Private libraries using the same library name, in the same context, defined in
 the same folder.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.13)
-  > EOF
+  $ make_dune_project 3.13
 
   $ cat > dune << EOF
   > (library

--- a/test/blackbox-tests/test-cases/lib-collision/lib-collision-private.t
+++ b/test/blackbox-tests/test-cases/lib-collision/lib-collision-private.t
@@ -3,9 +3,7 @@ different folders.
 
   $ mkdir -p a b
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.13)
-  > EOF
+  $ make_dune_project 3.13
 
   $ cat > a/dune << EOF
   > (library

--- a/test/blackbox-tests/test-cases/lib-errors.t/run.t
+++ b/test/blackbox-tests/test-cases/lib-errors.t/run.t
@@ -16,7 +16,7 @@ Select with no solution
 
   $ mkdir select
   $ cd select
-  $ echo "(lang dune 3.0)" > dune-project
+  $ make_dune_project 3.0
   $ cat <<EOF > dune
   > (executable
   >  (name select_error)

--- a/test/blackbox-tests/test-cases/lib-modes.t
+++ b/test/blackbox-tests/test-cases/lib-modes.t
@@ -1,8 +1,6 @@
 Test library modes field
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.7)
-  > EOF
+  $ make_dune_project 3.7
 
   $ mkdir lib
 
@@ -40,9 +38,7 @@ in a version of dune lang that does not support them
   3.8).
   [1]
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.8)
-  > EOF
+  $ make_dune_project 3.8
 
 Works for the most recent version
 

--- a/test/blackbox-tests/test-cases/lib.t
+++ b/test/blackbox-tests/test-cases/lib.t
@@ -10,7 +10,7 @@ Testsuite for the %{lib...} and %{lib-private...} variable.
 ----------------------------------------------------------------------------------
 * Find a public library using the %{lib:...} variable
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ mkdir -p src
   $ cat >src/dune <<EOF
   > (library
@@ -89,7 +89,7 @@ Testsuite for the %{lib...} and %{lib-private...} variable.
 * Find a public library by its private name using the %{lib-private:...} variable
 * Success when using Dune language 2.1
 
-  $ echo "(lang dune 2.1)" > dune-project
+  $ make_dune_project 2.1
 
   $ ./sdune build @find-a
   src/a.ml

--- a/test/blackbox-tests/test-cases/libexec.t
+++ b/test/blackbox-tests/test-cases/libexec.t
@@ -17,7 +17,7 @@ Testsuite for the %{libexec...} and %{libexec-private...} variable.
 ----------------------------------------------------------------------------------
 * Find a host-context public library using the %{libexec:...} variable
 
-  $ echo "(lang dune 2.8)" > dune-project
+  $ make_dune_project 2.8
   $ mkdir -p src
   $ cat >src/dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/library-name-starts-with-digit-gh5273.t
+++ b/test/blackbox-tests/test-cases/library-name-starts-with-digit-gh5273.t
@@ -1,8 +1,6 @@
 Rejects library names that are not valid module names.
 
-  $ cat > dune-project << EOF
-  > (lang dune 1.0)
-  > EOF
+  $ make_dune_project 1.0
   $ cat > dune << EOF
   > (library (name 03))
   > EOF

--- a/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps.t
+++ b/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps.t
@@ -1,7 +1,7 @@
 We create two libraries where one depends on the other. The dependency library
 also has more than one src dir.
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ mkdir -p lib1/sub
   $ cat >lib1/dune <<EOF
   > (include_subdirs unqualified)

--- a/test/blackbox-tests/test-cases/missing-action-alias-hint-gh10685.t
+++ b/test/blackbox-tests/test-cases/missing-action-alias-hint-gh10685.t
@@ -1,8 +1,6 @@
 Suggests the `(alias ...)` stanza when a dependency-only rule is missing an action.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ cat > dune << EOF
   > (rule

--- a/test/blackbox-tests/test-cases/ml-mli-mismatch-error-path-gh12057.t
+++ b/test/blackbox-tests/test-cases/ml-mli-mismatch-error-path-gh12057.t
@@ -4,9 +4,7 @@ A mismatch between an ml file and its mli file usually gives an error message
 mentioning both files. However in dune, it appears that we trigger the mention
 of the .ml twice.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.20)
-  > EOF
+  $ make_dune_project 3.20
 
   $ cat > dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/multiple-targets.t
+++ b/test/blackbox-tests/test-cases/multiple-targets.t
@@ -1,7 +1,5 @@
 
-  $ cat > dune-project <<EOF
-  > (lang dune 1.11)
-  > EOF
+  $ make_dune_project 1.11
 
   $ cat > dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/name-must-be-listed-in-modules-gh5787.t
+++ b/test/blackbox-tests/test-cases/name-must-be-listed-in-modules-gh5787.t
@@ -1,9 +1,7 @@
 When (name) points to a module that is not part of (modules), a specific error
 message is printed.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ touch a.ml b.ml
 

--- a/test/blackbox-tests/test-cases/no-infer.t
+++ b/test/blackbox-tests/test-cases/no-infer.t
@@ -1,9 +1,7 @@
 An action with source dependencies that are generated outside of dune
 should work if wrapped in (no-infer ...) but not otherwise.
 
-  $ cat > dune-project << EOF
-  > (lang dune 2.6)
-  > EOF
+  $ make_dune_project 2.6
 
   $ cat >dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/ocaml-index/builds-too-much.t
+++ b/test/blackbox-tests/test-cases/ocaml-index/builds-too-much.t
@@ -19,9 +19,7 @@ depends on defaultlib which is only enabled in the default context.
 tries to index the alt context too — and fails because defaultlib
 is hidden there.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ cat > dune-workspace <<EOF
   > (lang dune 3.23)
@@ -79,9 +77,7 @@ Test 2: @ocaml-index correctly skips disabled stanzas (not a bug)
 Verify that (enabled_if false) libraries are already correctly
 excluded from indexing.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ cat > dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/ocaml-index/overlapping-exes-different-deps.t
+++ b/test/blackbox-tests/test-cases/ocaml-index/overlapping-exes-different-deps.t
@@ -6,9 +6,7 @@ dependencies but share modules due to missing (modules) field.
   $ ln -s $(which ocaml_index) bin/ocaml-index
   $ export PATH=bin:$PATH
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
 Create two local libraries with different modules:
   $ mkdir lib_a lib_b

--- a/test/blackbox-tests/test-cases/ocaml-index/overlapping-exes.t
+++ b/test/blackbox-tests/test-cases/ocaml-index/overlapping-exes.t
@@ -6,9 +6,7 @@ Test for https://github.com/ocaml/dune/issues/13566
   $ export PATH=bin:$PATH
 
 Create project with two executables in same directory:
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ cat > dune <<EOF
   > (executable (name foo))

--- a/test/blackbox-tests/test-cases/ocaml-syntax/cross-context-ocaml-syntax-github9239.t
+++ b/test/blackbox-tests/test-cases/ocaml-syntax/cross-context-ocaml-syntax-github9239.t
@@ -2,9 +2,7 @@ When `-x` is passed and a dune file in OCaml syntax is loaded, we should not
 crash.
 See #9239.
 
-  $ cat > dune-project << EOF
-  > (lang dune 1.0)
-  > EOF
+  $ make_dune_project 1.0
 
   $ cat > dune << EOF
   > (* -*- tuareg -*- *)

--- a/test/blackbox-tests/test-cases/odoc/eif-lib-unavailable-doc-private.t
+++ b/test/blackbox-tests/test-cases/odoc/eif-lib-unavailable-doc-private.t
@@ -1,8 +1,6 @@
 Show behavior of doc-private alias when it's part of an unavailable library
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.13)
-  > EOF
+  $ make_dune_project 3.13
 
   $ cat > dune << EOF
   > (library

--- a/test/blackbox-tests/test-cases/ordered-set-language-errors.t
+++ b/test/blackbox-tests/test-cases/ordered-set-language-errors.t
@@ -1,8 +1,6 @@
 Test the error cases for dune's Ordered Set Language (OSL) DSL.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.14)
-  > EOF
+  $ make_dune_project 3.14
 
   $ cat > foo.ml <<EOF
   > let () = print_endline "foo"

--- a/test/blackbox-tests/test-cases/oversize-action-output-gh4194.t
+++ b/test/blackbox-tests/test-cases/oversize-action-output-gh4194.t
@@ -1,8 +1,6 @@
 Truncates oversized action output instead of crashing.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ cat > dune << EOF
   > (rule

--- a/test/blackbox-tests/test-cases/oxcaml/local.t
+++ b/test/blackbox-tests/test-cases/oxcaml/local.t
@@ -1,8 +1,6 @@
 The test ensures we are able to run OxCaml tests for Dune.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.20)
-  > EOF
+  $ make_dune_project 3.20
 
   $ cat > main.ml << EOF
   > let fst_local ((x, _) @ local) = x

--- a/test/blackbox-tests/test-cases/oxcaml/vendor-parameterised.t
+++ b/test/blackbox-tests/test-cases/oxcaml/vendor-parameterised.t
@@ -1,8 +1,6 @@
 Testing that vendoring a parameterised library works as expected:
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.20)
-  > EOF
+  $ make_dune_project 3.20
 
 Note that this root `dune-project` does not enables `(using oxcaml 0.1)`, but
 will depend on a vendored project that does.

--- a/test/blackbox-tests/test-cases/package-dep.t
+++ b/test/blackbox-tests/test-cases/package-dep.t
@@ -1,8 +1,6 @@
 Tests package-scoped library dependencies.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 1.0)
-  > EOF
+  $ make_dune_project 1.0
 
   $ cat >foo.opam
 

--- a/test/blackbox-tests/test-cases/package-materialization/nonexistent-package.t
+++ b/test/blackbox-tests/test-cases/package-materialization/nonexistent-package.t
@@ -1,9 +1,7 @@
 Test that depending on a non-existent package produces an error with a
 proper source location.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.24)
-  > EOF
+  $ make_dune_project 3.24
 
   $ cat >dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/add-unreferenced-sibling-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/add-unreferenced-sibling-lib.t
@@ -16,9 +16,7 @@ the stanza's [(libraries ...)] list. Neither [consumes_dep] nor
 rebuild. Records the rebuild counts on each so a future change
 can flip them to 0.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ cat > dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/alias-reexport.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/alias-reexport.t
@@ -8,9 +8,7 @@ must always trigger it.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
 A library where we'll perform the changes:
 

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/auto-wrapped-child-reexport.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/auto-wrapped-child-reexport.t
@@ -37,9 +37,7 @@ over [lib_re_export]'s objdir does not capture [Original_name.mli]
 changes either. The cctx-wide compile-rule deps still cover
 [dep_lib] on trunk, so [consumer] rebuilds.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ cat > dune <<EOF
   > (library (name dep_lib) (wrapped false) (modules original_name))

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/basic-wrapped.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/basic-wrapped.t
@@ -6,9 +6,7 @@ reference it.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ mkdir lib
   $ cat > lib/dune <<EOF

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/consumer-is-virtual-impl.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/consumer-is-virtual-impl.t
@@ -16,9 +16,7 @@ implementation of [vmod] references [Dep_module] from
 [dep_lib]. Editing [Dep_module]'s interface should rebuild
 [vlib_impl]'s [vmod].
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ cat > dune <<EOF
   > (library (name dep_lib) (wrapped false) (modules dep_module))

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-action-preprocess.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-action-preprocess.t
@@ -9,9 +9,7 @@ outside the producing rule must tolerate this mismatch with the raw
 [Module.t]'s [.ml] source path; this test guards against breaking
 consumers of action-preprocessed libs.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
 A trivial preprocessor that passes its input through unchanged. The
 critical property is that dune's pp pipeline writes a [.pp.ml] file

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-walk-pre-pp-implicit-transitive.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-walk-pre-pp-implicit-transitive.t
@@ -21,9 +21,7 @@ through [pp_dep]'s interface. The consumer's include flags
 must therefore conservatively retain [other_dep]'s [-I]/[-H]
 even though dune sees no direct link.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
 [other_dep]:
 

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/lib-deps-preserved.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/lib-deps-preserved.t
@@ -3,9 +3,7 @@ Verify that library file deps are declared for module compilation rules.
 Every non-alias module should declare glob deps on its library
 dependencies' .cmi files.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ mkdir lib
   $ cat > lib/dune <<EOF

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/lib-to-lib-unwrapped.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/lib-to-lib-unwrapped.t
@@ -6,9 +6,7 @@ coarse dependency analysis.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ mkdir base_unwrapped
   $ cat > base_unwrapped/dune <<EOF

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/lib-to-lib-wrapped.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/lib-to-lib-wrapped.t
@@ -5,9 +5,7 @@ in A are recompiled due to coarse dependency analysis.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ mkdir base_lib
   $ cat > base_lib/dune <<EOF

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/lib-vs-lib-name-collision.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/lib-vs-lib-name-collision.t
@@ -21,9 +21,7 @@ resolves through, and must conservatively depend on both.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ mkdir active_lib
   $ cat > active_lib/dune <<EOF

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/module-name-shadowing.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/module-name-shadowing.t
@@ -5,9 +5,7 @@ internal) correctly reflects the compiler's resolution order.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
 --- Unwrapped library: internal module shadows library module ---
 

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/modules-without-implementation-cross-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/modules-without-implementation-cross-lib.t
@@ -12,9 +12,7 @@ libs might escape the per-module dep filter (the intra-stanza
 rule without a dep on the aliased lib's [.cmi] — which surfaces
 as a hard build error on rebuild.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ cat > dune <<EOF
   > (library (name dep_lib) (wrapped false) (modules original_name))

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/multiple-libraries.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/multiple-libraries.t
@@ -6,9 +6,7 @@ library.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ mkdir lib
   $ cat > lib/dune <<EOF

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/no-ocamldep-leaf-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/no-ocamldep-leaf-lib.t
@@ -1,9 +1,7 @@
 A multi-module consumer of a single-module leaf library builds
 without error.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
 [leaf]: unwrapped, single-module, no library dependencies. This is
 exactly the shape that triggers the no-ocamldep fast path:

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-cmx-deps-external.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-cmx-deps-external.t
@@ -5,9 +5,7 @@ omits the [.cmx] from the dep set for *local* libraries. The [unix]
 library, shipped with OCaml and resolved through findlib, plays the
 role of "external".
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ cat > dune <<EOF
   > (executable (name main) (libraries unix))

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-cmx-deps-local.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-cmx-deps-local.t
@@ -3,9 +3,7 @@ A consumer's [.cmx] compilation rule depends on a local library's
 [.cmi] under the dev profile (opaque=true). External libraries
 behave differently; see [opaque-cmx-deps-external.t].
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ mkdir local_dep
   $ cat > local_dep/dune <<EOF

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-mli-change.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-mli-change.t
@@ -5,9 +5,7 @@ whether cross-module inlining tracks a dep's [.cmx].
 
 Companion to [opaque.t], which covers the [.ml]-only change axis.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ mkdir dep_lib
   $ cat > dep_lib/dune <<EOF

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque.t
@@ -8,9 +8,7 @@ implementation-only change triggers no module recompilation at all.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ mkdir lib
   $ cat > lib/dune <<EOF

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/open-flag-invalid-identifier.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/open-flag-invalid-identifier.t
@@ -5,9 +5,7 @@ the compiler is the authority on whether a given [-open] argument
 is acceptable, and dune should not pre-empt that decision by
 raising on syntactically invalid names.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
 A trivial dependency library so the consumer's compile rule has
 inter-library deps to filter — this exercises any future code path

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/per-module-include-flags.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/per-module-include-flags.t
@@ -11,9 +11,7 @@ library's objdir from the [-I] path. This test records today's
 [-I] contents so that a future filter improvement can flip the
 asserted array to a single entry.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ cat > dune <<EOF
   > (library (name dep_lib) (wrapped false) (modules dep_module))

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/private-modules.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/private-modules.t
@@ -1,9 +1,7 @@
 A consumer of an unwrapped library that has [private_modules] builds
 without error.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
 [dep]: unwrapped library with one public entry module [Pub] and one
 private module [Priv]. Consumers can see [Pub] via [-I] search but

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/root-module-tight-deps.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/root-module-tight-deps.t
@@ -10,9 +10,7 @@ Root that references itself transitively). Any future change to
 inter-library dep handling that misses this short-circuit would
 regress this scenario.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
 [dep_lib]: an unwrapped dep library.
 

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/sibling-unreferenced-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/sibling-unreferenced-lib.t
@@ -25,9 +25,7 @@ deps, tightening this corner to zero rebuilds.
 See: https://github.com/ocaml/dune/issues/4572
 See: https://github.com/ocaml/dune/pull/14116#issuecomment-4301275263
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ cat > dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/single-module-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/single-module-lib.t
@@ -9,9 +9,7 @@ unnecessary recompilation of the consumer module's .cmo/.cmx.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ mkdir base_lib
   $ cat > base_lib/dune <<EOF

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/single-module-unreferenced-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/single-module-unreferenced-lib.t
@@ -25,9 +25,7 @@ single-module-consumer skip-ocamldep limitation.
 See: https://github.com/ocaml/dune/issues/4572
 See: https://github.com/ocaml/dune/pull/14116#issuecomment-4286949811
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ cat > dune <<EOF
   > (library (name dep_lib) (wrapped false) (modules dep_module))

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/stdlib-modules.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/stdlib-modules.t
@@ -5,9 +5,7 @@ not need recompilation when the library changes.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ mkdir lib
   $ cat > lib/dune <<EOF

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-lib.t
@@ -20,9 +20,7 @@ runs unconditionally for both stanzas. Single-module stanzas trigger
 a short-circuit in [dep_rules.ml] that skips ocamldep, which would
 mask the per-module dependency filtering being baselined here.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ cat > dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-module.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-module.t
@@ -8,9 +8,7 @@ unreferenced ones.
 stanza is single-module — single-module stanzas take a fast path that would
 mask the behaviour being baselined here.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ cat > dune <<EOF
   > (library (name dep_lib) (wrapped false) (modules reached_module unreached_module))

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transitive.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transitive.t
@@ -5,9 +5,7 @@ modules in the consuming stanza, even those that don't use A.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ mkdir libB
   $ cat > libB/dune <<EOF

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transparent-alias-chain.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transparent-alias-chain.t
@@ -5,9 +5,7 @@ direct library reference, but the compiler follows alias chains and reads
 
 Any per-module inter-library dependency optimization must account for this.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
 Set up a chain: libA -> libB -> libC -> libD, where each intermediate
 library creates a transparent alias to the next.

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transparent-alias.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transparent-alias.t
@@ -5,9 +5,7 @@ consumers that use the alias must be recompiled when the library changes.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ mkdir lib
   $ cat > lib/dune <<EOF

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped-tight-deps.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped-tight-deps.t
@@ -18,9 +18,7 @@ list becomes empty.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
 [dep_lib] is an unwrapped library with three entry modules, each
 with an explicit interface so signature changes propagate through

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped.t
@@ -6,9 +6,7 @@ different modules in the library.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ mkdir unwrapped
   $ cat > unwrapped/dune <<EOF

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/virtual-library.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/virtual-library.t
@@ -5,9 +5,7 @@ modules in stanzas that depend on it, even those that don't reference it.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ mkdir vlib
   $ cat > vlib/dune <<EOF

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-closure-precision.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-closure-precision.t
@@ -37,9 +37,7 @@ transitively-globbed lib still rebuilds the consumer.
 A future filter improvement that walks wrapped libs' children
 flips the expected target_files array to [].
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ cat > dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-compat.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-compat.t
@@ -5,9 +5,7 @@ Currently, all inner modules are recompiled when any library dependency changes.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ cat > dune-project <<EOF
-  > (lang dune 2.0)
-  > EOF
+  $ make_dune_project 2.0
 
   $ mkdir baselib
   $ cat > baselib/dune <<EOF

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-internal-leak.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-internal-leak.t
@@ -26,9 +26,7 @@ The flip is acceptable because the leak was never supported;
 downstream consumers depending on the mangled form should migrate
 to the wrapper API.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ mkdir mylib
   $ cat > mylib/dune <<EOF

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-reexport-via-open-flag.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-reexport-via-open-flag.t
@@ -20,9 +20,7 @@ Structure: [dep_lib] is unwrapped with module [Original_name];
 and uses [-open Lib_re_export] in its flags; [consumer.ml] writes
 [Re.x] without naming [dep_lib] or [lib_re_export] in source.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ cat > dune <<EOF
   > (library (name dep_lib) (wrapped false) (modules original_name))

--- a/test/blackbox-tests/test-cases/pkg/build-package-logs.t
+++ b/test/blackbox-tests/test-cases/pkg/build-package-logs.t
@@ -5,9 +5,7 @@ Test the error message when installing package that fails.
 
 Make a project with two packages, one successful and one that fails:
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.12)
-  > EOF
+  $ make_dune_project 3.12
 
 Create a package with a failing command that throws an error:
 

--- a/test/blackbox-tests/test-cases/pkg/build-with-executable-script-on-windows.t
+++ b/test/blackbox-tests/test-cases/pkg/build-with-executable-script-on-windows.t
@@ -12,9 +12,7 @@ Setup dune-project, dune-workspace, etc.
 
   $ mkdir scripts/
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ pkg() {
   > make_lockpkg $1 <<EOF

--- a/test/blackbox-tests/test-cases/pkg/build-with-executable-script.t
+++ b/test/blackbox-tests/test-cases/pkg/build-with-executable-script.t
@@ -7,9 +7,7 @@ Setup dune-project, dune-workspace, etc.
 
   $ mkdir scripts/
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ pkg() {
   > make_lockpkg $1 <<EOF

--- a/test/blackbox-tests/test-cases/pkg/dependency-hash.t
+++ b/test/blackbox-tests/test-cases/pkg/dependency-hash.t
@@ -135,9 +135,7 @@ the hash:
 Make sure that the hash changes when the formula changes from a conjunction to
 a disjunction, thus changing the solution:
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.11)
-  > EOF
+  $ make_dune_project 3.11
   $ cat > local.opam <<EOF
   > opam-version: "2.0"
   > depends: [ "a" "b" ]

--- a/test/blackbox-tests/test-cases/pkg/depexts/print-depexts.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/print-depexts.t
@@ -4,9 +4,7 @@ Show that the depexts that a project has can be printed.
 
 Make a project:
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.13)
-  > EOF
+  $ make_dune_project 3.13
 
 Create a lockdir with a package that features some depexts.
 

--- a/test/blackbox-tests/test-cases/pkg/lockdir-load-dedup.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-load-dedup.t
@@ -15,9 +15,7 @@ the same lock dir.
   > (lang package 0.1)
   > EOF
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ dune build @check
 

--- a/test/blackbox-tests/test-cases/pkg/ocaml-index-private-lib-gh10985.t
+++ b/test/blackbox-tests/test-cases/pkg/ocaml-index-private-lib-gh10985.t
@@ -24,9 +24,7 @@ the package directory in the dune file:
 
 Now we set up a lock file with this package and then attempt to use it:
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.11)
-  > EOF
+  $ make_dune_project 3.11
 
   $ make_lockdir
   $ make_lockpkg mypkg <<EOF

--- a/test/blackbox-tests/test-cases/pkg/opam-only-metadata.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-only-metadata.t
@@ -13,9 +13,7 @@ Test that we can read package metadata from opam files.
 
   $ mkpkg d
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.12)
-  > EOF
+  $ make_dune_project 3.12
 
   $ cat > foo.opam <<EOF
   > opam-version: "2.0"

--- a/test/blackbox-tests/test-cases/pkg/pkg-deps-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-deps-lock.t
@@ -11,9 +11,7 @@ lock-file package.
   >   (system "echo lock-data > %{pkg-self:share}/data.txt")))
   > EOF
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.24)
-  > EOF
+  $ make_dune_project 3.24
 
 The rule depends on the lock-file package cookie and the resolved file:
 

--- a/test/blackbox-tests/test-cases/plugin-mode.t
+++ b/test/blackbox-tests/test-cases/plugin-mode.t
@@ -1,8 +1,6 @@
 Testsuite for (mode plugin).
 
-  $ cat > dune-project <<EOF
-  > (lang dune 2.4)
-  > EOF
+  $ make_dune_project 2.4
 
   $ cat > dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/ppx/ppx-flags-plus.t
+++ b/test/blackbox-tests/test-cases/ppx/ppx-flags-plus.t
@@ -1,8 +1,6 @@
 Create ppx1 and exe:
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.7)
-  > EOF
+  $ make_dune_project 3.7
   $ cat > dune <<EOF
   > (library
   >  (name ppx)
@@ -43,7 +41,5 @@ Create ppx1 and exe:
 
 Works since Dune 3.18
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.18)
-  > EOF
+  $ make_dune_project 3.18
   $ dune build ./the_exe.exe

--- a/test/blackbox-tests/test-cases/ppx/ppx-nested-cookies.t
+++ b/test/blackbox-tests/test-cases/ppx/ppx-nested-cookies.t
@@ -6,9 +6,7 @@ Set up a PPX driver that accepts --cookie and produces a valid output file,
 an inner ppx with cookies, and a wrapper ppx that depends on the inner one:
 
   $ export DUNE_TRACE="process"
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
   $ cat > dune <<EOF
   > (library
   >  (name driver)

--- a/test/blackbox-tests/test-cases/predicate-language-errors.t
+++ b/test/blackbox-tests/test-cases/predicate-language-errors.t
@@ -1,8 +1,6 @@
 Test the error cases for dune's Predicate Language DSL.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.14)
-  > EOF
+  $ make_dune_project 3.14
 
   $ cat > foo.ml <<EOF
   > let () = print_endline "foo"

--- a/test/blackbox-tests/test-cases/print-diff.t
+++ b/test/blackbox-tests/test-cases/print-diff.t
@@ -1,6 +1,4 @@
-  $ cat > dune-project << EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ cat > dune << EOF
   > (rule

--- a/test/blackbox-tests/test-cases/print-directory.t
+++ b/test/blackbox-tests/test-cases/print-directory.t
@@ -1,9 +1,7 @@
 Test that "Entering directory" messages are only shown when dune changes
 directory and there is actual output. Silent builds should not print anything.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.17)
-  > EOF
+  $ make_dune_project 3.17
 
   $ cat > dune <<EOF
   > (library (name foo))

--- a/test/blackbox-tests/test-cases/private-modules/private-module-compilation.t
+++ b/test/blackbox-tests/test-cases/private-modules/private-module-compilation.t
@@ -30,9 +30,7 @@ Test demonstrating private modules in wrapped library
   >  (libraries mylib))
   > EOF
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
 Build should fail because Secret is private:
   $ dune build

--- a/test/blackbox-tests/test-cases/private-modules/private-module-excluded-by-modules-field.t
+++ b/test/blackbox-tests/test-cases/private-modules/private-module-excluded-by-modules-field.t
@@ -1,9 +1,7 @@
 Demonstrate the behavior when a module is listed by private_modules by not by
 modules:
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.7)
-  > EOF
+  $ make_dune_project 3.7
 
   $ mkdir src
   $ cat > src/dune << EOF
@@ -39,9 +37,7 @@ X is warned about:
 
 In 3.11 onwards this warning becomes an error
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.11)
-  > EOF
+  $ make_dune_project 3.11
 
   $ dune build
   File "src/dune", line 5, characters 18-19:

--- a/test/blackbox-tests/test-cases/promote/dep-on-promoted-target.t
+++ b/test/blackbox-tests/test-cases/promote/dep-on-promoted-target.t
@@ -1,8 +1,6 @@
 Depending on a promoted file works.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 2.0)
-  > EOF
+  $ make_dune_project 2.0
 
   $ cat > dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/promote/ignore-until-clean-promotion-github4401.t
+++ b/test/blackbox-tests/test-cases/promote/ignore-until-clean-promotion-github4401.t
@@ -1,9 +1,7 @@
 When --ignore-promoted-rules is passed, rules marked `(promote (until-clean))`
 are ignored. See #4401.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.4)
-  > EOF
+  $ make_dune_project 3.4
 
   $ echo foobar > reference
 
@@ -24,9 +22,7 @@ are ignored. See #4401.
 
 This is correctly ignored if `dune-lang` is bumped to 3.5.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.5)
-  > EOF
+  $ make_dune_project 3.5
 
   $ dune clean
   $ dune runtest --ignore-promoted-rules

--- a/test/blackbox-tests/test-cases/promote/old-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/promote/old-tests.t/run.t
@@ -188,7 +188,7 @@ Reproduction case for #3069
 ---------------------------
 
   $ mkdir 3069 && cd 3069
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ cat >dune <<EOF
   > (rule
   >  (action (with-stdout-to x (echo bar)))

--- a/test/blackbox-tests/test-cases/promote/overlapping-diff.t
+++ b/test/blackbox-tests/test-cases/promote/overlapping-diff.t
@@ -1,8 +1,6 @@
 Test how overlapping diff actions are handled
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
   $ touch foo
 

--- a/test/blackbox-tests/test-cases/promote/overlapping-promotions.t
+++ b/test/blackbox-tests/test-cases/promote/overlapping-promotions.t
@@ -3,7 +3,7 @@ Targets can be promoted on to existing targets
 The test is not reproducible without this
   $ export DUNE_CONFIG__BACKGROUND_DIGESTS=disabled
 
-  $ echo "(lang dune 3.20)" > dune-project
+  $ make_dune_project 3.20
 
   $ mkdir subdir
 

--- a/test/blackbox-tests/test-cases/promote/promote-executable-bit.t
+++ b/test/blackbox-tests/test-cases/promote/promote-executable-bit.t
@@ -1,9 +1,7 @@
 Promotion repairs executable permissions even when the promoted file already has
 the right contents.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.0)
-  > EOF
+  $ make_dune_project 3.0
 
   $ cat > dune <<'EOF'
   > (rule

--- a/test/blackbox-tests/test-cases/promote/promote-file-to-dir.t
+++ b/test/blackbox-tests/test-cases/promote/promote-file-to-dir.t
@@ -4,9 +4,7 @@ This caused Dune to get confused and stuck.
 
 Create a cram test:
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.8)
-  > EOF
+  $ make_dune_project 3.8
 
   $ cat > my_cram.t << EOF
   >   $ echo hello

--- a/test/blackbox-tests/test-cases/promote/promote-foo-deleted.t
+++ b/test/blackbox-tests/test-cases/promote/promote-foo-deleted.t
@@ -2,7 +2,7 @@ Test that [promote-foo] syntax is deleted in Dune 3.0 with good error messages.
 
 First, check that the syntax still works with Dune 2.9.
 
-  $ echo "(lang dune 2.9)" > dune-project
+  $ make_dune_project 2.9
   $ cat >dune <<EOF
   > (rule
   >  (targets promoted)
@@ -29,7 +29,7 @@ First, check that the syntax still works with Dune 2.9.
 
 Now switch to Dune 3.0.
 
-  $ echo "(lang dune 3.0)" > dune-project
+  $ make_dune_project 3.0
   $ dune build promoted
   File "dune", line 4, characters 7-28:
   4 |  (mode (promote-into subdir)))

--- a/test/blackbox-tests/test-cases/promote/promote-only-when-needed.t
+++ b/test/blackbox-tests/test-cases/promote/promote-only-when-needed.t
@@ -1,6 +1,6 @@
 Test that targets aren't re-promoted if they are up to date.
 
-  $ echo "(lang dune 3.0)" > dune-project
+  $ make_dune_project 3.0
   $ cat >dune <<EOF
   > (rule
   >  (targets promoted)

--- a/test/blackbox-tests/test-cases/promote/promote-over-running-binary.t
+++ b/test/blackbox-tests/test-cases/promote/promote-over-running-binary.t
@@ -4,9 +4,7 @@ process keeps its file descriptor.
 
 Regression test for https://github.com/ocaml/dune/issues/3484
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ cat > dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/promote/promote-variables.t
+++ b/test/blackbox-tests/test-cases/promote/promote-variables.t
@@ -1,6 +1,6 @@
 Test expanding variables in `(promote (into ..))`
 
-  $ echo "(lang dune 3.21)" > dune-project
+  $ make_dune_project 3.21
   $ mkdir -p a/b another
   $ cat > a/b/dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/promote/promotion-apply.t
+++ b/test/blackbox-tests/test-cases/promote/promotion-apply.t
@@ -1,8 +1,6 @@
 `dune promotion run` is equivalent to `dune promote`.
 
-  $ cat > dune-project << EOF
-  > (lang dune 2.0)
-  > EOF
+  $ make_dune_project 2.0
 
   $ cat > dune << EOF
   > (rule

--- a/test/blackbox-tests/test-cases/promote/promotion-diff.t
+++ b/test/blackbox-tests/test-cases/promote/promotion-diff.t
@@ -1,8 +1,6 @@
 Tests dune promotion diff output.
 
-  $ cat > dune-project << EOF
-  > (lang dune 2.0)
-  > EOF
+  $ make_dune_project 2.0
 
   $ cat > dune << EOF
   > (rule

--- a/test/blackbox-tests/test-cases/promote/promotion-list.t
+++ b/test/blackbox-tests/test-cases/promote/promotion-list.t
@@ -1,8 +1,6 @@
 Tests dune promotion list output.
 
-  $ cat > dune-project << EOF
-  > (lang dune 2.0)
-  > EOF
+  $ make_dune_project 2.0
 
   $ cat > dune << EOF
   > (rule

--- a/test/blackbox-tests/test-cases/promote/promotion-show.t
+++ b/test/blackbox-tests/test-cases/promote/promotion-show.t
@@ -33,9 +33,7 @@ We create different promotion scenarios to test various behaviors:
 - b.expected: uses 'diff?' in progn (creates promotion when files differ)
 - c.expected: uses 'diff?' in separate action (may not create promotion)
 
-  $ cat > dune-project << EOF
-  > (lang dune 2.0)
-  > EOF
+  $ make_dune_project 2.0
 
   $ cat > dune << EOF
   > (rule

--- a/test/blackbox-tests/test-cases/quoting/cat.t/run.t
+++ b/test/blackbox-tests/test-cases/quoting/cat.t/run.t
@@ -1,8 +1,6 @@
   $ cat > a
   $ cat > b
-  $ cat > dune-project << EOF
-  > (lang dune 3.9)
-  > EOF
+  $ make_dune_project 3.9
 
 It should be possible to expand %{deps} in a cat action since it allows multiple
 arguments.
@@ -27,8 +25,6 @@ This isn't possible in 3.9.
 
 But it is in 3.10:
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.10)
-  > EOF
+  $ make_dune_project 3.10
 
   $ dune build @foo

--- a/test/blackbox-tests/test-cases/rocq/no-rebuild-on-dep-change.t
+++ b/test/blackbox-tests/test-cases/rocq/no-rebuild-on-dep-change.t
@@ -1,5 +1,5 @@
   $ echo "(rocq.theory (name bug) (mode vo))" > dune
-  $ echo "(lang dune 3.21)" > dune-project
+  $ make_dune_project 3.21
   $ echo "(using rocq 0.11)" >> dune-project
   $ touch root.v leaf.v
   $ dune build

--- a/test/blackbox-tests/test-cases/root-module/incremental-rebuild.t
+++ b/test/blackbox-tests/test-cases/root-module/incremental-rebuild.t
@@ -5,9 +5,7 @@ implementation changes. This locks in the incremental-rebuild
 property for [Root]-aliased dependencies that any future change
 to dune's inter-library-dependency tracking must preserve.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ mkdir dep_lib consumer_lib
   $ cat > dep_lib/dune <<EOF

--- a/test/blackbox-tests/test-cases/rule/digest.t/run.t
+++ b/test/blackbox-tests/test-cases/rule/digest.t/run.t
@@ -3,7 +3,7 @@ Test that rule digest doesn't depend on irrelevant details of the dune file
 
   $ export DUNE_PWD_STORE="$(mktemp)"
 
-  $ echo "(lang dune 3.0)" > dune-project
+  $ make_dune_project 3.0
 
   $ cat >dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/run-parse-error.t
+++ b/test/blackbox-tests/test-cases/run-parse-error.t
@@ -2,7 +2,7 @@ Test that parse errors in the run error produce the expected error message.
 
 See #9529.
 
-  $ echo "(lang dune 3.11)" > dune-project
+  $ make_dune_project 3.11
   $ cat > dune <<EOF
   > (rule
   >  (target foo.txt)

--- a/test/blackbox-tests/test-cases/runtest-control-sequences-gh5528.t
+++ b/test/blackbox-tests/test-cases/runtest-control-sequences-gh5528.t
@@ -1,8 +1,6 @@
 Strips terminal control sequences from `dune runtest` output.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 1.0)
-  > EOF
+  $ make_dune_project 1.0
 
   $ cat > dune <<EOF
   > (test

--- a/test/blackbox-tests/test-cases/runtest/runtest-cmd-hints.t
+++ b/test/blackbox-tests/test-cases/runtest/runtest-cmd-hints.t
@@ -1,8 +1,6 @@
 Test the "did you mean" hints for dune runtest command.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
   $ mkdir dir.t other_dir
   $ cat > dir.t/run.t <<EOF

--- a/test/blackbox-tests/test-cases/runtest/runtest-cmd-inline-tests.t
+++ b/test/blackbox-tests/test-cases/runtest/runtest-cmd-inline-tests.t
@@ -1,8 +1,6 @@
 Test running inline tests by specifying ML source files directly.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
 Set up a simple inline tests backend and libraries:
 

--- a/test/blackbox-tests/test-cases/runtest/runtest-cmd-sandbox-context.t
+++ b/test/blackbox-tests/test-cases/runtest/runtest-cmd-sandbox-context.t
@@ -1,8 +1,6 @@
 Sandboxed cram failures should preserve their build context.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ cat > dune-workspace <<EOF
   > (lang dune 3.23)

--- a/test/blackbox-tests/test-cases/runtest/runtest-cmd-subdir.t
+++ b/test/blackbox-tests/test-cases/runtest/runtest-cmd-subdir.t
@@ -4,9 +4,7 @@ Reproduction case for https://github.com/ocaml/dune/issues/12250
   > (lang dune 3.19)
   > EOF
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.19)
-  > EOF
+  $ make_dune_project 3.19
 
   $ mkdir -p somelib/my/path
   $ cat > somelib/my/path/test.t <<EOF

--- a/test/blackbox-tests/test-cases/runtest/runtest-cmd-tests.t
+++ b/test/blackbox-tests/test-cases/runtest/runtest-cmd-tests.t
@@ -1,8 +1,6 @@
 Test running tests by specifying ML source files directly.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
 Set up a simple test with multiple test executables:
 

--- a/test/blackbox-tests/test-cases/runtest/runtest-cmd.t
+++ b/test/blackbox-tests/test-cases/runtest/runtest-cmd.t
@@ -1,8 +1,6 @@
 Here we test the features of the `dune runtest` command. 
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.16)
-  > EOF
+  $ make_dune_project 3.16
 
   $ cat > mytest.t <<EOF
   >   $ echo "Hello, world!"

--- a/test/blackbox-tests/test-cases/sandbox/patch-back-source-tree.t
+++ b/test/blackbox-tests/test-cases/sandbox/patch-back-source-tree.t
@@ -3,9 +3,7 @@ Test for (sandbox patch_back_source_tree)
 This sandbox allows to safely "modify" source files by turning modifications
 into promotions.
 
-  $ cat >dune-project<<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
 Targest are not promoted
 ------------------------
@@ -333,9 +331,7 @@ from promotion output. Unrelated source-tree changes made by the same action are
 still reported.
 
   $ rm -rf out sub dune
-  $ cat >dune-project<<EOF
-  > (lang dune 3.24)
-  > EOF
+  $ make_dune_project 3.24
   $ cat >dune<<EOF
   > (rule
   >  (deps (sandbox patch_back_source_tree))

--- a/test/blackbox-tests/test-cases/select-field/legacy-cxx-names-select-gh13802.t
+++ b/test/blackbox-tests/test-cases/select-field/legacy-cxx-names-select-gh13802.t
@@ -1,8 +1,6 @@
 Legacy `cxx_names` should keep working with non-OCaml `(select ..)` targets.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 1.0)
-  > EOF
+  $ make_dune_project 1.0
 
   $ cat >dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/select-field/select-2-0-rules.t
+++ b/test/blackbox-tests/test-cases/select-field/select-2-0-rules.t
@@ -1,6 +1,6 @@
 Rejects invalid select branch filenames in Dune 2.0.
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ cat > dune <<EOF
   > (library (name foo) (libraries (select foo.ml from (!bar -> f.ml))))
   > EOF

--- a/test/blackbox-tests/test-cases/select-field/select-conflict.t
+++ b/test/blackbox-tests/test-cases/select-field/select-conflict.t
@@ -1,9 +1,7 @@
 We test the `(select)` field of the `(libraries)` field in the presence of
 a conflicting rule
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ cat > dune <<EOF
   > (ocamllex (modules lexer))

--- a/test/blackbox-tests/test-cases/select-field/select-in-test.t
+++ b/test/blackbox-tests/test-cases/select-field/select-in-test.t
@@ -1,8 +1,6 @@
 We test the (select) field of the (libraries) field of the test stanza.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.11)
-  > EOF
+  $ make_dune_project 3.11
 
   $ cat > dune <<EOF
   > (test

--- a/test/blackbox-tests/test-cases/select-field/select-qualified.t
+++ b/test/blackbox-tests/test-cases/select-field/select-qualified.t
@@ -1,9 +1,7 @@
 We test the `(select)` field of the `(libraries)` field in the presence of
 `(include_subdirs qualified)`
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ cat > dune <<EOF
   > (include_subdirs qualified)

--- a/test/blackbox-tests/test-cases/select-field/select-relative-parent.t
+++ b/test/blackbox-tests/test-cases/select-field/select-relative-parent.t
@@ -1,9 +1,7 @@
 We test the `(select)` field of the `(libraries)` field with relative parent
 paths
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ mkdir -p sub
   $ cat > sub/dune <<EOF

--- a/test/blackbox-tests/test-cases/select-field/select-resolve-optional.t
+++ b/test/blackbox-tests/test-cases/select-field/select-resolve-optional.t
@@ -1,9 +1,7 @@
 Show that failing to resolve an optional library via `(select ..)` falls back
 to the default select branch.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ mkdir -p mylib_opt
   $ cat > mylib_opt/dune <<EOF

--- a/test/blackbox-tests/test-cases/select-field/select-unqualified.t
+++ b/test/blackbox-tests/test-cases/select-field/select-unqualified.t
@@ -1,9 +1,7 @@
 We test the `(select)` field of the `(libraries)` field in the presence of
 `(include_subdirs unqualified)`
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ cat > dune <<EOF
   > (include_subdirs unqualified)

--- a/test/blackbox-tests/test-cases/select-field/select-validation.t
+++ b/test/blackbox-tests/test-cases/select-field/select-validation.t
@@ -1,9 +1,7 @@
 Test module path validation for `(select ..)` targets when using
 `(include_subdirs qualified)`
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ cat > dune <<EOF
   > (include_subdirs qualified)

--- a/test/blackbox-tests/test-cases/sendfile-large-file.t
+++ b/test/blackbox-tests/test-cases/sendfile-large-file.t
@@ -1,8 +1,6 @@
 We create a large file and check that it is copied completely.
 
-  $ cat > dune-project << EOF
-  > (lang dune 1.0)
-  > EOF
+  $ make_dune_project 1.0
 
   $ cat > create.ml << EOF
   > let () = Unix.truncate "file.dat" 0x1_00_00_00_03

--- a/test/blackbox-tests/test-cases/separate-compilation-github3622/jsoo.t
+++ b/test/blackbox-tests/test-cases/separate-compilation-github3622/jsoo.t
@@ -4,7 +4,7 @@ being ran and channels not being flushed.
 
 Setup fixtures:
 
-  $ echo "(lang dune 2.6)" > dune-project
+  $ make_dune_project 2.6
   $ echo 'let () = print_string "bla"' > main.ml
   $ cat >dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/separate-compilation-github3622/wasmoo.t
+++ b/test/blackbox-tests/test-cases/separate-compilation-github3622/wasmoo.t
@@ -4,7 +4,7 @@ hooks didn't run and the channels weren't flushed.
 
 Setup fixtures:
 
-  $ echo "(lang dune 3.17)" > dune-project
+  $ make_dune_project 3.17
   $ echo 'let () = print_string "bla"' > main.ml
   $ cat >dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/staged-pps-relative-directory-gh8158.t
+++ b/test/blackbox-tests/test-cases/staged-pps-relative-directory-gh8158.t
@@ -3,9 +3,7 @@ executable that uses as staged_pps it in bin/.
 This test ensures that path expansion is done relatively to the right
 directory.
 
-  $ cat > dune-project << EOF
-  > (lang dune 1.1)
-  > EOF
+  $ make_dune_project 1.1
 
   $ mkdir ppx
   $ cat > ppx/dune << EOF

--- a/test/blackbox-tests/test-cases/stanzas/env/env-unused.t
+++ b/test/blackbox-tests/test-cases/stanzas/env/env-unused.t
@@ -1,6 +1,4 @@
-  $ cat > dune-project << EOF
-  > (lang dune 3.3)
-  > EOF
+  $ make_dune_project 3.3
 
 (env) is evaluated sequentially:
 
@@ -27,9 +25,7 @@ A warning is displayed when there are unreachable cases.
 
 In 3.4, this warning becomes fatal.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.4)
-  > EOF
+  $ make_dune_project 3.4
 
   $ dune runtest
   File "dune", lines 5-7, characters 0-71:

--- a/test/blackbox-tests/test-cases/stanzas/env/standard-in-include.t
+++ b/test/blackbox-tests/test-cases/stanzas/env/standard-in-include.t
@@ -3,9 +3,7 @@
 When :standard is used inside an :include'd file, environment flags are not
 applied.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.18)
-  > EOF
+  $ make_dune_project 3.18
 
 Set a custom flag in the environment:
 

--- a/test/blackbox-tests/test-cases/stanzas/exe-name-collision.t
+++ b/test/blackbox-tests/test-cases/stanzas/exe-name-collision.t
@@ -1,8 +1,6 @@
 Executables using the same name, defined in the same folder.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.13)
-  > EOF
+  $ make_dune_project 3.13
 
   $ cat > dune << EOF
   > (executable

--- a/test/blackbox-tests/test-cases/stanzas/forbidden_libraries.t
+++ b/test/blackbox-tests/test-cases/stanzas/forbidden_libraries.t
@@ -1,8 +1,6 @@
 Test the `forbidden_libraries` feature
 
-  $ cat > dune-project <<EOF
-  > (lang dune 2.0)
-  > EOF
+  $ make_dune_project 2.0
 
   $ cat > dune <<EOF
   > (library (name a) (modules))

--- a/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-gh10301.t
+++ b/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-gh10301.t
@@ -1,8 +1,6 @@
 Show an edge case of `(include_subdirs ..)` and ocamllex
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.13)
-  > EOF
+  $ make_dune_project 3.13
 
   $ mkdir -p src/a
   $ cat > dune << EOF

--- a/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-include-qualified-empty-dir.t
+++ b/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-include-qualified-empty-dir.t
@@ -1,9 +1,7 @@
 Test `(include_subdirs qualified)` in the presence of invalid module name
 directories that don't contain source files
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ cat > dune <<EOF
   > (include_subdirs qualified)

--- a/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-include-qualified.t
+++ b/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-include-qualified.t
@@ -1,8 +1,6 @@
 Builds `ocamllex` generators under `(include_subdirs qualified)`.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
   $ mkdir -p lib/bar
   $ cat > lib/dune <<EOF
   > (include_subdirs qualified)

--- a/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-include-unqualified.t
+++ b/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-include-unqualified.t
@@ -1,9 +1,7 @@
 Builds `ocamllex` generators under `(include_subdirs unqualified)`.
 
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
   $ mkdir -p lib/foo
   $ cat > lib/dune <<EOF
   > (include_subdirs unqualified)

--- a/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-no-stanza.t
+++ b/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-no-stanza.t
@@ -1,8 +1,6 @@
 Test building a module group containing a `.mll` file, without `(ocamllex ..)`
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
   $ cat > dune <<EOF
   > (library (name foo))
   > EOF

--- a/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-two-stanzas.t
+++ b/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-two-stanzas.t
@@ -1,9 +1,7 @@
 Test building 2 ocamllex stanzas in the same group, by 2 different stanzas 
 (library + executable)
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
   $ cat > dune <<EOF
   > (library (name foo) (modules foo foo_lex))
   > (executable (name bar) (modules bar bar_lex))

--- a/test/blackbox-tests/test-cases/stanzas/subdir-stanza/basic.t
+++ b/test/blackbox-tests/test-cases/stanzas/subdir-stanza/basic.t
@@ -1,6 +1,6 @@
 (subdir ..) allows us to interpret stanzas in a sub directory
 
-  $ echo "(lang dune 2.5)" > dune-project
+  $ make_dune_project 2.5
   $ cat >dune <<EOF
   > (rule (with-stdout-to foo.txt (echo "bar")))
   > (subdir bar
@@ -45,7 +45,7 @@ dir.
 Overriding dune files in the sub directory is possible:
 
   $ mkdir override; cd override
-  $ echo "(lang dune 2.5)" > dune-project
+  $ make_dune_project 2.5
   $ cat >dune <<EOF
   > (data_only_dirs shadow)
   > (subdir shadow (rule (with-stdout-to bar (echo shadow))))
@@ -60,7 +60,7 @@ Overriding dune files in the sub directory is possible:
 In conjunction with dune generated files:
 
   $ mkdir dune-syntax; cd dune-syntax
-  $ echo "(lang dune 2.5)" > dune-project
+  $ make_dune_project 2.5
   $ cat >dune <<EOF
   > (subdir sub (rule (with-stdout-to fromparent (echo parent))))
   > EOF
@@ -114,7 +114,7 @@ Include stanzas within subdir stanzas
   Hello!
 
 
-  $ echo "(lang dune 2.5)" > dune-project
+  $ make_dune_project 2.5
   $ cat >dune <<EOF
   > (rule (with-stdout-to foo.txt (echo "bar")))
   > (subdir /absolute/path/to/bar

--- a/test/blackbox-tests/test-cases/stanzas/tests/tests-stanza-alias.t
+++ b/test/blackbox-tests/test-cases/stanzas/tests/tests-stanza-alias.t
@@ -1,8 +1,6 @@
 Tests stanzas produce aliases with the executable names
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.17)
-  > EOF
+  $ make_dune_project 3.17
 
   $ cat > dune << EOF
   > (tests

--- a/test/blackbox-tests/test-cases/stanzas/tests/tests-stanza-expected-deps.t
+++ b/test/blackbox-tests/test-cases/stanzas/tests/tests-stanza-expected-deps.t
@@ -1,9 +1,7 @@
 For a test based on an .expected file, the deps field is ignored.
 This is visible when trying to build the `@all` alias. See #5950.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.3)
-  > EOF
+  $ make_dune_project 3.3
 
   $ cat > dune << EOF
   > (test

--- a/test/blackbox-tests/test-cases/symlink-targets.t
+++ b/test/blackbox-tests/test-cases/symlink-targets.t
@@ -1,6 +1,6 @@
 Test demonstrating the handling of actions that produce symlinks.
 
-  $ echo "(lang dune 2.8)" > dune-project
+  $ make_dune_project 2.8
   $ cat >dune <<EOF
   > (rule (targets b) (deps a) (action (run ln -s a b)))
   > EOF

--- a/test/blackbox-tests/test-cases/test-build-if/feature.t
+++ b/test/blackbox-tests/test-cases/test-build-if/feature.t
@@ -3,9 +3,7 @@ build_if controls whether the tests builds, while enabled_if controls whether
 the test runs as part of @runtest
 
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.9)
-  > EOF
+  $ make_dune_project 3.9
 
   $ cat > dune << EOF
   > (test

--- a/test/blackbox-tests/test-cases/test-build-if/version.t
+++ b/test/blackbox-tests/test-cases/test-build-if/version.t
@@ -1,8 +1,6 @@
 Tests version-based build_if constraints.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.8)
-  > EOF
+  $ make_dune_project 3.8
 
   $ cat > dune << EOF
   > (test
@@ -20,8 +18,6 @@ Tests version-based build_if constraints.
   Please update your dune-project file to have (lang dune 3.9).
   [1]
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.9)
-  > EOF
+  $ make_dune_project 3.9
 
   $ dune build

--- a/test/blackbox-tests/test-cases/test-modes-byte.t
+++ b/test/blackbox-tests/test-cases/test-modes-byte.t
@@ -1,8 +1,6 @@
 Dune should execute inline tests whose only mode is `byte`.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ cat > dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/trace/action-traces/basic.t
+++ b/test/blackbox-tests/test-cases/trace/action-traces/basic.t
@@ -1,8 +1,6 @@
 Dune's actions may produce trace events
 
-  $ cat >dune-project<<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ cat >dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/trace/action-traces/compound.t
+++ b/test/blackbox-tests/test-cases/trace/action-traces/compound.t
@@ -1,8 +1,6 @@
 Dune actions may produce multiple trace events
 
-  $ cat >dune-project<<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ cat >dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/trace/action-traces/dune.t
+++ b/test/blackbox-tests/test-cases/trace/action-traces/dune.t
@@ -1,8 +1,6 @@
 Dune itself produces action traces
 
-  $ cat >dune-project<<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ cat >dune <<EOF
   > (rule (with-stdout-to foo (echo bar)))

--- a/test/blackbox-tests/test-cases/trace/action-traces/invalid-trace.t
+++ b/test/blackbox-tests/test-cases/trace/action-traces/invalid-trace.t
@@ -1,8 +1,6 @@
 Invalid traces should be an error
 
-  $ cat >dune-project<<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ cat >dune <<'EOF'
   > (rule

--- a/test/blackbox-tests/test-cases/trace/action-traces/multiple-actions.t
+++ b/test/blackbox-tests/test-cases/trace/action-traces/multiple-actions.t
@@ -1,8 +1,6 @@
 Dune should collect traces from all actions
 
-  $ cat >dune-project<<EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ cat >dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/unreadable-target.t
+++ b/test/blackbox-tests/test-cases/unreadable-target.t
@@ -1,8 +1,6 @@
 Reports unreadable or broken targets after a rule runs.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 2.9)
-  > EOF
+  $ make_dune_project 2.9
 
   $ cat > dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/unused-libs/unused-libs-alias.t
+++ b/test/blackbox-tests/test-cases/unused-libs/unused-libs-alias.t
@@ -1,8 +1,6 @@
 Test that the unused-libs alias exists and can be built
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
   $ cat > dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/unused-libs/unused-libs-exe.t
+++ b/test/blackbox-tests/test-cases/unused-libs/unused-libs-exe.t
@@ -3,9 +3,7 @@ Test unused library detection in executables
 The unused-libs alias should detect unused libraries in executables just like
 it does for libraries.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
 Create two libraries - one that will be used and one that won't:
 

--- a/test/blackbox-tests/test-cases/unused-libs/unused-libs-external.t
+++ b/test/blackbox-tests/test-cases/unused-libs/unused-libs-external.t
@@ -40,9 +40,7 @@ Compile the external libraries:
 
 Create a dune project that uses these external libraries:
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
   $ cat > dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/unused-libs/unused-libs-limitation.t
+++ b/test/blackbox-tests/test-cases/unused-libs/unused-libs-limitation.t
@@ -1,9 +1,7 @@
 Test that the unused-libs alias cannot detect some instances of unused
 libraries
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
   $ cat > dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/unused-preprocessor-deps.t/run.t
+++ b/test/blackbox-tests/test-cases/unused-preprocessor-deps.t/run.t
@@ -3,7 +3,7 @@ Should warn.
 
   $ touch a.ml b.ml
 
-  $ echo "(lang dune 1.11)" > dune-project
+  $ make_dune_project 1.11
   $ dune build
   File "dune", line 5, characters 1-39:
   5 |  (preprocessor_deps does-not-exist.txt))
@@ -16,7 +16,7 @@ Should warn.
   Warning: This preprocessor_deps field will be ignored because no preprocessor
   that might use them is configured.
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ dune build
   File "dune", line 5, characters 1-39:
   5 |  (preprocessor_deps does-not-exist.txt))

--- a/test/blackbox-tests/test-cases/utop/utop-ignores-optional-libraries-github3188.t
+++ b/test/blackbox-tests/test-cases/utop/utop-ignores-optional-libraries-github3188.t
@@ -8,7 +8,7 @@ This test makes sure that the utop subcommand does not load optional libraries.
   >  (libraries does_not_exist))
   > EOF
   $ echo 'let run () = print_endline "this will never run"' > testutop/testutop.ml
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ echo 'let () = print_endline "No Error"' > init_test.ml
 
   $ dune utop testutop -- init_test.ml

--- a/test/blackbox-tests/test-cases/variables-for-artifacts/cmt-cmti.t
+++ b/test/blackbox-tests/test-cases/variables-for-artifacts/cmt-cmti.t
@@ -1,8 +1,6 @@
 Test that %{cmt:...} and %{cmti:...} variables work correctly.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.20)
-  > EOF
+  $ make_dune_project 3.20
 
 Create a library with both .ml and .mli files:
 
@@ -41,9 +39,7 @@ This feature is guarded behind dune lang 3.21:
   Please update your dune-project file to have (lang dune 3.21).
   [1]
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
 Build and check that cmt and cmti files are found:
 

--- a/test/blackbox-tests/test-cases/variables-for-artifacts/deps-fail.t
+++ b/test/blackbox-tests/test-cases/variables-for-artifacts/deps-fail.t
@@ -4,7 +4,7 @@ field of a (rule).
 This test is no longer failing. It should fail because
 %{cmo:...} wasn't allowed in the deps field in (lang dune <3.0).
 
-  $ echo "(lang dune 2.1)" > dune-project
+  $ make_dune_project 2.1
   $ cat > dune << EOF
   > (rule
   >  (target t)

--- a/test/blackbox-tests/test-cases/variables-for-artifacts/does-not-exist-cma.t
+++ b/test/blackbox-tests/test-cases/variables-for-artifacts/does-not-exist-cma.t
@@ -1,6 +1,6 @@
 This test tries to build a non-existent .cma.
 
-  $ echo "(lang dune 2.1)" > dune-project
+  $ make_dune_project 2.1
   $ cat > dune << EOF
   > (alias
   >  (name t)

--- a/test/blackbox-tests/test-cases/variables-for-artifacts/does-not-exist-cmo.t
+++ b/test/blackbox-tests/test-cases/variables-for-artifacts/does-not-exist-cmo.t
@@ -1,6 +1,6 @@
 The next test tries to build a module that does not exist.
 
-  $ echo "(lang dune 2.1)" > dune-project
+  $ make_dune_project 2.1
   $ cat > dune << EOF
   > (alias
   >  (name t)

--- a/test/blackbox-tests/test-cases/version-corruption.t
+++ b/test/blackbox-tests/test-cases/version-corruption.t
@@ -28,7 +28,7 @@ shared buffer):
   $ git init --quiet
   $ git commit -m init --allow-empty --quiet
   $ git tag -a v0.0.1 -m v0.0.1
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ touch xapi-datamodel.opam
   $ cat >dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/virtual-libraries/invalid-kind.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/invalid-kind.t
@@ -1,7 +1,7 @@
 Test that trying to use virtual_modules with an incompatible kind reports a user
 error
 
-  $ echo "(lang dune 3.20)" > dune-project
+  $ make_dune_project 3.20
 
   $ touch empty.mli
   $ cat >dune <<EOF

--- a/test/blackbox-tests/test-cases/virtual-libraries/private-module-shadowing-github1855.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/private-module-shadowing-github1855.t
@@ -4,9 +4,7 @@ An implementation and a virtual library both define the same (non virtual
 ) module. However, the module is private in the public library hence it should
 just quietly shadow the module in the virtual library.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 2.0)
-  > EOF
+  $ make_dune_project 2.0
 
   $ mkdir vlib impl
   $ touch impl/dom.ml vlib/dom.mli vlib/overlap.ml impl/overlap.ml

--- a/test/blackbox-tests/test-cases/virtual-libraries/same-directory.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/same-directory.t
@@ -1,6 +1,6 @@
 Test that includes vlib and implementations all in the same folder.
 
-  $ echo "(lang dune 3.6)" > dune-project
+  $ make_dune_project 3.6
 
   $ touch empty.mli
   $ cat >dune <<EOF

--- a/test/blackbox-tests/test-cases/virtual-libraries/select-fallback-optional-vlib-github13299.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/select-fallback-optional-vlib-github13299.t
@@ -3,9 +3,7 @@ https://github.com/ocaml/dune/issues/13299
 Select with unavailable library should fallback, but optional vlib
 implementation is incorrectly marked as having unavailable dependencies.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.22)
-  > EOF
+  $ make_dune_project 3.22
 
   $ mkdir -p mylib_opt
   $ cat > mylib_opt/dune << EOF

--- a/test/blackbox-tests/test-cases/virtual-libraries/virtual-library-check-alias-github12636.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/virtual-library-check-alias-github12636.t
@@ -1,8 +1,6 @@
 Test for issue https://github.com/ocaml/dune/issues/12636
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.21)
-  > EOF
+  $ make_dune_project 3.21
 
   $ cat > dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/virtual-libraries/virtual-library-cycle-github2896.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/virtual-library-cycle-github2896.t
@@ -4,7 +4,7 @@ We have a dependency cycle of the form impl <- lib <- vlib
 
 where vlib is a virtual library, and impl implements this library.
 
-  $ echo "(lang dune 2.3)" > dune-project
+  $ make_dune_project 2.3
   $ mkdir vlib impl lib
   $ touch impl/vlib.ml
   $ echo "val run : unit -> unit" > vlib/vlib.mli

--- a/test/blackbox-tests/test-cases/virtual-libraries/virtual-modules-excluded-by-modules-field.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/virtual-modules-excluded-by-modules-field.t
@@ -1,8 +1,6 @@
 Specifying a virtual module that isn't inside the (modules ..) field:
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.7)
-  > EOF
+  $ make_dune_project 3.7
 
   $ mkdir src
   $ cat > src/dune << EOF
@@ -44,9 +42,7 @@ X is warned about:
 
 In 3.11 onwards this warning becomes an error
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.11)
-  > EOF
+  $ make_dune_project 3.11
 
   $ dune build ./bar.exe
   File "src/dune", line 4, characters 18-19:

--- a/test/blackbox-tests/test-cases/wasmoo/build-info.t/run.t
+++ b/test/blackbox-tests/test-cases/wasmoo/build-info.t/run.t
@@ -1,6 +1,6 @@
 Jsoo and build-info
 
-  $ echo "(lang dune 3.17)" > dune-project
+  $ make_dune_project 3.17
   $ dune build
   Warning [missing-debug-event]: '--source-map' is enabled but the bytecode program was compiled with no debugging information.
   Warning: Consider passing '-g' option to ocamlc.

--- a/test/blackbox-tests/test-cases/watching/basic.t
+++ b/test/blackbox-tests/test-cases/watching/basic.t
@@ -3,7 +3,7 @@ Basic tests for the file-watching mode.
 ----------------------------------------------------------------------------------
 * Compile a simple rule
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
 
   $ cat > x <<EOF
   > original-contents

--- a/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo-permissions.t
+++ b/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo-permissions.t
@@ -26,7 +26,7 @@ events. This is a known bug.
   >   rm .#tmp
   > }
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ cat >dune <<EOF
   > (rule
   >  (alias default)

--- a/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo-symlinks.t
+++ b/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo-symlinks.t
@@ -24,7 +24,7 @@ Tests for [Fs_memo] symlink handling.
 The action ignores the dependency [dep]. We use it to force rerunning the action
 when necessary.
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ cat >dune <<EOF
   > (rule
   >  (alias default)

--- a/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo.t
+++ b/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo.t
@@ -24,7 +24,7 @@ Tests for [Fs_memo] module.
 The action ignores the dependency [dep]. We use it to force rerunning the action
 when necessary.
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
   $ cat >dune <<EOF
   > (rule
   >  (alias default)

--- a/test/blackbox-tests/test-cases/watching/multiple-errors.t
+++ b/test/blackbox-tests/test-cases/watching/multiple-errors.t
@@ -1,6 +1,6 @@
 We test the behavior of watch mode when we have multiple errors
 
-  $ echo "(lang dune 3.11)" > dune-project
+  $ make_dune_project 3.11
 
   $ start_dune
 

--- a/test/blackbox-tests/test-cases/watching/path-pwd.t
+++ b/test/blackbox-tests/test-cases/watching/path-pwd.t
@@ -4,7 +4,7 @@ adding . to $CWD
 Reproduce #6907
 
   $ export PATH=.:$PATH
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
 
   $ start_dune
 

--- a/test/blackbox-tests/test-cases/watching/quick-cancel.t
+++ b/test/blackbox-tests/test-cases/watching/quick-cancel.t
@@ -1,7 +1,7 @@
 Modify an input file during the build so that dune interrupts the
 build
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
 
   $ cat > x <<EOF
   > original-contents

--- a/test/blackbox-tests/test-cases/watching/rpc-bind-failure.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-bind-failure.t
@@ -2,7 +2,7 @@ Startup RPC bind failures should be reported immediately and terminate dune.
 
   $ export DUNE_TRACE=rpc
 
-  $ echo "(lang dune 3.23)" > dune-project
+  $ make_dune_project 3.23
 
   $ cat > dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/watching/rpc-build-during-eager-build.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-during-eager-build.t
@@ -1,9 +1,7 @@
 RPC build requests sent while the eager loop is building are serialized with
 that eager iteration instead of entering the build loop concurrently.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.18)
-  > EOF
+  $ make_dune_project 3.18
 
   $ marker_dir="$(mktemp -d)"
   $ marker="$marker_dir/eager-build-started"

--- a/test/blackbox-tests/test-cases/watching/rpc-build-shutdown-exit.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-shutdown-exit.t
@@ -1,7 +1,7 @@
 Minimal RPC watch shutdown after an RPC build, separating the shutdown command
 from server exit.
 
-  $ echo "(lang dune 3.23)" > dune-project
+  $ make_dune_project 3.23
 
   $ cat > dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/watching/rpc-build-status-line.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-status-line.t
@@ -2,7 +2,7 @@ Forwarded builds display a rich status line once connected over RPC.
 
   $ setup_xdg_runtime_dir
 
-  $ echo "(lang dune 3.23)" > dune-project
+  $ make_dune_project 3.23
 
   $ cat > dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/watching/rpc-build-stop.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-stop.t
@@ -2,7 +2,7 @@ Minimal RPC watch shutdown after an RPC build.
 
   $ export DUNE_TRACE=rpc
 
-  $ echo "(lang dune 3.23)" > dune-project
+  $ make_dune_project 3.23
 
   $ cat > dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/watching/rpc-shutdown-exit.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-shutdown-exit.t
@@ -2,7 +2,7 @@ Minimal RPC watch shutdown, separating the shutdown command from server exit.
 
   $ export DUNE_TRACE=rpc
 
-  $ echo "(lang dune 3.23)" > dune-project
+  $ make_dune_project 3.23
 
   $ cat > dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/watching/rpc-start-stop.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-start-stop.t
@@ -2,7 +2,7 @@ Minimal RPC watch startup and shutdown without an RPC build.
 
   $ export DUNE_TRACE=rpc
 
-  $ echo "(lang dune 3.23)" > dune-project
+  $ make_dune_project 3.23
 
   $ cat > dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/watching/sandbox-mkdir.t
+++ b/test/blackbox-tests/test-cases/watching/sandbox-mkdir.t
@@ -3,7 +3,7 @@ Test that Dune mkdirs the right set of directories in the sandbox.
 ----------------------------------------------------------------------------------
 * Compile a simple rule
 
-  $ echo "(lang dune 2.0)" > dune-project
+  $ make_dune_project 2.0
 
   $ mkdir test
   $ touch test/baz

--- a/test/blackbox-tests/test-cases/wrapped-transition-incremental.t
+++ b/test/blackbox-tests/test-cases/wrapped-transition-incremental.t
@@ -5,9 +5,7 @@ A library migrating from unwrapped to wrapped exposes compat shims so that
 downstream code can keep using the bare module name (Foo) instead of the
 new qualified name (Mylib.Foo). 
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.23
 
   $ mkdir mylib
   $ cat > mylib/dune <<EOF


### PR DESCRIPTION
Replace trivial `dune-project` setup snippets with the existing `make_dune_project` helper.

This removes repeated one-line lang boilerplate from many cram tests without changing their setup semantics.