### PR TITLE
test: share fs_memo watch harness in setup script

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -177,6 +177,8 @@ export GIT_CONFIG_SYSTEM="/dev/null"
 
 export DUNE_RUNNING=0
 
+# Called from cram tests with optional dune build arguments.
+# shellcheck disable=SC2120
 start_dune () {
     ( (dune build "$@" --passive-watch-mode > .#dune-output 2>&1) || (echo exit $? >> .#dune-output) ) &
     DUNE_PID=$!;
@@ -258,6 +260,29 @@ stop_dune () {
 
 build () {
     with_timeout dune rpc build --wait "$@"
+}
+
+fs_memo_test () {
+    local action="$1"
+    local before between after
+
+    echo "------------------------------------------"
+    before=$(cat _build/default/result 2>/dev/null)
+    # No initial targets: start the passive watch server only.
+    # shellcheck disable=SC2119
+    start_dune
+    build . | grep -v Success
+    between=$(cat _build/default/result)
+    bash -c "$action"
+    build . | grep -v Success
+    stop_dune >> .#tmp
+    after=$(cat _build/default/result)
+    cat .#tmp
+    echo "------------------------------------------"
+    echo "result = '$before' -> '$between' -> '$after'"
+    echo "------------------------------------------"
+    dune trace cat | jq -c 'select(.name == "fs_update") | .args' | sort
+    rm .#tmp
 }
 
 stop_dune_quiet () {

--- a/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo-permissions.t
+++ b/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo-permissions.t
@@ -8,23 +8,6 @@ events. This is a known bug.
   $ export DUNE_TRACE=cache
   $ setup_xdg_runtime_dir
 
-  $ test () {
-  >   echo "------------------------------------------"
-  >   before=$(cat _build/default/result 2>/dev/null)
-  >   start_dune
-  >   build . | grep -v Success
-  >   between=$(cat _build/default/result)
-  >   eval "$@"
-  >   build . | grep -v Success
-  >   stop_dune >> .#tmp
-  >   after=$(cat _build/default/result)
-  >   cat .#tmp
-  >   echo "------------------------------------------"
-  >   echo "result = '$before' -> '$between' -> '$after'"
-  >   echo "------------------------------------------"
-  >   dune trace cat | jq -c 'select(.name == "fs_update") | .args' | sort
-  >   rm .#tmp
-  > }
 
   $ make_dune_project 2.0
   $ cat >dune <<EOF
@@ -53,7 +36,7 @@ events. This is a known bug.
 Dune doesn't notice that a directory's permission changed and succeeds instead
 of failing.
 
-  $ test "chmod -r subdir"
+  $ fs_memo_test "chmod -r subdir"
   ------------------------------------------
   Executing rule...
   Success, waiting for filesystem changes...
@@ -67,7 +50,7 @@ of failing.
 
 If we repeat the test, we finally see the failure.
 
-  $ test "echo How about now?"
+  $ fs_memo_test "echo How about now?"
   ------------------------------------------
   Failure
   How about now?
@@ -85,7 +68,7 @@ If we repeat the test, we finally see the failure.
 
 Same problem in the other direction.
 
-  $ test "chmod +r subdir"
+  $ fs_memo_test "chmod +r subdir"
   ------------------------------------------
   Failure
   Failure
@@ -100,7 +83,7 @@ Same problem in the other direction.
   {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
   {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}
 
-  $ test "echo How about now?"
+  $ fs_memo_test "echo How about now?"
   ------------------------------------------
   How about now?
   Success, waiting for filesystem changes...
@@ -114,7 +97,7 @@ Same problem in the other direction.
 
 Same problem for files.
 
-  $ test "chmod -r file-1"
+  $ fs_memo_test "chmod -r file-1"
   ------------------------------------------
   Success, waiting for filesystem changes...
   Success, waiting for filesystem changes...
@@ -125,7 +108,7 @@ Same problem for files.
   {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
   {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}
 
-  $ test "chmod +r file-1"
+  $ fs_memo_test "chmod +r file-1"
   ------------------------------------------
   Failure
   Failure

--- a/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo-symlinks.t
+++ b/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo-symlinks.t
@@ -3,23 +3,6 @@ Tests for [Fs_memo] symlink handling.
   $ export DUNE_TRACE=cache
   $ setup_xdg_runtime_dir
 
-  $ test () {
-  >   echo "------------------------------------------"
-  >   before=$(cat _build/default/result 2>/dev/null)
-  >   start_dune
-  >   build . | grep -v Success
-  >   between=$(cat _build/default/result)
-  >   eval "$@"
-  >   build . | grep -v Success
-  >   stop_dune >> .#tmp
-  >   after=$(cat _build/default/result)
-  >   cat .#tmp
-  >   echo "------------------------------------------"
-  >   echo "result = '$before' -> '$between' -> '$after'"
-  >   echo "------------------------------------------"
-  >   dune trace cat | jq -c 'select(.name == "fs_update") | .args' | sort
-  >   rm .#tmp
-  > }
 
 The action ignores the dependency [dep]. We use it to force rerunning the action
 when necessary.
@@ -51,7 +34,7 @@ Tests for watching symbolic links.
 
 First, create a symbolic link. Dune correctly updates the [result].
 
-  $ test "ln -s ../file-3 dir/file-6"
+  $ fs_memo_test "ln -s ../file-3 dir/file-6"
   ------------------------------------------
   Executing rule...
   Success, waiting for filesystem changes...
@@ -73,7 +56,7 @@ First, create a symbolic link. Dune correctly updates the [result].
 Now, delete the symbolic link. Dune receives the corresponding events and
 reruns the affected action.
 
-  $ test "rm dir/file-6"
+  $ fs_memo_test "rm dir/file-6"
   ------------------------------------------
   Success, waiting for filesystem changes...
   Executing rule...
@@ -100,7 +83,7 @@ Now test symbolic links to directories.
 At first, things appear to be working well: we correctly discover [dir/file-7]
 and re-execute the rule.
 
-  $ test "echo -n 7 > another-dir/file-7"
+  $ fs_memo_test "echo -n 7 > another-dir/file-7"
   ------------------------------------------
   Success, waiting for filesystem changes...
   Executing rule...
@@ -123,7 +106,7 @@ and re-execute the rule.
 
 Deleting [dir] triggers a rebuild.
 
-  $ test "rm dir"
+  $ fs_memo_test "rm dir"
   ------------------------------------------
   Success, waiting for filesystem changes...
   Executing rule...
@@ -143,7 +126,7 @@ Deleting [dir] triggers a rebuild.
 
 Restoring the symlink is correctly noticed.
 
-  $ test "ln -s another-dir dir"
+  $ fs_memo_test "ln -s another-dir dir"
   ------------------------------------------
   Success, waiting for filesystem changes...
   Executing rule...
@@ -165,7 +148,7 @@ However, deleting [another-dir] isn't handled correctly.
 
 # CR-someday amokhov: Fix this.
 
-  $ test "rm another-dir/file-7; sleep 0.001; rmdir another-dir"
+  $ fs_memo_test "rm another-dir/file-7; sleep 0.001; rmdir another-dir"
   ------------------------------------------
   Success, waiting for filesystem changes...
   Executing rule...
@@ -193,7 +176,7 @@ If we force a rebuild, Dune belatedly notices that [another-dir/file-7] is now
 unreachable but doesn't complain about the symlink [dir] now being broken. We
 should fix this too.
 
-  $ test "echo force > dep"
+  $ fs_memo_test "echo force > dep"
   ------------------------------------------
   Success, waiting for filesystem changes...
   Executing rule...

--- a/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo.t
+++ b/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo.t
@@ -3,23 +3,6 @@ Tests for [Fs_memo] module.
   $ export DUNE_TRACE=cache
   $ setup_xdg_runtime_dir
 
-  $ test () {
-  >   echo "------------------------------------------"
-  >   before=$(cat _build/default/result 2>/dev/null)
-  >   start_dune
-  >   build . | grep -v Success
-  >   between=$(cat _build/default/result)
-  >   eval "$@"
-  >   build . | grep -v Success
-  >   stop_dune >> .#tmp
-  >   after=$(cat _build/default/result)
-  >   cat .#tmp
-  >   echo "------------------------------------------"
-  >   echo "result = '$before' -> '$between' -> '$after'"
-  >   echo "------------------------------------------"
-  >   dune trace cat | jq -c 'select(.name == "fs_update") | .args' | sort
-  >   rm .#tmp
-  > }
 
 The action ignores the dependency [dep]. We use it to force rerunning the action
 when necessary.
@@ -48,7 +31,7 @@ when necessary.
 Note that we receive two events for [file-2] because it's first created empty
 and then the contents is written to it.
 
-  $ test "echo -n 2 > file-2"
+  $ fs_memo_test "echo -n 2 > file-2"
   ------------------------------------------
   Executing rule...
   Success, waiting for filesystem changes...
@@ -78,7 +61,7 @@ Verify that filesystem cache events are being traced:
 Note that Dune did not re-execute the rule because the set of files matching
 the glob remains unchanged.
 
-  $ test "mkdir dir"
+  $ fs_memo_test "mkdir dir"
   ------------------------------------------
   Success, waiting for filesystem changes...
   Success, waiting for filesystem changes...
@@ -99,7 +82,7 @@ We create [dir/file-3] before running Dune, so we only observe a single
 [file_digest] change event with the file watcher.
 
   $ echo -n '?' > dir/file-3
-  $ test "echo -n 3 > dir/file-3"
+  $ fs_memo_test "echo -n 3 > dir/file-3"
   ------------------------------------------
   Executing rule...
   Success, waiting for filesystem changes...
@@ -117,7 +100,7 @@ We create [dir/file-3] before running Dune, so we only observe a single
 
 Now, Dune similarly updates [file_digest] for [file-2].
 
-  $ test "echo -n '*' > file-2"
+  $ fs_memo_test "echo -n '*' > file-2"
   ------------------------------------------
   Success, waiting for filesystem changes...
   Executing rule...
@@ -134,7 +117,7 @@ Now, Dune similarly updates [file_digest] for [file-2].
 
 On deletion of a file, we receive events for the file and the parent directory.
 
-  $ test "rm file-2"
+  $ fs_memo_test "rm file-2"
   ------------------------------------------
   Success, waiting for filesystem changes...
   Executing rule...
@@ -155,7 +138,7 @@ On deletion of a file, we receive events for the file and the parent directory.
 Dune notices that [dir_contents] of both [dir] and [.] changed, and also that
 [dir/file-3]'s digest changed (from a digest to the error about missing file).
 
-  $ test "mv dir/file-3 ."
+  $ fs_memo_test "mv dir/file-3 ."
   ------------------------------------------
   Success, waiting for filesystem changes...
   Executing rule...
@@ -179,7 +162,7 @@ Dune notices that [dir_contents] of both [dir] and [.] changed, and also that
   {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}
   {"cache_type":"path_stat","path":"file-3","result":"skipped"}
 
-  $ test "mkdir dir/subdir"
+  $ fs_memo_test "mkdir dir/subdir"
   ------------------------------------------
   Success, waiting for filesystem changes...
   Success, waiting for filesystem changes...
@@ -198,7 +181,7 @@ Dune notices that [dir_contents] of both [dir] and [.] changed, and also that
 
 Again, there are two events for [file-4]: for creation and modification.
 
-  $ test "echo -n 4 > dir/subdir/file-4"
+  $ fs_memo_test "echo -n 4 > dir/subdir/file-4"
   ------------------------------------------
   Success, waiting for filesystem changes...
   Executing rule...
@@ -222,7 +205,7 @@ Again, there are two events for [file-4]: for creation and modification.
 Here we are getting duplicate events for directories [dir] and [dir/subdir]
 because we watch each of them both directly and via their parents.
 
-  $ test "mv dir/subdir ."
+  $ fs_memo_test "mv dir/subdir ."
   ------------------------------------------
   Success, waiting for filesystem changes...
   Executing rule...
@@ -257,7 +240,7 @@ and two events for [file-5]: for moving and for changing. There are two events
 for [dir_contents] of [.] because moving a file is interpreted as deleting and
 then creating a file.
 
-  $ test "mv file-1 file-5; echo -n 5 > file-5"
+  $ fs_memo_test "mv file-1 file-5; echo -n 5 > file-5"
   ------------------------------------------
   Success, waiting for filesystem changes...
   Executing rule...


### PR DESCRIPTION
Extract the repeated watch-mode wrapper used by the fs_memo blackbox tests into `test/blackbox-tests/setup-script.sh`.

This removes the duplicated local shell function from the three fs_memo watcher tests while keeping their behavior unchanged.