### PR TITLE
test(pkg): share build_single_package helper

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -256,6 +256,19 @@ solve_project() {
   dune_pkg_lock_normalized "$@"
 }
 
+build_single_package() {
+  local pkg="${1}"
+
+  solve_project <<EOF
+(lang dune 3.11)
+(package
+ (name x)
+ (depends
+  ${pkg}))
+EOF
+  build_pkg "${pkg}"
+}
+
 make_lockdir() {
   mkdir -p "${source_lock_dir}"
   cat > "${source_lock_dir}"/lock.dune <<- EOF

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-dep-filtering.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-dep-filtering.t
@@ -1,16 +1,5 @@
 Demonstrate how dependencies are filtered in opam files:
 
-  $ build_single_package() {
-  > solve_project <<EOF
-  > (lang dune 3.11)
-  > (package
-  >  (name x)
-  >  (depends
-  >   $1))
-  > EOF
-  > build_pkg $1
-  > }
-
   $ mkrepo
 
   $ mkpkg "foo"

--- a/test/blackbox-tests/test-cases/pkg/run-converted-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/run-converted-opam-commands.t
@@ -64,17 +64,6 @@ Generate a mock opam repository
   > ]
   > EOF
 
-  $ build_single_package() {
-  > solve_project <<EOF
-  > (lang dune 3.11)
-  > (package
-  >  (name x)
-  >  (depends
-  >   $1))
-  > EOF
-  > build_pkg $1
-  > }
-
   $ build_single_package foo
   Solution for dune.lock:
   - foo.0.0.1


### PR DESCRIPTION
Extract the duplicated `build_single_package` shell helper into `test/blackbox-tests/test-cases/pkg/helpers.sh` and reuse it from the affected package tests.

This keeps the test setup logic in one place without changing the test behavior.