### PR TITLE
test(watching): share simple RPC watch project helper

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -98,6 +98,15 @@ make_dune_project() {
 	EOF
 }
 
+make_simple_rpc_watch_project() {
+  make_dune_project 3.23
+  cat > dune <<-'EOF'
+	(rule
+	 (target x)
+	 (action (write-file %{target} ok)))
+	EOF
+}
+
 query_ocaml_merlin() {
   file="$1"
   shift

--- a/test/blackbox-tests/test-cases/watching/rpc-bind-failure.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-bind-failure.t
@@ -2,13 +2,7 @@ Startup RPC bind failures should be reported immediately and terminate dune.
 
   $ export DUNE_TRACE=rpc
 
-  $ make_dune_project 3.23
-
-  $ cat > dune <<EOF
-  > (rule
-  >  (target x)
-  >  (action (write-file %{target} ok)))
-  > EOF
+  $ make_simple_rpc_watch_project
 
 Poison the parent of the Unix-domain RPC socket so that binding
 _build/.rpc/dune fails during startup.

--- a/test/blackbox-tests/test-cases/watching/rpc-build-shutdown-exit.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-shutdown-exit.t
@@ -1,13 +1,7 @@
 Minimal RPC watch shutdown after an RPC build, separating the shutdown command
 from server exit.
 
-  $ make_dune_project 3.23
-
-  $ cat > dune <<EOF
-  > (rule
-  >  (target x)
-  >  (action (write-file %{target} ok)))
-  > EOF
+  $ make_simple_rpc_watch_project
 
   $ export DUNE_TRACE=rpc
 

--- a/test/blackbox-tests/test-cases/watching/rpc-build-status-line.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-status-line.t
@@ -2,13 +2,7 @@ Forwarded builds display a rich status line once connected over RPC.
 
   $ setup_xdg_runtime_dir
 
-  $ make_dune_project 3.23
-
-  $ cat > dune <<EOF
-  > (rule
-  >  (target x)
-  >  (action (write-file %{target} ok)))
-  > EOF
+  $ make_simple_rpc_watch_project
 
   $ export INSIDE_EMACS=1
   $ export DUNE_CONFIG__THREADED_CONSOLE=disabled

--- a/test/blackbox-tests/test-cases/watching/rpc-build-stop.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-stop.t
@@ -2,13 +2,7 @@ Minimal RPC watch shutdown after an RPC build.
 
   $ export DUNE_TRACE=rpc
 
-  $ make_dune_project 3.23
-
-  $ cat > dune <<EOF
-  > (rule
-  >  (target x)
-  >  (action (write-file %{target} ok)))
-  > EOF
+  $ make_simple_rpc_watch_project
 
   $ start_dune
   $ build_quiet x

--- a/test/blackbox-tests/test-cases/watching/rpc-shutdown-exit.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-shutdown-exit.t
@@ -2,13 +2,7 @@ Minimal RPC watch shutdown, separating the shutdown command from server exit.
 
   $ export DUNE_TRACE=rpc
 
-  $ make_dune_project 3.23
-
-  $ cat > dune <<EOF
-  > (rule
-  >  (target x)
-  >  (action (write-file %{target} ok)))
-  > EOF
+  $ make_simple_rpc_watch_project
 
   $ start_dune
 

--- a/test/blackbox-tests/test-cases/watching/rpc-start-stop.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-start-stop.t
@@ -2,13 +2,7 @@ Minimal RPC watch startup and shutdown without an RPC build.
 
   $ export DUNE_TRACE=rpc
 
-  $ make_dune_project 3.23
-
-  $ cat > dune <<EOF
-  > (rule
-  >  (target x)
-  >  (action (write-file %{target} ok)))
-  > EOF
+  $ make_simple_rpc_watch_project
 
   $ start_dune
 


### PR DESCRIPTION
Extract the repeated minimal RPC watch project setup into a helper and reuse it from the small RPC watch tests.

This removes duplicated setup boilerplate while keeping the tests focused on their shutdown and trace assertions.