### PR TITLE
test: wait for watch-mode Dune in sandbox-mkdir

### DIFF
--- a/test/blackbox-tests/test-cases/watching/sandbox-mkdir.t
+++ b/test/blackbox-tests/test-cases/watching/sandbox-mkdir.t
@@ -29,8 +29,7 @@ memoization).
   $ build test
   Success
 
-  $ with_timeout dune shutdown
-  $ cat .#dune-output | sed -e 's#.sandbox/[^/]*/default/test/subdir#.sandbox/<hash>/default/test/subdir#'
+  $ stop_dune | sed -e 's#.sandbox/[^/]*/default/test/subdir#.sandbox/<hash>/default/test/subdir#'
   $TESTCASE_ROOT/_build/.sandbox/<hash>/default/test/subdir
   Success, waiting for filesystem changes...
   $TESTCASE_ROOT/_build/.sandbox/<hash>/default/test/subdir


### PR DESCRIPTION
Use stop_dune so the passive watch-mode Dune process exits before the cram action finishes and its sandbox is removed. This avoids racing sandbox cleanup with nested Dune shutdown.