### PR TITLE
test(rocq): share flags trace helper

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -294,6 +294,14 @@ summarize_rpc_trace () {
         end'
 }
 
+trace_rocq_flags () {
+    local target="${1}"
+
+    dune clean
+    dune build "${target}"
+    dune trace cat | jq_dune -c 'rocqFlags'
+}
+
 wait_for_dune_exit_with_timeout () {
     exit_code=0
     wait_for_pid_to_exit_with_timeout "$DUNE_PID" 200 || exit_code=$?

--- a/test/blackbox-tests/test-cases/rocq/flags.t
+++ b/test/blackbox-tests/test-cases/rocq/flags.t
@@ -16,13 +16,8 @@ Test case: default flags
   >  (name foo))
   > EOF
 
-  $ runFlags() {
-  > dune clean
-  > dune build foo.vo
-  > dune trace cat | jq_dune -c 'rocqFlags'
-  > }
 
-  $ runFlags
+  $ trace_rocq_flags foo.vo
   {"name":"rocq","args":["c","--config"]}
   {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
   {"name":"rocq","args":["compile","-q","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
@@ -35,7 +30,7 @@ TC: :standard
   >  (flags :standard))
   > EOF
 
-  $ runFlags
+  $ trace_rocq_flags foo.vo
   {"name":"rocq","args":["c","--config"]}
   {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
   {"name":"rocq","args":["compile","-q","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
@@ -48,7 +43,7 @@ TC: override :standard
   >  (flags ))
   > EOF
 
-  $ runFlags
+  $ trace_rocq_flags foo.vo
   {"name":"rocq","args":["c","--config"]}
   {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
   {"name":"rocq","args":["compile","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
@@ -61,7 +56,7 @@ TC: add to :standard
   >  (flags :standard -type-in-type))
   > EOF
 
-  $ runFlags
+  $ trace_rocq_flags foo.vo
   {"name":"rocq","args":["c","--config"]}
   {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
   {"name":"rocq","args":["compile","-q","-type-in-type","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
@@ -79,7 +74,7 @@ TC: extend in workspace + override standard
   > (env (dev (rocq (flags -type-in-type))))
   > EOF
 
-  $ runFlags
+  $ trace_rocq_flags foo.vo
   {"name":"rocq","args":["c","--config"]}
   {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
   {"name":"rocq","args":["compile","-type-in-type","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
@@ -91,7 +86,7 @@ TC: extend in workspace + override standard
   > (env (dev (rocq (flags :standard -type-in-type))))
   > EOF
 
-  $ runFlags
+  $ trace_rocq_flags foo.vo
   {"name":"rocq","args":["c","--config"]}
   {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
   {"name":"rocq","args":["compile","-q","-type-in-type","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
@@ -104,7 +99,7 @@ TC: extend in dune (env) + override standard
   > (env (dev (rocq (flags -type-in-type))))
   > EOF
 
-  $ runFlags
+  $ trace_rocq_flags foo.vo
   {"name":"rocq","args":["c","--config"]}
   {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
   {"name":"rocq","args":["compile","-type-in-type","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
@@ -117,7 +112,7 @@ TC: extend in dune (env) + standard
   > (env (dev (rocq (flags :standard -type-in-type))))
   > EOF
 
-  $ runFlags
+  $ trace_rocq_flags foo.vo
   {"name":"rocq","args":["c","--config"]}
   {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
   {"name":"rocq","args":["compile","-q","-type-in-type","-type-in-type","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
@@ -135,7 +130,7 @@ TC: extend in dune (env) + workspace + standard
   > (env (dev (rocq (flags :standard -type-in-type))))
   > EOF
 
-  $ runFlags
+  $ trace_rocq_flags foo.vo
   {"name":"rocq","args":["c","--config"]}
   {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
   {"name":"rocq","args":["compile","-q","-type-in-type","-bt","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}

--- a/test/blackbox-tests/test-cases/rocq/rocq-native/flags.t
+++ b/test/blackbox-tests/test-cases/rocq/rocq-native/flags.t
@@ -9,11 +9,6 @@ Test cases to check Coq's flag setting is correct:
   > Definition t := 3.
   > EOF
 
-  $ runFlags() {
-  > dune clean
-  > dune build foo.vo
-  > dune trace cat | jq_dune -c 'rocqFlags'
-  > }
 
 Test case: default flags
 
@@ -22,7 +17,7 @@ Test case: default flags
   >  (name foo))
   > EOF
 
-  $ runFlags
+  $ trace_rocq_flags foo.vo
   {"name":"rocq","args":["c","--config"]}
   {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
   {"name":"rocq","args":["compile","-q","-w","-deprecated-native-compiler-option","-native-output-dir",".","-native-compiler","on","-nI","rocq-runtime/kernel","-nI",".","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
@@ -35,7 +30,7 @@ TC: :standard
   >  (flags :standard))
   > EOF
 
-  $ runFlags
+  $ trace_rocq_flags foo.vo
   {"name":"rocq","args":["c","--config"]}
   {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
   {"name":"rocq","args":["compile","-q","-w","-deprecated-native-compiler-option","-native-output-dir",".","-native-compiler","on","-nI","rocq-runtime/kernel","-nI",".","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
@@ -48,7 +43,7 @@ TC: override :standard
   >  (flags ))
   > EOF
 
-  $ runFlags
+  $ trace_rocq_flags foo.vo
   {"name":"rocq","args":["c","--config"]}
   {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
   {"name":"rocq","args":["compile","-w","-deprecated-native-compiler-option","-native-output-dir",".","-native-compiler","on","-nI","rocq-runtime/kernel","-nI",".","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
@@ -61,7 +56,7 @@ TC: add to :standard
   >  (flags :standard -type-in-type))
   > EOF
 
-  $ runFlags
+  $ trace_rocq_flags foo.vo
   {"name":"rocq","args":["c","--config"]}
   {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
   {"name":"rocq","args":["compile","-q","-type-in-type","-w","-deprecated-native-compiler-option","-native-output-dir",".","-native-compiler","on","-nI","rocq-runtime/kernel","-nI",".","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
@@ -79,7 +74,7 @@ TC: extend in workspace + override standard
   > (env (dev (rocq (flags -type-in-type))))
   > EOF
 
-  $ runFlags
+  $ trace_rocq_flags foo.vo
   {"name":"rocq","args":["c","--config"]}
   {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
   {"name":"rocq","args":["compile","-type-in-type","-w","-deprecated-native-compiler-option","-native-output-dir",".","-native-compiler","on","-nI","rocq-runtime/kernel","-nI",".","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
@@ -91,7 +86,7 @@ TC: extend in workspace + override standard
   > (env (dev (rocq (flags :standard -type-in-type))))
   > EOF
 
-  $ runFlags
+  $ trace_rocq_flags foo.vo
   {"name":"rocq","args":["c","--config"]}
   {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
   {"name":"rocq","args":["compile","-q","-type-in-type","-w","-deprecated-native-compiler-option","-native-output-dir",".","-native-compiler","on","-nI","rocq-runtime/kernel","-nI",".","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
@@ -104,7 +99,7 @@ TC: extend in dune (env) + override standard
   > (env (dev (rocq (flags -type-in-type))))
   > EOF
 
-  $ runFlags
+  $ trace_rocq_flags foo.vo
   {"name":"rocq","args":["c","--config"]}
   {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
   {"name":"rocq","args":["compile","-type-in-type","-w","-deprecated-native-compiler-option","-native-output-dir",".","-native-compiler","on","-nI","rocq-runtime/kernel","-nI",".","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
@@ -117,7 +112,7 @@ TC: extend in dune (env) + standard
   > (env (dev (rocq (flags :standard -type-in-type))))
   > EOF
 
-  $ runFlags
+  $ trace_rocq_flags foo.vo
   {"name":"rocq","args":["c","--config"]}
   {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
   {"name":"rocq","args":["compile","-q","-type-in-type","-type-in-type","-w","-deprecated-native-compiler-option","-native-output-dir",".","-native-compiler","on","-nI","rocq-runtime/kernel","-nI",".","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
@@ -135,7 +130,7 @@ TC: extend in dune (env) + workspace + standard
   > (env (dev (rocq (flags :standard -type-in-type))))
   > EOF
 
-  $ runFlags
+  $ trace_rocq_flags foo.vo
   {"name":"rocq","args":["c","--config"]}
   {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
   {"name":"rocq","args":["compile","-q","-type-in-type","-bt","-w","-deprecated-native-compiler-option","-native-output-dir",".","-native-compiler","on","-nI","rocq-runtime/kernel","-nI",".","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}


### PR DESCRIPTION
Extract the duplicated rocq flag tracing shell helper from the two rocq flags tests into the shared blackbox setup script.

The tests still build the same target and inspect the same trace output; only the repeated shell function is shared.