### PR TITLE
Use Repr for more to_dyn definitions

### DIFF
--- a/src/dune_cache/mode.ml
+++ b/src/dune_cache/mode.ml
@@ -23,10 +23,19 @@ let to_string = function
   | Copy -> "copy"
 ;;
 
-let to_dyn = function
-  | Copy -> Dyn.Variant ("Copy", [])
-  | Hardlink -> Dyn.Variant ("Hardlink", [])
+let repr =
+  Repr.variant
+    "cache-mode"
+    [ Repr.case0 "Copy" ~test:(function
+        | Copy -> true
+        | Hardlink -> false)
+    ; Repr.case0 "Hardlink" ~test:(function
+        | Hardlink -> true
+        | Copy -> false)
+    ]
 ;;
+
+let to_dyn = Repr.to_dyn repr
 
 (* CR-someday amokhov: Check that hard links can actually be created and, if
    not, return [Copy] instead. *)

--- a/src/dune_config_file/display.ml
+++ b/src/dune_config_file/display.ml
@@ -30,15 +30,27 @@ let all =
   [ "progress", progress; "verbose", verbose; "short", short; "quiet", quiet; "tui", Tui ]
 ;;
 
-let to_dyn : t -> Dyn.t = function
-  | Simple { verbosity; status_line } ->
-    Variant
-      ( "Simple"
-      , [ Record
-            [ "verbosity", Display.to_dyn verbosity; "status_line", Dyn.Bool status_line ]
-        ] )
-  | Tui -> Variant ("Tui", [])
+let simple_repr =
+  Repr.record
+    "simple-display"
+    [ Repr.field "verbosity" (Repr.abstract Display.to_dyn) ~get:fst
+    ; Repr.field "status_line" Repr.bool ~get:snd
+    ]
 ;;
+
+let repr =
+  Repr.variant
+    "display"
+    [ Repr.case "Simple" simple_repr ~proj:(function
+        | Simple { verbosity; status_line } -> Some (verbosity, status_line)
+        | Tui -> None)
+    ; Repr.case0 "Tui" ~test:(function
+        | Tui -> true
+        | Simple _ -> false)
+    ]
+;;
+
+let to_dyn = Repr.to_dyn repr
 
 let console_backend = function
   | Tui -> Dune_tui.backend ()

--- a/src/dune_engine/alias.ml
+++ b/src/dune_engine/alias.ml
@@ -56,11 +56,15 @@ let hash { dir; name } = Tuple.T2.hash Path.Build.hash Name.hash (dir, name)
 let name t = t.name
 let dir t = t.dir
 
-let to_dyn { dir; name } =
-  let open Dyn in
-  Record [ "dir", Path.Build.to_dyn dir; "name", Name.to_dyn name ]
+let repr =
+  Repr.record
+    "alias"
+    [ Repr.field "dir" Path.Build.repr ~get:(fun t -> t.dir)
+    ; Repr.field "name" (Repr.abstract Name.to_dyn) ~get:(fun t -> t.name)
+    ]
 ;;
 
+let to_dyn = Repr.to_dyn repr
 let fully_qualified_name t = Path.Build.relative t.dir (Name.to_string t.name)
 
 let get_ctx (path : Path.Build.t) =

--- a/src/dune_engine/clflags.ml
+++ b/src/dune_engine/clflags.ml
@@ -1,3 +1,5 @@
+open Stdune
+
 module Promote = struct
   type t =
     | Automatically
@@ -9,10 +11,19 @@ module Promote = struct
     | _, _ -> false
   ;;
 
-  let to_dyn = function
-    | Automatically -> Dyn.variant "Automatically" []
-    | Never -> Dyn.variant "Never" []
+  let repr =
+    Repr.variant
+      "promote"
+      [ Repr.case0 "Automatically" ~test:(function
+          | Automatically -> true
+          | Never -> false)
+      ; Repr.case0 "Never" ~test:(function
+          | Never -> true
+          | Automatically -> false)
+      ]
   ;;
+
+  let to_dyn = Repr.to_dyn repr
 end
 
 let target_exec = ref None

--- a/src/dune_engine/display.ml
+++ b/src/dune_engine/display.ml
@@ -1,3 +1,5 @@
+open Stdune
+
 type t =
   | Quiet
   | Short
@@ -9,8 +11,19 @@ let equal a b =
   | _, _ -> false
 ;;
 
-let to_dyn : t -> Dyn.t = function
-  | Quiet -> Variant ("Quiet", [])
-  | Short -> Variant ("Short", [])
-  | Verbose -> Variant ("Verbose", [])
+let repr =
+  Repr.variant
+    "display"
+    [ Repr.case0 "Quiet" ~test:(function
+        | Quiet -> true
+        | Short | Verbose -> false)
+    ; Repr.case0 "Short" ~test:(function
+        | Short -> true
+        | Quiet | Verbose -> false)
+    ; Repr.case0 "Verbose" ~test:(function
+        | Verbose -> true
+        | Quiet | Short -> false)
+    ]
 ;;
+
+let to_dyn = Repr.to_dyn repr

--- a/src/dune_engine/rule.ml
+++ b/src/dune_engine/rule.ml
@@ -11,11 +11,22 @@ module Info = struct
     | Some loc -> From_dune_file loc
   ;;
 
-  let to_dyn : t -> Dyn.t = function
-    | From_dune_file loc -> Dyn.Variant ("From_dune_file", [ Loc.to_dyn loc ])
-    | Internal -> Dyn.Variant ("Internal", [])
-    | Source_file_copy p -> Dyn.Variant ("Source_file_copy", [ Path.Source.to_dyn p ])
+  let repr =
+    Repr.variant
+      "rule-info"
+      [ Repr.case "From_dune_file" (Repr.abstract Loc.to_dyn) ~proj:(function
+          | From_dune_file loc -> Some loc
+          | Internal | Source_file_copy _ -> None)
+      ; Repr.case0 "Internal" ~test:(function
+          | Internal -> true
+          | From_dune_file _ | Source_file_copy _ -> false)
+      ; Repr.case "Source_file_copy" Path.Source.repr ~proj:(function
+          | Source_file_copy path -> Some path
+          | From_dune_file _ | Internal -> None)
+      ]
   ;;
+
+  let to_dyn = Repr.to_dyn repr
 end
 
 module Promote = struct
@@ -63,7 +74,16 @@ module T = struct
   let equal a b = Id.equal a.id b.id
   let hash t = Id.hash t.id
   let loc t = t.loc
-  let to_dyn t : Dyn.t = Record [ "id", Id.to_dyn t.id; "info", Info.to_dyn t.info ]
+
+  let repr =
+    Repr.record
+      "rule"
+      [ Repr.field "id" (Repr.abstract Id.to_dyn) ~get:(fun t -> t.id)
+      ; Repr.field "info" Info.repr ~get:(fun t -> t.info)
+      ]
+  ;;
+
+  let to_dyn = Repr.to_dyn repr
 end
 
 include T

--- a/src/dune_findlib/config.ml
+++ b/src/dune_findlib/config.ml
@@ -9,9 +9,12 @@ module File = struct
     ; preds : Ps.t
     }
 
-  let to_dyn { vars; preds } =
-    let open Dyn in
-    record [ "vars", Vars.to_dyn vars; "preds", Ps.to_dyn preds ]
+  let repr =
+    Repr.record
+      "findlib-config-file"
+      [ Repr.field "vars" (Repr.abstract Vars.to_dyn) ~get:(fun t -> t.vars)
+      ; Repr.field "preds" (Repr.abstract Ps.to_dyn) ~get:(fun t -> t.preds)
+      ]
   ;;
 
   let load config_file =
@@ -65,10 +68,15 @@ type t =
   ; toolchain : string option
   }
 
-let to_dyn { config; ocamlpath = _; toolchain; which = _ } =
-  let open Dyn in
-  record [ "config", File.to_dyn config; "toolchain", option string toolchain ]
+let repr =
+  Repr.record
+    "findlib-config"
+    [ Repr.field "config" File.repr ~get:(fun t -> t.config)
+    ; Repr.field "toolchain" Repr.(option string) ~get:(fun t -> t.toolchain)
+    ]
 ;;
+
+let to_dyn = Repr.to_dyn repr
 
 let ocamlpath_sep =
   if Sys.cygwin

--- a/src/dune_findlib/rule.ml
+++ b/src/dune_findlib/rule.ml
@@ -9,14 +9,18 @@ type t =
   ; value : string
   }
 
-let to_dyn { preds_required; preds_forbidden; value } =
-  let open Dyn in
-  record
-    [ "preds_required", Ps.to_dyn preds_required
-    ; "preds_forbidden", Ps.to_dyn preds_forbidden
-    ; "value", string value
+let repr =
+  Repr.record
+    "findlib-rule"
+    [ Repr.field "preds_required" (Repr.abstract Ps.to_dyn) ~get:(fun t ->
+        t.preds_required)
+    ; Repr.field "preds_forbidden" (Repr.abstract Ps.to_dyn) ~get:(fun t ->
+        t.preds_forbidden)
+    ; Repr.field "value" Repr.string ~get:(fun t -> t.value)
     ]
 ;;
+
+let to_dyn = Repr.to_dyn repr
 
 let formal_predicates_count t =
   Ps.cardinal t.preds_required + Ps.cardinal t.preds_forbidden

--- a/src/dune_findlib/rules.ml
+++ b/src/dune_findlib/rules.ml
@@ -13,11 +13,21 @@ type t =
   ; add_rules : Rule.t list
   }
 
-let to_dyn { set_rules; add_rules } =
-  let open Dyn in
-  record
-    [ "set_rules", list Rule.to_dyn set_rules; "add_rules", list Rule.to_dyn add_rules ]
+let repr =
+  Repr.record
+    "findlib-rules"
+    [ Repr.field
+        "set_rules"
+        Repr.(list (abstract Rule.to_dyn))
+        ~get:(fun t -> t.set_rules)
+    ; Repr.field
+        "add_rules"
+        Repr.(list (abstract Rule.to_dyn))
+        ~get:(fun t -> t.add_rules)
+    ]
 ;;
+
+let to_dyn = Repr.to_dyn repr
 
 let interpret t ~preds =
   let rec find_set_rule = function

--- a/src/dune_lang/dune_project_name.ml
+++ b/src/dune_lang/dune_project_name.ml
@@ -27,12 +27,7 @@ module T = struct
       ]
   ;;
 
-  let to_dyn =
-    let open Dyn in
-    function
-    | Named n -> variant "Named" [ string n ]
-    | Anonymous p -> variant "Anonymous" [ Path.Source.to_dyn p ]
-  ;;
+  let to_dyn = Repr.to_dyn repr
 end
 
 include T

--- a/src/dune_lang/package_dependency.ml
+++ b/src/dune_lang/package_dependency.ml
@@ -100,13 +100,18 @@ let decode =
       { name; constraint_ = None }
 ;;
 
-let to_dyn { name; constraint_ } =
-  let open Dyn in
-  record
-    [ "name", Package_name.to_dyn name
-    ; "constr", Dyn.Option (Option.map ~f:Package_constraint.to_dyn constraint_)
+let repr =
+  Repr.record
+    "package-dependency"
+    [ Repr.field "name" Package_name.repr ~get:(fun t -> t.name)
+    ; Repr.field
+        "constr"
+        Repr.(option (abstract Package_constraint.to_dyn))
+        ~get:(fun t -> t.constraint_)
     ]
 ;;
+
+let to_dyn = Repr.to_dyn repr
 
 let equal { name; constraint_ } t =
   Package_name.equal name t.name

--- a/src/dune_lang/package_id.ml
+++ b/src/dune_lang/package_id.ml
@@ -12,9 +12,15 @@ module T = struct
     | e -> e
   ;;
 
-  let to_dyn { dir; name } =
-    Dyn.record [ "name", Package_name.to_dyn name; "dir", Path.Source.to_dyn dir ]
+  let repr =
+    Repr.record
+      "package-id"
+      [ Repr.field "name" Package_name.repr ~get:(fun t -> t.name)
+      ; Repr.field "dir" Path.Source.repr ~get:(fun t -> t.dir)
+      ]
   ;;
+
+  let to_dyn = Repr.to_dyn repr
 end
 
 include T

--- a/src/dune_lang/package_variable_name.ml
+++ b/src/dune_lang/package_variable_name.ml
@@ -3,7 +3,8 @@ open Import
 module T = struct
   type t = OpamVariable.t
 
-  let to_dyn s = Dyn.string (OpamVariable.to_string s)
+  let repr = Repr.view Repr.string ~to_:OpamVariable.to_string
+  let to_dyn = Repr.to_dyn repr
   let compare x y = Ordering.of_int (OpamVariable.compare x y)
 end
 
@@ -87,7 +88,7 @@ let all_known =
 ;;
 
 let encode t = Encoder.string (to_string t)
-let repr = Repr.view Repr.string ~to_:to_string
+let repr = T.repr
 
 let check_typo_underscore_instead_of_dash =
   let possible_typos =

--- a/src/dune_pkg/file_entry.ml
+++ b/src/dune_pkg/file_entry.ml
@@ -11,9 +11,16 @@ let source_equal a b =
   | Path _, Content _ | Content _, Path _ -> false
 ;;
 
-let dyn_of_source = function
-  | Path path -> Dyn.variant "Path" [ Path.to_dyn path ]
-  | Content content -> Dyn.variant "Content" [ Dyn.string content ]
+let source_repr =
+  Repr.variant
+    "file-entry-source"
+    [ Repr.case "Path" Path.repr ~proj:(function
+        | Path path -> Some path
+        | Content _ -> None)
+    ; Repr.case "Content" Repr.string ~proj:(function
+        | Content content -> Some content
+        | Path _ -> None)
+    ]
 ;;
 
 type t =
@@ -25,7 +32,12 @@ let equal { original; local_file } t =
   source_equal original t.original && Path.Local.equal local_file t.local_file
 ;;
 
-let to_dyn { original; local_file } =
-  Dyn.record
-    [ "original", dyn_of_source original; "local_file", Path.Local.to_dyn local_file ]
+let repr =
+  Repr.record
+    "file-entry"
+    [ Repr.field "original" source_repr ~get:(fun t -> t.original)
+    ; Repr.field "local_file" Path.Local.repr ~get:(fun t -> t.local_file)
+    ]
 ;;
+
+let to_dyn = Repr.to_dyn repr

--- a/src/dune_pkg/package_variable.ml
+++ b/src/dune_pkg/package_variable.ml
@@ -13,9 +13,16 @@ module Scope = struct
     | Package x, Package y -> Package_name.compare x y
   ;;
 
-  let to_dyn = function
-    | Self -> Dyn.variant "Self" []
-    | Package name -> Dyn.variant "Package" [ Package_name.to_dyn name ]
+  let repr =
+    Repr.variant
+      "package-variable-scope"
+      [ Repr.case0 "Self" ~test:(function
+          | Self -> true
+          | Package _ -> false)
+      ; Repr.case "Package" Package_name.repr ~proj:(function
+          | Package name -> Some name
+          | Self -> None)
+      ]
   ;;
 end
 
@@ -31,10 +38,15 @@ module T = struct
     | x -> x
   ;;
 
-  let to_dyn { name; scope } =
-    let open Dyn in
-    record [ "name", Package_variable_name.to_dyn name; "scope", Scope.to_dyn scope ]
+  let repr =
+    Repr.record
+      "package-variable"
+      [ Repr.field "name" Package_variable_name.repr ~get:(fun t -> t.name)
+      ; Repr.field "scope" Scope.repr ~get:(fun t -> t.scope)
+      ]
   ;;
+
+  let to_dyn = Repr.to_dyn repr
 end
 
 include T

--- a/src/dune_pkg/resolve_opam_formula.ml
+++ b/src/dune_pkg/resolve_opam_formula.ml
@@ -30,9 +30,7 @@ module Version_constraint = struct
     Package_dependency.Constraint.Op.of_opam relop, package_version
   ;;
 
-  let to_dyn (op, package_version) =
-    Dyn.Tuple [ Relop.to_dyn op; Package_version.to_dyn package_version ]
-  ;;
+  let repr = Repr.(pair (abstract Relop.to_dyn) Package_version.repr)
 
   let to_string (op, package_version) =
     sprintf "%s %s" (Relop.to_string op) (Package_version.to_string package_version)
@@ -48,20 +46,34 @@ module Unsatisfied_formula_hint = struct
         ; version_constraint : Version_constraint.t
         }
 
-  let to_dyn = function
-    | Missing_package package_name ->
-      Dyn.variant "Missing_package" [ Package_name.to_dyn package_name ]
-    | Unsatisfied_version_constraint { package_name; found_version; version_constraint }
-      ->
-      Dyn.variant
-        "Unsatisfied_version_constraint"
-        [ Dyn.record
-            [ "package_name", Package_name.to_dyn package_name
-            ; "found_version", Package_version.to_dyn found_version
-            ; "version_constraint", Version_constraint.to_dyn version_constraint
-            ]
-        ]
+  let unsatisfied_version_constraint_repr =
+    Repr.record
+      "unsatisfied-version-constraint"
+      [ Repr.field "package_name" Package_name.repr ~get:(fun (name, _, _) -> name)
+      ; Repr.field "found_version" Package_version.repr ~get:(fun (_, version, _) ->
+          version)
+      ; Repr.field "version_constraint" Version_constraint.repr ~get:(fun (_, _, c) -> c)
+      ]
   ;;
+
+  let repr =
+    Repr.variant
+      "unsatisfied-formula-hint"
+      [ Repr.case "Missing_package" Package_name.repr ~proj:(function
+          | Missing_package package_name -> Some package_name
+          | Unsatisfied_version_constraint _ -> None)
+      ; Repr.case
+          "Unsatisfied_version_constraint"
+          unsatisfied_version_constraint_repr
+          ~proj:(function
+          | Unsatisfied_version_constraint
+              { package_name; found_version; version_constraint } ->
+            Some (package_name, found_version, version_constraint)
+          | Missing_package _ -> None)
+      ]
+  ;;
+
+  let to_dyn = Repr.to_dyn repr
 
   let pp = function
     | Missing_package missing_package ->

--- a/src/dune_pkg/solver_stats.ml
+++ b/src/dune_pkg/solver_stats.ml
@@ -93,15 +93,21 @@ module Expanded_variable_bindings = struct
     && List.equal Package_variable_name.equal unset_variables t.unset_variables
   ;;
 
-  let to_dyn { variable_values; unset_variables } =
-    Dyn.record
-      [ ( "variable_values"
-        , Dyn.list
-            (Tuple.T2.to_dyn Package_variable_name.to_dyn Variable_value.to_dyn)
-            variable_values )
-      ; "unset_variables", Dyn.list Package_variable_name.to_dyn unset_variables
+  let repr =
+    Repr.record
+      "expanded-variable-bindings"
+      [ Repr.field
+          "variable_values"
+          Repr.(list (pair Package_variable_name.repr Variable_value.repr))
+          ~get:(fun t -> t.variable_values)
+      ; Repr.field
+          "unset_variables"
+          Repr.(list Package_variable_name.repr)
+          ~get:(fun t -> t.unset_variables)
       ]
   ;;
+
+  let to_dyn = Repr.to_dyn repr
 
   let to_solver_env { variable_values; unset_variables = _ } =
     List.fold_left variable_values ~init:Solver_env.empty ~f:(fun acc (variable, value) ->

--- a/src/dune_pkg/source_backend.ml
+++ b/src/dune_pkg/source_backend.ml
@@ -11,9 +11,16 @@ let equal a b =
   | _, _ -> false
 ;;
 
-let to_dyn =
-  let open Dyn in
-  function
-  | Directory d -> variant "Directory" [ Path.to_dyn d ]
-  | Repo r -> variant "Repo" [ opaque r ]
+let repr =
+  Repr.variant
+    "source-backend"
+    [ Repr.case "Directory" Path.repr ~proj:(function
+        | Directory path -> Some path
+        | Repo _ -> None)
+    ; Repr.case "Repo" (Repr.abstract Dyn.opaque) ~proj:(function
+        | Repo repo -> Some repo
+        | Directory _ -> None)
+    ]
 ;;
+
+let to_dyn = Repr.to_dyn repr

--- a/src/dune_rules/compilation_mode.ml
+++ b/src/dune_rules/compilation_mode.ml
@@ -15,10 +15,19 @@ let equal a b =
   | Ocaml, Melange | Melange, Ocaml -> false
 ;;
 
-let to_dyn = function
-  | Ocaml -> Dyn.variant "Ocaml" []
-  | Melange -> Dyn.variant "Melange" []
+let repr =
+  Repr.variant
+    "compilation-mode"
+    [ Repr.case0 "Ocaml" ~test:(function
+        | Ocaml -> true
+        | Melange -> false)
+    ; Repr.case0 "Melange" ~test:(function
+        | Melange -> true
+        | Ocaml -> false)
+    ]
 ;;
+
+let to_dyn = Repr.to_dyn repr
 
 let of_lib_mode = function
   | Lib_mode.Ocaml _ -> Ocaml

--- a/src/dune_vcs/vcs.ml
+++ b/src/dune_vcs/vcs.ml
@@ -25,12 +25,16 @@ module Kind = struct
     | None -> kind Filename.hg_dir_basename
   ;;
 
-  let to_dyn t =
-    Dyn.Variant
-      ( (match t with
-         | Git -> "Git"
-         | Hg -> "Hg")
-      , [] )
+  let repr =
+    Repr.variant
+      "vcs-kind"
+      [ Repr.case0 "Git" ~test:(function
+          | Git -> true
+          | Hg -> false)
+      ; Repr.case0 "Hg" ~test:(function
+          | Hg -> true
+          | Git -> false)
+      ]
   ;;
 
   let equal = ( = )
@@ -42,9 +46,15 @@ module T = struct
     ; kind : Kind.t
     }
 
-  let to_dyn { root; kind } =
-    Dyn.record [ "root", Path.to_dyn root; "kind", Kind.to_dyn kind ]
+  let repr =
+    Repr.record
+      "vcs"
+      [ Repr.field "root" Path.repr ~get:(fun t -> t.root)
+      ; Repr.field "kind" Kind.repr ~get:(fun t -> t.kind)
+      ]
   ;;
+
+  let to_dyn = Repr.to_dyn repr
 
   let equal { root = ra; kind = ka } { root = rb; kind = kb } =
     Path.equal ra rb && Kind.equal ka kb

--- a/src/ocaml/cm_kind.ml
+++ b/src/ocaml/cm_kind.ml
@@ -27,13 +27,22 @@ let choose cmi cmo cmx = function
 let ext = Filename.Extension.(choose cmi cmo cmx)
 let source = choose Ml_kind.Intf Impl Impl
 
-let to_dyn =
-  let open Dyn in
-  function
-  | Cmi -> variant "cmi" []
-  | Cmo -> variant "cmo" []
-  | Cmx -> variant "cmx" []
+let repr =
+  Repr.variant
+    "cm-kind"
+    [ Repr.case0 "cmi" ~test:(function
+        | Cmi -> true
+        | Cmo | Cmx -> false)
+    ; Repr.case0 "cmo" ~test:(function
+        | Cmo -> true
+        | Cmi | Cmx -> false)
+    ; Repr.case0 "cmx" ~test:(function
+        | Cmx -> true
+        | Cmi | Cmo -> false)
+    ]
 ;;
+
+let to_dyn = Repr.to_dyn repr
 
 module Dict = struct
   type 'a t =

--- a/src/ocaml/ml_kind.ml
+++ b/src/ocaml/ml_kind.ml
@@ -13,7 +13,8 @@ let choose t ~impl ~intf =
 ;;
 
 let to_string = choose ~impl:"impl" ~intf:"intf"
-let to_dyn t = Dyn.String (to_string t)
+let repr = Repr.view Repr.string ~to_:to_string
+let to_dyn = Repr.to_dyn repr
 
 let cmt_ext = function
   | Impl -> Filename.Extension.cmt

--- a/src/ocaml/mode.ml
+++ b/src/ocaml/mode.ml
@@ -27,7 +27,20 @@ let choose byte native = function
 
 let to_string = choose "byte" "native"
 let encode t = Dune_sexp.Encoder.string (to_string t)
-let to_dyn t = Dyn.variant (to_string t) []
+
+let repr =
+  Repr.variant
+    "mode"
+    [ Repr.case0 "byte" ~test:(function
+        | Byte -> true
+        | Native -> false)
+    ; Repr.case0 "native" ~test:(function
+        | Native -> true
+        | Byte -> false)
+    ]
+;;
+
+let to_dyn = Repr.to_dyn repr
 let compiled_unit_ext = choose (Cm_kind.ext Cmo) (Cm_kind.ext Cmx)
 let compiled_lib_ext = choose Filename.Extension.cma Filename.Extension.cmxa
 let plugin_ext = choose Filename.Extension.cma Filename.Extension.cmxs
@@ -149,12 +162,21 @@ module Select = struct
     | _, _ -> false
   ;;
 
-  let to_dyn t =
-    let open Dyn in
-    match t with
-    | All -> Variant ("All", [])
-    | Only m -> Variant ("Only", [ to_dyn m ])
+  let mode_repr = repr
+
+  let repr =
+    Repr.variant
+      "mode-select"
+      [ Repr.case0 "All" ~test:(function
+          | All -> true
+          | Only _ -> false)
+      ; Repr.case "Only" mode_repr ~proj:(function
+          | Only mode -> Some mode
+          | All -> None)
+      ]
   ;;
+
+  let to_dyn = Repr.to_dyn repr
 
   let encode t =
     let open Dune_sexp.Encoder in

--- a/src/source/source_dir_status.ml
+++ b/src/source/source_dir_status.ml
@@ -41,13 +41,22 @@ module Map = struct
   let init ~f = { data_only = f Data_only; vendored = f Vendored; normal = f Normal }
 end
 
-let to_dyn t =
-  let open Dyn in
-  match t with
-  | Data_only -> Variant ("Data_only", [])
-  | Vendored -> Variant ("Vendored", [])
-  | Normal -> Variant ("Normal", [])
+let repr =
+  Repr.variant
+    "source-dir-status"
+    [ Repr.case0 "Data_only" ~test:(function
+        | Data_only -> true
+        | Normal | Vendored -> false)
+    ; Repr.case0 "Vendored" ~test:(function
+        | Vendored -> true
+        | Data_only | Normal -> false)
+    ; Repr.case0 "Normal" ~test:(function
+        | Normal -> true
+        | Data_only | Vendored -> false)
+    ]
 ;;
+
+let to_dyn = Repr.to_dyn repr
 
 let to_string = function
   | Data_only -> "data_only"


### PR DESCRIPTION
Replace several manually written to_dyn functions with explicit Repr.t values and Repr.to_dyn across engine, language, package, findlib, VCS, and OCaml utility types.