### PR TITLE
test(odoc): share syntax detection helper

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -107,6 +107,18 @@ make_simple_rpc_watch_project() {
 	EOF
 }
 
+odoc_detect_syntax() {
+  if grep -q '>sig<' "$1"
+  then
+    echo it is ocaml
+  elif grep -q '{ ... }' "$1"
+  then
+    echo it is reason
+  else
+    echo it is unknown
+  fi
+}
+
 query_ocaml_merlin() {
   file="$1"
   shift

--- a/test/blackbox-tests/test-cases/odoc/odoc-syntax-env-github1117/legacy.t
+++ b/test/blackbox-tests/test-cases/odoc/odoc-syntax-env-github1117/legacy.t
@@ -15,20 +15,11 @@ variable, and can rebuild as needed.
   > module type X = sig end
   > EOF
 
-  $ detect () {
-  > if grep -q '>sig<' $1 ; then
-  >   echo it is ocaml
-  > elif grep -q '{ ... }' $1 ; then
-  >   echo it is reason
-  > else
-  >   echo it is unknown
-  > fi
-  > }
 
   $ dune build @doc
-  $ detect _build/default/_doc/_html/l/L/index.html
+  $ odoc_detect_syntax _build/default/_doc/_html/l/L/index.html
   it is ocaml
 
   $ ODOC_SYNTAX=re dune build @doc
-  $ detect _build/default/_doc/_html/l/L/index.html
+  $ odoc_detect_syntax _build/default/_doc/_html/l/L/index.html
   it is reason

--- a/test/blackbox-tests/test-cases/odoc/odoc-syntax-env-github1117/new.t
+++ b/test/blackbox-tests/test-cases/odoc/odoc-syntax-env-github1117/new.t
@@ -15,20 +15,11 @@ variable, and can rebuild as needed.
   > module type X = sig end
   > EOF
 
-  $ detect () {
-  > if grep -q '>sig<' $1 ; then
-  >   echo it is ocaml
-  > elif grep -q '{ ... }' $1 ; then
-  >   echo it is reason
-  > else
-  >   echo it is unknown
-  > fi
-  > }
 
   $ dune build @doc-new
-  $ detect _build/default/_doc_new/html/docs/local/l/L/index.html
+  $ odoc_detect_syntax _build/default/_doc_new/html/docs/local/l/L/index.html
   it is ocaml
 
   $ ODOC_SYNTAX=re dune build @doc-new
-  $ detect _build/default/_doc_new/html/docs/local/l/L/index.html
+  $ odoc_detect_syntax _build/default/_doc_new/html/docs/local/l/L/index.html
   it is reason


### PR DESCRIPTION
Extract the duplicated shell helper used by the odoc syntax-env tests to detect whether generated HTML reflects OCaml or Reason syntax.

This keeps the tests concise while preserving the same assertions.