### PR TITLE
test(bin-pform): share mypkg binary fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -98,6 +98,21 @@ make_dune_project() {
 	EOF
 }
 
+make_mypkg_bin_project() {
+  local message="${1:-hello from mybin}"
+  cat > dune-project <<- EOF
+	(lang dune 3.24)
+	(package (name mypkg))
+	EOF
+  mkdir src
+  cat > src/dune <<-'EOF'
+	(executable (public_name mybin) (package mypkg))
+	EOF
+  cat > src/mybin.ml <<- EOF
+	let () = print_endline "$message"
+	EOF
+}
+
 make_simple_rpc_watch_project() {
   make_dune_project 3.23
   cat > dune <<-'EOF'

--- a/test/blackbox-tests/test-cases/bin-pform/cram-path.t
+++ b/test/blackbox-tests/test-cases/bin-pform/cram-path.t
@@ -1,16 +1,7 @@
 %{bin:...} in cram (deps ...) makes the binary callable by name.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.24)
-  > (package (name mypkg))
-  > EOF
-  $ mkdir src tests
-  $ cat >src/dune <<'EOF'
-  > (executable (public_name mybin) (package mypkg))
-  > EOF
-  $ cat >src/mybin.ml <<'EOF'
-  > let () = print_endline "hello from mybin"
-  > EOF
+  $ make_mypkg_bin_project
+  $ mkdir tests
 
   $ cat >tests/dune <<'EOF'
   > (cram (deps %{bin:mybin}))

--- a/test/blackbox-tests/test-cases/bin-pform/include-deps.t
+++ b/test/blackbox-tests/test-cases/bin-pform/include-deps.t
@@ -2,17 +2,7 @@
 .binaries dir gets added to the action's PATH and the binary is a
 tracked dep of the rule.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.24)
-  > (package (name mypkg))
-  > EOF
-  $ mkdir src
-  $ cat >src/dune <<'EOF'
-  > (executable (public_name mybin) (package mypkg))
-  > EOF
-  $ cat >src/mybin.ml <<'EOF'
-  > let () = print_endline "hello from mybin"
-  > EOF
+  $ make_mypkg_bin_project
 
   $ cat >deps.sexp <<'EOF'
   > (%{bin:mybin})

--- a/test/blackbox-tests/test-cases/bin-pform/inline-tests-include.t
+++ b/test/blackbox-tests/test-cases/bin-pform/inline-tests-include.t
@@ -4,17 +4,7 @@ behavior of a top-level %{bin:NAME} dep (see inline-tests.t).
 Dep_conf_eval.unnamed mirrors named_paths_builder's include_envs
 collection to drain the env contribution from Include_result.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.24)
-  > (package (name mypkg))
-  > EOF
-  $ mkdir src
-  $ cat >src/dune <<'EOF'
-  > (executable (public_name mybin) (package mypkg))
-  > EOF
-  $ cat >src/mybin.ml <<'EOF'
-  > let () = print_endline "hello from mybin"
-  > EOF
+  $ make_mypkg_bin_project
 
   $ cat >dump_path.ml <<EOF
   > let () =

--- a/test/blackbox-tests/test-cases/bin-pform/inline-tests.t
+++ b/test/blackbox-tests/test-cases/bin-pform/inline-tests.t
@@ -1,17 +1,7 @@
 %{bin:...} in (inline_tests (deps ...)) adds a bin-layout dir to
 the test runner's PATH.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.24)
-  > (package (name mypkg))
-  > EOF
-  $ mkdir src
-  $ cat >src/dune <<'EOF'
-  > (executable (public_name mybin) (package mypkg))
-  > EOF
-  $ cat >src/mybin.ml <<'EOF'
-  > let () = print_endline "hello from mybin"
-  > EOF
+  $ make_mypkg_bin_project
 
 Custom backend whose runner records PATH to a file outside the
 sandbox:

--- a/test/blackbox-tests/test-cases/bin-pform/run-literal-vs-pform.t
+++ b/test/blackbox-tests/test-cases/bin-pform/run-literal-vs-pform.t
@@ -3,17 +3,7 @@ a dep on the build artifact. Before wrv only the bare-literal form
 did, since the pform default was where=Install_dir; wrv flips the
 pform default to Original_path so both paths agree.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.24)
-  > (package (name mypkg))
-  > EOF
-  $ mkdir src
-  $ cat >src/dune <<'EOF'
-  > (executable (public_name mybin) (package mypkg))
-  > EOF
-  $ cat >src/mybin.ml <<'EOF'
-  > let () = print_endline "hello"
-  > EOF
+  $ make_mypkg_bin_project hello
   $ cat >dune <<'EOF'
   > (rule
   >  (with-stdout-to out-literal

--- a/test/blackbox-tests/test-cases/bin-pform/sandbox.t
+++ b/test/blackbox-tests/test-cases/bin-pform/sandbox.t
@@ -8,17 +8,7 @@ filesystem paths are still readable from inside the sandbox; it would
 break under remote action execution. Tracked as a follow-up to the
 .binaries PR.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.24)
-  > (package (name mypkg))
-  > EOF
-  $ mkdir src
-  $ cat >src/dune <<'EOF'
-  > (executable (public_name mybin) (package mypkg))
-  > EOF
-  $ cat >src/mybin.ml <<'EOF'
-  > let () = print_endline "hello from mybin"
-  > EOF
+  $ make_mypkg_bin_project
 
   $ cat >dune <<'EOF'
   > (rule

--- a/test/blackbox-tests/test-cases/bin-pform/shared-layout.t
+++ b/test/blackbox-tests/test-cases/bin-pform/shared-layout.t
@@ -2,17 +2,7 @@ Two rules with the same set of %{bin:...} deps share a single
 .binaries directory (keyed by the digest of the sorted unique bin
 names).
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.24)
-  > (package (name mypkg))
-  > EOF
-  $ mkdir src
-  $ cat >src/dune <<'EOF'
-  > (executable (public_name mybin) (package mypkg))
-  > EOF
-  $ cat >src/mybin.ml <<'EOF'
-  > let () = print_endline "hello from mybin"
-  > EOF
+  $ make_mypkg_bin_project
 
   $ cat >dune <<'EOF'
   > (rule

--- a/test/blackbox-tests/test-cases/bin-pform/test-stanza.t
+++ b/test/blackbox-tests/test-cases/bin-pform/test-stanza.t
@@ -1,16 +1,6 @@
 %{bin:...} in a test stanza adds the binary to PATH.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.24)
-  > (package (name mypkg))
-  > EOF
-  $ mkdir src
-  $ cat >src/dune <<'EOF'
-  > (executable (public_name mybin) (package mypkg))
-  > EOF
-  $ cat >src/mybin.ml <<'EOF'
-  > let () = print_endline "hello from mybin"
-  > EOF
+  $ make_mypkg_bin_project
 
   $ cat >dune <<'EOF'
   > (test


### PR DESCRIPTION
Extract the repeated mypkg/mybin project setup used by the %{bin:...} blackbox tests into a shared helper.

The helper keeps the tests focused on their bin pform assertions while preserving the generated project layout.