### PR TITLE
test(pkg): share package project fixture

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -277,6 +277,18 @@ make_lockdir() {
 	EOF
 }
 
+make_package_project() {
+  local version="$1"
+  shift
+  cat > dune-project <<- EOF
+	(lang dune ${version})
+	(package
+	 (name x)
+	 (allow_empty)
+	 (depends $@))
+	EOF
+}
+
 make_project() {
   cat <<- EOF
 	(lang dune 3.20)

--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/absolute-symlink-inside.t
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/absolute-symlink-inside.t
@@ -17,13 +17,7 @@ Since we use realpath, these resolve correctly and work with caching.
   >    && touch %{lib}/%{pkg-self:name}/META"))
   > EOF
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > (package
-  >  (name x)
-  >  (allow_empty)
-  >  (depends foo))
-  > EOF
+  $ make_package_project 3.22 foo
 
   $ build_pkg foo
 

--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/basic-caching.t
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/basic-caching.t
@@ -22,13 +22,7 @@ This is similar to how compilers install binaries (e.g., ocamlc -> ocamlc.opt).
   >    && touch %{lib}/%{pkg-self:name}/META"))
   > EOF
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > (package
-  >  (name x)
-  >  (allow_empty)
-  >  (depends foo))
-  > EOF
+  $ make_package_project 3.22 foo
 
 Build the package:
 

--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/broken-symlink.t
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/broken-symlink.t
@@ -11,13 +11,7 @@ Test that broken symlinks are detected during symlink resolution.
   >    && touch %{lib}/%{pkg-self:name}/META"))
   > EOF
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > (package
-  >  (name x)
-  >  (allow_empty)
-  >  (depends foo))
-  > EOF
+  $ make_package_project 3.22 foo
 
 The broken symlink is detected:
 

--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/chain-through-outside.t
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/chain-through-outside.t
@@ -24,13 +24,7 @@ Create a directory outside the build for the intermediate symlink:
   >    && touch %{lib}/%{pkg-self:name}/META"))
   > EOF
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > (package
-  >  (name x)
-  >  (allow_empty)
-  >  (depends foo))
-  > EOF
+  $ make_package_project 3.22 foo
 
 Build the package:
 

--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/link-permission-error.t
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/link-permission-error.t
@@ -16,13 +16,7 @@ symlink before hardlinking will fail with EACCES.
   >    && chmod -w %{lib}/%{pkg-self:name}"))
   > EOF
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > (package
-  >  (name x)
-  >  (allow_empty)
-  >  (depends foo))
-  > EOF
+  $ make_package_project 3.22 foo
 
 Build fails with a symlink resolution error:
 

--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/nested-symlinks.t
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/nested-symlinks.t
@@ -19,13 +19,7 @@ Create a package with nested symlinks: link2 -> link1 -> real.txt
   >    && touch %{lib}/%{pkg-self:name}/META"))
   > EOF
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > (package
-  >  (name x)
-  >  (allow_empty)
-  >  (depends foo))
-  > EOF
+  $ make_package_project 3.22 foo
 
 Build the package:
 

--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/symlink-outside-target.t
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/symlink-outside-target.t
@@ -24,13 +24,7 @@ Create a package with a symlink pointing outside target:
   >    && touch %{lib}/%{pkg-self:name}/META"))
   > EOF
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > (package
-  >  (name x)
-  >  (allow_empty)
-  >  (depends foo))
-  > EOF
+  $ make_package_project 3.22 foo
 
   $ build_pkg foo
 

--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/symlink-to-directory-with-contents.t
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/symlink-to-directory-with-contents.t
@@ -26,13 +26,7 @@ code is exercised:
   >    && touch %{lib}/%{pkg-self:name}/META"))
   > EOF
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > (package
-  >  (name x)
-  >  (allow_empty)
-  >  (depends foo))
-  > EOF
+  $ make_package_project 3.22 foo
 
   $ build_pkg foo
 


### PR DESCRIPTION
Add a helper for the simple package project used by the install-symlinks package tests and reuse it from the repeated setup blocks.

The helper preserves the same package metadata while keeping each test focused on its lock package contents and assertions.