### PR TITLE
test(promote): share directory-targets project helper

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -113,6 +113,14 @@ make_mypkg_bin_project() {
 	EOF
 }
 
+make_directory_targets_project() {
+  local version="${1:-3.23}"
+  cat > dune-project <<- EOF
+	(lang dune ${version})
+	(using directory-targets 0.1)
+	EOF
+}
+
 make_simple_rpc_watch_project() {
   make_dune_project 3.23
   cat > dune <<-'EOF'

--- a/test/blackbox-tests/test-cases/promote/directory-diff/add-file.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/add-file.t
@@ -1,9 +1,6 @@
 Directory diff promotes files that are missing from the source directory.
 
-  $ cat > dune-project <<'EOF'
-  > (lang dune 3.23)
-  > (using directory-targets 0.1)
-  > EOF
+  $ make_directory_targets_project
 
   $ mkdir expected
 

--- a/test/blackbox-tests/test-cases/promote/directory-diff/cli-commands.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/cli-commands.t
@@ -1,9 +1,6 @@
 Directory diff integrates with the promotion CLI.
 
-  $ cat > dune-project <<'EOF'
-  > (lang dune 3.23)
-  > (using directory-targets 0.1)
-  > EOF
+  $ make_directory_targets_project
 
 Deletion promotions are visible to `dune promotion list` and `diff`.
 

--- a/test/blackbox-tests/test-cases/promote/directory-diff/create-empty-directory.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/create-empty-directory.t
@@ -1,9 +1,6 @@
 Directory diff can create an empty directory.
 
-  $ cat > dune-project <<'EOF'
-  > (lang dune 3.23)
-  > (using directory-targets 0.1)
-  > EOF
+  $ make_directory_targets_project
 
   $ mkdir expected
   $ cat > dune <<'EOF'

--- a/test/blackbox-tests/test-cases/promote/directory-diff/delete-directory.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/delete-directory.t
@@ -1,9 +1,6 @@
 Directory diff records directory deletions.
 
-  $ cat > dune-project <<'EOF'
-  > (lang dune 3.23)
-  > (using directory-targets 0.1)
-  > EOF
+  $ make_directory_targets_project
 
   $ mkdir -p expected/stale
   $ printf 'keep\n' > expected/keep

--- a/test/blackbox-tests/test-cases/promote/directory-diff/delete-file.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/delete-file.t
@@ -1,9 +1,6 @@
 Directory diff records file deletions.
 
-  $ cat > dune-project <<'EOF'
-  > (lang dune 3.23)
-  > (using directory-targets 0.1)
-  > EOF
+  $ make_directory_targets_project
 
   $ mkdir expected
   $ printf 'keep\n' > expected/keep

--- a/test/blackbox-tests/test-cases/promote/directory-diff/multiple-file-promotions.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/multiple-file-promotions.t
@@ -1,9 +1,6 @@
 Directory diff promotes each changed file separately.
 
-  $ cat > dune-project <<'EOF'
-  > (lang dune 3.23)
-  > (using directory-targets 0.1)
-  > EOF
+  $ make_directory_targets_project
 
   $ mkdir expected
   $ printf 'old a\n' > expected/a

--- a/test/blackbox-tests/test-cases/promote/directory-diff/replace-directory-with-file.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/replace-directory-with-file.t
@@ -1,9 +1,6 @@
 Directory diff can replace a directory with a file.
 
-  $ cat > dune-project <<'EOF'
-  > (lang dune 3.23)
-  > (using directory-targets 0.1)
-  > EOF
+  $ make_directory_targets_project
 
   $ mkdir -p expected/node
   $ printf 'child\n' > expected/node/file

--- a/test/blackbox-tests/test-cases/promote/directory-diff/replace-file-with-directory.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/replace-file-with-directory.t
@@ -1,9 +1,6 @@
 Directory diff can replace a file with a directory.
 
-  $ cat > dune-project <<'EOF'
-  > (lang dune 3.23)
-  > (using directory-targets 0.1)
-  > EOF
+  $ make_directory_targets_project
 
   $ mkdir expected
   $ printf 'file\n' > expected/node

--- a/test/blackbox-tests/test-cases/promote/directory-diff/targeted-promotion.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/targeted-promotion.t
@@ -1,9 +1,6 @@
 Targeted promotion works for directory creation and deletion.
 
-  $ cat > dune-project <<'EOF'
-  > (lang dune 3.23)
-  > (using directory-targets 0.1)
-  > EOF
+  $ make_directory_targets_project
 
 Prefix promotion can create a directory subtree without promoting siblings.
 

--- a/test/blackbox-tests/test-cases/promote/directory-diff/version-guard.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/version-guard.t
@@ -1,9 +1,6 @@
 Directory diffing requires lang dune 3.23.
 
-  $ cat > dune-project <<'EOF'
-  > (lang dune 3.23)
-  > (using directory-targets 0.1)
-  > EOF
+  $ make_directory_targets_project
 
   $ mkdir expected
 


### PR DESCRIPTION
Extract the repeated dune-project setup for directory diff promotion tests into a small helper that enables directory targets.

This removes boilerplate from the promotion scenarios without changing the rules or assertions under test.