### PR TITLE
test(pkg): reuse package project helper in dev-tool tests

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -277,16 +277,23 @@ make_lockdir() {
 	EOF
 }
 
-make_package_project() {
-  local version="$1"
-  shift
+make_named_package_project() {
+  local name="$1"
+  local version="$2"
+  shift 2
   cat > dune-project <<- EOF
 	(lang dune ${version})
 	(package
-	 (name x)
+	 (name ${name})
 	 (allow_empty)
 	 (depends $@))
 	EOF
+}
+
+make_package_project() {
+  local version="$1"
+  shift
+  make_named_package_project x "${version}" "$@"
 }
 
 make_project() {

--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-basic.t
@@ -8,15 +8,7 @@ a lockdir containing an "ocaml" lockfile.
 
   $ setup_merlin_workspace
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.16)
-  > 
-  > (package
-  >  (name foo)
-  >  (allow_empty)
-  >  (depends
-  >    (ocaml (= 5.2.0))))
-  > EOF
+  $ make_named_package_project foo 3.16 "(ocaml (= 5.2.0))"
 
   $ dune build
 

--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-env.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-env.t
@@ -7,15 +7,7 @@ executable in PATH is the one installed by dune as a dev tool.
 
   $ setup_merlin_workspace
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.16)
-  > 
-  > (package
-  >  (name foo)
-  >  (allow_empty)
-  >  (depends
-  >    (ocaml (= 5.2.0))))
-  > EOF
+  $ make_named_package_project foo 3.16 "(ocaml (= 5.2.0))"
 
   $ dune build
 

--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-version-change.t
@@ -11,15 +11,7 @@ same version of the ocaml compiler as the code that it's analyzing.
 
   $ setup_merlin_workspace
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.16)
-  > 
-  > (package
-  >  (name foo)
-  >  (allow_empty)
-  >  (depends
-  >  (ocaml (= 5.2.0))))
-  > EOF
+  $ make_named_package_project foo 3.16 "(ocaml (= 5.2.0))"
 
   $ dune build
 
@@ -50,15 +42,7 @@ We can re-run "dune tools exec ocamlmerlin" without relocking or rebuilding.
 
 Change the version of ocaml that the project depends on.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.16)
-  > 
-  > (package
-  >  (name foo)
-  >  (allow_empty)
-  >  (depends
-  >  (ocaml (= 5.1.0))))
-  > EOF
+  $ make_named_package_project foo 3.16 "(ocaml (= 5.1.0))"
 
   $ dune build
 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
@@ -7,15 +7,7 @@ a lockdir containing an "ocaml" lockfile.
   $ mk_ocaml 5.2.0
   $ setup_ocamllsp_workspace
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.16)
-  > 
-  > (package
-  >  (name foo)
-  >  (allow_empty)
-  >  (depends
-  >   (ocaml (= 5.2.0))))
-  > EOF
+  $ make_named_package_project foo 3.16 "(ocaml (= 5.2.0))"
 
   $ dune build
 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-configure.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-configure.t
@@ -15,15 +15,7 @@ Test that adding constraints to ocamllsp via `lock_dir` works.
   $ mkpkg ocamlbuild 0.0.2
   $ mkpkg ocamlbuild 0.0.3
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.21)
-  > 
-  > (package
-  >  (name foo)
-  >  (allow_empty)
-  >  (depends
-  >    (ocaml (= 5.2.0))))
-  > EOF
+  $ make_named_package_project foo 3.21 "(ocaml (= 5.2.0))"
 
 Add ocamlbuild 0.0.2 as a constraint to make sure the constraint field makes the solver pick the correct version
 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
@@ -14,15 +14,7 @@ Make a fake ocamllsp package that prints out the PATH variable:
   > ]
   > EOF
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.16)
-  > 
-  > (package
-  >  (name foo)
-  >  (allow_empty)
-  >  (depends
-  >    (ocaml (= 5.2.0))))
-  > EOF
+  $ make_named_package_project foo 3.16 "(ocaml (= 5.2.0))"
 
   $ dune build
 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
@@ -11,15 +11,7 @@ same version of the ocaml compiler as the code that it's analyzing.
 
   $ setup_ocamllsp_workspace
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.16)
-  > 
-  > (package
-  >  (name foo)
-  >  (allow_empty)
-  >  (depends
-  >    (ocaml (= 5.2.0))))
-  > EOF
+  $ make_named_package_project foo 3.16 "(ocaml (= 5.2.0))"
 
   $ dune build
 
@@ -49,15 +41,7 @@ We can re-run "dune tools exec ocamllsp" without relocking or rebuilding.
   hello from fake ocamllsp
 
 Change the version of ocaml that the project depends on.
-  $ cat > dune-project <<EOF
-  > (lang dune 3.16)
-  > 
-  > (package
-  >  (name foo)
-  >  (allow_empty)
-  >  (depends
-  >    (ocaml (= 5.1.0))))
-  > EOF
+  $ make_named_package_project foo 3.16 "(ocaml (= 5.1.0))"
 
   $ dune build
 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-special-compiler-version.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-special-compiler-version.t
@@ -10,16 +10,7 @@ Test the special compiler version is picked up by ocamllsp.
 
   $ setup_ocamllsp_workspace
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.21)
-  > 
-  > (package
-  >  (name foo)
-  >  (allow_empty)
-  >  (depends
-  >    (ocaml (= 5.2.0))
-  >    (ocaml-variants (= 5.2.0+ox))))
-  > EOF
+  $ make_named_package_project foo 3.21 "(ocaml (= 5.2.0))" "(ocaml-variants (= 5.2.0+ox))"
 
   $ dune build
 

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-basic.t
@@ -7,15 +7,7 @@ a lockdir containing an "ocaml" lockfile.
   $ mk_ocaml 5.2.0
   $ setup_odoc_workspace
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.16)
-  > 
-  > (package
-  >  (name foo)
-  >  (allow_empty)
-  >  (depends
-  >    (ocaml (= 5.2.0))))
-  > EOF
+  $ make_named_package_project foo 3.16 "(ocaml (= 5.2.0))"
 
   $ dune build
 

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
@@ -11,15 +11,7 @@ same version of the ocaml compiler as the code that it's analyzing.
 
   $ setup_odoc_workspace
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.16)
-  > 
-  > (package
-  >  (name foo)
-  >  (allow_empty)
-  >  (depends
-  >  (ocaml (= 5.2.0))))
-  > EOF
+  $ make_named_package_project foo 3.16 "(ocaml (= 5.2.0))"
 
   $ dune build
 
@@ -60,15 +52,7 @@ We can re-run "dune ocaml doc" without relocking or rebuilding.
   [1]
 
 Change the version of ocaml that the project depends on.
-  $ cat > dune-project <<EOF
-  > (lang dune 3.16)
-  > 
-  > (package
-  >  (name foo)
-  >  (allow_empty)
-  >  (depends
-  >  (ocaml (= 5.1.0))))
-  > EOF
+  $ make_named_package_project foo 3.16 "(ocaml (= 5.1.0))"
 
   $ dune build
 


### PR DESCRIPTION
Add a named variant of the package project helper and reuse it in dev-tool tests that repeatedly set up the same `foo` package with OCaml compiler dependencies.

This keeps the generated package name stable while removing repeated dune-project boilerplate.