### PR TITLE
test(pkg): share dev-tool helper setup

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -203,6 +203,36 @@ create_mock_repo() {
 	EOF
 }
 
+setup_dev_tool_workspace() {
+  : "${dev_tool_lock_dir:?}"
+  cat > dune-workspace <<- EOF
+	(lang dune 3.20)
+	(lock_dir
+	 (path "${dev_tool_lock_dir}")
+	 (repositories mock))
+	(lock_dir
+	 (repositories mock))
+	(repository
+	 (name mock)
+	 (url "file://$(pwd)/mock-opam-repository"))
+	(pkg enabled)
+	EOF
+}
+
+make_mock_dev_tool_package() {
+  local pkg="$1"
+  local exe="$2"
+  local message="$3"
+
+  mkpkg "${pkg}" <<- EOF
+	install: [
+	  [ "sh" "-c" "echo '#!/bin/sh' > %{bin}%/${exe}" ]
+	  [ "sh" "-c" "echo 'echo ${message}' >> %{bin}%/${exe}" ]
+	  [ "sh" "-c" "chmod a+x %{bin}%/${exe}" ]
+	]
+	EOF
+}
+
 make_lockpkg() {
   local pkg="$1"
   mkdir -p "${source_lock_dir}"

--- a/test/blackbox-tests/test-cases/pkg/merlin/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/merlin/helpers.sh
@@ -1,30 +1,14 @@
-dev_tool_lock_dir="_build/.dev-tools.locks/merlin"
+export dev_tool_lock_dir="_build/.dev-tools.locks/merlin"
 
 # Create a dune-workspace file with mock repos configured for the main
 # project lockdir and the merlin dev-tool lockdir.
 setup_merlin_workspace() {
-  cat > dune-workspace <<- EOF
-	(lang dune 3.20)
-	(lock_dir
-	 (path "${dev_tool_lock_dir}")
-	 (repositories mock))
-	 (lock_dir
-	  (repositories mock))
-	(repository
-	 (name mock)
-	 (url "file://$(pwd)/mock-opam-repository"))
-	(pkg enabled)
-	EOF
+  setup_dev_tool_workspace
 }
 
 # Create a fake merlin package containing an executable that
 # just prints a message.
 make_mock_merlin_package() {
-  mkpkg merlin <<- EOF
-	install: [
-	  [ "sh" "-c" "echo '#!/bin/sh' > %{bin}%/ocamlmerlin" ]
-	  [ "sh" "-c" "echo 'echo hello from fake ocamlmerlin' >> %{bin}%/ocamlmerlin" ]
-	  [ "sh" "-c" "chmod a+x %{bin}%/ocamlmerlin" ]
-	]
-	EOF
+  make_mock_dev_tool_package merlin ocamlmerlin \
+    "hello from fake ocamlmerlin"
 }

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/helpers.sh
@@ -1,30 +1,14 @@
-dev_tool_lock_dir="_build/.dev-tools.locks/ocaml-lsp-server"
+export dev_tool_lock_dir="_build/.dev-tools.locks/ocaml-lsp-server"
 
 # Create a dune-workspace file with mock repos set up for the main
 # project and the ocamllsp lockdir.
 setup_ocamllsp_workspace() {
-  cat > dune-workspace <<- EOF
-	(lang dune 3.20)
-	(lock_dir
-	 (path "${dev_tool_lock_dir}")
-	 (repositories mock))
-	 (lock_dir
-	  (repositories mock))
-	(repository
-	 (name mock)
-	 (url "file://$(pwd)/mock-opam-repository"))
-	(pkg enabled)
-	EOF
+  setup_dev_tool_workspace
 }
 
 # Create a fake ocaml-lsp-server package containing an executable that
 # just prints a message.
 make_mock_ocamllsp_package() {
-  mkpkg ocaml-lsp-server <<- EOF
-	install: [
-	  [ "sh" "-c" "echo '#!/bin/sh' > %{bin}%/ocamllsp" ]
-	  [ "sh" "-c" "echo 'echo hello from fake ocamllsp' >> %{bin}%/ocamllsp" ]
-	  [ "sh" "-c" "chmod a+x %{bin}%/ocamllsp" ]
-	]
-	EOF
+  make_mock_dev_tool_package ocaml-lsp-server ocamllsp \
+    "hello from fake ocamllsp"
 }

--- a/test/blackbox-tests/test-cases/pkg/odoc/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/odoc/helpers.sh
@@ -1,30 +1,13 @@
-dev_tool_lock_dir="_build/.dev-tools.locks/odoc"
+export dev_tool_lock_dir="_build/.dev-tools.locks/odoc"
 
 # Create a dune-workspace file with mock repos set up for the main
 # project and the odoc lockdir.
 setup_odoc_workspace() {
-  cat > dune-workspace <<- EOF
-	(lang dune 3.20)
-	(pkg enabled)
-	(lock_dir
-	 (path "${dev_tool_lock_dir}")
-	 (repositories mock))
-	 (lock_dir
-	  (repositories mock))
-	(repository
-	 (name mock)
-	 (url "file://$(pwd)/mock-opam-repository"))
-	EOF
+  setup_dev_tool_workspace
 }
 
 # Create a fake odoc package containing an executable that
 # just prints a message.
 make_mock_odoc_package() {
-  mkpkg odoc <<- EOF
-	install: [
-	  [ "sh" "-c" "echo '#!/bin/sh' > %{bin}%/odoc" ]
-	  [ "sh" "-c" "echo 'echo hello from fake odoc' >> %{bin}%/odoc" ]
-	  [ "sh" "-c" "chmod a+x %{bin}%/odoc" ]
-	]
-	EOF
+  make_mock_dev_tool_package odoc odoc "hello from fake odoc"
 }


### PR DESCRIPTION
Move the duplicated dev-tool workspace and fake executable package setup into shared package test helpers.

The merlin, ocamllsp, and odoc helpers keep their tool-specific entry points while delegating the common boilerplate.