### PR TITLE
test(enabled_if): share two-context workspace helper

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -121,6 +121,18 @@ make_directory_targets_project() {
 	EOF
 }
 
+make_two_context_workspace() {
+  cat > dune-workspace <<- EOF
+	(lang dune 3.13)
+	
+	(context default)
+	
+	(context
+	 (default
+	  (name alt-context)))
+	EOF
+}
+
 make_simple_rpc_watch_project() {
   make_dune_project 3.23
   cat > dune <<-'EOF'

--- a/test/blackbox-tests/test-cases/enabled_if/eif-exe-name-collision-same-folder.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-exe-name-collision-same-folder.t
@@ -3,15 +3,7 @@ in the same dune file
 
   $ make_dune_project 3.13
 
-  $ cat > dune-workspace << EOF
-  > (lang dune 3.13)
-  > 
-  > (context default)
-  > 
-  > (context
-  >  (default
-  >   (name alt-context)))
-  > EOF
+  $ make_two_context_workspace
   $ cat > dune << EOF
   > (executable
   >  (name foo)

--- a/test/blackbox-tests/test-cases/enabled_if/eif-exe-name-collision.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-exe-name-collision.t
@@ -3,15 +3,7 @@ Using same executable name in two contexts
   $ mkdir -p a b
   $ make_dune_project 3.13
 
-  $ cat > dune-workspace << EOF
-  > (lang dune 3.13)
-  > 
-  > (context default)
-  > 
-  > (context
-  >  (default
-  >   (name alt-context)))
-  > EOF
+  $ make_two_context_workspace
   $ cat > a/dune << EOF
   > (executable
   >  (name foo)

--- a/test/blackbox-tests/test-cases/enabled_if/eif-library-name-collision-same-folder.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-library-name-collision-same-folder.t
@@ -7,15 +7,7 @@ in the same dune file
   > (package (name baz) (allow_empty))
   > EOF
 
-  $ cat > dune-workspace << EOF
-  > (lang dune 3.13)
-  > 
-  > (context default)
-  > 
-  > (context
-  >  (default
-  >   (name alt-context)))
-  > EOF
+  $ make_two_context_workspace
   $ cat > dune << EOF
   > (library
   >  (name foo)

--- a/test/blackbox-tests/test-cases/enabled_if/eif-library-name-collision.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-library-name-collision.t
@@ -9,15 +9,7 @@ For private libraries
   > (package (name baz) (allow_empty))
   > EOF
 
-  $ cat > dune-workspace << EOF
-  > (lang dune 3.13)
-  > 
-  > (context default)
-  > 
-  > (context
-  >  (default
-  >   (name alt-context)))
-  > EOF
+  $ make_two_context_workspace
   $ cat > a/dune << EOF
   > (library
   >  (name foo)

--- a/test/blackbox-tests/test-cases/melange/enabled-if/eif-melange-emit-name-collision-same-folder.t
+++ b/test/blackbox-tests/test-cases/melange/enabled-if/eif-melange-emit-name-collision-same-folder.t
@@ -6,15 +6,7 @@ in the same dune file
   > (using melange 0.1)
   > EOF
 
-  $ cat > dune-workspace << EOF
-  > (lang dune 3.13)
-  > 
-  > (context default)
-  > 
-  > (context
-  >  (default
-  >   (name alt-context)))
-  > EOF
+  $ make_two_context_workspace
   $ cat > dune << EOF
   > (melange.emit
   >  (target foo)

--- a/test/blackbox-tests/test-cases/melange/enabled-if/eif-melange-emit-name-collision.t
+++ b/test/blackbox-tests/test-cases/melange/enabled-if/eif-melange-emit-name-collision.t
@@ -6,15 +6,7 @@ Using same melange.emit target in two contexts
   > (using melange 0.1)
   > EOF
 
-  $ cat > dune-workspace << EOF
-  > (lang dune 3.13)
-  > 
-  > (context default)
-  > 
-  > (context
-  >  (default
-  >   (name alt-context)))
-  > EOF
+  $ make_two_context_workspace
   $ cat > a/dune << EOF
   > (melange.emit
   >  (target foo)


### PR DESCRIPTION
Extract the repeated default plus alt-context dune-workspace setup used by enabled_if name-collision tests.

The tests still define their own project and stanzas; only the shared workspace boilerplate moves into the setup script.