### PR TITLE
test(package): share mypkg library fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -113,6 +113,20 @@ make_mypkg_bin_project() {
 	EOF
 }
 
+make_mypkg_lib_project() {
+  make_dune_project 3.24
+  cat >> dune-project <<-'EOF'
+	(package (name mypkg))
+	EOF
+  mkdir src
+  cat > src/dune <<-'EOF'
+	(library (public_name mypkg))
+	EOF
+  cat > src/mypkg.ml <<-'EOF'
+	let x = 1
+	EOF
+}
+
 make_directory_targets_project() {
   local version="${1:-3.23}"
   cat > dune-project <<- EOF

--- a/test/blackbox-tests/test-cases/depend-on/named-binding-with-package-error.t
+++ b/test/blackbox-tests/test-cases/depend-on/named-binding-with-package-error.t
@@ -2,17 +2,7 @@ Writing `(package ...)` inside a named dependency binding like
 `(:name (package foo))` is rejected: the binding would resolve to an
 empty path list, which is rarely what the user intended.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.24)
-  > (package (name mypkg))
-  > EOF
-  $ mkdir src
-  $ cat >src/dune <<EOF
-  > (library (public_name mypkg))
-  > EOF
-  $ cat >src/mypkg.ml <<'EOF'
-  > let x = 1
-  > EOF
+  $ make_mypkg_lib_project
 
   $ cat >dune <<'EOF'
   > (rule

--- a/test/blackbox-tests/test-cases/package-materialization/env/ocamlfind-ignore-dups-in.t
+++ b/test/blackbox-tests/test-cases/package-materialization/env/ocamlfind-ignore-dups-in.t
@@ -1,16 +1,6 @@
 Test that (deps (package ...)) adds lib/ to OCAMLFIND_IGNORE_DUPS_IN.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.24)
-  > (package (name mypkg))
-  > EOF
-  $ mkdir src
-  $ cat >src/dune <<EOF
-  > (library (public_name mypkg))
-  > EOF
-  $ cat >src/mypkg.ml <<'EOF'
-  > let x = 1
-  > EOF
+  $ make_mypkg_lib_project
   $ cat >dune <<'EOF'
   > (rule
   >  (deps (package mypkg))

--- a/test/blackbox-tests/test-cases/package-materialization/env/ocamlpath.t
+++ b/test/blackbox-tests/test-cases/package-materialization/env/ocamlpath.t
@@ -1,16 +1,6 @@
 Test that (deps (package ...)) adds the package's lib/ to OCAMLPATH.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.24)
-  > (package (name mypkg))
-  > EOF
-  $ mkdir src
-  $ cat >src/dune <<EOF
-  > (library (public_name mypkg))
-  > EOF
-  $ cat >src/mypkg.ml <<'EOF'
-  > let x = 1
-  > EOF
+  $ make_mypkg_lib_project
   $ cat >dune <<'EOF'
   > (rule
   >  (deps (package mypkg))

--- a/test/blackbox-tests/test-cases/package-materialization/env/ocamltop-include-path.t
+++ b/test/blackbox-tests/test-cases/package-materialization/env/ocamltop-include-path.t
@@ -1,16 +1,6 @@
 Test that (deps (package ...)) adds lib/toplevel/ to OCAMLTOP_INCLUDE_PATH.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.24)
-  > (package (name mypkg))
-  > EOF
-  $ mkdir src
-  $ cat >src/dune <<EOF
-  > (library (public_name mypkg))
-  > EOF
-  $ cat >src/mypkg.ml <<'EOF'
-  > let x = 1
-  > EOF
+  $ make_mypkg_lib_project
   $ cat >dune <<'EOF'
   > (rule
   >  (deps (package mypkg))

--- a/test/blackbox-tests/test-cases/package-materialization/inline-tests.t
+++ b/test/blackbox-tests/test-cases/package-materialization/inline-tests.t
@@ -1,17 +1,7 @@
 Test that (inline_tests (deps (package ...))) sets up layout env vars
 for the test runner.
 
-  $ make_dune_project 3.24
-  $ cat >>dune-project <<EOF
-  > (package (name mypkg))
-  > EOF
-  $ mkdir src
-  $ cat >src/dune <<EOF
-  > (library (public_name mypkg))
-  > EOF
-  $ cat >src/mypkg.ml <<'EOF'
-  > let x = 1
-  > EOF
+  $ make_mypkg_lib_project
 
 Custom backend that writes OCAMLPATH to a file outside the sandbox:
 


### PR DESCRIPTION
Extract the repeated simple mypkg library project setup into a shared blackbox helper and reuse it from package materialization tests.

This keeps the tests focused on package environment and dependency assertions instead of recreating the same fixture.