### PR TITLE
chore: run packaging CI tests on 4.14

### DIFF
--- a/.github/workflows/isolated-package-build.yml
+++ b/.github/workflows/isolated-package-build.yml
@@ -18,6 +18,12 @@ on:
 jobs:
   packaging-check:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ocaml-compiler:
+          - "4.14" # The oldest supported compiler version
+          - "5"    # The latest available compiler version
 
     steps:
       - uses: actions/checkout@v6
@@ -38,7 +44,7 @@ jobs:
 
       - uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 5.4
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
           dune-cache: true
           opam-pin: false
 


### PR DESCRIPTION
We did not regressions in the packaging configuration affecting 4.14 prior to cutting the pre-release for https://github.com/ocaml/opam-repository/pull/29969. This should ensure we catch those errors in the future.

