### PR TITLE
test(foreign-stubs): share header consumer fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -127,6 +127,20 @@ make_mypkg_lib_project() {
 	EOF
 }
 
+make_foreign_header_consumer() {
+  make_dune_project 3.8
+  cat > dune <<-'EOF'
+	(executable
+	 (name bar)
+	 (foreign_stubs
+	  (language c)
+	  (include_dirs (lib mypkg))
+	  (names foo)))
+	EOF
+  touch bar.ml
+  cat > foo.c
+}
+
 make_directory_targets_project() {
   local version="${1:-3.23}"
   cat > dune-project <<- EOF

--- a/test/blackbox-tests/test-cases/foreign-stubs/installed-headers-sub-library.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/installed-headers-sub-library.t
@@ -30,20 +30,9 @@ foo.h should only be visible when we use mypkg.sub
   $ mkdir subdir
   $ cd subdir
 
-  $ make_dune_project 3.8
-
 We depend on mypkg, but we can see the header of mypkg.sub
 
-  $ cat >dune <<EOF
-  > (executable
-  >  (name bar)
-  >  (foreign_stubs
-  >   (language c)
-  >   (include_dirs (lib mypkg))
-  >   (names foo)))
-  > EOF
-  $ touch bar.ml
-  $ cat >foo.c <<EOF
+  $ make_foreign_header_consumer <<EOF
   > // This header shouldn't be visible
   > #include <sub/foo.h>
   > EOF

--- a/test/blackbox-tests/test-cases/foreign-stubs/installed-headers.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/installed-headers.t
@@ -43,18 +43,7 @@ Now we try to use the installed headers:
   $ mkdir subdir
   $ cd subdir
 
-  $ make_dune_project 3.8
-
-  $ cat >dune <<EOF
-  > (executable
-  >  (name bar)
-  >  (foreign_stubs
-  >   (language c)
-  >   (include_dirs (lib mypkg))
-  >   (names foo)))
-  > EOF
-  $ touch bar.ml
-  $ cat >foo.c <<EOF
+  $ make_foreign_header_consumer <<EOF
   > #include <foo.h>
   > #include <inc/bar.h>
   > EOF

--- a/test/blackbox-tests/test-cases/foreign-stubs/public-headers-nested.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/public-headers-nested.t
@@ -30,18 +30,7 @@ Now we try to use the installed headers:
   $ mkdir subdir
   $ cd subdir
 
-  $ make_dune_project 3.8
-
-  $ cat >dune <<EOF
-  > (executable
-  >  (name bar)
-  >  (foreign_stubs
-  >   (language c)
-  >   (include_dirs (lib mypkg))
-  >   (names foo)))
-  > EOF
-  $ touch bar.ml
-  $ cat >foo.c <<EOF
+  $ make_foreign_header_consumer <<EOF
   > #include <foo.h>
   > #include <inc/foo.h>
   > EOF

--- a/test/blackbox-tests/test-cases/foreign-stubs/public-headers.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/public-headers.t
@@ -27,18 +27,7 @@ Now we try to use the installed headers:
   $ mkdir subdir
   $ cd subdir
 
-  $ make_dune_project 3.8
-
-  $ cat >dune <<EOF
-  > (executable
-  >  (name bar)
-  >  (foreign_stubs
-  >   (language c)
-  >   (include_dirs (lib mypkg))
-  >   (names foo)))
-  > EOF
-  $ touch bar.ml
-  $ cat >foo.c <<EOF
+  $ make_foreign_header_consumer <<EOF
   > #include <foo.h>
   > #include <inc/foo.h>
   > EOF


### PR DESCRIPTION
Extract the repeated installed-header consumer project setup into a shared blackbox helper.

Each test still supplies the C includes it wants to exercise, while the common executable/foreign-stubs boilerplate is centralized.