### PR TITLE
test(foreign-stubs): share include-dirs fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -170,6 +170,17 @@ make_trivial_ocamllex() {
 	EOF
 }
 
+make_foreign_stubs_include_dirs_project() {
+  cat > dune <<-'EOF'
+	(library
+	 (name foo)
+	 (foreign_stubs
+	  (language c)
+	  (names bar)
+	  (include_dirs (include foo))))
+	EOF
+}
+
 make_directory_targets_project() {
   local version="${1:-3.23}"
   cat > dune-project <<- EOF

--- a/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/include-dir-chain.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/include-dir-chain.t
@@ -4,14 +4,7 @@ Include a file with an `(include ...)` statement, which iteslf contains an
 
   $ make_dune_project 3.5
 
-  $ cat >dune <<EOF
-  > (library
-  >  (name foo)
-  >  (foreign_stubs
-  >   (language c)
-  >   (names bar)
-  >   (include_dirs (include foo))))
-  > EOF
+  $ make_foreign_stubs_include_dirs_project
 
   $ cat >bar.c <<EOF
   > #include <caml/mlvalues.h>

--- a/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/include-dir-include-lib.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/include-dir-include-lib.t
@@ -3,14 +3,7 @@ Test use of `(lib ...)` statements inside a file included with `(include ...)`
 
   $ make_dune_project 3.5
 
-  $ cat >dune <<EOF
-  > (library
-  >  (name foo)
-  >  (foreign_stubs
-  >   (language c)
-  >   (names bar)
-  >   (include_dirs (include foo))))
-  > EOF
+  $ make_foreign_stubs_include_dirs_project
 
   $ echo "(inc_a inc_b (lib lib_a))" > foo
 

--- a/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/include-dir-include-loop.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/include-dir-include-loop.t
@@ -3,14 +3,7 @@ Detect loops of `(include ...)` statements
 
   $ make_dune_project 3.5
 
-  $ cat >dune <<EOF
-  > (library
-  >  (name foo)
-  >  (foreign_stubs
-  >   (language c)
-  >   (names bar)
-  >   (include_dirs (include foo))))
-  > EOF
+  $ make_foreign_stubs_include_dirs_project
 
   $ cat >bar.c <<EOF
   > #include <caml/mlvalues.h>

--- a/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/multiple-include-dirs.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/multiple-include-dirs.t
@@ -3,14 +3,7 @@ Test where a multiple include directories are added via a `(include ...)` statem
 
   $ make_dune_project 3.5
 
-  $ cat >dune <<EOF
-  > (library
-  >  (name foo)
-  >  (foreign_stubs
-  >   (language c)
-  >   (names bar)
-  >   (include_dirs (include foo))))
-  > EOF
+  $ make_foreign_stubs_include_dirs_project
 
   $ cat >bar.c <<EOF
   > #include <caml/mlvalues.h>

--- a/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/single-include-dir.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/include-dirs-include/single-include-dir.t
@@ -5,14 +5,7 @@ Test where a single include directory is added via a `(include ...)` statement
 * Versions of dune before 3.5 do not support this feature
 
   $ make_dune_project 3.4
-  $ cat >dune <<EOF
-  > (library
-  >  (name foo)
-  >  (foreign_stubs
-  >   (language c)
-  >   (names bar)
-  >   (include_dirs (include foo))))
-  > EOF
+  $ make_foreign_stubs_include_dirs_project
   $ dune build
   File "dune", line 6, characters 16-29:
   6 |   (include_dirs (include foo))))


### PR DESCRIPTION
Extract the repeated foreign_stubs stanza that reads include directories from an included file.

The include-dir tests still set up their own include files and sources; only the common dune stanza is shared.