### PR TITLE
test(ocamllex): share trivial lexer fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -141,6 +141,16 @@ make_foreign_header_consumer() {
   cat > foo.c
 }
 
+make_trivial_ocamllex() {
+  cat > "$1" <<-'EOF'
+	{
+	}
+	rule lex = parse
+	  | _   { true  }
+	  | eof { false }
+	EOF
+}
+
 make_directory_targets_project() {
   local version="${1:-3.23}"
   cat > dune-project <<- EOF

--- a/test/blackbox-tests/test-cases/melange/melange-include-subdirs-qualified-nested.t
+++ b/test/blackbox-tests/test-cases/melange/melange-include-subdirs-qualified-nested.t
@@ -16,13 +16,7 @@ in a nested subdirectory.
   $ cat > a/b/c/dune <<EOF
   > (ocamllex lexer)
   > EOF
-  $ cat > a/b/c/lexer.mll <<EOF
-  > {
-  > }
-  > rule lex = parse
-  >   | _   { true  }
-  >   | eof { false }
-  > EOF
+  $ make_trivial_ocamllex a/b/c/lexer.mll
 
   $ cat > a/foo.ml <<EOF
   > module L = B.C.Lexer

--- a/test/blackbox-tests/test-cases/melange/ocamllex-melange.t
+++ b/test/blackbox-tests/test-cases/melange/ocamllex-melange.t
@@ -10,13 +10,7 @@ directories that don't contain source files
   > (library (name foo) (modes melange))
   > (ocamllex lexer)
   > EOF
-  $ cat > lexer.mll <<EOF
-  > {
-  > }
-  > rule lex = parse
-  >   | _   { true  }
-  >   | eof { false }
-  > EOF
+  $ make_trivial_ocamllex lexer.mll
   $ dune build
 
 Lexer ends up in the melange src

--- a/test/blackbox-tests/test-cases/menhir/include-subdirs-ocamllex-menhir-gh10301.t
+++ b/test/blackbox-tests/test-cases/menhir/include-subdirs-ocamllex-menhir-gh10301.t
@@ -17,13 +17,7 @@ We add a `(menhir ..)` stanza in the group root dune file
   > (ocamllex lexer)
   > EOF
 
-  $ cat >lexer.mll  <<EOF
-  > {
-  > }
-  > rule lex = parse
-  >   | _   { true  }
-  >   | eof { false }
-  > EOF
+  $ make_trivial_ocamllex lexer.mll
   $ cat >src/a/parser.mly <<'EOF'
   > %token EOF
   > %start main

--- a/test/blackbox-tests/test-cases/menhir/menhir-dynamic-modules.t
+++ b/test/blackbox-tests/test-cases/menhir/menhir-dynamic-modules.t
@@ -28,13 +28,7 @@ We add a `(menhir ..)` stanza in the group root dune file
   >  (flags --dump))
   > EOF
 
-  $ cat >src/lexer.mll  <<EOF
-  > {
-  > }
-  > rule lex = parse
-  >   | _   { true  }
-  >   | eof { false }
-  > EOF
+  $ make_trivial_ocamllex src/lexer.mll
   $ cat >src/a/my_parser.mly <<'EOF'
   > %token EOF
   > %start main

--- a/test/blackbox-tests/test-cases/menhir/menhir-missing-module.t
+++ b/test/blackbox-tests/test-cases/menhir/menhir-missing-module.t
@@ -14,13 +14,7 @@ We add a `(menhir ..)` stanza in the group root dune file
   > (menhir
   >  (modules parser))
   > EOF
-  $ cat >src/lexer.mll  <<EOF
-  > {
-  > }
-  > rule lex = parse
-  >   | _   { true  }
-  >   | eof { false }
-  > EOF
+  $ make_trivial_ocamllex src/lexer.mll
 
 Show that the menhir stanza must live next to the source
 

--- a/test/blackbox-tests/test-cases/select-field/select-conflict.t
+++ b/test/blackbox-tests/test-cases/select-field/select-conflict.t
@@ -12,13 +12,7 @@ a conflicting rule
   >    (unix -> lexer.unix.ml)
   >    (!unix -> lexer.nounix.ml))))
   > EOF
-  $ cat > lexer.mll <<EOF
-  > {
-  > }
-  > rule lex = parse
-  >   | _   { true  }
-  >   | eof { false }
-  > EOF
+  $ make_trivial_ocamllex lexer.mll
 
   $ cat > lexer.unix.ml <<EOF
   > let () = print_endline "Test: Unix was found!"

--- a/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-conflict.t
+++ b/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-conflict.t
@@ -8,13 +8,7 @@ The unit `mod.mll` is present in the working tree, `lib.ml` uses it:
   > let lex _ = true
   > EOF
 
-  $ cat > mod.mll <<EOF
-  > {
-  > }
-  > rule lex = parse
-  >   | _   { true  }
-  >   | eof { false }
-  > EOF
+  $ make_trivial_ocamllex mod.mll
   $ cat > mod.mli <<EOF
   > val lex: Lexing.lexbuf -> bool
   > EOF

--- a/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-dynamic-modules.t
+++ b/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-dynamic-modules.t
@@ -15,13 +15,7 @@ We define a rule that creates a file (in sexp syntax, to be passed to
 
 The unit `mod.mll` is present in the working tree, `lib.ml` uses it:
 
-  $ cat > mod.mll <<EOF
-  > {
-  > }
-  > rule lex = parse
-  >   | _   { true  }
-  >   | eof { false }
-  > EOF
+  $ make_trivial_ocamllex mod.mll
 
   $ cat >foo.ml <<EOF
   > let x = Mod.lex

--- a/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-gh10301.t
+++ b/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-gh10301.t
@@ -9,13 +9,7 @@ Show an edge case of `(include_subdirs ..)` and ocamllex
   > (ocamllex lexer)
   > EOF
 
-  $ cat > src/a/lexer.mll <<EOF
-  > {
-  > }
-  > rule lex = parse
-  >   | _   { true  }
-  >   | eof { false }
-  > EOF
+  $ make_trivial_ocamllex src/a/lexer.mll
 
   $ dune build
   File "dune", line 3, characters 0-16:

--- a/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-include-qualified-empty-dir.t
+++ b/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-include-qualified-empty-dir.t
@@ -13,13 +13,7 @@ directories that don't contain source files
 There's no corresponding `(ocamllex ..)` stanza for `lexer.mll`, so it should
 not be considered as a module source.
 
-  $ cat > bar-baz/lexer.mll <<EOF
-  > {
-  > }
-  > rule lex = parse
-  >   | _   { true  }
-  >   | eof { false }
-  > EOF
+  $ make_trivial_ocamllex bar-baz/lexer.mll
 
 The directory `bar-baz`, even though not a valid module name, doesn't have any
 source files. The library should still compile.
@@ -34,21 +28,9 @@ lexer with the invalid name.
   > (ocamllex lexer)
   > EOF
 
-  $ cat > bar/lexer.mll <<EOF
-  > {
-  > }
-  > rule lex = parse
-  >   | _   { true  }
-  >   | eof { false }
-  > EOF
+  $ make_trivial_ocamllex bar/lexer.mll
 
-  $ cat > bar/lex-er.mll <<EOF
-  > {
-  > }
-  > rule lex = parse
-  >   | _   { true  }
-  >   | eof { false }
-  > EOF
+  $ make_trivial_ocamllex bar/lex-er.mll
 
   $ dune build foo.cma
 

--- a/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-include-qualified.t
+++ b/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-include-qualified.t
@@ -15,12 +15,6 @@ Builds `ocamllex` generators under `(include_subdirs qualified)`.
   > (ocamllex lexer)
   > EOF
 
-  $ cat > lib/bar/lexer.mll <<EOF
-  > {
-  > }
-  > rule lex = parse
-  >   | _   { true  }
-  >   | eof { false }
-  > EOF
+  $ make_trivial_ocamllex lib/bar/lexer.mll
 
   $ dune build

--- a/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-include-unqualified.t
+++ b/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-include-unqualified.t
@@ -14,11 +14,5 @@ Builds `ocamllex` generators under `(include_subdirs unqualified)`.
   $ cat > lib/foo.ml <<EOF
   > let x = Lexer.lex
   > EOF
-  $ cat > lib/foo/lexer.mll <<EOF
-  > {
-  > }
-  > rule lex = parse
-  >   | _   { true  }
-  >   | eof { false }
-  > EOF
+  $ make_trivial_ocamllex lib/foo/lexer.mll
   $ dune build

--- a/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-intf.t
+++ b/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-intf.t
@@ -4,13 +4,7 @@ Test `(ocamllex ..)` stanza with an interface file for the lexer
 
 The unit `mod.mll` is present in the working tree, `lib.ml` uses it:
 
-  $ cat > mod.mll <<EOF
-  > {
-  > }
-  > rule lex = parse
-  >   | _   { true  }
-  >   | eof { false }
-  > EOF
+  $ make_trivial_ocamllex mod.mll
 
   $ cat > mod.mli <<EOF
   > val lex: Lexing.lexbuf -> bool

--- a/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-no-stanza.t
+++ b/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-no-stanza.t
@@ -4,13 +4,7 @@ Test building a module group containing a `.mll` file, without `(ocamllex ..)`
   $ cat > dune <<EOF
   > (library (name foo))
   > EOF
-  $ cat > lexer.mll <<EOF
-  > {
-  > }
-  > rule lex = parse
-  >   | _   { true  }
-  >   | eof { false }
-  > EOF
+  $ make_trivial_ocamllex lexer.mll
 
 module `Lexer` can't be found if no `(ocamllex ..)` stanza defines it
 

--- a/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-two-stanzas.t
+++ b/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-two-stanzas.t
@@ -7,21 +7,9 @@ Test building 2 ocamllex stanzas in the same group, by 2 different stanzas
   > (executable (name bar) (modules bar bar_lex))
   > (ocamllex (modules bar_lex foo_lex))
   > EOF
-  $ cat > bar_lex.mll <<EOF
-  > {
-  > }
-  > rule lex = parse
-  >   | _   { true  }
-  >   | eof { false }
-  > EOF
+  $ make_trivial_ocamllex bar_lex.mll
 
-  $ cat > foo_lex.mll <<EOF
-  > {
-  > }
-  > rule lex = parse
-  >   | _   { true  }
-  >   | eof { false }
-  > EOF
+  $ make_trivial_ocamllex foo_lex.mll
 
   $ cat > foo.ml<<EOF
   > let x = Foo_lex.lex


### PR DESCRIPTION
Extract the repeated minimal ocamllex source used across ocamllex, menhir, and melange blackbox tests into a shared helper.

The helper writes the same lexer body to each requested path while keeping the individual tests focused on their stanza behavior.