### PR TITLE
test(per-module): share value library fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -127,6 +127,25 @@ make_mypkg_lib_project() {
 	EOF
 }
 
+make_value_library() {
+  local dir="$1"
+  local name="$2"
+  local value="$3"
+  local value_name="${4:-value}"
+
+  mkdir "$dir"
+  cat > "$dir/dune" <<- EOF
+	(library
+	 (name ${name}))
+	EOF
+  cat > "$dir/${name}.ml" <<- EOF
+	let ${value_name} = ${value}
+	EOF
+  cat > "$dir/${name}.mli" <<- EOF
+	val ${value_name} : int
+	EOF
+}
+
 make_foreign_header_consumer() {
   make_dune_project 3.8
   cat > dune <<-'EOF'

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/basic-wrapped.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/basic-wrapped.t
@@ -8,17 +8,7 @@ See: https://github.com/ocaml/dune/issues/4572
 
   $ make_dune_project 3.0
 
-  $ mkdir lib
-  $ cat > lib/dune <<EOF
-  > (library
-  >  (name mylib))
-  > EOF
-  $ cat > lib/mylib.ml <<EOF
-  > let value = 42
-  > EOF
-  $ cat > lib/mylib.mli <<EOF
-  > val value : int
-  > EOF
+  $ make_value_library lib mylib 42
 
   $ cat > dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/multiple-libraries.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/multiple-libraries.t
@@ -8,29 +8,9 @@ See: https://github.com/ocaml/dune/issues/4572
 
   $ make_dune_project 3.0
 
-  $ mkdir lib
-  $ cat > lib/dune <<EOF
-  > (library
-  >  (name mylib))
-  > EOF
-  $ cat > lib/mylib.ml <<EOF
-  > let value = 42
-  > EOF
-  $ cat > lib/mylib.mli <<EOF
-  > val value : int
-  > EOF
+  $ make_value_library lib mylib 42
 
-  $ mkdir lib2
-  $ cat > lib2/dune <<EOF
-  > (library
-  >  (name otherlib))
-  > EOF
-  $ cat > lib2/otherlib.ml <<EOF
-  > let other_value = 100
-  > EOF
-  $ cat > lib2/otherlib.mli <<EOF
-  > val other_value : int
-  > EOF
+  $ make_value_library lib2 otherlib 100 other_value
 
   $ cat > uses_lib.ml <<EOF
   > let get_value () = Mylib.value

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque.t
@@ -10,17 +10,7 @@ See: https://github.com/ocaml/dune/issues/4572
 
   $ make_dune_project 3.0
 
-  $ mkdir lib
-  $ cat > lib/dune <<EOF
-  > (library
-  >  (name mylib))
-  > EOF
-  $ cat > lib/mylib.ml <<EOF
-  > let value = 42
-  > EOF
-  $ cat > lib/mylib.mli <<EOF
-  > val value : int
-  > EOF
+  $ make_value_library lib mylib 42
 
   $ cat > dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/stdlib-modules.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/stdlib-modules.t
@@ -7,17 +7,7 @@ See: https://github.com/ocaml/dune/issues/4572
 
   $ make_dune_project 3.0
 
-  $ mkdir lib
-  $ cat > lib/dune <<EOF
-  > (library
-  >  (name mylib))
-  > EOF
-  $ cat > lib/mylib.ml <<EOF
-  > let value = 42
-  > EOF
-  $ cat > lib/mylib.mli <<EOF
-  > val value : int
-  > EOF
+  $ make_value_library lib mylib 42
 
   $ cat > dune <<EOF
   > (executable


### PR DESCRIPTION
Extract the repeated tiny integer-valued library fixture used by several per-module-lib-deps tests into a shared helper.

The helper keeps each test focused on recompilation behavior rather than recreating identical library files.