### PR TITLE
test(promote): share promotion CLI fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -190,6 +190,41 @@ make_two_context_workspace() {
 	EOF
 }
 
+make_promotion_test_project() {
+  make_dune_project 2.0
+  cat > dune <<-'EOF'
+	(rule
+	 (alias runtest)
+	 (action
+	  (diff a.expected a.actual)))
+	
+	(rule
+	 (with-stdout-to a.actual
+	  (echo "A actual\n")))
+	
+	(rule
+	 (alias runtest)
+	 (action
+	  (progn
+	   (with-stdout-to b.actual
+	    (echo "B actual\n"))
+	   (diff? b.expected b.actual))))
+	EOF
+  if [ "${1:-}" = "with-c" ]; then
+    cat >> dune <<-'EOF'
+	
+	(rule
+	 (with-stdout-to c.actual
+	  (echo "C actual\n")))
+	
+	(rule
+	 (alias runtest)
+	 (action
+	  (diff? c.expected c.actual)))
+	EOF
+  fi
+}
+
 make_simple_rpc_watch_project() {
   make_dune_project 3.23
   cat > dune <<-'EOF'

--- a/test/blackbox-tests/test-cases/promote/promotion-diff.t
+++ b/test/blackbox-tests/test-cases/promote/promotion-diff.t
@@ -1,25 +1,6 @@
 Tests dune promotion diff output.
 
-  $ make_dune_project 2.0
-
-  $ cat > dune << EOF
-  > (rule
-  >  (alias runtest)
-  >  (action
-  >   (diff a.expected a.actual)))
-  > 
-  > (rule
-  >  (with-stdout-to a.actual
-  >   (echo "A actual\n")))
-  > 
-  > (rule
-  >  (alias runtest)
-  >  (action
-  >   (progn
-  >    (with-stdout-to b.actual
-  >     (echo "B actual\n"))
-  >   (diff? b.expected b.actual))))
-  > EOF
+  $ make_promotion_test_project
 
   $ echo 'A expected' > a.expected
   $ echo 'B expected' > b.expected

--- a/test/blackbox-tests/test-cases/promote/promotion-list.t
+++ b/test/blackbox-tests/test-cases/promote/promotion-list.t
@@ -1,25 +1,6 @@
 Tests dune promotion list output.
 
-  $ make_dune_project 2.0
-
-  $ cat > dune << EOF
-  > (rule
-  >  (alias runtest)
-  >  (action
-  >   (diff a.expected a.actual)))
-  > 
-  > (rule
-  >  (with-stdout-to a.actual
-  >   (echo "A actual\n")))
-  > 
-  > (rule
-  >  (alias runtest)
-  >  (action
-  >   (progn
-  >    (with-stdout-to b.actual
-  >     (echo "B actual\n"))
-  >   (diff? b.expected b.actual))))
-  > EOF
+  $ make_promotion_test_project
 
   $ echo 'A expected' > a.expected
   $ echo 'B expected' > b.expected

--- a/test/blackbox-tests/test-cases/promote/promotion-show.t
+++ b/test/blackbox-tests/test-cases/promote/promotion-show.t
@@ -33,35 +33,7 @@ We create different promotion scenarios to test various behaviors:
 - b.expected: uses 'diff?' in progn (creates promotion when files differ)
 - c.expected: uses 'diff?' in separate action (may not create promotion)
 
-  $ make_dune_project 2.0
-
-  $ cat > dune << EOF
-  > (rule
-  >  (alias runtest)
-  >  (action
-  >   (diff a.expected a.actual)))
-  > 
-  > (rule
-  >  (with-stdout-to a.actual
-  >   (echo "A actual\n")))
-  > 
-  > (rule
-  >  (alias runtest)
-  >  (action
-  >   (progn
-  >    (with-stdout-to b.actual
-  >     (echo "B actual\n"))
-  >    (diff? b.expected b.actual))))
-  > 
-  > (rule
-  >  (with-stdout-to c.actual
-  >   (echo "C actual\n")))
-  > 
-  > (rule
-  >  (alias runtest)
-  >  (action
-  >   (diff? c.expected c.actual)))
-  > EOF
+  $ make_promotion_test_project with-c
 
   $ echo 'A expected' > a.expected
   $ echo 'B expected' > b.expected


### PR DESCRIPTION
Extract the repeated dune rules used by promotion diff/list/show tests into a shared helper.

The helper supports the extra `c.expected` case needed by the show test while keeping the generated rules unchanged.