### PR TITLE
test(melange): share runtime deps library fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -146,6 +146,29 @@ make_value_library() {
 	EOF
 }
 
+make_melange_runtime_deps_lib() {
+  local dir="${1:-lib}"
+
+  mkdir -p "$dir/nested"
+  echo "Some text" > "$dir/index.txt"
+  echo "Some nested text" > "$dir/nested/hello.txt"
+  cat > "$dir/dune" <<-'EOF'
+	(library
+	 (public_name foo)
+	 (modes melange)
+	 (preprocess (pps melange.ppx))
+	 (melange.runtime_deps index.txt nested/hello.txt))
+	EOF
+  cat > "$dir/foo.ml" <<-'EOF'
+	external readFileSync : string -> encoding:string -> string = "readFileSync"
+	[@@mel.module "fs"]
+	let dirname = [%mel.raw "__dirname"]
+	let () = Js.log2 "dirname:" dirname
+	let file_path = "./index.txt"
+	let read_asset () = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
+	EOF
+}
+
 make_foreign_header_consumer() {
   make_dune_project 3.8
   cat > dune <<-'EOF'

--- a/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps.t
@@ -7,24 +7,7 @@ Test `melange.runtime_deps` in a library that has been installed
   > (using melange 0.1)
   > EOF
 
-  $ mkdir -p lib/nested
-  $ echo "Some text" > lib/index.txt
-  $ echo "Some nested text" > lib/nested/hello.txt
-  $ cat > lib/dune <<EOF
-  > (library
-  >  (public_name foo)
-  >  (modes melange)
-  >  (preprocess (pps melange.ppx))
-  >  (melange.runtime_deps index.txt nested/hello.txt))
-  > EOF
-  $ cat > lib/foo.ml <<EOF
-  > external readFileSync : string -> encoding:string -> string = "readFileSync"
-  > [@@mel.module "fs"]
-  > let dirname = [%mel.raw "__dirname"]
-  > let () = Js.log2 "dirname:" dirname
-  > let file_path = "./index.txt"
-  > let read_asset () = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
-  > EOF
+  $ make_melange_runtime_deps_lib
 
   $ dune build --root lib
 

--- a/test/blackbox-tests/test-cases/melange/promote-in-source-installed-lib-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/promote-in-source-installed-lib-with-runtime-deps.t
@@ -6,25 +6,7 @@ Show target promotion in-source for `melange.emit`
   > (package (name foo))
   > (using melange 1.0)
   > EOF
-  $ mkdir -p lib/nested
-  $ echo "Some text" > lib/index.txt
-  $ echo "Some nested text" > lib/nested/hello.txt
-
-  $ cat > lib/dune <<EOF
-  > (library
-  >  (public_name foo)
-  >  (modes melange)
-  >  (preprocess (pps melange.ppx))
-  >  (melange.runtime_deps index.txt nested/hello.txt))
-  > EOF
-  $ cat > lib/foo.ml <<EOF
-  > external readFileSync : string -> encoding:string -> string = "readFileSync"
-  > [@@mel.module "fs"]
-  > let dirname = [%mel.raw "__dirname"]
-  > let () = Js.log2 "dirname:" dirname
-  > let file_path = "./index.txt"
-  > let read_asset () = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
-  > EOF
+  $ make_melange_runtime_deps_lib
 
   $ dune build --root lib
 

--- a/test/blackbox-tests/test-cases/melange/public-library-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/public-library-with-runtime-deps.t
@@ -7,24 +7,7 @@ Test `melange.runtime_deps` in a public library in the workspace
   > (using melange 0.1)
   > EOF
 
-  $ mkdir -p lib/nested
-  $ echo "Some text" > lib/index.txt
-  $ echo "Some nested text" > lib/nested/hello.txt
-  $ cat > lib/dune <<EOF
-  > (library
-  >  (public_name foo)
-  >  (modes melange)
-  >  (preprocess (pps melange.ppx))
-  >  (melange.runtime_deps index.txt nested/hello.txt))
-  > EOF
-  $ cat > lib/foo.ml <<EOF
-  > external readFileSync : string -> encoding:string -> string = "readFileSync"
-  > [@@mel.module "fs"]
-  > let dirname = [%mel.raw "__dirname"]
-  > let () = Js.log2 "dirname:" dirname
-  > let file_path = "./index.txt"
-  > let read_asset () = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
-  > EOF
+  $ make_melange_runtime_deps_lib
 
   $ dune build
   $ dune install --prefix $PWD/prefix


### PR DESCRIPTION
Extract the repeated melange library-with-runtime-deps setup into a shared blackbox-test helper.

This keeps the installed, in-source promotion, and workspace tests focused on their differing build flows.