### PR TITLE
test(watching): share fs_memo project fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -375,6 +375,26 @@ build () {
     with_timeout dune rpc build --wait "$@"
 }
 
+make_fs_memo_project () {
+    make_dune_project 2.0
+    cat >dune <<-'EOF'
+	(rule
+	 (alias default)
+	 (deps dep
+	  (glob_files file-?)
+	  (glob_files dir/file-?)
+	  (glob_files dir/subdir/file-?))
+	 (target result)
+	 (action (system "\| echo Executing rule...
+	               "\| echo %{deps}       |
+	               "\|   tr ' ' '\n'      |
+	               "\|   xargs -n 1       |
+	               "\|   grep -v dep      |
+	               "\|   xargs cat > result
+	)))
+	EOF
+}
+
 fs_memo_test () {
     local action="$1"
     local before between after

--- a/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo-permissions.t
+++ b/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo-permissions.t
@@ -9,23 +9,7 @@ events. This is a known bug.
   $ setup_xdg_runtime_dir
 
 
-  $ make_dune_project 2.0
-  $ cat >dune <<EOF
-  > (rule
-  >  (alias default)
-  >  (deps dep
-  >   (glob_files file-?)
-  >   (glob_files dir/file-?)
-  >   (glob_files dir/subdir/file-?))
-  >  (target result)
-  >  (action (system "\| echo Executing rule...
-  >                "\| echo %{deps}       |
-  >                "\|   tr ' ' '\n'      |
-  >                "\|   xargs -n 1       |
-  >                "\|   grep -v dep      |
-  >                "\|   xargs cat > result
-  > )))
-  > EOF
+  $ make_fs_memo_project
 
   $ echo -n 1 > file-1
   $ echo -n 3 > file-3

--- a/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo-symlinks.t
+++ b/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo-symlinks.t
@@ -7,23 +7,7 @@ Tests for [Fs_memo] symlink handling.
 The action ignores the dependency [dep]. We use it to force rerunning the action
 when necessary.
 
-  $ make_dune_project 2.0
-  $ cat >dune <<EOF
-  > (rule
-  >  (alias default)
-  >  (deps dep
-  >   (glob_files file-?)
-  >   (glob_files dir/file-?)
-  >   (glob_files dir/subdir/file-?))
-  >  (target result)
-  >  (action (system "\| echo Executing rule...
-  >                "\| echo %{deps}       |
-  >                "\|   tr ' ' '\n'      |
-  >                "\|   xargs -n 1       |
-  >                "\|   grep -v dep      |
-  >                "\|   xargs cat > result
-  > )))
-  > EOF
+  $ make_fs_memo_project
 
   $ echo -n 3 > file-3
   $ echo -n 5 > file-5

--- a/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo.t
+++ b/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo.t
@@ -7,23 +7,7 @@ Tests for [Fs_memo] module.
 The action ignores the dependency [dep]. We use it to force rerunning the action
 when necessary.
 
-  $ make_dune_project 2.0
-  $ cat >dune <<EOF
-  > (rule
-  >  (alias default)
-  >  (deps dep
-  >   (glob_files file-?)
-  >   (glob_files dir/file-?)
-  >   (glob_files dir/subdir/file-?))
-  >  (target result)
-  >  (action (system "\| echo Executing rule...
-  >                "\| echo %{deps}       |
-  >                "\|   tr ' ' '\n'      |
-  >                "\|   xargs -n 1       |
-  >                "\|   grep -v dep      |
-  >                "\|   xargs cat > result
-  > )))
-  > EOF
+  $ make_fs_memo_project
 
   $ echo -n 1 > file-1
   $ touch dep


### PR DESCRIPTION
Extract the repeated fs_memo watch-mode project setup into a shared helper.

The existing fs_memo_test helper still drives each scenario; this just removes the duplicated dune project/rule fixture.