### PR TITLE
test(pkg): share foo tarball fixture

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/autolock-detects-changes.t
+++ b/test/blackbox-tests/test-cases/pkg/autolock-detects-changes.t
@@ -6,22 +6,7 @@ Test that auto-locking correctly detects when to rebuild based on repository cha
 
 Make a library package:
 
-  $ mkdir foo
-  $ cd foo
-  $ cat > dune-project <<EOF
-  > (lang dune 3.13)
-  > (package (name foo))
-  > EOF
-  $ cat > foo.ml <<EOF
-  > let message = "Hello from foo version 0.0.1!"
-  > EOF
-  $ cat > dune <<EOF
-  > (library
-  >  (public_name foo))
-  > EOF
-  $ cd ..
-  $ tar cf foo.tar foo
-  $ rm -rf foo
+  $ make_foo_tarball 'let message = "Hello from foo version 0.0.1!"'
 
 Make a package for the library using a local file source:
 

--- a/test/blackbox-tests/test-cases/pkg/e2e-autolock.t
+++ b/test/blackbox-tests/test-cases/pkg/e2e-autolock.t
@@ -6,22 +6,7 @@ Same setup as e2e.t but this time using building without an explicit
   $ enable_pkg
 
 Make a library:
-  $ mkdir foo
-  $ cd foo
-  $ cat > dune-project <<EOF
-  > (lang dune 3.13)
-  > (package (name foo))
-  > EOF
-  $ cat > foo.ml <<EOF
-  > let foo = "Hello, World!"
-  > EOF
-  $ cat > dune <<EOF
-  > (library
-  >  (public_name foo))
-  > EOF
-  $ cd ..
-  $ tar cf foo.tar foo
-  $ rm -rf foo
+  $ make_foo_tarball 'let foo = "Hello, World!"'
 
 Configure our fake curl to serve the tarball
 

--- a/test/blackbox-tests/test-cases/pkg/e2e.t
+++ b/test/blackbox-tests/test-cases/pkg/e2e.t
@@ -4,22 +4,7 @@ Exercises end to end locking and building a simple project.
   $ add_mock_repo_if_needed
 
 Make a library:
-  $ mkdir foo
-  $ cd foo
-  $ cat > dune-project <<EOF
-  > (lang dune 3.13)
-  > (package (name foo))
-  > EOF
-  $ cat > foo.ml <<EOF
-  > let foo = "Hello, World!"
-  > EOF
-  $ cat > dune <<EOF
-  > (library
-  >  (public_name foo))
-  > EOF
-  $ cd ..
-  $ tar cf foo.tar foo
-  $ rm -rf foo
+  $ make_foo_tarball 'let foo = "Hello, World!"'
 
 Configure our fake curl to serve the tarball
 

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -85,6 +85,23 @@ mkpkg() {
   cat >> "$mock_packages/$name/$name.$version/opam"
 }
 
+make_foo_tarball() {
+  local implementation="$1"
+
+  mkdir foo
+  cat > foo/dune-project <<-'EOF'
+	(lang dune 3.13)
+	(package (name foo))
+	EOF
+  printf '%s\n' "$implementation" > foo/foo.ml
+  cat > foo/dune <<-'EOF'
+	(library
+	 (public_name foo))
+	EOF
+  tar cf foo.tar foo
+  rm -rf foo
+}
+
 mk_ocaml() {
   local version="$1"
   local major

--- a/test/blackbox-tests/test-cases/pkg/pkg-lock-then-autolock.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-lock-then-autolock.t
@@ -6,22 +6,7 @@ and does not trigger unnecessary rebuilds.
 
 Make a library package:
 
-  $ mkdir foo
-  $ cd foo
-  $ cat > dune-project <<EOF
-  > (lang dune 3.13)
-  > (package (name foo))
-  > EOF
-  $ cat > foo.ml <<EOF
-  > let message = "Hello from foo 0.0.1!"
-  > EOF
-  $ cat > dune <<EOF
-  > (library
-  >  (public_name foo))
-  > EOF
-  $ cd ..
-  $ tar cf foo.tar foo
-  $ rm -rf foo
+  $ make_foo_tarball 'let message = "Hello from foo 0.0.1!"'
 
 Make a package for the library using a local file source:
 


### PR DESCRIPTION
Extract the repeated tiny `foo` package tarball setup used by package e2e tests into a shared helper.

The helper takes the implementation line so tests can keep their differing module contents while sharing the project/tarball boilerplate.