### PR TITLE
test(watching): share target promotion rules

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -259,6 +259,22 @@ make_promotion_test_project() {
   fi
 }
 
+write_target_promotion_rules() {
+  local mode="$1"
+
+  cat > dune <<- EOF
+	(rule
+	 (mode ${mode})
+	 (deps original)
+	 (target promoted)
+	 (action (copy %{deps} %{target})))
+	(rule
+	 (deps promoted)
+	 (target result)
+	 (action (system "cat promoted promoted > result")))
+	EOF
+}
+
 make_simple_rpc_watch_project() {
   make_dune_project 3.23
   cat > dune <<-'EOF'

--- a/test/blackbox-tests/test-cases/watching/target-promotion.t
+++ b/test/blackbox-tests/test-cases/watching/target-promotion.t
@@ -3,17 +3,7 @@ Test target promotion in file-watching mode.
   $ export DUNE_TRACE="cache"
 
   $ echo '(lang dune 3.0)' > dune-project
-  $ cat > dune <<EOF
-  > (rule
-  >  (mode promote)
-  >  (deps original)
-  >  (target promoted)
-  >  (action (copy %{deps} %{target})))
-  > (rule
-  >  (deps promoted)
-  >  (target result)
-  >  (action (system "cat promoted promoted > result")))
-  > EOF
+  $ write_target_promotion_rules promote
   $ echo hi > original
 
   $ start_dune
@@ -62,17 +52,7 @@ Now try replacing its content.
 Now switch the mode to standard. Dune reports an error about multiple rules for
 [_build/default/promoted], as expected (see the error at the end of the test).
 
-  $ cat > dune <<EOF
-  > (rule
-  >  (mode standard)
-  >  (deps original)
-  >  (target promoted)
-  >  (action (copy %{deps} %{target})))
-  > (rule
-  >  (deps promoted)
-  >  (target result)
-  >  (action (system "cat promoted promoted > result")))
-  > EOF
+  $ write_target_promotion_rules standard
 
   $ build result
   Failure
@@ -93,17 +73,7 @@ We use the hint and it starts to work.
 
 Now use [fallback] to override the rule that generates [promoted].
 
-  $ cat > dune <<EOF
-  > (rule
-  >  (mode fallback)
-  >  (deps original)
-  >  (target promoted)
-  >  (action (copy %{deps} %{target})))
-  > (rule
-  >  (deps promoted)
-  >  (target result)
-  >  (action (system "cat promoted promoted > result")))
-  > EOF
+  $ write_target_promotion_rules fallback
 
 At first, we don't have the source, so the rule is used.
 
@@ -149,17 +119,7 @@ We're done.
 
 Now test file-system events generated during target promotion.
 
-  $ cat > dune <<EOF
-  > (rule
-  >  (mode promote)
-  >  (deps original)
-  >  (target promoted)
-  >  (action (copy %{deps} %{target})))
-  > (rule
-  >  (deps promoted)
-  >  (target result)
-  >  (action (system "cat promoted promoted > result")))
-  > EOF
+  $ write_target_promotion_rules promote
 
   $ cat promoted
   hi


### PR DESCRIPTION
Extract the repeated target-promotion dune rules into a helper parameterized by the rule mode.

The test still exercises promote, standard, and fallback modes while avoiding repeated rule boilerplate.