### PR TITLE
test(virtual-lib): share private module fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -219,6 +219,47 @@ make_melange_virtual_time_project() {
 	EOF
 }
 
+make_private_module_virtual_lib_fixture() {
+  local modes="${1:-}"
+
+  mkdir -p vlib impl
+  {
+    echo "(library"
+    echo " (name vlib)"
+    if [ -n "$modes" ]; then
+      echo " ${modes}"
+    fi
+    echo " (public_name pkg.vlib)"
+    echo " (virtual_modules virt)"
+    echo " (private_modules helper))"
+  } > vlib/dune
+  cat > vlib/vlib.ml <<-'EOF'
+	let run () = Virt.run () + Helper.value
+	EOF
+  cat > vlib/vlib.mli <<-'EOF'
+	val run : unit -> int
+	EOF
+  cat > vlib/virt.mli <<-'EOF'
+	val run : unit -> int
+	EOF
+  cat > vlib/helper.ml <<-'EOF'
+	let value = 42
+	EOF
+
+  {
+    echo "(library"
+    echo " (name impl)"
+    if [ -n "$modes" ]; then
+      echo " ${modes}"
+    fi
+    echo " (public_name pkg.impl)"
+    echo " (implements pkg.vlib))"
+  } > impl/dune
+  cat > impl/virt.ml <<-'EOF'
+	let run () = 1
+	EOF
+}
+
 make_hello_ppx_runtime_fixture() {
   local mode="${1:-byte}"
 

--- a/test/blackbox-tests/test-cases/melange/virtual-lib-private-module.t
+++ b/test/blackbox-tests/test-cases/melange/virtual-lib-private-module.t
@@ -1,7 +1,6 @@
 Test that virtual libraries with private modules work with public implementations
 (Issue #10635)
 
-  $ mkdir -p vlib impl
   $ cat > dune-project <<EOF
   > (lang dune 3.22)
   > (using melange 0.1)
@@ -10,39 +9,10 @@ Test that virtual libraries with private modules work with public implementation
 
 Virtual library with a private (non-virtual) helper module:
 
-  $ cat > vlib/dune <<EOF
-  > (library
-  >  (name vlib)
-  >  (modes byte melange)
-  >  (public_name pkg.vlib)
-  >  (virtual_modules virt)
-  >  (private_modules helper))
-  > EOF
-  $ cat > vlib/vlib.ml <<EOF
-  > let run () = Virt.run () + Helper.value
-  > EOF
-  $ cat > vlib/vlib.mli <<EOF
-  > val run : unit -> int
-  > EOF
-  $ cat > vlib/virt.mli <<EOF
-  > val run : unit -> int
-  > EOF
-  $ cat > vlib/helper.ml <<EOF
-  > let value = 42
-  > EOF
+  $ make_private_module_virtual_lib_fixture '(modes byte melange)'
 
 Implementation with public_name (but no private modules of its own):
 
-  $ cat > impl/dune <<EOF
-  > (library
-  >  (name impl)
-  >  (modes byte melange)
-  >  (public_name pkg.impl)
-  >  (implements pkg.vlib))
-  > EOF
-  $ cat > impl/virt.ml <<EOF
-  > let run () = 1
-  > EOF
 
 Should build without "External.cm_dir" errors:
 

--- a/test/blackbox-tests/test-cases/virtual-libraries/private-modules-public-impl-github10635.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/private-modules-public-impl-github10635.t
@@ -1,7 +1,6 @@
 Test that virtual libraries with private modules work with public implementations
 (Issue #10635)
 
-  $ mkdir -p vlib impl
   $ cat > dune-project <<EOF
   > (lang dune 3.13)
   > (package (name pkg))
@@ -9,37 +8,10 @@ Test that virtual libraries with private modules work with public implementation
 
 Virtual library with a private (non-virtual) helper module:
 
-  $ cat > vlib/dune <<EOF
-  > (library
-  >  (name vlib)
-  >  (public_name pkg.vlib)
-  >  (virtual_modules virt)
-  >  (private_modules helper))
-  > EOF
-  $ cat > vlib/vlib.ml <<EOF
-  > let run () = Virt.run () + Helper.value
-  > EOF
-  $ cat > vlib/vlib.mli <<EOF
-  > val run : unit -> int
-  > EOF
-  $ cat > vlib/virt.mli <<EOF
-  > val run : unit -> int
-  > EOF
-  $ cat > vlib/helper.ml <<EOF
-  > let value = 42
-  > EOF
+  $ make_private_module_virtual_lib_fixture
 
 Implementation with public_name (but no private modules of its own):
 
-  $ cat > impl/dune <<EOF
-  > (library
-  >  (name impl)
-  >  (public_name pkg.impl)
-  >  (implements pkg.vlib))
-  > EOF
-  $ cat > impl/virt.ml <<EOF
-  > let run () = 1
-  > EOF
 
 Should build without "External.cm_dir" errors:
 


### PR DESCRIPTION
Extract the repeated virtual-library-with-private-helper setup used by the melange and regular virtual-library tests into a shared helper.

The helper accepts the optional modes stanza so both tests keep their original coverage.