### PR TITLE
test(oxcaml): share vendored parameterised dune fixture

### DIFF
--- a/test/blackbox-tests/test-cases/oxcaml/vendor-parameterised.t
+++ b/test/blackbox-tests/test-cases/oxcaml/vendor-parameterised.t
@@ -32,35 +32,49 @@ The parameter definition must reside in a separate folder from its implementatio
   > (library_parameter (public_name vendored.param) (name param) (modules param))
   > EOF
 
+  $ write_vendored_dune() {
+  >   local param_impl_public_name="${1:-}"
+  >   local lib_param_public_name="${2:-}"
+  >   local vendored_lib_public_name="${3:-}"
+  > 
+  >   {
+  >     echo "(library"
+  >     if [ -n "$param_impl_public_name" ]; then
+  >       echo "   (public_name ${param_impl_public_name})"
+  >     fi
+  >     echo "   (name param_impl)"
+  >     echo "   (modules param_impl)"
+  >     echo "   (implements param))"
+  >     echo ""
+  >     echo "(library"
+  >     if [ -n "$lib_param_public_name" ]; then
+  >       echo "  (public_name ${lib_param_public_name})"
+  >     fi
+  >     echo "  (name lib_param)"
+  >     echo "  (modules lib_param)"
+  >     echo "  (parameters param))"
+  >     echo ""
+  >     echo "(library"
+  >     if [ -n "$vendored_lib_public_name" ]; then
+  >       echo "  (public_name ${vendored_lib_public_name})"
+  >     fi
+  >     echo "  (name vendored_lib)"
+  >     echo "  (modules vendored_lib)"
+  >     echo "  (libraries"
+  >     echo "    (instantiate lib_param param_impl)))"
+  >     echo ""
+  >     echo "(executable"
+  >     echo "  (name vendored_bin)"
+  >     echo "  (modules vendored_bin)"
+  >     echo "  (libraries vendored_lib))"
+  >   } > vendored/dune
+  > }
+
 Then three vendored libraries, one for the implementation of the parameter, one
 parameterised library, one library which depends on its instantation, and a
 non-public executable:
 
-  $ cat > vendored/dune <<EOF
-  > (library
-  >    (public_name vendored.param_impl)
-  >    (name param_impl)
-  >    (modules param_impl)
-  >    (implements param))
-  > 
-  > (library
-  >   (public_name vendored.lib_param)
-  >   (name lib_param)
-  >   (modules lib_param)
-  >   (parameters param))
-  > 
-  > (library
-  >   (public_name vendored.vendored_lib)
-  >   (name vendored_lib)
-  >   (modules vendored_lib)
-  >   (libraries
-  >     (instantiate lib_param param_impl)))
-  > 
-  > (executable
-  >   (name vendored_bin)
-  >   (modules vendored_bin)
-  >   (libraries vendored_lib))
-  > EOF
+  $ write_vendored_dune vendored.param_impl vendored.lib_param vendored.vendored_lib
 
 A simple implementation for each:
 
@@ -105,28 +119,7 @@ scope:
 
 But the vendored binary could use private libraries:
 
-  $ cat > vendored/dune <<EOF
-  > (library
-  >    (name param_impl)
-  >    (modules param_impl)
-  >    (implements param))
-  > 
-  > (library
-  >   (name lib_param)
-  >   (modules lib_param)
-  >   (parameters param))
-  > 
-  > (library
-  >   (name vendored_lib)
-  >   (modules vendored_lib)
-  >   (libraries
-  >     (instantiate lib_param param_impl)))
-  > 
-  > (executable
-  >   (name vendored_bin)
-  >   (modules vendored_bin)
-  >   (libraries vendored_lib))
-  > EOF
+  $ write_vendored_dune
 
   $ dune clean
   $ dune exec ./vendored/vendored_bin.exe
@@ -145,29 +138,7 @@ param_impl)`:
 We can also have a mix of public/private, with e.g. the parameterised library
 being public:
 
-  $ cat > vendored/dune <<EOF
-  > (library
-  >    (name param_impl)
-  >    (modules param_impl)
-  >    (implements param))
-  > 
-  > (library
-  >   (public_name vendored.lib_param)
-  >   (name lib_param)
-  >   (modules lib_param)
-  >   (parameters param))
-  > 
-  > (library
-  >   (name vendored_lib)
-  >   (modules vendored_lib)
-  >   (libraries
-  >     (instantiate lib_param param_impl)))
-  > 
-  > (executable
-  >   (name vendored_bin)
-  >   (modules vendored_bin)
-  >   (libraries vendored_lib))
-  > EOF
+  $ write_vendored_dune "" vendored.lib_param
 
   $ dune clean
   $ dune exec ./vendored/vendored_bin.exe
@@ -188,29 +159,7 @@ being public:
 
 Or only the parameter being public:
 
-  $ cat > vendored/dune <<EOF
-  > (library
-  >    (public_name vendored.param_impl)
-  >    (name param_impl)
-  >    (modules param_impl)
-  >    (implements param))
-  > 
-  > (library
-  >   (name lib_param)
-  >   (modules lib_param)
-  >   (parameters param))
-  > 
-  > (library
-  >   (name vendored_lib)
-  >   (modules vendored_lib)
-  >   (libraries
-  >     (instantiate lib_param param_impl)))
-  > 
-  > (executable
-  >   (name vendored_bin)
-  >   (modules vendored_bin)
-  >   (libraries vendored_lib))
-  > EOF
+  $ write_vendored_dune vendored.param_impl
 
   $ dune clean
   $ dune exec ./vendored/vendored_bin.exe
@@ -242,28 +191,7 @@ The parameter itself could be private too,
 
 But only if there are no public stanza depending on it:
 
-  $ cat > vendored/dune <<EOF
-  > (library
-  >    (name param_impl)
-  >    (modules param_impl)
-  >    (implements param))
-  > 
-  > (library
-  >   (name lib_param)
-  >   (modules lib_param)
-  >   (parameters param))
-  > 
-  > (library
-  >   (name vendored_lib)
-  >   (modules vendored_lib)
-  >   (libraries
-  >     (instantiate lib_param param_impl)))
-  > 
-  > (executable
-  >   (name vendored_bin)
-  >   (modules vendored_bin)
-  >   (libraries vendored_lib))
-  > EOF
+  $ write_vendored_dune
 
   $ dune exec ./vendored/vendored_bin.exe
   vendored_bin:vendored:lib_param:impl


### PR DESCRIPTION
Extract the repeated vendored/dune setup in the parameterised vendoring test into a local helper.

The helper is parameterized by the optional public names so each public/private combination keeps the same generated stanzas.