### PR TITLE
Fix build of stdune on 4.14.0

### DIFF
--- a/otherlibs/stdune/src/dune
+++ b/otherlibs/stdune/src/dune
@@ -6,7 +6,6 @@
  (libraries
   unix
   csexp
-  threads
   threads.posix
   (re_export top-closure)
   (re_export ordering)


### PR DESCRIPTION
Currently the build is broken (as seen at
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/cf61b44b20bb45b17951d5b49adb72c2ca63771a/variant/compilers,4.14,ordering.3.24.0~alpha0,revdeps,dream-html.3.7.0) because the packaging expects a specific implementation of threads. This patch fixes it, and the build works with OCaml 4.14.0