### PR TITLE
test(pkg): pin baseline for lockdir pkgs declaring workspace deps

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/basic.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/basic.t
@@ -1,0 +1,49 @@
+A lock-dir package depends on a workspace library package.
+
+  $ make_dune_project 3.24
+  $ cat >> dune-project <<EOF
+  > (package (name workspace-lib))
+  > EOF
+
+  $ mkdir src
+  $ cat > src/dune <<EOF
+  > (library
+  >  (name workspace_lib)
+  >  (public_name workspace-lib))
+  > EOF
+  $ cat > src/workspace_lib.ml <<EOF
+  > let greeting = "Hello from workspace-lib!"
+  > EOF
+
+The lock dir contains one package "consumer" that declares
+"workspace-lib" as a dependency:
+
+  $ make_lockdir
+  $ make_lockpkg consumer <<EOF
+  > (version 0.0.1)
+  > (depends workspace-lib)
+  > (build (run echo "building consumer"))
+  > EOF
+
+A rule depends on the lock-dir package:
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (deps (package consumer))
+  >  (action (with-stdout-to out (echo "ok"))))
+  > EOF
+
+Lock-dir validation does not currently recognise workspace packages as
+valid dependency targets:
+
+  $ dune build out 2>&1
+  File "_build/_private/default/.lock/dune.lock/consumer.pkg", line 2,
+  characters 9-22:
+  The package "consumer" depends on the package "workspace-lib", but
+  "workspace-lib" does not appear in the lockdir
+  _build/_private/default/.lock/dune.lock.
+  Error: At least one package dependency is itself not present as a package in
+  the lockdir _build/_private/default/.lock/dune.lock.
+  Hint: This could indicate that the lockdir is corrupted. Delete it and then
+  regenerate it by running: 'dune pkg lock'
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/compile-against-workspace-lib.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/compile-against-workspace-lib.t
@@ -1,0 +1,55 @@
+A lock-dir package depends on a workspace library and its build
+action inspects [OCAMLPATH].
+
+  $ make_dune_project 3.24
+  $ cat >> dune-project <<EOF
+  > (package (name workspace-lib))
+  > EOF
+
+  $ mkdir src
+  $ cat > src/dune <<EOF
+  > (library
+  >  (name workspace_lib)
+  >  (public_name workspace-lib))
+  > EOF
+  $ cat > src/workspace_lib.ml <<EOF
+  > let greeting = "Hello from workspace-lib!"
+  > EOF
+
+The lock dir contains one package "consumer" whose build action
+writes [OCAMLPATH] to a file and installs it. The intent is that the
+file should later be inspectable to confirm the workspace install
+layout was prepended.
+
+  $ make_lockdir
+  $ make_lockpkg consumer <<EOF
+  > (version 0.0.1)
+  > (depends workspace-lib)
+  > (build
+  >  (system "echo \$OCAMLPATH > ocamlpath.txt"))
+  > (install
+  >  (system "mkdir -p %{lib}/consumer && cp ocamlpath.txt %{lib}/consumer/"))
+  > EOF
+
+A rule depends on the lock-dir package:
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (deps (package consumer))
+  >  (action (with-stdout-to out (echo "ok"))))
+  > EOF
+
+Lock-dir validation does not currently recognise workspace packages as
+valid dependency targets, so the consumer's build action never runs:
+
+  $ dune build out 2>&1
+  File "_build/_private/default/.lock/dune.lock/consumer.pkg", line 2,
+  characters 9-22:
+  The package "consumer" depends on the package "workspace-lib", but
+  "workspace-lib" does not appear in the lockdir
+  _build/_private/default/.lock/dune.lock.
+  Error: At least one package dependency is itself not present as a package in
+  the lockdir _build/_private/default/.lock/dune.lock.
+  Hint: This could indicate that the lockdir is corrupted. Delete it and then
+  regenerate it by running: 'dune pkg lock'
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/empty-package.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/empty-package.t
@@ -1,0 +1,39 @@
+A lock-dir package depends on an empty workspace package (one declared
+with [(allow_empty)] and no source content).
+
+  $ make_dune_project 3.24
+  $ cat >> dune-project <<EOF
+  > (package (name ws-empty) (allow_empty))
+  > EOF
+
+The lock dir contains one package "consumer" that declares "ws-empty"
+as a dependency:
+
+  $ make_lockdir
+  $ make_lockpkg consumer <<EOF
+  > (version 0.0.1)
+  > (depends ws-empty)
+  > (build (run echo "building consumer"))
+  > EOF
+
+A rule depends on the lock-dir package:
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (deps (package consumer))
+  >  (action (with-stdout-to out (echo "ok"))))
+  > EOF
+
+Lock-dir validation does not currently recognise workspace packages as
+valid dependency targets:
+
+  $ dune build out 2>&1
+  File "_build/_private/default/.lock/dune.lock/consumer.pkg", line 2,
+  characters 9-17:
+  The package "consumer" depends on the package "ws-empty", but "ws-empty" does
+  not appear in the lockdir _build/_private/default/.lock/dune.lock.
+  Error: At least one package dependency is itself not present as a package in
+  the lockdir _build/_private/default/.lock/dune.lock.
+  Hint: This could indicate that the lockdir is corrupted. Delete it and then
+  regenerate it by running: 'dune pkg lock'
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/executable.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/executable.t
@@ -1,0 +1,50 @@
+A lock-dir package depends on a workspace package that provides a
+public executable.
+
+  $ make_dune_project 3.24
+  $ cat >> dune-project <<EOF
+  > (package (name ws-tool))
+  > EOF
+
+  $ mkdir src
+  $ cat > src/dune <<EOF
+  > (executable
+  >  (name main)
+  >  (package ws-tool)
+  >  (public_name ws-tool))
+  > EOF
+  $ cat > src/main.ml <<EOF
+  > let () = print_endline "Hello from ws-tool!"
+  > EOF
+
+The lock dir contains one package "consumer" that declares "ws-tool"
+as a dependency:
+
+  $ make_lockdir
+  $ make_lockpkg consumer <<EOF
+  > (version 0.0.1)
+  > (depends ws-tool)
+  > (build (run echo "building consumer"))
+  > EOF
+
+A rule depends on the lock-dir package:
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (deps (package consumer))
+  >  (action (with-stdout-to out (echo "ok"))))
+  > EOF
+
+Lock-dir validation does not currently recognise workspace packages as
+valid dependency targets:
+
+  $ dune build out 2>&1
+  File "_build/_private/default/.lock/dune.lock/consumer.pkg", line 2,
+  characters 9-16:
+  The package "consumer" depends on the package "ws-tool", but "ws-tool" does
+  not appear in the lockdir _build/_private/default/.lock/dune.lock.
+  Error: At least one package dependency is itself not present as a package in
+  the lockdir _build/_private/default/.lock/dune.lock.
+  Hint: This could indicate that the lockdir is corrupted. Delete it and then
+  regenerate it by running: 'dune pkg lock'
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/multiple-workspace-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-workspace-deps/multiple-workspace-deps.t
@@ -1,0 +1,62 @@
+A lock-dir package depends on multiple workspace packages.
+
+  $ make_dune_project 3.24
+  $ cat >> dune-project <<EOF
+  > (package (name ws-lib-a))
+  > (package (name ws-lib-b))
+  > EOF
+
+  $ mkdir src-a src-b
+  $ cat > src-a/dune <<EOF
+  > (library
+  >  (name ws_lib_a)
+  >  (public_name ws-lib-a))
+  > EOF
+  $ cat > src-a/ws_lib_a.ml <<EOF
+  > let value_a = "from lib a"
+  > EOF
+
+  $ cat > src-b/dune <<EOF
+  > (library
+  >  (name ws_lib_b)
+  >  (public_name ws-lib-b))
+  > EOF
+  $ cat > src-b/ws_lib_b.ml <<EOF
+  > let value_b = "from lib b"
+  > EOF
+
+The lock dir contains one package "consumer" that declares both
+workspace libraries as dependencies:
+
+  $ make_lockdir
+  $ make_lockpkg consumer <<EOF
+  > (version 0.0.1)
+  > (depends ws-lib-a ws-lib-b)
+  > (build (run echo "building consumer"))
+  > EOF
+
+A rule depends on the lock-dir package:
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (deps (package consumer))
+  >  (action (with-stdout-to out (echo "ok"))))
+  > EOF
+
+Lock-dir validation does not currently recognise workspace packages as
+valid dependency targets. Both missing workspace deps are reported:
+
+  $ dune build out 2>&1
+  File "_build/_private/default/.lock/dune.lock/consumer.pkg", line 2,
+  characters 9-17:
+  The package "consumer" depends on the package "ws-lib-a", but "ws-lib-a" does
+  not appear in the lockdir _build/_private/default/.lock/dune.lock.
+  File "_build/_private/default/.lock/dune.lock/consumer.pkg", line 2,
+  characters 18-26:
+  The package "consumer" depends on the package "ws-lib-b", but "ws-lib-b" does
+  not appear in the lockdir _build/_private/default/.lock/dune.lock.
+  Error: At least one package dependency is itself not present as a package in
+  the lockdir _build/_private/default/.lock/dune.lock.
+  Hint: This could indicate that the lockdir is corrupted. Delete it and then
+  regenerate it by running: 'dune pkg lock'
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/workspace-deps/depends-on-workspace-package.t
+++ b/test/blackbox-tests/test-cases/pkg/workspace-deps/depends-on-workspace-package.t
@@ -1,0 +1,48 @@
+A lock-dir package depends on a workspace package.
+
+  $ make_dune_project 3.24
+  $ cat >> dune-project <<EOF
+  > (package (name myws))
+  > EOF
+
+  $ mkdir src
+  $ cat > src/dune <<EOF
+  > (library (public_name myws))
+  > EOF
+  $ cat > src/myws.ml <<EOF
+  > let x = 1
+  > EOF
+
+The lock dir contains one package "mylock" that declares "myws" as a
+dependency:
+
+  $ make_lockdir
+  $ make_lockpkg mylock <<EOF
+  > (version 0.0.1)
+  > (depends myws)
+  > (build (run echo "building mylock"))
+  > EOF
+
+A rule depends on the lock-dir package:
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (alias check)
+  >  (deps (package mylock))
+  >  (action (with-stdout-to out (echo "done"))))
+  > EOF
+
+Building rejects the lock dir because "myws" is a dependency of "mylock" but is
+not itself a package in the lock dir. Lock-dir validation does not currently
+recognise workspace packages as valid dependency targets.
+
+  $ dune build @check 2>&1
+  File "_build/_private/default/.lock/dune.lock/mylock.pkg", line 2, characters
+  9-13:
+  The package "mylock" depends on the package "myws", but "myws" does not
+  appear in the lockdir _build/_private/default/.lock/dune.lock.
+  Error: At least one package dependency is itself not present as a package in
+  the lockdir _build/_private/default/.lock/dune.lock.
+  Hint: This could indicate that the lockdir is corrupted. Delete it and then
+  regenerate it by running: 'dune pkg lock'
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/workspace-deps/solver-missing-package.t
+++ b/test/blackbox-tests/test-cases/pkg/workspace-deps/solver-missing-package.t
@@ -1,0 +1,29 @@
+A mock-repository package depends on a package that exists neither in
+the repository nor in the workspace. The solver should reject this.
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ mkpkg consumer <<EOF
+  > depends: [ "nonexistent-pkg" ]
+  > EOF
+
+  $ make_dune_project 3.24
+  $ cat >> dune-project <<EOF
+  > (package (name proj) (allow_empty) (depends consumer))
+  > EOF
+
+  $ dune pkg lock
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.lock
+  
+  The dependency solver failed to find a solution for the following platforms:
+  - arch = x86_64; os = linux
+  - arch = arm64; os = linux
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
+  ...with this error:
+  Couldn't solve the package dependency formula.
+  The following packages couldn't be found: nonexistent-pkg
+  [1]
+

--- a/test/blackbox-tests/test-cases/pkg/workspace-deps/solver-workspace-dep.t
+++ b/test/blackbox-tests/test-cases/pkg/workspace-deps/solver-workspace-dep.t
@@ -1,0 +1,32 @@
+[dune pkg lock] is asked to lock a project where a mock-repository
+package depends on a workspace package.
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+The mock package [mylock] declares the workspace package [util] as a
+dependency:
+
+  $ mkpkg mylock <<EOF
+  > depends: [
+  >  "util"
+  > ]
+  > EOF
+
+The workspace has two packages: [main] depends on the mock package
+[mylock], and [util] has no dependencies.
+
+  $ make_dune_project 3.24
+  $ cat >> dune-project <<EOF
+  > (package (name main) (depends mylock))
+  > (package (name util))
+  > EOF
+
+The solver rejects the dependency because [mylock] is outside the
+workspace and [util] is inside it:
+
+  $ dune pkg lock 2>&1
+  Error: Dune does not support packages outside the workspace depending on
+  packages in the workspace. The package "mylock" is not in the workspace but
+  it depends on the package "util" which is in the workspace.
+  [1]


### PR DESCRIPTION
Add cram tests that exercise the current rejection paths when a lock-dir package declares a workspace package as a dependency, both at solve time (solver-workspace-dep.t) and at build time via lock-dir validation (lockdir-workspace-deps/*.t, depends-on-workspace-package.t). The build fixtures cover library, executable, empty, multi-dep, and OCAMLPATH-shaped workspace packages so that follow-up work only needs to promote expected output for each variant.