### PR TITLE
test(per-module): share noop ppx fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -260,6 +260,26 @@ make_private_module_virtual_lib_fixture() {
 	EOF
 }
 
+make_noop_ppx_rewriter() {
+  mkdir ppx
+  cat > ppx/dune <<-'EOF'
+	(library
+	 (name ppx_noop)
+	 (kind ppx_rewriter)
+	 (ppx.driver (main Ppx_noop.main)))
+	EOF
+  cat > ppx/ppx_noop.ml <<-'EOF'
+	let main () =
+	  let n = Array.length Sys.argv in
+	  if n < 4 || Sys.argv.(1) <> "--as-ppx" then assert false;
+	  let input = Sys.argv.(n - 2) in
+	  let output = Sys.argv.(n - 1) in
+	  Filename.quote_command "cp" [input; output]
+	  |> Sys.command
+	  |> exit
+	EOF
+}
+
 make_hello_ppx_runtime_fixture() {
   local mode="${1:-byte}"
 

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/mixed-per-module-preprocess-precision.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/mixed-per-module-preprocess-precision.t
@@ -12,23 +12,7 @@ Companion to `mixed-per-module-preprocess.t` (the soundness sibling).
 
 A no-op staged ppx (identical to the soundness reproducer).
 
-  $ mkdir ppx
-  $ cat > ppx/dune <<EOF
-  > (library
-  >  (name ppx_noop)
-  >  (kind ppx_rewriter)
-  >  (ppx.driver (main Ppx_noop.main)))
-  > EOF
-  $ cat > ppx/ppx_noop.ml <<EOF
-  > let main () =
-  >   let n = Array.length Sys.argv in
-  >   if n < 4 || Sys.argv.(1) <> "--as-ppx" then assert false;
-  >   let input = Sys.argv.(n - 2) in
-  >   let output = Sys.argv.(n - 1) in
-  >   Filename.quote_command "cp" [input; output]
-  >   |> Sys.command
-  >   |> exit
-  > EOF
+  $ make_noop_ppx_rewriter
 
 `mylib`: `a` uses default preprocessing (Some-entry); `b` uses
 `(staged_pps ...)` (None-entry). `a`'s source is independent of `b`;

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/mixed-per-module-preprocess.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/mixed-per-module-preprocess.t
@@ -10,23 +10,7 @@ A no-op staged ppx, modelled on
 `test/blackbox-tests/test-cases/staged-pps-relative-directory-gh8158.t`.
 The driver copies its input verbatim.
 
-  $ mkdir ppx
-  $ cat > ppx/dune <<EOF
-  > (library
-  >  (name ppx_noop)
-  >  (kind ppx_rewriter)
-  >  (ppx.driver (main Ppx_noop.main)))
-  > EOF
-  $ cat > ppx/ppx_noop.ml <<EOF
-  > let main () =
-  >   let n = Array.length Sys.argv in
-  >   if n < 4 || Sys.argv.(1) <> "--as-ppx" then assert false;
-  >   let input = Sys.argv.(n - 2) in
-  >   let output = Sys.argv.(n - 1) in
-  >   Filename.quote_command "cp" [input; output]
-  >   |> Sys.command
-  >   |> exit
-  > EOF
+  $ make_noop_ppx_rewriter
 
 `mylib` is `(wrapped false)` with `a` default-pp and `b` staged-pps.
 `a`'s interface mentions `B.t`, so the consumer's call to


### PR DESCRIPTION
Extract the repeated no-op ppx rewriter setup used by the mixed per-module preprocess tests into a shared blackbox-test helper.

The tests keep their library and dependency assertions unchanged.