### PR TITLE
test(per-module): share mylib consumer fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -146,6 +146,31 @@ make_value_library() {
 	EOF
 }
 
+make_mylib_consumer_executable() {
+  cat > dune <<-'EOF'
+	(executable
+	 (name main)
+	 (libraries mylib))
+	EOF
+  cat > uses_lib.ml <<-'EOF'
+	let get_value () = Mylib.value
+	EOF
+  cat > uses_lib.mli <<-'EOF'
+	val get_value : unit -> int
+	EOF
+  cat > no_use_lib.ml <<-'EOF'
+	let compute x = x + 1
+	EOF
+  cat > no_use_lib.mli <<-'EOF'
+	val compute : int -> int
+	EOF
+  cat > main.ml <<-'EOF'
+	let () =
+	  print_int (Uses_lib.get_value ());
+	  print_int (No_use_lib.compute 5)
+	EOF
+}
+
 make_melange_runtime_deps_lib() {
   local dir="${1:-lib}"
 

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/basic-wrapped.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/basic-wrapped.t
@@ -10,28 +10,7 @@ See: https://github.com/ocaml/dune/issues/4572
 
   $ make_value_library lib mylib 42
 
-  $ cat > dune <<EOF
-  > (executable
-  >  (name main)
-  >  (libraries mylib))
-  > EOF
-  $ cat > uses_lib.ml <<EOF
-  > let get_value () = Mylib.value
-  > EOF
-  $ cat > uses_lib.mli <<EOF
-  > val get_value : unit -> int
-  > EOF
-  $ cat > no_use_lib.ml <<EOF
-  > let compute x = x + 1
-  > EOF
-  $ cat > no_use_lib.mli <<EOF
-  > val compute : int -> int
-  > EOF
-  $ cat > main.ml <<EOF
-  > let () =
-  >   print_int (Uses_lib.get_value ());
-  >   print_int (No_use_lib.compute 5)
-  > EOF
+  $ make_mylib_consumer_executable
 
   $ dune build ./main.exe
 

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque.t
@@ -12,28 +12,7 @@ See: https://github.com/ocaml/dune/issues/4572
 
   $ make_value_library lib mylib 42
 
-  $ cat > dune <<EOF
-  > (executable
-  >  (name main)
-  >  (libraries mylib))
-  > EOF
-  $ cat > uses_lib.ml <<EOF
-  > let get_value () = Mylib.value
-  > EOF
-  $ cat > uses_lib.mli <<EOF
-  > val get_value : unit -> int
-  > EOF
-  $ cat > no_use_lib.ml <<EOF
-  > let compute x = x + 1
-  > EOF
-  $ cat > no_use_lib.mli <<EOF
-  > val compute : int -> int
-  > EOF
-  $ cat > main.ml <<EOF
-  > let () =
-  >   print_int (Uses_lib.get_value ());
-  >   print_int (No_use_lib.compute 5)
-  > EOF
+  $ make_mylib_consumer_executable
 
 --- Release profile (opaque=false): .cmx deps are tracked ---
 


### PR DESCRIPTION
Extract the repeated executable fixture that consumes `mylib` into a shared blackbox-test helper.

The recompilation tests still differ only in how they mutate and build the library.