### PR TITLE
scheduler: wait for process groups after actions exit

### DIFF
--- a/doc/changes/fixed/14868.md
+++ b/doc/changes/fixed/14868.md
@@ -1,0 +1,4 @@
+- Linux: dune will now wait for the process group to be dead after the group
+  leader is dead. This tightens dune's policy for what constitutes
+  a successful action. Actions for which dune cannot be clean up the process
+  group will now fail. (@rgrinberg, #14868)

--- a/otherlibs/stdune/src/pid.ml
+++ b/otherlibs/stdune/src/pid.ml
@@ -32,6 +32,12 @@ let signal pid where signal =
   | exception Unix.Unix_error (Unix.ESRCH, _, _) -> `Dead
 ;;
 
+let check pid where =
+  match signal pid where `Null with
+  | `Not_allowed | `Delivered -> `Alive
+  | `Dead -> `Dead
+;;
+
 let kill pid where (signal' : Signal.t) =
   match signal pid where (`Signal signal') with
   | `Delivered -> `Delivered

--- a/otherlibs/stdune/src/pid.mli
+++ b/otherlibs/stdune/src/pid.mli
@@ -13,5 +13,6 @@ val of_int_exn : int -> t
 
 val kill : t -> [ `Pid | `Group ] -> Signal.t -> [ `Delivered | `Dead ]
 val kill_exn : t -> [ `Pid | `Group ] -> Signal.t -> unit
+val check : t -> [ `Pid | `Group ] -> [ `Dead | `Alive ]
 
 module Set : Set.S with type elt = t

--- a/otherlibs/stdune/src/proc.ml
+++ b/otherlibs/stdune/src/proc.ml
@@ -69,6 +69,13 @@ module Process_info = struct
 end
 
 module Linux = struct
+  let read_pid_max () =
+    match Io.String_path.read_file "/proc/sys/kernel/pid_max" with
+    | exception Sys_error _ -> None
+    | exception Unix.Unix_error _ -> None
+    | pid_max -> String.trim pid_max |> Int.of_string
+  ;;
+
   module Process_tree = struct
     type error =
       | Cannot_read_directory of

--- a/otherlibs/stdune/src/proc.mli
+++ b/otherlibs/stdune/src/proc.mli
@@ -48,6 +48,8 @@ module Process_info : sig
 end
 
 module Linux : sig
+  val read_pid_max : unit -> int option
+
   module Process_tree : sig
     type error
 

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -206,14 +206,91 @@ let cleanup_subreaper_child_processes () =
   else Fiber.return ()
 ;;
 
+let terminate_process_group =
+  let trace_process_group_cleanup pid stage =
+    Dune_trace.emit Process (fun () -> Dune_trace.Event.process_group_cleanup ~pid stage)
+  in
+  let process_group_cleanup_after_exit_enabled =
+    (* Once an action's process exits, its pid can be reused as a pgid. Only
+       use pgid-based cleanup after process exit when pid reuse during the grace
+       period is unlikely. *)
+    let process_group_cleanup_after_exit_min_pid_max = 4_000_000 in
+    lazy
+      (match Platform.OS.value with
+       | Platform.OS.Linux ->
+         (match Proc.Linux.read_pid_max () with
+          | Some pid_max -> pid_max >= process_group_cleanup_after_exit_min_pid_max
+          | None -> false)
+       | _ -> false)
+  in
+  let process_group_poll_interval = Time.Span.of_secs 0.01 in
+  let await_process_group_exit t pid =
+    (* After sending SIGTERM once, poll with signal 0 instead of sending SIGTERM
+       again. A process may use its SIGTERM handler for cleanup, and repeatedly
+       running that handler during the grace period can interfere with that
+       cleanup. *)
+    let deadline = Time.add (Time.now ()) sigterm_grace_period in
+    let rec loop () =
+      match Pid.check pid `Group with
+      | `Dead -> Fiber.return `Exited
+      | `Alive ->
+        if Time.(now () >= deadline)
+        then Fiber.return `Timed_out
+        else
+          Async_io.Task.await (Async_io.sleep t.async_io process_group_poll_interval)
+          >>= (function
+           | Ok () -> loop ()
+           | Error `Cancelled -> Fiber.return `Timed_out
+           | Error (`Exn _) -> assert false)
+    in
+    let+ res = loop () in
+    let () =
+      match res with
+      | `Timed_out -> trace_process_group_cleanup pid (`Timed_out sigterm_grace_period)
+      | `Exited -> trace_process_group_cleanup pid `Finished
+    in
+    res
+  in
+  fun t pid ~is_process_group_leader ->
+    if
+      (not is_process_group_leader)
+      || not (Lazy.force process_group_cleanup_after_exit_enabled)
+    then Fiber.return ()
+    else (
+      match Pid.kill pid `Group Term with
+      | `Dead ->
+        trace_process_group_cleanup pid `Already_exited;
+        Fiber.return ()
+      | `Delivered ->
+        trace_process_group_cleanup pid (`Sent_signal Term);
+        await_process_group_exit t pid
+        >>= (function
+         | `Exited -> Fiber.return ()
+         | `Timed_out ->
+           (match Pid.kill pid `Group Kill with
+            | `Dead -> Fiber.return ()
+            | `Delivered ->
+              trace_process_group_cleanup pid (`Sent_signal Kill);
+              await_process_group_exit t pid
+              >>| (function
+               | `Exited -> ()
+               | `Timed_out ->
+                 User_error.raise
+                   [ Pp.textf "failed to terminate process group %d" (Pid.to_int pid)
+                   ; Pp.text "Processes remained alive after SIGTERM and SIGKILL."
+                   ; Pp.text
+                       "This can happen if an action is repeatedly spawning new \
+                        processes."
+                   ]))))
+;;
+
 (* We use this version privately in this module whenever we can pass the
    scheduler explicitly *)
 let wait_for_build_process t ?cancellation ~is_process_group_leader pid =
   let sigkill_alarm = ref None in
   let wait () =
     let* r = wait_for_process t ~is_process_group_leader pid in
-    if not Sys.win32
-    then Process_watcher.kill_process_group pid Term ~is_process_group_leader;
+    let* () = terminate_process_group t pid ~is_process_group_leader in
     let+ () =
       match !sigkill_alarm with
       | None -> Fiber.return ()

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -124,6 +124,15 @@ module Event : sig
     -> [ `Started | `Sent_signal of Signal.t | `Finished | `Failed ]
     -> t
 
+  val process_group_cleanup
+    :  pid:Pid.t
+    -> [ `Already_exited
+       | `Sent_signal of Signal.t
+       | `Timed_out of Time.Span.t
+       | `Finished
+       ]
+    -> t
+
   val watch_build_start : run_id:int -> restart:bool -> start:Time.t -> t
   val watch_build_restart : run_id:int -> reasons:string list -> at:Time.t -> t
 

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -284,6 +284,22 @@ let child_process_cleanup ~pids stage =
     Process
 ;;
 
+let process_group_cleanup ~pid stage =
+  let stage, extra_args =
+    match stage with
+    | `Already_exited -> "already-exited", []
+    | `Sent_signal signal -> "sent-signal", [ "signal", Arg.string (Signal.name signal) ]
+    | `Timed_out timeout -> "timed-out", [ "timeout", Arg.span timeout ]
+    | `Finished -> "finished", []
+  in
+  let args = [ "pid", Arg.int (Pid.to_int pid); "stage", Arg.string stage ] in
+  Event.instant
+    ~args:(args @ extra_args)
+    ~name:"process-group-cleanup"
+    (Time.now ())
+    Process
+;;
+
 let watch_build_start ~run_id ~restart ~start =
   let args =
     [ "run_id", Arg.int run_id; "restart", Arg.bool restart ]

--- a/test/blackbox-tests/test-cases/cram/dune
+++ b/test/blackbox-tests/test-cases/cram/dune
@@ -1,5 +1,7 @@
 (cram
  (applies_to subprocess)
+ (enabled_if
+  (= %{system} linux))
  (deps %{bin:ps}))
 
 (cram

--- a/test/blackbox-tests/test-cases/cram/subprocess.t
+++ b/test/blackbox-tests/test-cases/cram/subprocess.t
@@ -3,9 +3,35 @@ project with a single cram test.
 
   $ make_dune_project 3.19
 
+Cleanup via process groups is only enabled on Linux when pid_max is high enough
+that pid/pgid reuse is unlikely during the grace period.
+
+  $ pgid_cleanup_enabled () {
+  >   [ "$(uname -s)" = "Linux" ] || return 1
+  >   [ -r /proc/sys/kernel/pid_max ] || return 1
+  >   pid_max=$(cat /proc/sys/kernel/pid_max)
+  >   case "$pid_max" in
+  >     ''|*[!0-9]*) return 1 ;;
+  >   esac
+  >   [ "$pid_max" -ge 4000000 ]
+  > }
+
 We create a file for tracking the PID of a subprocess.
 
   $ pidFile="$PWD/pid.txt"
+
+  $ assert_process_terminated () {
+  >   pid_file="$1"
+  >   [ -s "$pid_file" ] || {
+  >     echo "pid file was not created"
+  >     return 1
+  >   }
+  >   if ps -p "$(cat "$pid_file")" > /dev/null
+  >   then
+  >     echo "Process still running"
+  >     return 1
+  >   fi
+  > }
 
 We create a cram test that spawns a subprocess and records its PID in the file
 we gave before.
@@ -15,14 +41,26 @@ we gave before.
   >   $ echo \$! > $pidFile
   > EOF
 
-We can now run this test, which will record its PID in the file.
+We can now run this test, which will record its PID in the file. If pgid cleanup
+is enabled, the subprocess should be terminated before the test action finishes.
 
-  $ dune runtest mycram.t
+  $ if pgid_cleanup_enabled
+  > then
+  >   dune runtest mycram.t
+  >   assert_process_terminated "$pidFile"
+  > fi
 
-The test finished successfully, now we make sure that the PID was correctly
-terminated.
+Processes that ignore SIGTERM are escalated to SIGKILL before the test action
+finishes.
 
-  $ [ -s $pidFile ] && echo pid file created
-  pid file created
-  $ ps -p $(cat $pidFile) > /dev/null || echo "Process terminated"
-  Process terminated
+  $ stubbornPidFile="$PWD/stubborn-pid.txt"
+  $ cat > stubborn.t <<EOF
+  >   $ (trap '' TERM; sleep 5) &
+  >   $ echo \$! > $stubbornPidFile
+  > EOF
+
+  $ if pgid_cleanup_enabled
+  > then
+  >   dune runtest stubborn.t
+  >   assert_process_terminated "$stubbornPidFile"
+  > fi

--- a/test/blackbox-tests/test-cases/graceful-shutdown.t
+++ b/test/blackbox-tests/test-cases/graceful-shutdown.t
@@ -33,7 +33,7 @@ be ready, sends SIGINT to dune, and checks if the cleanup handler ran.
   $ wait $DUNE_PID
   [130]
 
-  $ dune trace cat | jq 'select(.name | startswith("process-")) | { name, args }'
+  $ dune trace cat | jq 'select(.name | startswith("process-cleanup-")) | { name, args }'
   {
     "name": "process-cleanup-start",
     "args": {}

--- a/test/blackbox-tests/test-cases/trace/cat.t
+++ b/test/blackbox-tests/test-cases/trace/cat.t
@@ -2,24 +2,7 @@ dune trace cat can be used to view the trace:
 
   $ make_dune_project 3.21
   $ dune build
-  $ dune trace cat | jq -c 'keys'
-  ["args","cat","name","ts"]
-  ["args","cat","name","ts"]
-  ["args","cat","name","ts"]
-  ["args","cat","name","ts"]
-  ["args","cat","name","ts"]
-  ["args","cat","name","ts"]
-  ["args","cat","name","ts"]
-  ["args","cat","name","ts"]
-  ["args","cat","name","ts"]
-  ["args","cat","dur","name","ts"]
-  ["args","cat","name","ts"]
-  ["args","cat","name","ts"]
-  ["args","cat","name","ts"]
-  ["args","cat","dur","name","ts"]
-  ["args","cat","dur","name","ts"]
-  ["args","cat","dur","name","ts"]
-  ["args","cat","name","ts"]
+  $ dune trace cat | jq -c -s 'map(keys) | unique[]'
   ["args","cat","dur","name","ts"]
   ["args","cat","name","ts"]
 


### PR DESCRIPTION
After a process-group leader exits, check whether its group still contains processes. If so, send SIGTERM, poll for the group to disappear, escalate to SIGKILL after the existing grace period, and abort if it still remains.

Extend the cram subprocess test with a SIGTERM-ignoring background job.