### PR TITLE
test(package): share mypkg stubs fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -127,6 +127,26 @@ make_mypkg_lib_project() {
 	EOF
 }
 
+make_mypkg_stubs_project() {
+  make_dune_project 3.24
+  cat >> dune-project <<-'EOF'
+	(package (name mypkg))
+	EOF
+  mkdir src
+  cat > src/dune <<-'EOF'
+	(library
+	 (public_name mypkg)
+	 (foreign_stubs (language c) (names stub)))
+	EOF
+  cat > src/mypkg.ml <<-'EOF'
+	let x = 1
+	EOF
+  cat > src/stub.c <<-'EOF'
+	#include <caml/mlvalues.h>
+	CAMLprim value mypkg_stub(value unit) { return Val_unit; }
+	EOF
+}
+
 make_value_library() {
   local dir="$1"
   local name="$2"

--- a/test/blackbox-tests/test-cases/package-materialization/cram-integration.t
+++ b/test/blackbox-tests/test-cases/package-materialization/cram-integration.t
@@ -1,22 +1,6 @@
 Test that (deps (package ...)) in a cram stanza sets up all layout env vars.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.24)
-  > (package (name mypkg))
-  > EOF
-  $ mkdir src
-  $ cat >src/dune <<EOF
-  > (library
-  >  (public_name mypkg)
-  >  (foreign_stubs (language c) (names stub)))
-  > EOF
-  $ cat >src/mypkg.ml <<'EOF'
-  > let x = 1
-  > EOF
-  $ cat >src/stub.c <<'EOF'
-  > #include <caml/mlvalues.h>
-  > CAMLprim value mypkg_stub(value unit) { return Val_unit; }
-  > EOF
+  $ make_mypkg_stubs_project
 
 Capture baselines into a setup script for the inner test:
 

--- a/test/blackbox-tests/test-cases/package-materialization/env/caml-ld-library-path.t
+++ b/test/blackbox-tests/test-cases/package-materialization/env/caml-ld-library-path.t
@@ -1,22 +1,6 @@
 Test that (deps (package ...)) adds lib/stublibs/ to CAML_LD_LIBRARY_PATH.
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.24)
-  > (package (name mypkg))
-  > EOF
-  $ mkdir src
-  $ cat >src/dune <<EOF
-  > (library
-  >  (public_name mypkg)
-  >  (foreign_stubs (language c) (names stub)))
-  > EOF
-  $ cat >src/mypkg.ml <<'EOF'
-  > let x = 1
-  > EOF
-  $ cat >src/stub.c <<'EOF'
-  > #include <caml/mlvalues.h>
-  > CAMLprim value mypkg_stub(value unit) { return Val_unit; }
-  > EOF
+  $ make_mypkg_stubs_project
   $ cat >dune <<'EOF'
   > (rule
   >  (deps (package mypkg))


### PR DESCRIPTION
Extract the repeated `mypkg` library-with-foreign-stubs setup into a shared blackbox-test helper.

Both package-materialization tests keep their environment assertions while sharing the package fixture.