### PR TITLE
refactor(bin): remove timeout on acquiring build lock

### DIFF
--- a/bin/build.ml
+++ b/bin/build.ml
@@ -146,7 +146,7 @@ let build =
        the status of the lock by taking prevents a race condition where the
        state of the lock could otherwise change between checking it and taking
        it. *)
-    match Global_lock.lock ~timeout:None with
+    match Global_lock.lock () with
     | Error lock_held_by ->
       (* This case is reached if dune detects that another instance of dune
          is already running. Rather than performing the build itself, the

--- a/bin/clean.ml
+++ b/bin/clean.ml
@@ -19,7 +19,7 @@ let command =
        https://github.com/ocaml/dune/issues/2964). *)
     let builder = Common.Builder.disable_log_file builder in
     let common, _config = Common.init builder in
-    Global_lock.lock_exn ~timeout:None;
+    Global_lock.lock_exn ();
     match paths with
     | [] ->
       Dune_engine.Target_promotion.files_in_source_tree_to_delete ()

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1173,16 +1173,7 @@ let build (root : Workspace_root.t) (builder : Builder.t) =
              | Yes _ -> `Add
              | No -> `Skip
            in
-           let lock_timeout =
-             match builder.watch with
-             | Yes Passive -> Some (Time.Span.of_secs 1.0)
-             | _ -> None
-           in
-           Dune_rpc_impl.Server.create
-             ~lock_timeout
-             ~registry
-             ~root:root.dir
-             builder.watch))
+           Dune_rpc_impl.Server.create ~registry ~root:root.dir builder.watch))
     else `Forbid_builds
   in
   { builder; root; rpc }
@@ -1220,7 +1211,7 @@ let init_with_root ~(root : Workspace_root.t) (builder : Builder.t) =
            an existing trace from another dune process *)
          match trace_config with
          | `Default ->
-           (match Global_lock.lock ~timeout:None with
+           (match Global_lock.lock () with
             | Ok () -> `Create
             | Error _ -> `Skip)
          | `User_specified _ -> `Create

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -346,7 +346,7 @@ let term : unit Term.t =
      For watch mode, we should finalize the backend and then restart it in between
      runs. *)
   let common, config = Common.init builder in
-  match Global_lock.lock ~timeout:None with
+  match Global_lock.lock () with
   | Error lock_held_by ->
     (match Common.watch common with
      | Yes _ ->

--- a/bin/fmt.ml
+++ b/bin/fmt.ml
@@ -40,7 +40,7 @@ let run_fmt_command ~common ~config ~preview builder =
     | Ok () -> ()
     | Error `Already_reported -> raise Dune_util.Report_error.Already_reported
   in
-  match Global_lock.lock ~timeout:None with
+  match Global_lock.lock () with
   | Ok () -> Scheduler_setup.go_with_rpc_server ~common ~config once
   | Error lock_held_by ->
     (* The --preview flag is being ignored by the RPC server, warn the user. *)

--- a/bin/promotion.ml
+++ b/bin/promotion.ml
@@ -51,7 +51,7 @@ module Apply = struct
     let matching : Dune_rpc.Promote_targets.Matching.t =
       if exact then Exact else Prefix
     in
-    match Global_lock.lock ~timeout:None with
+    match Global_lock.lock () with
     | Ok () ->
       Diff_promotion.promote_files_registered_in_last_run ~matching files_to_promote
       |> on_missing

--- a/bin/runtest.ml
+++ b/bin/runtest.ml
@@ -39,7 +39,7 @@ let runtest_term =
   let+ builder = Common.Builder.term
   and+ test_paths = Arg.(value & pos_all string [ "." ] name) in
   let common, config = Common.init builder in
-  match Global_lock.lock ~timeout:None with
+  match Global_lock.lock () with
   | Ok () ->
     Build.run_build_command ~common ~config ~request:(fun setup ->
       Runtest_common.make_request

--- a/bin/tools/tools_common.ml
+++ b/bin/tools/tools_common.ml
@@ -49,7 +49,7 @@ let try_build_dev_tool_via_rpc builder lock_held_by dev_tool =
 
 let lock_and_build_dev_tool ~common ~config builder dev_tool =
   let open Fiber.O in
-  match Global_lock.lock ~timeout:None with
+  match Global_lock.lock () with
   | Error lock_held_by ->
     Scheduler_setup.no_build_no_rpc ~config (fun () ->
       let* () = Lock_dev_tool.lock_dev_tool dev_tool |> Memo.run in

--- a/otherlibs/stdune/src/global_lock.ml
+++ b/otherlibs/stdune/src/global_lock.ml
@@ -1,20 +1,6 @@
 let sprintf = Printf.sprintf
 let lock_file = Path.Build.(relative root ".lock")
 
-let with_timeout ~timeout f =
-  let now () = Time.now () in
-  let deadline = Time.add (now ()) timeout in
-  let rec loop () =
-    if Time.(now () >= deadline)
-    then `Timed_out
-    else (
-      match f () with
-      | `Continue -> loop ()
-      | `Stop -> `Success)
-  in
-  loop ()
-;;
-
 let write_pid fd =
   let pid = Int.to_string (Unix.getpid ()) in
   let len = String.length pid in
@@ -89,7 +75,7 @@ module Lock_held_by = struct
   ;;
 end
 
-let lock ~timeout =
+let lock () =
   match
     (* If Config hasn't been initialized yet, default to `Enabled behavior.
        This allows the lock to be acquired early (e.g., before creating trace
@@ -101,30 +87,15 @@ let lock ~timeout =
     if !locked
     then Ok ()
     else (
-      let res =
-        match timeout with
-        | None -> Lock.lock ()
-        | Some timeout ->
-          (match
-             with_timeout ~timeout (fun () ->
-               match Lock.lock () with
-               | `Success -> `Stop
-               | `Failure -> `Continue)
-           with
-           | `Timed_out -> `Failure
-           | `Success -> `Success)
-      in
-      match res with
+      match Lock.lock () with
       | `Success ->
         locked := true;
         Ok ()
-      | `Failure ->
-        let lock_held_by = Lock_held_by.read_lock_file () in
-        Error lock_held_by)
+      | `Failure -> Error (Lock_held_by.read_lock_file ()))
 ;;
 
-let lock_exn ~timeout =
-  match lock ~timeout with
+let lock_exn () =
+  match lock () with
   | Ok () -> ()
   | Error lock_held_by ->
     User_error.raise

--- a/otherlibs/stdune/src/global_lock.mli
+++ b/otherlibs/stdune/src/global_lock.mli
@@ -8,12 +8,12 @@ module Lock_held_by : sig
     | Unknown
 end
 
-(** Attempt to acquire a lock. once a lock is locked, subsequent locks always
-    succeed. Returns [Ok ()] if the lock is acquired within [timeout] seconds,
-    and [Error ()] otherwise. *)
-val lock : timeout:Time.Span.t option -> (unit, Lock_held_by.t) result
+(** Attempt to acquire a lock. Once a lock is locked, subsequent locks always
+    succeed. Returns [Ok ()] if the lock is acquired and [Error] when another
+    dune process has acquired the lock. *)
+val lock : unit -> (unit, Lock_held_by.t) result
 
-val lock_exn : timeout:Time.Span.t option -> unit
+val lock_exn : unit -> unit
 
 (** release a lock and allow it be re-acquired *)
 val unlock : unit -> unit

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -437,9 +437,9 @@ let handler (t : _ t Fdecl.t) : 'build_arg Handler.t =
   rpc
 ;;
 
-let create ~lock_timeout ~registry ~root watch_mode =
+let create ~registry ~root watch_mode =
   let where = Where.default () in
-  Global_lock.lock_exn ~timeout:lock_timeout;
+  Global_lock.lock_exn ();
   let t = Fdecl.create Dyn.opaque in
   let config =
     let server =

--- a/src/dune_rpc_impl/server.mli
+++ b/src/dune_rpc_impl/server.mli
@@ -6,8 +6,7 @@ open Import
 type 'build_arg t
 
 val create
-  :  lock_timeout:Time.Span.t option
-  -> registry:[ `Add | `Skip ]
+  :  registry:[ `Add | `Skip ]
   -> root:string
   -> Watch_mode_config.t
   -> Dune_lang.Dep_conf.t t


### PR DESCRIPTION
The only consumer left of the timeout was passive watch mode which is for testing, and it did not require this.

All the other user facing consumers of this timeout have been removed since their semantics were dubious in various cases, such as expecting an RPC server to be running the lock is acquired.