### PR TITLE
test(melange): share module systems emit stanzas

### DIFF
--- a/test/blackbox-tests/test-cases/melange/multiple-module-systems-node-modules.t
+++ b/test/blackbox-tests/test-cases/melange/multiple-module-systems-node-modules.t
@@ -8,7 +8,9 @@ directories, so there's no overlap
   > (using melange 0.1)
   > EOF
 
-  $ cat > dune <<EOF
+  $ write_module_systems_dune() {
+  > local promote_commonjs="$1"
+  > cat > dune <<'EOF'
   > (melange.emit
   >  (target target_esm)
   >  (emit_stdlib false)
@@ -22,9 +24,18 @@ directories, so there's no overlap
   >  (emit_stdlib false)
   >  (module_systems (commonjs js))
   >  (compile_flags :standard --mel-no-version-header)
+  > EOF
+  > if [ "$promote_commonjs" = "yes" ]; then
+  > cat >> dune <<'EOF'
   >  (promote (until-clean))
+  > EOF
+  > fi
+  > cat >> dune <<'EOF'
   >  (libraries melange.js))
   > EOF
+  > }
+
+  $ write_module_systems_dune yes
 
   $ dune build
 
@@ -58,22 +69,7 @@ write wins
 
 Only one can be promoted:
 
-  $ cat > dune <<EOF
-  > (melange.emit
-  >  (target target_esm)
-  >  (emit_stdlib false)
-  >  (module_systems (esm js))
-  >  (compile_flags :standard --mel-no-version-header)
-  >  (promote (until-clean))
-  >  (libraries melange.js))
-  > 
-  > (melange.emit
-  >  (target target_commonjs)
-  >  (emit_stdlib false)
-  >  (module_systems (commonjs js))
-  >  (compile_flags :standard --mel-no-version-header)
-  >  (libraries melange.js))
-  > EOF
+  $ write_module_systems_dune no
 
   $ dune build
   $ cat node_modules/melange.js/caml_string.js | head -n3


### PR DESCRIPTION
Extract the repeated pair of Melange emit stanzas in the multiple module systems test into a local helper parameterized by the commonjs promotion setting.