### PR TITLE
test(per-module): share sibling library stanza

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/add-unreferenced-sibling-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/add-unreferenced-sibling-lib.t
@@ -18,7 +18,9 @@ can flip them to 0.
 
   $ make_dune_project 3.23
 
-  $ cat > dune <<EOF
+  $ write_consumer_lib_dune() {
+  >   local libraries="$*"
+  >   cat > dune <<EOF
   > (library
   >  (name existing_dep)
   >  (wrapped false)
@@ -28,8 +30,11 @@ can flip them to 0.
   >  (name consumer_lib)
   >  (wrapped false)
   >  (modules consumes_dep unrelated_module)
-  >  (libraries existing_dep))
+  >  (libraries ${libraries}))
   > EOF
+  > }
+
+  $ write_consumer_lib_dune existing_dep
 
   $ cat > existing_dep_module.ml <<EOF
   > let x = 42
@@ -55,18 +60,7 @@ can flip them to 0.
 Add [added_lib] to [consumer_lib]'s [(libraries ...)]. Neither
 [consumes_dep] nor [unrelated_module] references [added_lib]:
 
-  $ cat > dune <<EOF
-  > (library
-  >  (name existing_dep)
-  >  (wrapped false)
-  >  (modules existing_dep_module))
-  > (library (name added_lib) (wrapped false) (modules added_lib_module))
-  > (library
-  >  (name consumer_lib)
-  >  (wrapped false)
-  >  (modules consumes_dep unrelated_module)
-  >  (libraries existing_dep added_lib))
-  > EOF
+  $ write_consumer_lib_dune existing_dep added_lib
 
   $ dune build @check
   $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("consumes_dep"))]'


### PR DESCRIPTION
Use a local writer for the repeated consumer-lib dune stanza in the unreferenced sibling library recompilation test.