### PR TITLE
test(promote): share directory diff rules

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -416,6 +416,18 @@ make_directory_targets_project() {
 	EOF
 }
 
+write_directory_diff_keep_rule() {
+  cat > dune <<-'EOF'
+	(rule
+	 (targets (dir actual))
+	 (action (system "mkdir -p actual && printf 'keep\n' > actual/keep")))
+	
+	(rule
+	 (alias runtest)
+	 (action (diff expected actual)))
+	EOF
+}
+
 make_two_context_workspace() {
   cat > dune-workspace <<- EOF
 	(lang dune 3.13)

--- a/test/blackbox-tests/test-cases/promote/directory-diff/cli-commands.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/cli-commands.t
@@ -7,15 +7,7 @@ Deletion promotions are visible to `dune promotion list` and `diff`.
   $ mkdir expected
   $ printf 'keep\n' > expected/keep
   $ printf 'delete me\n' > expected/delete
-  $ cat > dune <<'EOF'
-  > (rule
-  >  (targets (dir actual))
-  >  (action (system "mkdir -p actual && printf 'keep\n' > actual/keep")))
-  > 
-  > (rule
-  >  (alias runtest)
-  >  (action (diff expected actual)))
-  > EOF
+  $ write_directory_diff_keep_rule
 
   $ dune runtest
   File "dune", lines 5-7, characters 0-56:

--- a/test/blackbox-tests/test-cases/promote/directory-diff/delete-directory.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/delete-directory.t
@@ -6,15 +6,7 @@ Directory diff records directory deletions.
   $ printf 'keep\n' > expected/keep
   $ printf 'stale\n' > expected/stale/file
 
-  $ cat > dune <<'EOF'
-  > (rule
-  >  (targets (dir actual))
-  >  (action (system "mkdir -p actual && printf 'keep\n' > actual/keep")))
-  > 
-  > (rule
-  >  (alias runtest)
-  >  (action (diff expected actual)))
-  > EOF
+  $ write_directory_diff_keep_rule
 
   $ dune runtest
   File "dune", lines 5-7, characters 0-56:

--- a/test/blackbox-tests/test-cases/promote/directory-diff/delete-file.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/delete-file.t
@@ -6,15 +6,7 @@ Directory diff records file deletions.
   $ printf 'keep\n' > expected/keep
   $ printf 'delete me\n' > expected/delete
 
-  $ cat > dune <<'EOF'
-  > (rule
-  >  (targets (dir actual))
-  >  (action (system "mkdir -p actual && printf 'keep\n' > actual/keep")))
-  > 
-  > (rule
-  >  (alias runtest)
-  >  (action (diff expected actual)))
-  > EOF
+  $ write_directory_diff_keep_rule
 
   $ dune runtest
   File "dune", lines 5-7, characters 0-56:

--- a/test/blackbox-tests/test-cases/promote/directory-diff/targeted-promotion.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/targeted-promotion.t
@@ -43,15 +43,7 @@ Prefix promotion can also delete just the requested stale subtree.
   $ mkdir -p expected/stale
   $ printf 'keep\n' > expected/keep
   $ printf 'stale\n' > expected/stale/file
-  $ cat > dune <<'EOF'
-  > (rule
-  >  (targets (dir actual))
-  >  (action (system "mkdir -p actual && printf 'keep\n' > actual/keep")))
-  > 
-  > (rule
-  >  (alias runtest)
-  >  (action (diff expected actual)))
-  > EOF
+  $ write_directory_diff_keep_rule
 
   $ dune runtest > /dev/null 2>&1 || echo failed
   failed


### PR DESCRIPTION
Extract the repeated directory-diff keep/delete rule fixture into a shared blackbox-test helper.

The helper preserves the generated dune file layout used by diagnostics.