### PR TITLE
test(pkg): share pinned foo project fixture

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -102,6 +102,18 @@ make_foo_tarball() {
   rm -rf foo
 }
 
+make_project_pinned_to_foo() {
+  cat >dune-project <<- EOF
+	(lang dune 3.13)
+	(pin
+	 (url "file://$PWD/_foo")
+	 (package (name foo)))
+	(package
+	 (name main)
+	 (depends foo))
+	EOF
+}
+
 mk_ocaml() {
   local version="$1"
   local major

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/ignored-dirs.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/ignored-dirs.t
@@ -4,15 +4,7 @@ Pulling projects should respect ignored directories.
   $ add_mock_repo_if_needed
 
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.13)
-  > (pin
-  >  (url "file://$PWD/_foo")
-  >  (package (name foo)))
-  > (package
-  >  (name main)
-  >  (depends foo))
-  > EOF
+  $ make_project_pinned_to_foo
 
   $ mkdir -p _foo/subproject
   $ cat >_foo/dune-project <<EOF

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/opam-only.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/opam-only.t
@@ -3,15 +3,7 @@ We try to pull an opam package that isn't a dune project
   $ mkrepo
   $ add_mock_repo_if_needed
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.13)
-  > (pin
-  >  (url "file://$PWD/_foo")
-  >  (package (name foo)))
-  > (package
-  >  (name main)
-  >  (depends foo))
-  > EOF
+  $ make_project_pinned_to_foo
 
   $ mkdir _foo
   $ cat >_foo/foo.opam <<EOF

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-depends.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-depends.t
@@ -4,15 +4,7 @@ respect the pin-depends
   $ mkrepo
   $ add_mock_repo_if_needed
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.13)
-  > (pin
-  >  (url "file://$PWD/_foo")
-  >  (package (name foo)))
-  > (package
-  >  (name main)
-  >  (depends foo))
-  > EOF
+  $ make_project_pinned_to_foo
 
   $ mkdir _foo
   $ cat >_foo/foo.opam <<EOF

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/recursive.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/recursive.t
@@ -20,15 +20,7 @@ Sources are traversed recursively (unlike pins)
   > (package (name bar))
   > EOF
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.13)
-  > (pin
-  >  (url "file://$PWD/_foo")
-  >  (package (name foo)))
-  > (package
-  >  (name main)
-  >  (depends foo))
-  > EOF
+  $ make_project_pinned_to_foo
 
   $ dune_pkg_lock_normalized
   Solution for dune.lock:


### PR DESCRIPTION
Extract the repeated dune-project that pins package `foo` from `_foo` into a shared package-test helper.

The pin-stanza tests keep their differing source package layouts while sharing the main project boilerplate.