### PR TITLE
test(actions): share cat result rule fixture

### DIFF
--- a/test/blackbox-tests/test-cases/actions/cat-multiple.t
+++ b/test/blackbox-tests/test-cases/actions/cat-multiple.t
@@ -1,8 +1,8 @@
   $ make_dune_project 3.4
 
-It is an error to pass an empty list:
-
-  $ cat > dune << EOF
+  $ write_cat_result_rule() {
+  > local args="$1"
+  > cat > dune << EOF
   > (rule
   >  (alias runtest)
   >  (action
@@ -10,8 +10,13 @@ It is an error to pass an empty list:
   > 
   > (rule
   >  (with-stdout-to result
-  >   (cat)))
+  >   (cat${args})))
   > EOF
+  > }
+
+It is an error to pass an empty list:
+
+  $ write_cat_result_rule ""
 
   $ dune runtest
   File "dune", line 8, characters 2-7:
@@ -26,16 +31,7 @@ The cat action supports several files.
   $ echo "file b" > b
   $ echo "file c" > c
 
-  $ cat > dune << EOF
-  > (rule
-  >  (alias runtest)
-  >  (action
-  >   (cat result)))
-  > 
-  > (rule
-  >  (with-stdout-to result
-  >   (cat a b c)))
-  > EOF
+  $ write_cat_result_rule " a b c"
 
   $ dune runtest
   file a


### PR DESCRIPTION
Extract the repeated cat-result rule setup in cat-multiple.t into a local helper parameterized by the cat action arguments.