### PR TITLE
test(alias): share child alias rules fixture

### DIFF
--- a/test/blackbox-tests/test-cases/missing-action-alias-hint-gh10685.t
+++ b/test/blackbox-tests/test-cases/missing-action-alias-hint-gh10685.t
@@ -2,7 +2,8 @@ Suggests the `(alias ...)` stanza when a dependency-only rule is missing an acti
 
   $ make_dune_project 3.0
 
-  $ cat > dune << EOF
+  $ write_child_alias_rules() {
+  > cat > dune <<'EOF'
   > (rule
   >  (alias child_one)
   >  (action (echo "Child one")))
@@ -11,6 +12,11 @@ Suggests the `(alias ...)` stanza when a dependency-only rule is missing an acti
   >  (alias child_two)
   >  (action (echo "Child two")))
   > 
+  > EOF
+  > }
+
+  $ write_child_alias_rules
+  $ cat >> dune << EOF
   > (rule
   >  (alias parent)
   >  (deps
@@ -29,15 +35,8 @@ Suggests the `(alias ...)` stanza when a dependency-only rule is missing an acti
   Hint: You can use the (alias) stanza to add dependencies to an alias.
   [1]
 
-  $ cat > dune << EOF
-  > (rule
-  >  (alias child_one)
-  >  (action (echo "Child one")))
-  > 
-  > (rule
-  >  (alias child_two)
-  >  (action (echo "Child two")))
-  > 
+  $ write_child_alias_rules
+  $ cat >> dune << EOF
   > (rule
   >  (deps
   >   (alias child_one)


### PR DESCRIPTION
Extract the repeated child alias rules in the missing-action hint test into a local helper while preserving the generated dune file line numbers.