### PR TITLE
test(mdx): share needs-fixes mld fixture

### DIFF
--- a/test/blackbox-tests/test-cases/stanzas/mdx-stanza/mld-files.t
+++ b/test/blackbox-tests/test-cases/stanzas/mdx-stanza/mld-files.t
@@ -18,7 +18,8 @@ that that file is not being picked up:
   > 
   > A run of MDX should output a fixed version.
   > EOF
-  $ cat > needs-fixes.mld <<EOF
+  $ write_needs_fixes_mld() {
+  > cat > needs-fixes.mld <<'EOF'
   > This is a sample mld file. It has some code that is invalid.
   >  
   > {[
@@ -28,6 +29,8 @@ that that file is not being picked up:
   > 
   > A run of MDX should output a fixed version.
   > EOF
+  > }
+  $ write_needs_fixes_mld
   $ dune runtest
   File "needs-fixes.md", line 1, characters 0-0:
   --- needs-fixes.md
@@ -91,16 +94,7 @@ the stanza version.
   $ cat > dune <<EOF
   > (mdx)
   > EOF
-  $ cat > needs-fixes.mld <<EOF
-  > This is a sample mld file. It has some code that is invalid.
-  >  
-  > {[
-  >   # List.map (fun x -> x * x) [(1 + 9); 2; 3; 4];;
-  >   - : int list = [1; 2; 3; 8]
-  > ]}
-  > 
-  > A run of MDX should output a fixed version.
-  > EOF
+  $ write_needs_fixes_mld
 
 0.4 is only supported since dune-lang 3.8, so attempting to use it should fail:
 
@@ -144,16 +138,7 @@ We also make sure that `:standard` resolves properly:
   > (mdx
   >   (files :standard))
   > EOF
-  $ cat > needs-fixes.mld <<EOF
-  > This is a sample mld file. It has some code that is invalid.
-  >  
-  > {[
-  >   # List.map (fun x -> x * x) [(1 + 9); 2; 3; 4];;
-  >   - : int list = [1; 2; 3; 8]
-  > ]}
-  > 
-  > A run of MDX should output a fixed version.
-  > EOF
+  $ write_needs_fixes_mld
   $ dune runtest
   File "needs-fixes.mld", line 1, characters 0-0:
   --- needs-fixes.mld


### PR DESCRIPTION
Extract the repeated needs-fixes.mld contents in the mdx stanza test into a local helper.