### PR TITLE
test(pkg): share external mypkg source fixture

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -114,6 +114,22 @@ make_project_pinned_to_foo() {
 	EOF
 }
 
+make_external_mypkg_lib_source() {
+  local implementation="$1"
+
+  mkdir external_sources
+  cat >external_sources/dune-project <<-'EOF'
+	(lang dune 3.11)
+	(package (name mypkg))
+	EOF
+  cat >external_sources/dune <<-'EOF'
+	(library
+	 (public_name mypkg.lib)
+	 (name test_lib))
+	EOF
+  printf '%s\n' "$implementation" > external_sources/test_lib.ml
+}
+
 mk_ocaml() {
   local version="$1"
   local major

--- a/test/blackbox-tests/test-cases/pkg/libraries.t
+++ b/test/blackbox-tests/test-cases/pkg/libraries.t
@@ -3,19 +3,7 @@ use it inside dune.
 
 We set up a library that will be installed as part of the package:
 
-  $ mkdir external_sources
-  $ cat >external_sources/dune-project <<EOF
-  > (lang dune 3.11)
-  > (package (name mypkg))
-  > EOF
-  $ cat >external_sources/dune <<EOF
-  > (library
-  >  (public_name mypkg.lib)
-  >  (name test_lib))
-  > EOF
-  $ cat >external_sources/test_lib.ml <<EOF
-  > let x = ()
-  > EOF
+  $ make_external_mypkg_lib_source 'let x = ()'
 
 Now we set up a lock file with this package and then attempt to use it:
 

--- a/test/blackbox-tests/test-cases/pkg/ocaml-index-private-lib-gh10985.t
+++ b/test/blackbox-tests/test-cases/pkg/ocaml-index-private-lib-gh10985.t
@@ -3,19 +3,7 @@ installed through a lock file.
 
 We set up a library that will be installed as part of the package:
 
-  $ mkdir external_sources
-  $ cat >external_sources/dune-project <<EOF
-  > (lang dune 3.11)
-  > (package (name mypkg))
-  > EOF
-  $ cat >external_sources/dune <<EOF
-  > (library
-  >  (public_name mypkg.lib)
-  >  (name test_lib))
-  > EOF
-  $ cat >external_sources/test_lib.ml <<EOF
-  > let x = ()
-  > EOF
+  $ make_external_mypkg_lib_source 'let x = ()'
 
 We put the actual build in a separate directory, so we don't have to ignore
 the package directory in the dune file:

--- a/test/blackbox-tests/test-cases/pkg/watch-exec-crash-gh10959.t
+++ b/test/blackbox-tests/test-cases/pkg/watch-exec-crash-gh10959.t
@@ -1,18 +1,6 @@
 Repro `dune exec --watch` crash with pkg management
 
-  $ mkdir external_sources
-  $ cat >external_sources/dune-project <<EOF
-  > (lang dune 3.11)
-  > (package (name mypkg))
-  > EOF
-  $ cat >external_sources/dune <<EOF
-  > (library
-  >  (public_name mypkg.lib)
-  >  (name test_lib))
-  > EOF
-  $ cat >external_sources/test_lib.ml <<EOF
-  > let x = "hello"
-  > EOF
+  $ make_external_mypkg_lib_source 'let x = "hello"'
 
 Now we set up a lock file with this package and then attempt to use it:
 


### PR DESCRIPTION
Extract the repeated external_sources package fixture used by package tests that consume mypkg.lib from a lock file.

The callers still choose the Test_lib implementation used by each scenario.