### PR TITLE
test(install): share install include fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -147,6 +147,24 @@ make_mypkg_stubs_project() {
 	EOF
 }
 
+make_install_include_project() {
+  make_dune_project 3.5
+  cat >> dune-project <<-'EOF'
+	(package (name hello))
+	EOF
+  cat > dune <<-'EOF'
+	(executable
+	 (public_name hello))
+	
+	(install
+	 (files (include foo.sexp))
+	 (section share))
+	EOF
+  cat > hello.ml <<-'EOF'
+	let () = print_endline "Hello, World!"
+	EOF
+}
+
 make_value_library() {
   local dir="$1"
   local name="$2"

--- a/test/blackbox-tests/test-cases/install/install-include/install-include-chain.t
+++ b/test/blackbox-tests/test-cases/install/install-include/install-include-chain.t
@@ -1,22 +1,6 @@
 Including a file in the install stanza which includes another file
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.5)
-  > (package (name hello))
-  > EOF
-
-  $ cat >dune <<EOF
-  > (executable
-  >  (public_name hello))
-  > 
-  > (install
-  >  (files (include foo.sexp))
-  >  (section share))
-  > EOF
-
-  $ cat >hello.ml <<EOF
-  > let () = print_endline "Hello, World!"
-  > EOF
+  $ make_install_include_project
 
   $ cat >foo.sexp <<EOF
   > ((include bar.sexp))

--- a/test/blackbox-tests/test-cases/install/install-include/install-include-foo-as-bar.t
+++ b/test/blackbox-tests/test-cases/install/install-include/install-include-foo-as-bar.t
@@ -1,22 +1,6 @@
 Include a file which contains the (foo as bar) syntax for renaming a file
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.5)
-  > (package (name hello))
-  > EOF
-
-  $ cat >dune <<EOF
-  > (executable
-  >  (public_name hello))
-  > 
-  > (install
-  >  (files (include foo.sexp))
-  >  (section share))
-  > EOF
-
-  $ cat >hello.ml <<EOF
-  > let () = print_endline "Hello, World!"
-  > EOF
+  $ make_install_include_project
 
   $ cat >foo.sexp <<EOF
   > ((a.txt as b/c.txt))

--- a/test/blackbox-tests/test-cases/install/install-include/install-include-invalid-file.t
+++ b/test/blackbox-tests/test-cases/install/install-include/install-include-invalid-file.t
@@ -1,22 +1,6 @@
 Including a file in the install stanza which does not contain a sexp list
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.5)
-  > (package (name hello))
-  > EOF
-
-  $ cat >dune <<EOF
-  > (executable
-  >  (public_name hello))
-  > 
-  > (install
-  >  (files (include foo.sexp))
-  >  (section share))
-  > EOF
-
-  $ cat >hello.ml <<EOF
-  > let () = print_endline "Hello, World!"
-  > EOF
+  $ make_install_include_project
 
   $ cat >foo.sexp <<EOF
   > a.txt

--- a/test/blackbox-tests/test-cases/install/install-include/install-include-loop.t
+++ b/test/blackbox-tests/test-cases/install/install-include/install-include-loop.t
@@ -1,22 +1,6 @@
 Detect include loops in files included in the install stanza
 
-  $ cat >dune-project <<EOF
-  > (lang dune 3.5)
-  > (package (name hello))
-  > EOF
-
-  $ cat >dune <<EOF
-  > (executable
-  >  (public_name hello))
-  > 
-  > (install
-  >  (files (include foo.sexp))
-  >  (section share))
-  > EOF
-
-  $ cat >hello.ml <<EOF
-  > let () = print_endline "Hello, World!"
-  > EOF
+  $ make_install_include_project
 
   $ cat >foo.sexp <<EOF
   > ((include bar.sexp))


### PR DESCRIPTION
Extract the repeated hello executable plus install stanza setup used by the install include tests into a shared blackbox-test helper.

Each test still supplies its own included sexp files and expected behavior.