### PR TITLE
test(actions): share concurrent diff rule writer

### DIFF
--- a/test/blackbox-tests/test-cases/actions/concurrent-multi-diff.t/run.t
+++ b/test/blackbox-tests/test-cases/actions/concurrent-multi-diff.t/run.t
@@ -10,7 +10,9 @@ Say we want to diff 3 files.
 
 We set up a (progn ) rule to diff all of them against their generated versions.
 
-  $ cat > dune << EOF
+  $ write_multi_diff_rule() {
+  >   local mode="$1"
+  >   cat > dune <<EOF
   > (rule
   >  (action
   >   (progn
@@ -20,12 +22,15 @@ We set up a (progn ) rule to diff all of them against their generated versions.
   > 
   > (rule
   >  (action
-  >   (progn
+  >   (${mode}
   >    (with-outputs-to some-target (echo a))
   >    (diff A A.diff)
   >    (diff B B.diff)
   >    (diff C C.diff))))
   > EOF
+  > }
+
+  $ write_multi_diff_rule progn
 
 We can now run the rule and see that we fail before diffing C.
 
@@ -54,22 +59,7 @@ Let's reset B to its original state.
 
 If we implement the rule using (concurrent ) instead.
 
-  $ cat > dune << EOF
-  > (rule
-  >  (action
-  >   (progn
-  >    (with-outputs-to A.diff (echo "I am file A.\n"))
-  >    (with-outputs-to B.diff (echo "I am certainly file B.\n"))
-  >    (with-outputs-to C.diff (echo "I am most certainly file C.\n")))))
-  > 
-  > (rule
-  >  (action
-  >   (concurrent
-  >    (with-outputs-to some-target (echo a))
-  >    (diff A A.diff)
-  >    (diff B B.diff)
-  >    (diff C C.diff))))
-  > EOF
+  $ write_multi_diff_rule concurrent
 
 We see that all the files get diffed.
 


### PR DESCRIPTION
Use a local writer for the repeated multi-file diff rule in the concurrent action test, parameterized by the action combinator.

This keeps the test behavior unchanged while removing duplicated dune rule setup.