### PR TITLE
test(toplevel): share plugin host fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -509,6 +509,50 @@ write_target_promotion_rules() {
 	EOF
 }
 
+make_toplevel_plugin_host() {
+  local loader="${1:-}"
+
+  cat > dune-project <<-'EOF'
+	(lang dune 3.7)
+	(using dune_site 0.1)
+	(name top_with_plugins)
+	(wrapped_executables false)
+	(map_workspace_root false)
+	
+	(package
+	 (name top_with_plugins)
+	 (sites (lib top_plugins)))
+	EOF
+
+  cat > dune <<-'EOF'
+	(executable
+	 (public_name top_with_plugins)
+	 (name top_with_plugins)
+	 (modes byte)
+	 (flags :standard -safe-string)
+	 (modules sites top_with_plugins)
+	 (link_flags (-linkall))
+	 (libraries compiler-libs.toplevel
+	  top_with_plugins.register dune-site dune-site.plugins
+	EOF
+  if [ -n "$loader" ]; then
+    printf '\t  %s\n' "$loader" >> dune
+  fi
+  cat >> dune <<-'EOF'
+	))
+	
+	(library
+	 (public_name top_with_plugins.register)
+	 (modes byte)
+	 (name registration)
+	 (modules registration))
+	
+	(generate_sites_module
+	 (module sites)
+	 (plugins (top_with_plugins top_plugins)))
+	EOF
+}
+
 write_toplevel_plugin_sources() {
   cat > top_with_plugins.ml <<-'EOF'
 	let main () =

--- a/test/blackbox-tests/test-cases/toplevel-plugin/toplevel-plugin-fail.t
+++ b/test/blackbox-tests/test-cases/toplevel-plugin/toplevel-plugin-fail.t
@@ -2,40 +2,7 @@ Testsuite for (toplevel that loads plugins). This version
 uses ``dune-site.dynlink`` which uses ``Dynlink.loadfile``.
 This is not allowed in toplevels, so it fails.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.7)
-  > (using dune_site 0.1)
-  > (name top_with_plugins)
-  > (wrapped_executables false)
-  > (map_workspace_root false)
-  > 
-  > (package
-  >  (name top_with_plugins)
-  >  (sites (lib top_plugins)))
-  > EOF
-
-  $ cat > dune <<EOF
-  > (executable
-  >  (public_name top_with_plugins)
-  >  (name top_with_plugins)
-  >  (modes byte)
-  >  (flags :standard -safe-string)
-  >  (modules sites top_with_plugins)
-  >  (link_flags (-linkall))
-  >  (libraries compiler-libs.toplevel
-  >   top_with_plugins.register dune-site dune-site.plugins 
-  >   dune-site.dynlink))
-  > 
-  > (library
-  >  (public_name top_with_plugins.register)
-  >  (modes byte)
-  >  (name registration)
-  >  (modules registration))
-  > 
-  > (generate_sites_module
-  >  (module sites)
-  >  (plugins (top_with_plugins top_plugins)))
-  > EOF
+  $ make_toplevel_plugin_host dune-site.dynlink
 
   $ write_toplevel_plugin_sources
   $ make_toplevel_plugin 1

--- a/test/blackbox-tests/test-cases/toplevel-plugin/toplevel-plugin-fail2.t
+++ b/test/blackbox-tests/test-cases/toplevel-plugin/toplevel-plugin-fail2.t
@@ -4,39 +4,7 @@ the default implementation of the virtual library.
 It uses ``Dynlink.loadfile``.
 This is not allowed in toplevels, so it fails.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.7)
-  > (using dune_site 0.1)
-  > (name top_with_plugins)
-  > (wrapped_executables false)
-  > (map_workspace_root false)
-  > 
-  > (package
-  >  (name top_with_plugins)
-  >  (sites (lib top_plugins)))
-  > EOF
-
-  $ cat > dune <<EOF
-  > (executable
-  >  (public_name top_with_plugins)
-  >  (name top_with_plugins)
-  >  (modes byte)
-  >  (flags :standard -safe-string)
-  >  (modules sites top_with_plugins)
-  >  (link_flags (-linkall))
-  >  (libraries compiler-libs.toplevel
-  >   top_with_plugins.register dune-site dune-site.plugins))
-  > 
-  > (library
-  >  (public_name top_with_plugins.register)
-  >  (modes byte)
-  >  (name registration)
-  >  (modules registration))
-  > 
-  > (generate_sites_module
-  >  (module sites)
-  >  (plugins (top_with_plugins top_plugins)))
-  > EOF
+  $ make_toplevel_plugin_host
 
   $ write_toplevel_plugin_sources
   $ make_toplevel_plugin 1

--- a/test/blackbox-tests/test-cases/toplevel-plugin/toplevel-plugin.t
+++ b/test/blackbox-tests/test-cases/toplevel-plugin/toplevel-plugin.t
@@ -1,39 +1,6 @@
 Testsuite for (toplevel that loads plugins).
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.7)
-  > (using dune_site 0.1)
-  > (name top_with_plugins)
-  > (wrapped_executables false)
-  > (map_workspace_root false)
-  > 
-  > (package
-  >  (name top_with_plugins)
-  >  (sites (lib top_plugins)))
-  > EOF
-
-  $ cat > dune <<EOF
-  > (executable
-  >  (public_name top_with_plugins)
-  >  (name top_with_plugins)
-  >  (modes byte)
-  >  (flags :standard -safe-string)
-  >  (modules sites top_with_plugins)
-  >  (link_flags (-linkall))
-  >  (libraries compiler-libs.toplevel
-  >   top_with_plugins.register dune-site dune-site.plugins 
-  >   dune-site.toplevel))
-  > 
-  > (library
-  >  (public_name top_with_plugins.register)
-  >  (modes byte)
-  >  (name registration)
-  >  (modules registration))
-  > 
-  > (generate_sites_module
-  >  (module sites)
-  >  (plugins (top_with_plugins top_plugins)))
-  > EOF
+  $ make_toplevel_plugin_host dune-site.toplevel
 
   $ write_toplevel_plugin_sources
   $ make_toplevel_plugin 1


### PR DESCRIPTION
Extract the repeated toplevel plugin host dune-project and dune stanzas into a shared helper parameterized by the loader library.

The tests continue to cover the toplevel, dynlink, and default-loader cases.

Checks:
- shellcheck -s bash test/blackbox-tests/setup-script.sh
