### PR TITLE
test(pkg): share bar depends foo project fixture

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -114,6 +114,18 @@ make_project_pinned_to_foo() {
 	EOF
 }
 
+make_bar_depends_foo_project() {
+  cat > dune-project <<-'EOF'
+	(lang dune 3.10)
+	
+	(package
+	 (name bar)
+	 (depends foo))
+	EOF
+  cat > dune <<-'EOF'
+	EOF
+}
+
 make_external_mypkg_lib_source() {
   local implementation="$1"
 

--- a/test/blackbox-tests/test-cases/pkg/multiple-opam-repos.t
+++ b/test/blackbox-tests/test-cases/pkg/multiple-opam-repos.t
@@ -39,15 +39,7 @@ We have to define both repositories in the workspace, but will only use `new`.
   >  (url "git+file://$(pwd)/old-mock-opam-repository"))
   > EOF
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.10)
-  > 
-  > (package
-  >  (name bar)
-  >  (depends foo))
-  > EOF
-  $ cat > dune <<EOF
-  > EOF
+  $ make_bar_depends_foo_project
 
 Locking should produce the newest package from `new`
 

--- a/test/blackbox-tests/test-cases/pkg/rev-store-lock-linux.t
+++ b/test/blackbox-tests/test-cases/pkg/rev-store-lock-linux.t
@@ -14,15 +14,7 @@ Thus we first create a repo:
 
 We set the project up to depend on `foo`
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.10)
-  > 
-  > (package
-  >  (name bar)
-  >  (depends foo))
-  > EOF
-  $ cat > dune <<EOF
-  > EOF
+  $ make_bar_depends_foo_project
 
 There should be some kind of error message if getting the revision store lock
 fails (simulated here with a failing flock(2) call):

--- a/test/blackbox-tests/test-cases/pkg/rev-store-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/rev-store-lock.t
@@ -17,15 +17,7 @@ We set this repository as sole source for opam repositories.
 
 We set the project up to depend on `foo`
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.10)
-  > 
-  > (package
-  >  (name bar)
-  >  (depends foo))
-  > EOF
-  $ cat > dune <<EOF
-  > EOF
+  $ make_bar_depends_foo_project
 
 Creating a lock should thus work.
 


### PR DESCRIPTION
Extract the repeated package project where bar depends on foo into a shared pkg test helper used by rev-store and multiple-repository tests.

Checks:
- shellcheck -s bash test/blackbox-tests/test-cases/pkg/helpers.sh
