### PR TITLE
ci: remove cache steps in nix jobs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -98,12 +98,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: nixbuild/nix-quick-install-action@v34
-      - uses: nix-community/cache-nix-action@v7
-        with:
-          primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
-          gc-max-store-size-linux: 2G
       - run: nix develop -i .#bootstrap-check_4_14 -c make release
 
   nix-build-ox:
@@ -119,12 +113,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: nixbuild/nix-quick-install-action@v34
-      - uses: nix-community/cache-nix-action@v7
-        with:
-          primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
-          gc-max-store-size-linux: 2G
       - run: nix develop -i .#bootstrap-ox -c make release
 
 #
@@ -308,12 +296,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: nixbuild/nix-quick-install-action@v34
-      - uses: nix-community/cache-nix-action@v7
-        with:
-          primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
-          gc-max-store-size-linux: 5G
       - run: nix develop .#rocq -c make test-rocq
 
   rocq-native:
@@ -323,12 +305,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: nixbuild/nix-quick-install-action@v34
-      - uses: nix-community/cache-nix-action@v7
-        with:
-          primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
-          gc-max-store-size-linux: 5G
       - run: nix develop .#rocq-native -c make test-rocq-native
 
   wasm:

--- a/.github/workflows/workflow.yml.in
+++ b/.github/workflows/workflow.yml.in
@@ -97,12 +97,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: nixbuild/nix-quick-install-action@v34
-      - uses: nix-community/cache-nix-action@v7
-        with:
-          primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
-          gc-max-store-size-linux: 2G
       - run: nix develop -i .#bootstrap-check_4_14 -c make release
 
   nix-build-ox:
@@ -118,12 +112,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: nixbuild/nix-quick-install-action@v34
-      - uses: nix-community/cache-nix-action@v7
-        with:
-          primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
-          gc-max-store-size-linux: 2G
       - run: nix develop -i .#bootstrap-ox -c make release
 
 #
@@ -307,12 +295,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: nixbuild/nix-quick-install-action@v34
-      - uses: nix-community/cache-nix-action@v7
-        with:
-          primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
-          gc-max-store-size-linux: 5G
       - run: nix develop .#rocq -c make test-rocq
 
   rocq-native:
@@ -322,12 +304,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: nixbuild/nix-quick-install-action@v34
-      - uses: nix-community/cache-nix-action@v7
-        with:
-          primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
-          gc-max-store-size-linux: 5G
       - run: nix develop .#rocq-native -c make test-rocq-native
 
   wasm:

--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -256,6 +256,28 @@ We have the following shells for specific tasks:
   + ``make test-rocq``: these work well on a regular Dune opam dev switch
   + ``make test-rocq-native``: these require the Rocq native compiler to run, and thus need OCaml 4.x
 
+Warming the Cachix Cache
+========================
+
+Stable devShell closures are cached at ``https://ocaml-dune.cachix.org`` so
+contributors and CI don't rebuild them from scratch. The contents are
+declared by the ``cache-bundle`` package in ``flake.nix``.
+
+Maintainers with write access can refresh the cache after a ``flake.lock``
+change:
+
+.. code:: console
+
+   $ export CACHIX_AUTH_TOKEN=...
+   $ out=$(nix build --no-link --print-out-paths .#cache-bundle)
+   $ cachix push ocaml-dune "$out"
+
+The bundle excludes the ``ox`` and ``scope`` devShells because they override
+``dune_3`` to the repo-built binary, so their closures change per commit and
+would churn the cache without giving cross-PR hits. When adding a new
+devShell, include it in ``cache-bundle`` only if its closure is stable per
+``flake.lock``.
+
 Testing Reverse Dependencies
 ============================
 

--- a/flake.nix
+++ b/flake.nix
@@ -40,8 +40,14 @@
   };
 
   nixConfig = {
-    extra-substituters = "https://anmonteiro.nix-cache.workers.dev";
-    extra-trusted-public-keys = "ocaml.nix-cache.com-1:/xI2h2+56rwFfKyyFVbkJSeGqSIYMC/Je+7XXqGKDIY=";
+    extra-substituters = [
+      "https://ocaml-dune.cachix.org"
+      "https://anmonteiro.nix-cache.workers.dev"
+    ];
+    extra-trusted-public-keys = [
+      "ocaml-dune.cachix.org-1:kDYe5JY2FtD9pPxkikNA9QgtPrLvl6ryizPxW+0BsqA="
+      "ocaml.nix-cache.com-1:/xI2h2+56rwFfKyyFVbkJSeGqSIYMC/Je+7XXqGKDIY="
+    ];
   };
 
   outputs =
@@ -266,6 +272,33 @@
                 touch $out/success
               '';
             };
+          cache-bundle =
+            let
+              system = pkgs.stdenv.hostPlatform.system;
+              shells = self.devShells.${system};
+              # Skip shells using repo-built dune; closure changes per commit.
+              shellNames =
+                if system == "x86_64-linux" then
+                  [
+                    "default"
+                    "fmt"
+                    "doc"
+                    "microbench"
+                    "bootstrap-check"
+                    "bootstrap-check_4_14"
+                    "bootstrap-ox"
+                    "rocq"
+                    "rocq-native"
+                  ]
+                else
+                  [ ];
+            in
+            pkgs.linkFarm "dune-cache-bundle-${system}" (
+              map (n: {
+                name = "shell-${n}";
+                path = shells.${n}.inputDerivation;
+              }) shellNames
+            );
         }
       );
 


### PR DESCRIPTION
### Change

We remove the cache steps in the nix jobs in the CI. We replace them with a cachix cache hosted at https://ocaml-dune.cachix.org.

The flake is configured so that it consults this cache by default. This should speed up setting up local development too.

I've added instructions on how to warm nix cache which has to happen manually between flake updates.

### Motivation

The main motivation for this change was to give some relief to the GitHub actions cache which was evicting itself often leading to CI times suffering.


### Notes

We are currently caching a subset of all the nix jobs, I haven't for instance added the full oxcaml nix job because we override dune with the current scope which invalidates cache. If we can work out how to do this without, it should be no problem to add.

I have not cached anything for macos, because I don't currently know how to do this.

### p.s.

I can give permissions to push to this cache as needed from other maintainers.

cc @shonfeder @anmonteiro @rgrinberg 


