### PR TITLE
test(glob): share glob rule writer

### DIFF
--- a/test/blackbox-tests/test-cases/glob-deps-change.t/run.t
+++ b/test/blackbox-tests/test-cases/glob-deps-change.t/run.t
@@ -11,10 +11,12 @@ Tests rebuilds when glob dependencies change.
  Create a dune file with a rule that depends on 'some_directory/' directory
  listing but reports that depends only on listing of 'some_directory/*.1'.
 
-  $ cat> dune <<EOF
+  $ write_glob_rule() {
+  >   local glob="$1"
+  >   cat> dune <<EOF
   > (rule
   >  (target some_target)
-  >  (deps (glob_files some_directory/*.1))
+  >  (deps (glob_files ${glob}))
   >  (action
   >   (progn
   >    (bash "ls -1 some_directory > some_target"))))
@@ -24,6 +26,9 @@ Tests rebuilds when glob dependencies change.
   >  (deps (universe))
   >  (action (cat some_target)))
   > EOF
+  > }
+
+  $ write_glob_rule 'some_directory/*.1'
 
  Force foo.{1,2} to be copied to _build directory. That can
  happen in "real world" as a part of building other rules.
@@ -40,19 +45,7 @@ Tests rebuilds when glob dependencies change.
  so that list of files "seen" by glob does not change, but the content
  of some_target should change.
 
-  $ cat> dune <<EOF
-  > (rule
-  >  (target some_target)
-  >  (deps (glob_files some_directory/*))
-  >  (action
-  >   (progn
-  >    (bash "ls -1 some_directory > some_target"))))
-  > \
-  > (rule
-  >  (alias some_alias)
-  >  (deps (universe))
-  >  (action (cat some_target)))
-  > EOF
+  $ write_glob_rule 'some_directory/*'
 
   $ rm some_directory/foo.2
 


### PR DESCRIPTION
Use a local helper for the repeated dune rule in the glob dependency change test, parameterized by the glob pattern.
