### PR TITLE
test(pkg): share executable script package helper

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/build-with-executable-script-on-windows.t
+++ b/test/blackbox-tests/test-cases/pkg/build-with-executable-script-on-windows.t
@@ -15,16 +15,7 @@ Setup dune-project, dune-workspace, etc.
   $ make_dune_project 3.22
 
   $ pkg() {
-  > make_lockpkg $1 <<EOF
-  > (build (run $2))
-  > (version dev)
-  > EOF
-  > local files="${source_lock_dir}/$1.files"
-  > local exec_path="${source_lock_dir}/$1.files/$2"
-  > mkdir -p "${files}"
-  > touch "${exec_path}"
-  > chmod a+x "${exec_path}"
-  > cat > "${exec_path}"
+  > make_executable_script_pkg "$@"
   > }
 
 Running script with CRLF characters

--- a/test/blackbox-tests/test-cases/pkg/build-with-executable-script.t
+++ b/test/blackbox-tests/test-cases/pkg/build-with-executable-script.t
@@ -10,16 +10,7 @@ Setup dune-project, dune-workspace, etc.
   $ make_dune_project 3.22
 
   $ pkg() {
-  > make_lockpkg $1 <<EOF
-  > (build (run $2))
-  > (version dev)
-  > EOF
-  > local files="${source_lock_dir}/$1.files"
-  > local exec_path="${source_lock_dir}/$1.files/$2"
-  > mkdir -p "${files}"
-  > touch "${exec_path}"
-  > chmod a+x "${exec_path}"
-  > cat > "${exec_path}"
+  > make_executable_script_pkg "$@"
   > }
 
 Simple executable

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -142,6 +142,22 @@ make_external_mypkg_lib_source() {
   printf '%s\n' "$implementation" > external_sources/test_lib.ml
 }
 
+make_executable_script_pkg() {
+  local pkg="$1"
+  local script="$2"
+
+  make_lockpkg "$pkg" <<- EOF
+	(build (run ${script}))
+	(version dev)
+	EOF
+  local files="${source_lock_dir}/${pkg}.files"
+  local exec_path="${files}/${script}"
+  mkdir -p "${files}"
+  touch "${exec_path}"
+  chmod a+x "${exec_path}"
+  cat > "${exec_path}"
+}
+
 mk_ocaml() {
   local version="$1"
   local major


### PR DESCRIPTION
Extract the repeated lock-package setup for executable-script package tests into a shared pkg helper.

The cram tests keep the short local `pkg` wrapper for readability.
