### PR TITLE
test(melange): share sandbox project fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -232,6 +232,39 @@ make_melange_runtime_deps_lib() {
 	EOF
 }
 
+make_melange_sandbox_project() {
+  local runtime_deps="${1:-}"
+
+  cat > dune-project <<-'EOF'
+	(lang dune 3.22)
+	(using melange 1.0)
+	EOF
+  {
+    cat <<-'EOF'
+	(library
+	 (name lib)
+	 (modes melange)
+	 (modules lib))
+	(melange.emit
+	 (target output)
+	 (alias mel)
+	 (modules main)
+	 (libraries lib)
+	 (emit_stdlib false)
+	EOF
+    if [ -n "$runtime_deps" ]; then
+      echo " (runtime_deps ${runtime_deps})"
+    fi
+    echo ")"
+  } > dune
+  cat > lib.ml <<-'EOF'
+	let message = "hello from lib"
+	EOF
+  cat > main.ml <<-'EOF'
+	let () = Js.log Lib.message
+	EOF
+}
+
 make_melange_virtual_time_project() {
   local vlib_public_name="$1"
   local impl_public_name="$2"

--- a/test/blackbox-tests/test-cases/melange/sandbox-copy.t
+++ b/test/blackbox-tests/test-cases/melange/sandbox-copy.t
@@ -1,31 +1,6 @@
 Melange rules should work with the copying sandbox
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > (using melange 1.0)
-  > EOF
-
-  $ cat > dune <<EOF
-  > (library
-  >  (name lib)
-  >  (modes melange)
-  >  (modules lib))
-  > (melange.emit
-  >  (target output)
-  >  (alias mel)
-  >  (modules main)
-  >  (libraries lib)
-  >  (emit_stdlib false)
-  >  (runtime_deps assets/data.txt))
-  > EOF
-
-  $ cat > lib.ml <<EOF
-  > let message = "hello from lib"
-  > EOF
-
-  $ cat > main.ml <<EOF
-  > let () = Js.log Lib.message
-  > EOF
+  $ make_melange_sandbox_project assets/data.txt
 
   $ mkdir -p assets
   $ echo "asset ok" > assets/data.txt

--- a/test/blackbox-tests/test-cases/melange/sandbox-default.t
+++ b/test/blackbox-tests/test-cases/melange/sandbox-default.t
@@ -1,30 +1,6 @@
 Melange rules should be sandboxed by default
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.22)
-  > (using melange 1.0)
-  > EOF
-
-  $ cat > dune <<EOF
-  > (library
-  >  (name lib)
-  >  (modes melange)
-  >  (modules lib))
-  > (melange.emit
-  >  (target output)
-  >  (alias mel)
-  >  (emit_stdlib false)
-  >  (modules main)
-  >  (libraries lib))
-  > EOF
-
-  $ cat > lib.ml <<EOF
-  > let message = "hello from lib"
-  > EOF
-
-  $ cat > main.ml <<EOF
-  > let () = Js.log Lib.message
-  > EOF
+  $ make_melange_sandbox_project
 
 Use default sandbox preference. The test suite sets `DUNE_SANDBOX`, so clear it.
 


### PR DESCRIPTION
Extract the common Melange sandbox project setup, with optional runtime dependencies for the copy-sandbox case.
