### PR TITLE
test(dune-cache): share empty directory target fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -434,6 +434,19 @@ make_directory_targets_project() {
 	EOF
 }
 
+make_empty_child_directory_target_project() {
+  make_directory_targets_project 3.10
+  cat > dune <<-'EOF'
+	(rule
+	 (target (dir output))
+	 (action
+	  (progn
+	   (run mkdir output)
+	   (run mkdir output/child)
+	   (run touch output/file))))
+	EOF
+}
+
 write_directory_diff_keep_rule() {
   cat > dune <<-'EOF'
 	(rule

--- a/test/blackbox-tests/test-cases/dune-cache/empty-dir.t
+++ b/test/blackbox-tests/test-cases/dune-cache/empty-dir.t
@@ -2,20 +2,7 @@ Check the cache restores empty directories
 
   $ export DUNE_CACHE=enabled
   $ export DUNE_CACHE_ROOT=$PWD/dune-cache
-  $ cat >dune-project <<EOF
-  > (lang dune 3.10)
-  > (using directory-targets 0.1)
-  > EOF
-
-  $ cat >dune <<EOF
-  > (rule
-  >  (target (dir output))
-  >  (action
-  >   (progn
-  >    (run mkdir output)
-  >    (run mkdir output/child)
-  >    (run touch output/file))))
-  > EOF
+  $ make_empty_child_directory_target_project
 
 Build an empty directory.
 

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -248,19 +248,7 @@ Test metadata for multiple file targets produced by the same rule.
 Test metadata for directory targets, which are stored with no digest.
 
   $ reset
-  $ cat > dune-project <<EOF
-  > (lang dune 3.10)
-  > (using directory-targets 0.1)
-  > EOF
-  $ cat > dune <<EOF
-  > (rule
-  >  (target (dir output))
-  >  (action
-  >   (progn
-  >    (run mkdir output)
-  >    (run mkdir output/child)
-  >    (run touch output/file))))
-  > EOF
+  $ make_empty_child_directory_target_project
   $ dune build output
   $ metadata_dir="$PWD/.xdg-cache/dune/db/meta/v5"
   $ find "$metadata_dir" -mindepth 2 -maxdepth 2 -type f \


### PR DESCRIPTION
Extract the repeated directory-target project that creates an empty child directory and a file.
