### PR TITLE
test(pkg): share fetch cache project fixture

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/fetch-cache-symlink.t
+++ b/test/blackbox-tests/test-cases/pkg/fetch-cache-symlink.t
@@ -16,21 +16,7 @@ the package being downloaded has a symlink.
   $ echo "Contents" > tar-contents
   $ CONTENT_CHECKSUM=$(md5sum tar-contents | cut -f1 -d' ')
   $ ln -s tar-contents tar-symlink
-  $ tar cf test.tar tar-contents tar-symlink
-  $ echo test.tar > fake-curls
-  $ SRC_PORT=1
-  $ SRC_CHECKSUM=$(md5sum test.tar | cut -f1 -d' ')
-  $ make_lockpkg test <<EOF
-  > (version 0.0.1)
-  > (source
-  >  (fetch
-  >   (url http://localhost:$SRC_PORT)
-  >   (checksum md5=$SRC_CHECKSUM)))
-  > EOF
-  $ cat > dune-project <<EOF
-  > (lang dune 3.17)
-  > (package (name my) (depends test) (allow_empty))
-  > EOF
+  $ make_fetch_cache_project tar-contents tar-symlink
 
 The first build should succeed, fetching the source, populating the cache and
 disabling the download of the source a second time.

--- a/test/blackbox-tests/test-cases/pkg/fetch-cache.t
+++ b/test/blackbox-tests/test-cases/pkg/fetch-cache.t
@@ -12,21 +12,7 @@ Set up a project that depends on a package that is being downloaded
   $ make_lockdir
   $ echo "Contents" > tar-contents
   $ CONTENT_CHECKSUM=$(md5sum tar-contents | cut -f1 -d' ')
-  $ tar cf test.tar tar-contents
-  $ echo test.tar > fake-curls
-  $ SRC_PORT=1
-  $ SRC_CHECKSUM=$(md5sum test.tar | cut -f1 -d' ')
-  $ make_lockpkg test <<EOF
-  > (version 0.0.1)
-  > (source
-  >  (fetch
-  >   (url http://localhost:$SRC_PORT)
-  >   (checksum md5=$SRC_CHECKSUM)))
-  > EOF
-  $ cat > dune-project <<EOF
-  > (lang dune 3.17)
-  > (package (name my) (depends test) (allow_empty))
-  > EOF
+  $ make_fetch_cache_project tar-contents
 
 The first build should succeed, fetching the source, populating the cache and
 disabling the download of the source a second time.

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -158,6 +158,24 @@ make_executable_script_pkg() {
   cat > "${exec_path}"
 }
 
+make_fetch_cache_project() {
+  tar cf test.tar "$@"
+  echo test.tar > fake-curls
+  local src_checksum
+  src_checksum=$(md5sum test.tar | cut -f1 -d' ')
+  make_lockpkg test <<- EOF
+	(version 0.0.1)
+	(source
+	 (fetch
+	  (url http://localhost:1)
+	  (checksum md5=${src_checksum})))
+	EOF
+  cat > dune-project <<-'EOF'
+	(lang dune 3.17)
+	(package (name my) (depends test) (allow_empty))
+	EOF
+}
+
 mk_ocaml() {
   local version="$1"
   local major


### PR DESCRIPTION
Extract the repeated fetched-package lockfile and project setup in fetch-cache tests into a shared helper parameterized by the tar members.
