### PR TITLE
test(melange): share runtime deps asset reader

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -278,6 +278,24 @@ write_melange_promote_app_dune() {
 	EOF
 }
 
+write_melange_asset_reader() {
+  local dir="${1:-.}"
+
+  mkdir -p "$dir/assets"
+  cat > "$dir/assets/file.txt" <<-'EOF'
+	hello from file
+	EOF
+  cat > "$dir/main.ml" <<-'EOF'
+	external readFileSync : string -> encoding:string -> string = "readFileSync"
+	[@@mel.module "fs"]
+	let dirname = [%mel.raw "__dirname"]
+	let file_path = "./assets/file.txt"
+	let file_content = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
+	let () = Js.log file_content
+	let () = Js.log (Foo.read_asset ())
+	EOF
+}
+
 make_melange_virtual_time_project() {
   local vlib_public_name="$1"
   local impl_public_name="$2"

--- a/test/blackbox-tests/test-cases/melange/depend-on-installed-lib-with-dir-target-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/depend-on-installed-lib-with-dir-target-runtime-deps.t
@@ -49,10 +49,7 @@ Test `melange.runtime_deps` in a library that has been installed
 
   $ dune install --root lib --prefix $PWD/prefix
 
-  $ mkdir -p app/assets
-  $ cat > app/assets/file.txt <<EOF
-  > hello from file
-  > EOF
+  $ write_melange_asset_reader app
 
   $ cat > app/dune-project <<EOF
   > (lang dune 3.8)
@@ -68,15 +65,6 @@ Test `melange.runtime_deps` in a library that has been installed
   >  (preprocess (pps melange.ppx)))
   > EOF
 
-  $ cat > app/main.ml <<EOF
-  > external readFileSync : string -> encoding:string -> string = "readFileSync"
-  > [@@mel.module "fs"]
-  > let dirname = [%mel.raw "__dirname"]
-  > let file_path = "./assets/file.txt"
-  > let file_content = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
-  > let () = Js.log file_content
-  > let () = Js.log (Foo.read_asset ())
-  > EOF
 
   $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root app @mel --debug-dependency-path
 

--- a/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps.t
@@ -28,10 +28,7 @@ Test `melange.runtime_deps` in a library that has been installed
 
   $ dune install --root lib --prefix $PWD/prefix
 
-  $ mkdir -p app/assets
-  $ cat > app/assets/file.txt <<EOF
-  > hello from file
-  > EOF
+  $ write_melange_asset_reader app
 
   $ cat > app/dune-project <<EOF
   > (lang dune 3.8)
@@ -47,15 +44,6 @@ Test `melange.runtime_deps` in a library that has been installed
   >  (preprocess (pps melange.ppx)))
   > EOF
 
-  $ cat > app/main.ml <<EOF
-  > external readFileSync : string -> encoding:string -> string = "readFileSync"
-  > [@@mel.module "fs"]
-  > let dirname = [%mel.raw "__dirname"]
-  > let file_path = "./assets/file.txt"
-  > let file_content = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
-  > let () = Js.log file_content
-  > let () = Js.log (Foo.read_asset ())
-  > EOF
 
   $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root app @mel
 

--- a/test/blackbox-tests/test-cases/melange/library-with-dir-target-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/library-with-dir-target-runtime-deps.t
@@ -36,20 +36,7 @@ Test `melange.runtime_deps` in a private library
   > let read_asset () = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
   > EOF
 
-  $ mkdir assets
-  $ cat > assets/file.txt <<EOF
-  > hello from file
-  > EOF
-
-  $ cat > main.ml <<EOF
-  > external readFileSync : string -> encoding:string -> string = "readFileSync"
-  > [@@mel.module "fs"]
-  > let dirname = [%mel.raw "__dirname"]
-  > let file_path = "./assets/file.txt"
-  > let file_content = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
-  > let () = Js.log file_content
-  > let () = Js.log (Foo.read_asset ())
-  > EOF
+  $ write_melange_asset_reader
 
   $ dune build @mel
 

--- a/test/blackbox-tests/test-cases/melange/library-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/library-with-runtime-deps.t
@@ -32,20 +32,7 @@ Test `melange.runtime_deps` in a private library
   > let read_asset () = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
   > EOF
 
-  $ mkdir assets
-  $ cat > assets/file.txt <<EOF
-  > hello from file
-  > EOF
-
-  $ cat > main.ml <<EOF
-  > external readFileSync : string -> encoding:string -> string = "readFileSync"
-  > [@@mel.module "fs"]
-  > let dirname = [%mel.raw "__dirname"]
-  > let file_path = "./assets/file.txt"
-  > let file_content = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
-  > let () = Js.log file_content
-  > let () = Js.log (Foo.read_asset ())
-  > EOF
+  $ write_melange_asset_reader
 
   $ dune build @mel
 

--- a/test/blackbox-tests/test-cases/melange/public-library-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/public-library-with-runtime-deps.t
@@ -23,10 +23,7 @@ Test `melange.runtime_deps` in a public library in the workspace
     "_build/install/default/lib/foo/nested/hello.txt" {"nested/hello.txt"}
   ]
 
-  $ mkdir assets
-  $ cat > assets/file.txt <<EOF
-  > hello from file
-  > EOF
+  $ write_melange_asset_reader
   $ cat > dune <<EOF
   > (melange.emit
   >  (alias mel)
@@ -35,16 +32,6 @@ Test `melange.runtime_deps` in a public library in the workspace
   >  (preprocess (pps melange.ppx))
   >  (emit_stdlib false)
   >  (runtime_deps assets/file.txt))
-  > EOF
-
-  $ cat > main.ml <<EOF
-  > external readFileSync : string -> encoding:string -> string = "readFileSync"
-  > [@@mel.module "fs"]
-  > let dirname = [%mel.raw "__dirname"]
-  > let file_path = "./assets/file.txt"
-  > let file_content = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
-  > let () = Js.log file_content
-  > let () = Js.log (Foo.read_asset ())
   > EOF
 
   $ dune build @mel


### PR DESCRIPTION
Extract the repeated asset file and main.ml reader used by Melange runtime_deps tests into a shared helper parameterized by the project directory.
