### PR TITLE
test(lib-collision): share duplicate foo fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -539,6 +539,25 @@ make_promotion_test_project() {
   fi
 }
 
+make_bar_baz_packages_project() {
+  cat > dune-project <<-'EOF'
+	(lang dune 3.13)
+	(package (name bar) (allow_empty))
+	(package (name baz) (allow_empty))
+	EOF
+}
+
+write_duplicate_foo_public_libraries() {
+  cat > dune <<-'EOF'
+	(library
+	 (name foo)
+	 (public_name bar.foo))
+	(library
+	 (name foo)
+	 (public_name baz.foo))
+	EOF
+}
+
 write_target_promotion_rules() {
   local mode="$1"
 

--- a/test/blackbox-tests/test-cases/lib-collision/lib-collision-public-name.t
+++ b/test/blackbox-tests/test-cases/lib-collision/lib-collision-public-name.t
@@ -1,20 +1,9 @@
 Public libraries using the same library name, in the same context, defined in
 the same folder.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.13)
-  > (package (name bar) (allow_empty))
-  > (package (name baz) (allow_empty))
-  > EOF
+  $ make_bar_baz_packages_project
 
-  $ cat > dune << EOF
-  > (library
-  >  (name foo)
-  >  (public_name bar.foo))
-  > (library
-  >  (name foo)
-  >  (public_name baz.foo))
-  > EOF
+  $ write_duplicate_foo_public_libraries
 
 Without any consumers of the libraries
 

--- a/test/blackbox-tests/test-cases/lib-collision/lib-collision-public-same-folder.t
+++ b/test/blackbox-tests/test-cases/lib-collision/lib-collision-public-same-folder.t
@@ -1,20 +1,9 @@
 Public libraries using the same library name, in the same context, defined in
 the same folder.
 
-  $ cat > dune-project << EOF
-  > (lang dune 3.13)
-  > (package (name bar) (allow_empty))
-  > (package (name baz) (allow_empty))
-  > EOF
+  $ make_bar_baz_packages_project
 
-  $ cat > dune << EOF
-  > (library
-  >  (name foo)
-  >  (public_name bar.foo))
-  > (library
-  >  (name foo)
-  >  (public_name baz.foo))
-  > EOF
+  $ write_duplicate_foo_public_libraries
 
 Without any consumers of the libraries
 


### PR DESCRIPTION
Extract the repeated bar/baz project and duplicate foo public library stanzas used by the public-name collision tests.
