### PR TITLE
test(melange): share promote app stanza

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -265,6 +265,19 @@ make_melange_sandbox_project() {
 	EOF
 }
 
+write_melange_promote_app_dune() {
+  local promote="$1"
+
+  cat > app/dune <<- EOF
+	(include_subdirs unqualified)
+	(melange.emit
+	 (alias dist)
+	 (emit_stdlib false)
+	 (promote ${promote})
+	 (target dist))
+	EOF
+}
+
 make_melange_virtual_time_project() {
   local vlib_public_name="$1"
   local impl_public_name="$2"

--- a/test/blackbox-tests/test-cases/melange/promote-in-source.t
+++ b/test/blackbox-tests/test-cases/melange/promote-in-source.t
@@ -6,14 +6,7 @@ Show target promotion in-source for `melange.emit`
   > EOF
 
   $ mkdir -p app
-  $ cat > app/dune <<EOF
-  > (include_subdirs unqualified)
-  > (melange.emit
-  >  (alias dist)
-  >  (emit_stdlib false)
-  >  (promote (until-clean))
-  >  (target dist))
-  > EOF
+  $ write_melange_promote_app_dune "(until-clean)"
   $ cat > app/x.ml <<EOF
   > let () = print_endline "hello"
   > EOF
@@ -47,14 +40,7 @@ Dune clean gets rid of them
 
 `(into .)` is the same
 
-  $ cat > app/dune <<EOF
-  > (include_subdirs unqualified)
-  > (melange.emit
-  >  (alias dist)
-  >  (emit_stdlib false)
-  >  (promote (into .) (until-clean))
-  >  (target dist))
-  > EOF
+  $ write_melange_promote_app_dune "(into .) (until-clean)"
   $ dune build @dist
 
 Targets get emitted in source
@@ -81,14 +67,7 @@ Dune clean gets rid of them
 
 emit into a different dest dir
 
-  $ cat > app/dune <<EOF
-  > (include_subdirs unqualified)
-  > (melange.emit
-  >  (alias dist)
-  >  (emit_stdlib false)
-  >  (promote (into ../toplevel-dist) (until-clean))
-  >  (target dist))
-  > EOF
+  $ write_melange_promote_app_dune "(into ../toplevel-dist) (until-clean)"
 
   $ dune build @dist
   $ ls toplevel-dist
@@ -106,14 +85,7 @@ Cleaning also works
 
 Promote dir can't be outside the workspace
 
-  $ cat > app/dune <<EOF
-  > (include_subdirs unqualified)
-  > (melange.emit
-  >  (alias dist)
-  >  (emit_stdlib false)
-  >  (promote (into ../../foo))
-  >  (target dist))
-  > EOF
+  $ write_melange_promote_app_dune "(into ../../foo)"
   $ dune build @dist
   File "app/dune", line 5, characters 16-25:
   5 |  (promote (into ../../foo))
@@ -126,14 +98,7 @@ Promote dir can't be outside the workspace
 It's possible to recover the behavior of emitting in the dist folder with
 `(promote (into ..))`
 
-  $ cat > app/dune <<EOF
-  > (include_subdirs unqualified)
-  > (melange.emit
-  >  (alias dist)
-  >  (emit_stdlib false)
-  >  (promote (into ./dist) (until-clean))
-  >  (target dist))
-  > EOF
+  $ write_melange_promote_app_dune "(into ./dist) (until-clean)"
   $ dune build @dist
   $ ls app/dist
   other

--- a/test/blackbox-tests/test-cases/melange/promote-with-into.t
+++ b/test/blackbox-tests/test-cases/melange/promote-with-into.t
@@ -7,14 +7,7 @@ Promotion with targets `(into ..)` a directory
 
   $ mkdir app
   $ mkdir app/foo
-  $ cat > app/dune <<EOF
-  > (include_subdirs unqualified)
-  > (melange.emit
-  >  (alias dist)
-  >  (emit_stdlib false)
-  >  (promote (into ../../foo))
-  >  (target dist))
-  > EOF
+  $ write_melange_promote_app_dune "(into ../../foo)"
   $ cat > app/x.ml <<EOF
   > let () = print_endline "hello"
   > EOF


### PR DESCRIPTION
Use a single writer for the repeated melange promotion app dune stanza, parameterized by the promote field.
