### PR TITLE
test(pkg): share with-doc workspace fixture

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -294,6 +294,20 @@ create_mock_repo() {
 	EOF
 }
 
+create_mock_repo_with_doc_workspace() {
+  cat >dune-workspace <<- EOF
+	(lang dune 3.20)
+	(pkg enabled)
+	(lock_dir
+	 (repositories mock)
+	 (solver_env
+	  (with-doc true)))
+	(repository
+	 (name mock)
+	 (url "$PWD/mock-opam-repository"))
+	EOF
+}
+
 setup_dev_tool_workspace() {
   : "${dev_tool_lock_dir:?}"
   cat > dune-workspace <<- EOF

--- a/test/blackbox-tests/test-cases/pkg/opam-only-metadata.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-only-metadata.t
@@ -49,17 +49,7 @@ Test that we can read package metadata from opam files.
     - b.0.6
     
 
-  $ cat > dune-workspace <<EOF
-  > (lang dune 3.20)
-  > (pkg enabled)
-  > (lock_dir
-  >  (repositories mock)
-  >  (solver_env
-  >   (with-doc true)))
-  > (repository
-  >  (name mock)
-  >  (url "$PWD/mock-opam-repository"))
-  > EOF
+  $ create_mock_repo_with_doc_workspace
 
   $ dune_pkg_lock_normalized
   Solution for dune.lock:

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-with-doc.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-with-doc.t
@@ -4,17 +4,7 @@ dune-workspace.
   $ mkrepo
   $ add_mock_repo_if_needed
 
-  $ cat > dune-workspace <<EOF
-  > (lang dune 3.20)
-  > (pkg enabled)
-  > (lock_dir
-  >  (repositories mock)
-  >  (solver_env
-  >   (with-doc true)))
-  > (repository
-  >  (name mock)
-  >  (url "$PWD/mock-opam-repository"))
-  > EOF
+  $ create_mock_repo_with_doc_workspace
 
   $ cat > dune-project <<EOF
   > (lang dune 3.18)


### PR DESCRIPTION
Extract the repeated mock repository workspace with solver_env (with-doc true) into a package-test helper.
