### PR TITLE
test(melange): share installed foo library fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -354,6 +354,22 @@ write_melange_repro_foo_consumer() {
 	EOF
 }
 
+make_melange_foo_library_project() {
+  local dir="$1"
+  local package="$2"
+
+  mkdir -p "$dir"
+  cat > "$dir/dune-project" <<- EOF
+	(lang dune 3.8)
+	(package (name ${package}))
+	(using melange 0.1)
+	EOF
+  cat > "$dir/dune"
+  cat > "$dir/foo.ml" <<-'EOF'
+	let x = "foo"
+	EOF
+}
+
 make_melange_sandbox_project() {
   local runtime_deps="${1:-}"
 

--- a/test/blackbox-tests/test-cases/melange/depend-on-installed.t
+++ b/test/blackbox-tests/test-cases/melange/depend-on-installed.t
@@ -2,19 +2,10 @@ Test dependency on installed package
 
   $ mkdir a b prefix app
 
-  $ cat > a/dune-project <<EOF
-  > (lang dune 3.8)
-  > (package (name a))
-  > (using melange 0.1)
-  > EOF
-  $ cat > a/dune <<EOF
+  $ make_melange_foo_library_project a a <<EOF
   > (library
   >  (modes melange)
   >  (public_name a))
-  > EOF
-
-  $ cat > a/foo.ml <<EOF
-  > let x = "foo"
   > EOF
 
   $ dune build --root a

--- a/test/blackbox-tests/test-cases/melange/dune-package-source-path.t
+++ b/test/blackbox-tests/test-cases/melange/dune-package-source-path.t
@@ -2,20 +2,11 @@ Test that paths in `node_modules` are correct for sub-libraries of the
 form `foo.bar.baz`
 
   $ mkdir a app
-  $ cat > a/dune-project <<EOF
-  > (lang dune 3.8)
-  > (package (name a))
-  > (using melange 0.1)
-  > EOF
-  $ cat > a/dune <<EOF
+  $ make_melange_foo_library_project a a <<EOF
   > (library
   >  (modes melange)
   >  (name a)
   >  (public_name a.sub))
-  > EOF
-
-  $ cat > a/foo.ml <<EOF
-  > let x = "foo"
   > EOF
 
   $ dune build --root a


### PR DESCRIPTION
Extract the repeated installed Melange foo library setup, preserving the optional private library name for sub-library cases.
