### PR TITLE
test(pkg): share with-patch package fixture

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -176,6 +176,22 @@ make_fetch_cache_project() {
 	EOF
 }
 
+make_with_patch_package() {
+  mkpkg with-patch <<- EOF
+	EOF
+
+  fname1="foo.patch"
+  fname2="dir/bar.patch"
+  opam_repo="$mock_packages/with-patch/with-patch.0.0.1"
+  mkdir -p "$opam_repo/files/dir"
+  cat >"$opam_repo/files/$fname1" <<-'EOF'
+	foo
+	EOF
+  cat >"$opam_repo/files/$fname2" <<-'EOF'
+	bar
+	EOF
+}
+
 mk_ocaml() {
   local version="$1"
   local major

--- a/test/blackbox-tests/test-cases/pkg/opam-package-copy-files.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-copy-files.t
@@ -4,19 +4,7 @@ repository are copied correctly to the dune.lock file.
   $ mkrepo
 
 Make a package with a patch
-  $ mkpkg with-patch <<EOF
-  > EOF
-
-  $ fname1="foo.patch"
-  $ fname2="dir/bar.patch"
-  $ opam_repo="$mock_packages/with-patch/with-patch.0.0.1"
-  $ mkdir -p $opam_repo/files/dir
-  $ cat >$opam_repo/files/$fname1 <<EOF
-  > foo
-  > EOF
-  $ cat >$opam_repo/files/$fname2 <<EOF
-  > bar
-  > EOF
+  $ make_with_patch_package
 
   $ solve with-patch
   Solution for dune.lock:

--- a/test/blackbox-tests/test-cases/pkg/opam-package-files-unix-error.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-files-unix-error.t
@@ -4,19 +4,7 @@ files/ directory from a package directory inside an opam repository.
   $ mkrepo
 
 Make a package with a patch
-  $ mkpkg with-patch <<EOF
-  > EOF
-
-  $ fname1="foo.patch"
-  $ fname2="dir/bar.patch"
-  $ opam_repo="$mock_packages/with-patch/with-patch.0.0.1"
-  $ mkdir -p $opam_repo/files/dir
-  $ cat >$opam_repo/files/$fname1 <<EOF
-  > foo
-  > EOF
-  $ cat >$opam_repo/files/$fname2 <<EOF
-  > bar
-  > EOF
+  $ make_with_patch_package
 We remove the read permissions for dir/ making sure to add them back if we exit
 the test.
 


### PR DESCRIPTION
Extract the repeated opam repository package with files/foo.patch and files/dir/bar.patch into a package-test helper.
