### PR TITLE
test(melange): share private map fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -300,6 +300,60 @@ make_melange_runtime_deps_project() {
 	EOF
 }
 
+write_melange_private_map_library() {
+  cat > lib/dune <<-'EOF'
+	(library
+	 (name foo)
+	 (public_name repro.foo)
+	 (wrapped true)
+	 (libraries melange)
+	 (modes melange))
+	EOF
+  cat > lib/foo.ml <<-'EOF'
+	module Foo_map = Foo_map
+	EOF
+  cat > lib/foo_map.mli <<-'EOF'
+	module Int = Foo_mapInt
+	val size : Int.t -> int
+	EOF
+  cat > lib/foo_map.ml <<-'EOF'
+	module Int = Foo_mapInt
+	let size x = Int.size x
+	EOF
+  cat > lib/foo_mapInt.mli <<-'EOF'
+	type t
+	val size : t -> int
+	EOF
+  cat > lib/foo_mapInt.ml <<-'EOF'
+	type t = Foo_internalMapInt.t
+	let size x = Foo_internalMapInt.size x
+	EOF
+  cat > lib/foo_internalMapInt.mli <<-'EOF'
+	type t
+	val size : t -> int
+	EOF
+  cat > lib/foo_internalMapInt.ml <<-'EOF'
+	type t = int array
+	let size x = Foo_internalAVLtree.size x
+	EOF
+  cat > lib/foo_internalAVLtree.ml <<-'EOF'
+	let size x = Array.length x
+	EOF
+}
+
+write_melange_repro_foo_consumer() {
+  cat > app/dune <<-'EOF'
+	(melange.emit
+	 (target dist)
+	 (alias mel)
+	 (emit_stdlib false)
+	 (libraries repro.foo))
+	EOF
+  cat > app/main.ml <<-'EOF'
+	let () = ignore (Foo.Foo_map.Int.size (Obj.magic 0))
+	EOF
+}
+
 make_melange_sandbox_project() {
   local runtime_deps="${1:-}"
 

--- a/test/blackbox-tests/test-cases/melange/emit-installed-private-module.t
+++ b/test/blackbox-tests/test-cases/melange/emit-installed-private-module.t
@@ -10,52 +10,7 @@ stage the installed Melange object dirs rather than only the entry module's
   > (package (name repro))
   > EOF
 
-  $ cat > lib/dune <<'EOF'
-  > (library
-  >  (name foo)
-  >  (public_name repro.foo)
-  >  (wrapped true)
-  >  (libraries melange)
-  >  (modes melange))
-  > EOF
-
-  $ cat > lib/foo.ml <<'EOF'
-  > module Foo_map = Foo_map
-  > EOF
-
-  $ cat > lib/foo_map.mli <<'EOF'
-  > module Int = Foo_mapInt
-  > val size : Int.t -> int
-  > EOF
-
-  $ cat > lib/foo_map.ml <<'EOF'
-  > module Int = Foo_mapInt
-  > let size x = Int.size x
-  > EOF
-
-  $ cat > lib/foo_mapInt.mli <<'EOF'
-  > type t
-  > val size : t -> int
-  > EOF
-
-  $ cat > lib/foo_mapInt.ml <<'EOF'
-  > type t = Foo_internalMapInt.t
-  > let size x = Foo_internalMapInt.size x
-  > EOF
-
-  $ cat > lib/foo_internalMapInt.mli <<'EOF'
-  > type t
-  > val size : t -> int
-  > EOF
-
-  $ cat > lib/foo_internalMapInt.ml <<'EOF'
-  > type t = int array
-  > let size x = Foo_internalAVLtree.size x
-  > EOF
-
-  $ cat > lib/foo_internalAVLtree.ml <<'EOF'
-  > let size x = Array.length x
-  > EOF
+  $ write_melange_private_map_library
 
   $ dune build --root lib @install
 
@@ -99,17 +54,7 @@ stage the installed Melange object dirs rather than only the entry module's
   > (package (name app))
   > EOF
 
-  $ cat > app/dune <<'EOF'
-  > (melange.emit
-  >  (target dist)
-  >  (alias mel)
-  >  (emit_stdlib false)
-  >  (libraries repro.foo))
-  > EOF
-
-  $ cat > app/main.ml <<'EOF'
-  > let () = ignore (Foo.Foo_map.Int.size (Obj.magic 0))
-  > EOF
+  $ write_melange_repro_foo_consumer
 
   $ OCAMLPATH=$PWD/prefix/lib:$OCAMLPATH dune rules --format=json --deps --root app --display=quiet dist/node_modules/repro.foo/foo_map.js > deps.json
   $ jq_dune -r '.[] | depsGlobEntriesWithPredicate("*.cmj") | select(.dir | endswith("/repro/foo")) | "\(.dir_kind) \(.dir)"' deps.json

--- a/test/blackbox-tests/test-cases/melange/emit-local-transitive-private-module.t
+++ b/test/blackbox-tests/test-cases/melange/emit-local-transitive-private-module.t
@@ -9,64 +9,9 @@ transitive implementation closure, even across `.mli` boundaries.
   > (package (name repro))
   > EOF
 
-  $ cat > lib/dune <<'EOF'
-  > (library
-  >  (name foo)
-  >  (public_name repro.foo)
-  >  (wrapped true)
-  >  (libraries melange)
-  >  (modes melange))
-  > EOF
+  $ write_melange_private_map_library
 
-  $ cat > lib/foo.ml <<'EOF'
-  > module Foo_map = Foo_map
-  > EOF
-
-  $ cat > lib/foo_map.mli <<'EOF'
-  > module Int = Foo_mapInt
-  > val size : Int.t -> int
-  > EOF
-
-  $ cat > lib/foo_map.ml <<'EOF'
-  > module Int = Foo_mapInt
-  > let size x = Int.size x
-  > EOF
-
-  $ cat > lib/foo_mapInt.mli <<'EOF'
-  > type t
-  > val size : t -> int
-  > EOF
-
-  $ cat > lib/foo_mapInt.ml <<'EOF'
-  > type t = Foo_internalMapInt.t
-  > let size x = Foo_internalMapInt.size x
-  > EOF
-
-  $ cat > lib/foo_internalMapInt.mli <<'EOF'
-  > type t
-  > val size : t -> int
-  > EOF
-
-  $ cat > lib/foo_internalMapInt.ml <<'EOF'
-  > type t = int array
-  > let size x = Foo_internalAVLtree.size x
-  > EOF
-
-  $ cat > lib/foo_internalAVLtree.ml <<'EOF'
-  > let size x = Array.length x
-  > EOF
-
-  $ cat > app/dune <<'EOF'
-  > (melange.emit
-  >  (target dist)
-  >  (alias mel)
-  >  (emit_stdlib false)
-  >  (libraries repro.foo))
-  > EOF
-
-  $ cat > app/main.ml <<'EOF'
-  > let () = ignore (Foo.Foo_map.Int.size (Obj.magic 0))
-  > EOF
+  $ write_melange_repro_foo_consumer
 
   $ dune rules --root . --format=json --deps app/dist/node_modules/repro.foo/foo_map.js |
   > jq_dune -r '.[] | depsFilePaths | select(test("lib/\\.foo\\.objs/melange/.*\\.cmj$")) | sub("^_build/default/"; "")'


### PR DESCRIPTION
Extract the shared private-map Melange library graph and repro.foo
consumer used by installed and same-workspace tests.