### PR TITLE
test(melange): share old field fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -232,6 +232,23 @@ make_melange_runtime_deps_lib() {
 	EOF
 }
 
+make_old_melange_field_project() {
+  local field="$1"
+  local value="$2"
+
+  mkdir -p old
+  cat > old/dune-project <<-'EOF'
+	(lang dune 3.23)
+	(using melange 0.1)
+	EOF
+  cat > old/dune <<- EOF
+	(library
+	 (name old)
+	 (modes melange)
+	 (${field} ${value}))
+	EOF
+}
+
 make_melange_sandbox_project() {
   local runtime_deps="${1:-}"
 

--- a/test/blackbox-tests/test-cases/melange/conditional-libraries.t
+++ b/test/blackbox-tests/test-cases/melange/conditional-libraries.t
@@ -2,17 +2,7 @@
 
 The field is available starting in Dune 3.24.
 
-  $ mkdir old
-  $ cat > old/dune-project <<EOF
-  > (lang dune 3.23)
-  > (using melange 0.1)
-  > EOF
-  $ cat > old/dune <<EOF
-  > (library
-  >  (name old)
-  >  (modes melange)
-  >  (melange.libraries dep))
-  > EOF
+  $ make_old_melange_field_project melange.libraries dep
   $ dune build --root old
   Entering directory 'old'
   File "dune", line 4, characters 1-24:

--- a/test/blackbox-tests/test-cases/melange/conditional-modules.t
+++ b/test/blackbox-tests/test-cases/melange/conditional-modules.t
@@ -1,17 +1,7 @@
 Show that `(melange.modules ...)` is gated on Dune 3.24 and applies only to
 Melange compilation.
 
-  $ mkdir old
-  $ cat > old/dune-project <<EOF
-  > (lang dune 3.23)
-  > (using melange 0.1)
-  > EOF
-  $ cat > old/dune <<EOF
-  > (library
-  >  (name old)
-  >  (modes melange)
-  >  (melange.modules foo))
-  > EOF
+  $ make_old_melange_field_project melange.modules foo
   $ dune build --root old
   Entering directory 'old'
   File "dune", line 4, characters 1-22:


### PR DESCRIPTION
Extract the repeated Dune 3.23 Melange field rejection fixture,
parameterized by the field name and value.