### PR TITLE
test(menhir): share dep parser fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -483,6 +483,22 @@ write_bin_pform_inline_tests_fixture() {
   : > testlib.ml
 }
 
+make_menhir_parser_using_dep() {
+  mkdir -p parser
+  cat > parser/dune <<-'EOF'
+	(library
+	 (name parser)
+	 (libraries dep))
+	(menhir (modules grammar))
+	EOF
+  cat > parser/grammar.mly <<-'EOF'
+	%token EOF
+	%start <int> main
+	%%
+	main: EOF { Dep.value }
+	EOF
+}
+
 make_melange_virtual_time_project() {
   local vlib_public_name="$1"
   local impl_public_name="$2"

--- a/test/blackbox-tests/test-cases/menhir/with-library-deps.t
+++ b/test/blackbox-tests/test-cases/menhir/with-library-deps.t
@@ -26,19 +26,7 @@ semantic action references [Dep.value]. The build succeeds only if
 menhir's [--infer] pass sees [dep] on its [-I] path during the
 [ocamlc -i] inference step.
 
-  $ mkdir parser
-  $ cat > parser/dune <<EOF
-  > (library
-  >  (name parser)
-  >  (libraries dep))
-  > (menhir (modules grammar))
-  > EOF
-  $ cat > parser/grammar.mly <<EOF
-  > %token EOF
-  > %start <int> main
-  > %%
-  > main: EOF { Dep.value }
-  > EOF
+  $ make_menhir_parser_using_dep
 
   $ dune build @check
 

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/menhir-incremental-lib-cmi.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/menhir-incremental-lib-cmi.t
@@ -35,18 +35,7 @@ menhir grammar will reference. `dep.ml` carries both `value` and
 references `Dep.value`, plus a sibling module `helper` that also
 references `Dep.value`.
 
-  $ make_dir_with_dune parser <<EOF
-  > (library
-  >  (name parser)
-  >  (libraries dep))
-  > (menhir (modules grammar))
-  > EOF
-  $ cat > parser/grammar.mly <<EOF
-  > %token EOF
-  > %start <int> main
-  > %%
-  > main: EOF { Dep.value }
-  > EOF
+  $ make_menhir_parser_using_dep
   $ cat > parser/helper.ml <<EOF
   > let echo () = Dep.value
   > EOF


### PR DESCRIPTION
Extract the repeated parser library and grammar that reference Dep.value into a
shared Menhir helper.