### PR TITLE
test(menhir): share unit parser fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -296,6 +296,20 @@ write_melange_asset_reader() {
 	EOF
 }
 
+write_menhir_unit_parser_sources() {
+  cat >lang/ast.ml <<-'EOF'
+	type expr =
+	  | Unit
+	EOF
+  cat >lang/parser.mly <<-'EOF'
+	%token EOF
+	%start <Ast.expr> expr
+	%%
+	expr:
+	| EOF { Ast.Unit }
+	EOF
+}
+
 make_melange_virtual_time_project() {
   local vlib_public_name="$1"
   local impl_public_name="$2"

--- a/test/blackbox-tests/test-cases/menhir/include-subdirs-qualified.t
+++ b/test/blackbox-tests/test-cases/menhir/include-subdirs-qualified.t
@@ -30,17 +30,7 @@ $ cat >ast.ml <<EOF
   > (menhir (modules parser))
   > EOF
 
-  $ cat >lang/ast.ml <<EOF
-  > type expr =
-  >   | Unit
-  > EOF
-  $ cat >lang/parser.mly <<EOF
-  > %token EOF
-  > %start <Ast.expr> expr
-  > %%
-  > expr:
-  > | EOF { Ast.Unit }
-  > EOF
+  $ write_menhir_unit_parser_sources
 
 Menhir parsers in qualified subdirectories should be able to refer to sibling modules:
 

--- a/test/blackbox-tests/test-cases/menhir/include-subdirs-unqualified.t
+++ b/test/blackbox-tests/test-cases/menhir/include-subdirs-unqualified.t
@@ -27,17 +27,7 @@ $ cat >ast.ml <<EOF
   $ cat >lang/dune <<EOF
   > (menhir (modules parser))
   > EOF
-  $ cat >lang/ast.ml <<EOF
-  > type expr =
-  >   | Unit
-  > EOF
-  $ cat >lang/parser.mly <<EOF
-  > %token EOF
-  > %start <Ast.expr> expr
-  > %%
-  > expr:
-  > | EOF { Ast.Unit }
-  > EOF
+  $ write_menhir_unit_parser_sources
 
   $ dune build
 


### PR DESCRIPTION
Extract the common Ast/parser sources used before the Menhir include_subdirs
merge_into scenario into a shared helper.