### PR TITLE
test(inline): share simple backend fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -594,6 +594,20 @@ make_and_enter_private_only_packages_project() {
 	EOF
 }
 
+write_simple_inline_tests_backend() {
+  cat >dune <<-'EOF'
+	(library
+	 (name backend_simple)
+	 (modules ())
+	 (inline_tests.backend
+	  (generate_runner (run sed "s/(\\*TEST:\\(.*\\)\\*)/let () = if \"%{inline_tests}\" = \"enabled\" then \\1;;/" %{impl-files}))))
+	
+	(library
+	 (name foo_simple)
+	 (inline_tests (backend backend_simple)))
+	EOF
+}
+
 make_melange_virtual_time_project() {
   local vlib_public_name="$1"
   local impl_public_name="$2"

--- a/test/blackbox-tests/test-cases/inline-tests/alias-cycle.t
+++ b/test/blackbox-tests/test-cases/inline-tests/alias-cycle.t
@@ -7,16 +7,8 @@ turn depends on the inline-test-name alias of the inline tests of the library.
   > (*TEST: assert (1 = 2) *)
   > EOF
 
-  $ cat >dune <<EOF
-  > (library
-  >  (name backend_simple)
-  >  (modules ())
-  >  (inline_tests.backend
-  >   (generate_runner (run sed "s/(\\\\*TEST:\\\\(.*\\\\)\\\\*)/let () = if \\"%{inline_tests}\\" = \\"enabled\\" then \\\\1;;/" %{impl-files}))))
-  > 
-  > (library
-  >  (name foo_simple)
-  >  (inline_tests (backend backend_simple)))
+  $ write_simple_inline_tests_backend
+  $ cat >>dune <<EOF
   > 
   > (rule
   >  (deps

--- a/test/blackbox-tests/test-cases/inline-tests/simple.t
+++ b/test/blackbox-tests/test-cases/inline-tests/simple.t
@@ -4,16 +4,8 @@
 
   $ make_dune_project 2.6
 
-  $ cat >dune <<EOF
-  > (library
-  >  (name backend_simple)
-  >  (modules ())
-  >  (inline_tests.backend
-  >   (generate_runner (run sed "s/(\\\\*TEST:\\\\(.*\\\\)\\\\*)/let () = if \\"%{inline_tests}\\" = \\"enabled\\" then \\\\1;;/" %{impl-files}))))
-  > 
-  > (library
-  >  (name foo_simple)
-  >  (inline_tests (backend backend_simple)))
+  $ write_simple_inline_tests_backend
+  $ cat >>dune <<EOF
   > 
   > (env
   >  (ignore-inline-tests (inline_tests ignored))


### PR DESCRIPTION
Extract the repeated inline test backend/foo library setup into a shared helper,
leaving each test to append its env or cycle-specific rule.