### PR TITLE
test(cross): share repro project fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -523,6 +523,41 @@ write_directory_diff_keep_rule() {
 	EOF
 }
 
+write_cross_compilation_repro_project() {
+  local dir="${1:-.}"
+  local modules="${2:-}"
+
+  mkdir -p "$dir"
+  cat > "$dir/dune-project" <<-'EOF'
+	(lang dune 3.7)
+	(package (name repro))
+	EOF
+  cat > "$dir/dune" <<- EOF
+	(executable
+	 (name gen)
+	 (modules gen)
+	 (enabled_if
+	  (= %{context_name} "default"))
+	 (libraries libdep))
+	(rule
+	 (with-stdout-to
+	  gen.ml
+	  (echo "let () = Format.printf \"let x = 1\"")))
+	(library
+	 (name repro)
+	 (public_name repro)
+	 (modules${modules:+ ${modules}}))
+	EOF
+  if [ -n "$modules" ]; then
+    cat >> "$dir/dune" <<-'EOF'
+	(rule
+	 (with-stdout-to
+	  foo.ml
+	  (run ./gen.exe)))
+	EOF
+  fi
+}
+
 make_two_context_workspace() {
   cat > dune-workspace <<- EOF
 	(lang dune 3.13)

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation-ocamlfind.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation-ocamlfind.t
@@ -38,31 +38,7 @@ in the default findlib.conf
 
   $ dune install --root lib --prefix $PWD/prefix
 
-  $ mkdir app
-  $ cat > app/dune-project <<EOF
-  > (lang dune 3.7)
-  > (package (name repro))
-  > EOF
-  $ cat > app/dune <<EOF
-  > (executable
-  >  (name gen)
-  >  (modules gen)
-  >  (enabled_if
-  >   (= %{context_name} "default"))
-  >  (libraries libdep))
-  > (rule
-  >  (with-stdout-to
-  >   gen.ml
-  >   (echo "let () = Format.printf \"let x = 1\"")))
-  > (library
-  >  (name repro)
-  >  (public_name repro)
-  >  (modules foo))
-  > (rule
-  >  (with-stdout-to
-  >   foo.ml
-  >   (run ./gen.exe)))
-  > EOF
+  $ write_cross_compilation_repro_project app foo
 
 ocamlfind can find it
 

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/no-ocamlfind-in-path.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/no-ocamlfind-in-path.t
@@ -1,26 +1,7 @@
 Dune shows an error message when ocamlfind isn't in PATH and OCAMLFIND_CONF
 isn't set
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.7)
-  > (package (name repro))
-  > EOF
-  $ cat > dune <<EOF
-  > (executable
-  >  (name gen)
-  >  (modules gen)
-  >  (enabled_if
-  >   (= %{context_name} "default"))
-  >  (libraries libdep))
-  > (rule
-  >  (with-stdout-to
-  >   gen.ml
-  >   (echo "let () = Format.printf \"let x = 1\"")))
-  > (library
-  >  (name repro)
-  >  (public_name repro)
-  >  (modules))
-  > EOF
+  $ write_cross_compilation_repro_project
 
   $ mkdir ocaml-bin
   $ cat > ocaml-bin/ocamlc <<EOF


### PR DESCRIPTION
Extract the repeated cross-compilation repro project setup into a shared helper,
parameterized by the target library modules.