### PR TITLE
test(menhir): share merge_into parser fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -526,6 +526,24 @@ make_menhir_parser_using_dep() {
 	EOF
 }
 
+write_menhir_merge_into_sources() {
+  cat >lang/sub/tokens.mly <<-'EOF'
+	%token <char> TOKEN
+	%token EOF
+	%%
+	EOF
+  cat >lang/sub/parser.mly <<-'EOF'
+	%start <char list> main
+	%%
+	main:
+	| c = TOKEN EOF { [c] }
+	| c = TOKEN xs = main  { c :: xs }
+	EOF
+  cat >lang/sub/dune <<-'EOF'
+	(menhir (modules tokens parser) (merge_into both))
+	EOF
+}
+
 make_melange_virtual_time_project() {
   local vlib_public_name="$1"
   local impl_public_name="$2"

--- a/test/blackbox-tests/test-cases/menhir/include-subdirs-qualified.t
+++ b/test/blackbox-tests/test-cases/menhir/include-subdirs-qualified.t
@@ -38,21 +38,6 @@ Menhir parsers in qualified subdirectories should be able to refer to sibling mo
 
 Use `merge_into`
 
-  $ cat >lang/sub/tokens.mly <<EOF
-  > %token <char> TOKEN
-  > %token EOF
-  > %%
-  > EOF
-  $ cat >lang/sub/parser.mly <<EOF
-  > %start <char list> main
-  > %%
-  > main:
-  > | c = TOKEN EOF { [c] }
-  > | c = TOKEN xs = main  { c :: xs }
-  > EOF
-
-  $ cat >lang/sub/dune <<EOF
-  > (menhir (modules tokens parser) (merge_into both))
-  > EOF
+  $ write_menhir_merge_into_sources
 
   $ dune build

--- a/test/blackbox-tests/test-cases/menhir/include-subdirs-unqualified.t
+++ b/test/blackbox-tests/test-cases/menhir/include-subdirs-unqualified.t
@@ -33,22 +33,7 @@ $ cat >ast.ml <<EOF
 
 Use `merge_into`
 
-  $ cat >lang/sub/tokens.mly <<EOF
-  > %token <char> TOKEN
-  > %token EOF
-  > %%
-  > EOF
-  $ cat >lang/sub/parser.mly <<EOF
-  > %start <char list> main
-  > %%
-  > main:
-  > | c = TOKEN EOF { [c] }
-  > | c = TOKEN xs = main  { c :: xs }
-  > EOF
-
-  $ cat >lang/sub/dune <<EOF
-  > (menhir (modules tokens parser) (merge_into both))
-  > EOF
+  $ write_menhir_merge_into_sources
 
   $ dune build
 


### PR DESCRIPTION
Extract the repeated tokens/parser/dune files for the Menhir merge_into
subdirectory scenario into a shared helper.