### PR TITLE
test(bin-pform): share inline-test path fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -405,6 +405,30 @@ write_melange_dir_target_runtime_deps_lib() {
 	EOF
 }
 
+write_bin_pform_inline_tests_fixture() {
+  local deps="${1:?}"
+
+  cat > dump_path.ml <<- EOF
+	let () =
+	  let oc = open_out "$PWD/path.out" in
+	  output_string oc (Sys.getenv "PATH");
+	  close_out oc
+	EOF
+  cat > dune <<- EOF
+	(library
+	 (name check_backend)
+	 (modules ())
+	 (inline_tests.backend
+	  (generate_runner (cat dump_path.ml))))
+	(library
+	 (name testlib)
+	 (inline_tests
+	  (backend check_backend)
+	  (deps ${deps})))
+	EOF
+  : > testlib.ml
+}
+
 make_melange_virtual_time_project() {
   local vlib_public_name="$1"
   local impl_public_name="$2"

--- a/test/blackbox-tests/test-cases/bin-pform/inline-tests-include.t
+++ b/test/blackbox-tests/test-cases/bin-pform/inline-tests-include.t
@@ -6,32 +6,11 @@ collection to drain the env contribution from Include_result.
 
   $ make_mypkg_bin_project
 
-  $ cat >dump_path.ml <<EOF
-  > let () =
-  >   let oc = open_out "$PWD/path.out" in
-  >   output_string oc (Sys.getenv "PATH");
-  >   close_out oc
-  > EOF
-
   $ cat >deps.sexp <<'EOF'
   > (%{bin:mybin})
   > EOF
 
-  $ cat >dune <<'EOF'
-  > (library
-  >  (name check_backend)
-  >  (modules ())
-  >  (inline_tests.backend
-  >   (generate_runner (cat dump_path.ml))))
-  > (library
-  >  (name testlib)
-  >  (inline_tests
-  >   (backend check_backend)
-  >   (deps (include deps.sexp))))
-  > EOF
-
-  $ cat >testlib.ml <<EOF
-  > EOF
+  $ write_bin_pform_inline_tests_fixture '(include deps.sexp)'
 
   $ dune runtest 2>&1
 

--- a/test/blackbox-tests/test-cases/bin-pform/inline-tests.t
+++ b/test/blackbox-tests/test-cases/bin-pform/inline-tests.t
@@ -6,28 +6,7 @@ the test runner's PATH.
 Custom backend whose runner records PATH to a file outside the
 sandbox:
 
-  $ cat >dump_path.ml <<EOF
-  > let () =
-  >   let oc = open_out "$PWD/path.out" in
-  >   output_string oc (Sys.getenv "PATH");
-  >   close_out oc
-  > EOF
-
-  $ cat >dune <<'EOF'
-  > (library
-  >  (name check_backend)
-  >  (modules ())
-  >  (inline_tests.backend
-  >   (generate_runner (cat dump_path.ml))))
-  > (library
-  >  (name testlib)
-  >  (inline_tests
-  >   (backend check_backend)
-  >   (deps %{bin:mybin})))
-  > EOF
-
-  $ cat >testlib.ml <<EOF
-  > EOF
+  $ write_bin_pform_inline_tests_fixture '%{bin:mybin}'
 
   $ dune runtest 2>&1
   $ env_added "$(cat path.out)" "$PATH" | censor


### PR DESCRIPTION
Factor the repeated inline-test backend that records PATH into a
shared helper for bin pform blackbox tests.