### PR TITLE
test(pkg): share platform-dependent bar fixture

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -114,6 +114,36 @@ make_project_pinned_to_foo() {
 	EOF
 }
 
+make_platform_dependent_bar_package() {
+  mkpkg bar <<-'EOF'
+	build: [
+	  ["mkdir" "-p" share "%{lib}%/%{name}%"]
+	  ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
+	]
+	depends: [
+	  "foo" {= "1" & os = "linux"}
+	  "foo" {= "2" & os = "macos"}
+	]
+	EOF
+}
+
+make_x_depends_bar_project() {
+  cat > dune-project <<-'EOF'
+	(lang dune 3.18)
+	(package
+	 (name x)
+	 (depends bar))
+	EOF
+  cat > x.ml <<-'EOF'
+	let () = print_endline "Hello, World!"
+	EOF
+  cat > dune <<-'EOF'
+	(executable
+	 (public_name x)
+	 (libraries foo))
+	EOF
+}
+
 make_bar_depends_foo_project() {
   cat > dune-project <<-'EOF'
 	(lang dune 3.10)

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
@@ -37,34 +37,10 @@ during their build so we can validate which version was built.
 
 Define a package bar which conditionally depends on different versions of foo:
 
-  $ mkpkg bar <<EOF
-  > build: [
-  >   ["mkdir" "-p" share "%{lib}%/%{name}%"]
-  >   ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
-  > ]
-  > depends: [
-  >   "foo" {= "1" & os = "linux"}
-  >   "foo" {= "2" & os = "macos"}
-  > ]
-  > EOF
+  $ make_platform_dependent_bar_package
 
 Define a project with a package depending on bar:
-  $ cat > dune-project <<EOF
-  > (lang dune 3.18)
-  > (package
-  >  (name x)
-  >  (depends bar))
-  > EOF
-
-  $ cat > x.ml <<EOF
-  > let () = print_endline "Hello, World!"
-  > EOF
-
-  $ cat > dune <<EOF
-  > (executable
-  >  (public_name x)
-  >  (libraries foo))
-  > EOF
+  $ make_x_depends_bar_project
 
 Solve the project. The solution will contain extra files for both versions of foo:
   $ dune pkg lock

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
@@ -23,33 +23,9 @@ during their build so we can validate which version was built.
 
 Define a package bar which conditionally depends on different versions of foo:
 
-  $ mkpkg bar <<EOF
-  > build: [
-  >   ["mkdir" "-p" share "%{lib}%/%{name}%"]
-  >   ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
-  > ]
-  > depends: [
-  >   "foo" {= "1" & os = "linux"}
-  >   "foo" {= "2" & os = "macos"}
-  > ]
-  > EOF
+  $ make_platform_dependent_bar_package
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.18)
-  > (package
-  >  (name x)
-  >  (depends bar))
-  > EOF
-
-  $ cat > x.ml <<EOF
-  > let () = print_endline "Hello, World!"
-  > EOF
-
-  $ cat > dune <<EOF
-  > (executable
-  >  (public_name x)
-  >  (libraries foo))
-  > EOF
+  $ make_x_depends_bar_project
 
   $ dune pkg lock
   Solution for dune.lock


### PR DESCRIPTION
Extract the repeated platform-dependent bar package and x project
fixtures used by portable lockdir tests into pkg helpers.