### PR TITLE
test(melange): share runtime deps project

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -249,6 +249,31 @@ make_old_melange_field_project() {
 	EOF
 }
 
+make_melange_runtime_deps_project() {
+  local directory_targets="${1:-}"
+
+  cat > dune-project <<- EOF
+	(lang dune 3.8)
+	EOF
+  if [ -n "$directory_targets" ]; then
+    cat >> dune-project <<-'EOF'
+	(using directory-targets 0.1)
+	EOF
+  fi
+  cat >> dune-project <<-'EOF'
+	(using melange 0.1)
+	EOF
+  cat > dune <<-'EOF'
+	(melange.emit
+	 (target output)
+	 (alias mel)
+	 (libraries foo)
+	 (emit_stdlib false)
+	 (preprocess (pps melange.ppx))
+	 (runtime_deps assets/file.txt))
+	EOF
+}
+
 make_melange_sandbox_project() {
   local runtime_deps="${1:-}"
 

--- a/test/blackbox-tests/test-cases/melange/library-with-dir-target-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/library-with-dir-target-runtime-deps.t
@@ -1,20 +1,6 @@
 Test `melange.runtime_deps` in a private library
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.8)
-  > (using directory-targets 0.1)
-  > (using melange 0.1)
-  > EOF
-
-  $ cat > dune <<EOF
-  > (melange.emit
-  >  (target output)
-  >  (alias mel)
-  >  (libraries foo)
-  >  (emit_stdlib false)
-  >  (preprocess (pps melange.ppx))
-  >  (runtime_deps assets/file.txt))
-  > EOF
+  $ make_melange_runtime_deps_project with-directory-targets
 
   $ mkdir lib
   $ cat > lib/dune <<EOF

--- a/test/blackbox-tests/test-cases/melange/library-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/library-with-runtime-deps.t
@@ -1,19 +1,6 @@
 Test `melange.runtime_deps` in a private library
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.8)
-  > (using melange 0.1)
-  > EOF
-
-  $ cat > dune <<EOF
-  > (melange.emit
-  >  (target output)
-  >  (alias mel)
-  >  (libraries foo)
-  >  (emit_stdlib false)
-  >  (preprocess (pps melange.ppx))
-  >  (runtime_deps assets/file.txt))
-  > EOF
+  $ make_melange_runtime_deps_project
 
   $ mkdir lib
   $ echo "Some text" > lib/index.txt


### PR DESCRIPTION
Extract the common top-level Melange emit project used by file and
directory-target runtime dependency tests.