### PR TITLE
test(pkg): share wrong-to-right patch writer

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -266,6 +266,35 @@ make_with_patch_package() {
 	EOF
 }
 
+append_wrong_to_right_patch() {
+  local patch="$1"
+  local target="${2:-foo.ml}"
+
+  mkdir -p "$(dirname "$patch")"
+  if [ -s "$patch" ]; then
+    printf '
+' >> "$patch"
+  fi
+  cat >> "$patch" <<- EOF
+	diff --git a/${target} b/${target}
+	index b69a69a5a..ea988f6bd 100644
+	--- a/${target}
+	+++ b/${target}
+	@@ -1,1 +1,1 @@
+	-This is wrong
+	+This is right
+	EOF
+}
+
+write_wrong_to_right_patch() {
+  local patch="$1"
+  local target="${2:-foo.ml}"
+
+  mkdir -p "$(dirname "$patch")"
+  : > "$patch"
+  append_wrong_to_right_patch "$patch" "$target"
+}
+
 mk_ocaml() {
   local version="$1"
   local major

--- a/test/blackbox-tests/test-cases/pkg/opam-package-subst-patch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-subst-patch.t
@@ -36,15 +36,7 @@ The lockfile should contain the substitute and patch actions.
 
   $ mkdir source
 
-  $ cat > source/foo.patch.in <<EOF
-  > diff --git a/foo.ml b/foo.ml
-  > index b69a69a5a..ea988f6bd 100644
-  > --- a/foo.ml
-  > +++ b/foo.ml
-  > @@ -1,1 +1,1 @@
-  > -This is wrong
-  > +This is right
-  > EOF
+  $ write_wrong_to_right_patch source/foo.patch.in
 
   $ cat > source/foo.ml <<EOF
   > This is wrong

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-multiple.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-multiple.t
@@ -15,34 +15,10 @@ file and the second patches two, one of the files is in a subdirectory.:w
 
   $ mkdir -p $opam_dir/files/dir
 
-  $ cat >$opam_dir/files/foo.patch <<EOF
-  > diff --git a/foo.ml b/foo.ml
-  > index b69a69a5a..ea988f6bd 100644
-  > --- a/foo.ml
-  > +++ b/foo.ml
-  > @@ -1,1 +1,1 @@
-  > -This is wrong
-  > +This is right
-  > EOF
+  $ write_wrong_to_right_patch $opam_dir/files/foo.patch
 
-  $ cat >$opam_dir/files/dir/bar.patch <<EOF
-  > diff --git a/bar.ml b/bar.ml
-  > index b69a69a5a..ea988f6bd 100644
-  > --- a/bar.ml
-  > +++ b/bar.ml
-  > @@ -1,1 +1,1 @@
-  > -This is wrong
-  > +This is right
-  > 
-  > diff --git a/dir/baz.ml b/dir/baz.ml
-  > new file mode 100644
-  > index b69a69a5a..ea988f6bd 100644
-  > --- a/dir/baz.ml
-  > +++ b/dir/baz.ml
-  > @@ -1,1 +1,1 @@
-  > -This is wrong
-  > +This is right
-  > EOF
+  $ write_wrong_to_right_patch $opam_dir/files/dir/bar.patch bar.ml
+  $ append_wrong_to_right_patch $opam_dir/files/dir/bar.patch dir/baz.ml
 
   $ solve with-patch
   Solution for dune.lock:

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch.t
@@ -10,15 +10,7 @@ Make a package with a patch
   > EOF
 
   $ mkdir -p $mock_packages/with-patch/with-patch.0.0.1/files
-  $ cat >$mock_packages/with-patch/with-patch.0.0.1/files/foo.patch <<EOF
-  > diff --git a/foo.ml b/foo.ml
-  > index b69a69a5a..ea988f6bd 100644
-  > --- a/foo.ml
-  > +++ b/foo.ml
-  > @@ -1,1 +1,1 @@
-  > -This is wrong
-  > +This is right
-  > EOF
+  $ write_wrong_to_right_patch $mock_packages/with-patch/with-patch.0.0.1/files/foo.patch
 
   $ solve with-patch
   Solution for dune.lock:


### PR DESCRIPTION
Extract the repeated patch hunk that rewrites “This is wrong” to
“This is right” into pkg helpers, including append support for multi-file patches.