### PR TITLE
test(melange): share dir target runtime deps lib

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -327,6 +327,33 @@ write_menhir_unit_parser_sources() {
 	EOF
 }
 
+write_melange_dir_target_runtime_deps_lib() {
+  local dir="${1:-lib}"
+  local runtime_deps="$2"
+  local file_path="$3"
+
+  mkdir -p "$dir"
+  cat > "$dir/dune" <<- EOF
+	(rule (target (dir some_dir))
+	 (action
+	  (progn (system "mkdir %{target}")
+	   (system "echo hello from file inside dir target > %{target}/inside-dir-target.txt"))))
+	(library
+	 (public_name foo)
+	 (modes melange)
+	 (preprocess (pps melange.ppx))
+	 (melange.runtime_deps ${runtime_deps}))
+	EOF
+  cat > "$dir/foo.ml" <<- EOF
+	external readFileSync : string -> encoding:string -> string = "readFileSync"
+	[@@mel.module "fs"]
+	let dirname = [%mel.raw "__dirname"]
+	let () = Js.log2 "dirname:" dirname
+	let file_path = "${file_path}"
+	let read_asset () = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
+	EOF
+}
+
 make_melange_virtual_time_project() {
   local vlib_public_name="$1"
   local impl_public_name="$2"

--- a/test/blackbox-tests/test-cases/melange/depend-on-installed-lib-with-dir-target-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/depend-on-installed-lib-with-dir-target-runtime-deps.t
@@ -10,25 +10,10 @@ Test `melange.runtime_deps` in a library that has been installed
 
   $ mkdir -p lib
   $ echo "Some text" > lib/index.txt
-  $ cat > lib/dune <<EOF
-  > (rule (target (dir some_dir))
-  >  (action
-  >   (progn (system "mkdir %{target}")
-  >    (system "echo hello from file inside dir target > %{target}/inside-dir-target.txt"))))
-  > (library
-  >  (public_name foo)
-  >  (modes melange)
-  >  (preprocess (pps melange.ppx))
-  >  (melange.runtime_deps ./some_dir ./index.txt))
-  > EOF
-  $ cat > lib/foo.ml <<EOF
-  > external readFileSync : string -> encoding:string -> string = "readFileSync"
-  > [@@mel.module "fs"]
-  > let dirname = [%mel.raw "__dirname"]
-  > let () = Js.log2 "dirname:" dirname
-  > let file_path = "./some_dir/inside-dir-target.txt"
-  > let read_asset () = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
-  > EOF
+  $ write_melange_dir_target_runtime_deps_lib \
+  >   lib \
+  >   "./some_dir ./index.txt" \
+  >   "./some_dir/inside-dir-target.txt"
 
   $ dune build --root lib
 

--- a/test/blackbox-tests/test-cases/melange/installed-library-with-dir-target-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/installed-library-with-dir-target-runtime-deps.t
@@ -9,25 +9,10 @@ Test `melange.runtime_deps` in a library that has been installed
   > EOF
 
   $ echo 'hello' > lib/file.txt
-  $ cat > lib/dune <<EOF
-  > (rule (target (dir some_dir))
-  >  (action
-  >   (progn (system "mkdir %{target}")
-  >    (system "echo hello from file inside dir target > %{target}/inside-dir-target.txt"))))
-  > (library
-  >  (public_name foo)
-  >  (modes melange)
-  >  (preprocess (pps melange.ppx))
-  >  (melange.runtime_deps ./some_dir ./file.txt))
-  > EOF
-  $ cat > lib/foo.ml <<EOF
-  > external readFileSync : string -> encoding:string -> string = "readFileSync"
-  > [@@mel.module "fs"]
-  > let dirname = [%mel.raw "__dirname"]
-  > let () = Js.log2 "dirname:" dirname
-  > let file_path = "./index.txt"
-  > let read_asset () = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
-  > EOF
+  $ write_melange_dir_target_runtime_deps_lib \
+  >   lib \
+  >   "./some_dir ./file.txt" \
+  >   "./index.txt"
 
   $ dune build
   $ dune install --prefix $PWD/prefix --display short
@@ -42,17 +27,10 @@ Test `melange.runtime_deps` in a library that has been installed
 
   $ rm -rf $PWD/prefix
   $ dune clean
-  $ cat > lib/dune <<EOF
-  > (rule (target (dir some_dir))
-  >  (action
-  >   (progn (system "mkdir %{target}")
-  >    (system "echo hello from file inside dir target > %{target}/inside-dir-target.txt"))))
-  > (library
-  >  (public_name foo)
-  >  (modes melange)
-  >  (preprocess (pps melange.ppx))
-  >  (melange.runtime_deps ./some_dir/inside-dir-target.txt ./some_dir ./file.txt))
-  > EOF
+  $ write_melange_dir_target_runtime_deps_lib \
+  >   lib \
+  >   "./some_dir/inside-dir-target.txt ./some_dir ./file.txt" \
+  >   "./index.txt"
 
   $ dune build
   $ dune install --prefix $PWD/prefix --display short


### PR DESCRIPTION
Extract the repeated Melange library fixture with a directory-target runtime_dep
into a shared helper parameterized by the runtime_deps list and asset path.