### PR TITLE
test(lib): share private only-packages fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -563,6 +563,37 @@ make_melange_app_with_asset_reader() {
 	EOF
 }
 
+make_private_only_packages_project() {
+  local macro="$1"
+  local lib1_extra="${2:-}"
+
+  mkdir lib-private-only-packages
+  cd lib-private-only-packages || return
+  mkdir lib1 lib2
+  cat >dune-project <<-'EOF'
+	(lang dune 2.8)
+	(name lib-private-test)
+	(package (name public_lib1))
+	(package (name public_lib2))
+	EOF
+  {
+    echo "(library"
+    echo " (name lib1)"
+    if [ -n "$lib1_extra" ]; then
+      echo " ${lib1_extra}"
+    fi
+    echo " (public_name public_lib1))"
+  } > lib1/dune
+  touch lib1/lib1.ml
+  cat >lib2/dune <<- EOF
+	(library
+	 (name lib2)
+	 (public_name public_lib2))
+	(rule
+	 (with-stdout-to lib2.ml (echo "let _ = {|%{${macro}:lib1:lib1.ml}|}")))
+	EOF
+}
+
 make_melange_virtual_time_project() {
   local vlib_public_name="$1"
   local impl_public_name="$2"

--- a/test/blackbox-tests/test-cases/lib.t
+++ b/test/blackbox-tests/test-cases/lib.t
@@ -221,28 +221,7 @@ Testsuite for the %{lib...} and %{lib-private...} variable.
 In this test, two packages are defined in the same project, but we may not
 access the artifacts through %{lib-private}
 
-  $ mkdir lib-private-only-packages
-  $ cd lib-private-only-packages
-  $ mkdir lib1 lib2
-  $ cat >dune-project <<EOF
-  > (lang dune 2.8)
-  > (name lib-private-test)
-  > (package (name public_lib1))
-  > (package (name public_lib2))
-  > EOF
-  $ cat >lib1/dune <<EOF
-  > (library
-  >  (name lib1)
-  >  (public_name public_lib1))
-  > EOF
-  $ touch lib1/lib1.ml
-  $ cat >lib2/dune <<EOF
-  > (library
-  >  (name lib2)
-  >  (public_name public_lib2))
-  > (rule
-  >  (with-stdout-to lib2.ml (echo "let _ = {|%{lib-private:lib1:lib1.ml}|}")))
-  > EOF
+  $ make_private_only_packages_project lib-private
 
 The build works in development:
   $ dune build @install

--- a/test/blackbox-tests/test-cases/libexec.t
+++ b/test/blackbox-tests/test-cases/libexec.t
@@ -273,29 +273,9 @@ Testsuite for the %{libexec...} and %{libexec-private...} variable.
 In this test, two packages are defined in the same project, but we may not
 access the artifacts through %{libexec-private}
 
-  $ mkdir lib-private-only-packages
-  $ cd lib-private-only-packages
-  $ mkdir lib1 lib2
-  $ cat >dune-project <<EOF
-  > (lang dune 2.8)
-  > (name lib-private-test)
-  > (package (name public_lib1))
-  > (package (name public_lib2))
-  > EOF
-  $ cat >lib1/dune <<EOF
-  > (library
-  >  (name lib1)
-  >  (enabled_if (= %{context_name} host))
-  >  (public_name public_lib1))
-  > EOF
-  $ touch lib1/lib1.ml
-  $ cat >lib2/dune <<EOF
-  > (library
-  >  (name lib2)
-  >  (public_name public_lib2))
-  > (rule
-  >  (with-stdout-to lib2.ml (echo "let _ = {|%{libexec-private:lib1:lib1.ml}|}")))
-  > EOF
+  $ make_private_only_packages_project \
+  >   libexec-private \
+  >   "(enabled_if (= %{context_name} host))"
   $ cat >dune <<EOF
   > (alias
   >  (name host)


### PR DESCRIPTION
Extract the repeated two-package project used by lib-private and
libexec-private --only-packages tests into a shared helper parameterized by the
macro under test and optional lib1 fields.