### PR TITLE
test(pkg): share committed mock repo package

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -85,6 +85,21 @@ mkpkg() {
   cat >> "$mock_packages/$name/$name.$version/opam"
 }
 
+make_committed_mock_repo_package() {
+  local package="$1"
+  local version="$2"
+
+  mkrepo
+  mkpkg "$package" "$version" <<-'EOF'
+	EOF
+  (
+    cd mock-opam-repository || exit 1
+    git init --quiet
+    git add -A
+    git commit --quiet -m "Initial commit"
+  )
+}
+
 make_foo_tarball() {
   local implementation="$1"
 

--- a/test/blackbox-tests/test-cases/pkg/multiple-opam-repos.t
+++ b/test/blackbox-tests/test-cases/pkg/multiple-opam-repos.t
@@ -1,13 +1,6 @@
 We want to test that support for multiple opam repositories works.
 
-  $ mkrepo
-  $ mkpkg foo 1.0 <<EOF
-  > EOF
-  $ cd mock-opam-repository
-  $ git init --quiet
-  $ git add -A
-  $ git commit --quiet -m "Initial commit"
-  $ cd ..
+  $ make_committed_mock_repo_package foo 1.0
 
 We move this mock repo to a different place, so we have two mock repos:
 
@@ -15,14 +8,7 @@ We move this mock repo to a different place, so we have two mock repos:
 
 Create a new mock repo, with a different foo package
 
-  $ mkrepo
-  $ mkpkg foo 2.0 <<EOF
-  > EOF
-  $ cd mock-opam-repository
-  $ git init --quiet
-  $ git add -A
-  $ git commit --quiet -m "Initial commit"
-  $ cd ..
+  $ make_committed_mock_repo_package foo 2.0
 
 We have to define both repositories in the workspace, but will only use `new`.
 

--- a/test/blackbox-tests/test-cases/pkg/rev-store-lock-linux.t
+++ b/test/blackbox-tests/test-cases/pkg/rev-store-lock-linux.t
@@ -2,14 +2,7 @@ We want to test that a failing flock(2) shows an error.
 
 Thus we first create a repo:
 
-  $ mkrepo
-  $ mkpkg foo 1.0 <<EOF
-  > EOF
-  $ cd mock-opam-repository
-  $ git init --quiet
-  $ git add -A
-  $ git commit --quiet -m "Initial commit"
-  $ cd ..
+  $ make_committed_mock_repo_package foo 1.0
   $ add_mock_repo_if_needed "git+file://$(pwd)/mock-opam-repository"
 
 We set the project up to depend on `foo`

--- a/test/blackbox-tests/test-cases/pkg/rev-store-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/rev-store-lock.t
@@ -2,14 +2,7 @@ Testing whether the revision store locks properly.
 
 To start with we create a repository in with a `foo` package.
 
-  $ mkrepo
-  $ mkpkg foo 1.0 <<EOF
-  > EOF
-  $ cd mock-opam-repository
-  $ git init --quiet
-  $ git add -A
-  $ git commit --quiet -m "Initial commit"
-  $ cd ..
+  $ make_committed_mock_repo_package foo 1.0
 
 We set this repository as sole source for opam repositories.
 


### PR DESCRIPTION
Extract the repeated setup of a git-initialized mock opam repository
containing a single package into a pkg helper.