### PR TITLE
test(pkg): share e2e foo package fixture

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/e2e-autolock.t
+++ b/test/blackbox-tests/test-cases/pkg/e2e-autolock.t
@@ -14,47 +14,11 @@ Configure our fake curl to serve the tarball
   $ PORT=1
 
 Make a package for the library:
-  $ mkpkg foo <<EOF
-  > build: [
-  >   ["dune" "subst"] {dev}
-  >   [
-  >     "dune"
-  >     "build"
-  >     "-p"
-  >     name
-  >     "-j"
-  >     jobs
-  >     "@install"
-  >     "@runtest" {with-test}
-  >     "@doc" {with-doc}
-  >   ]
-  > ]
-  > url {
-  >  src: "http://0.0.0.0:$PORT"
-  >  checksum: [
-  >   "md5=$(md5sum foo.tar | cut -f1 -d' ')"
-  >  ]
-  > }
-  > EOF
+  $ make_foo_tarball_package
 
 Make a project that uses the library:
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.13)
-  > (package
-  >  (name bar)
-  >  (depends foo))
-  > EOF
-
-  $ cat > bar.ml <<EOF
-  > let () = print_endline Foo.foo
-  > EOF
-
-  $ cat > dune <<EOF
-  > (executable
-  >  (public_name bar)
-  >  (libraries foo))
-  > EOF
+  $ make_bar_executable_depends_foo_project
 
 Lock, build, and run the executable in the project (without dune pkg lock):
 

--- a/test/blackbox-tests/test-cases/pkg/e2e.t
+++ b/test/blackbox-tests/test-cases/pkg/e2e.t
@@ -12,47 +12,11 @@ Configure our fake curl to serve the tarball
   $ PORT=1
 
 Make a package for the library:
-  $ mkpkg foo <<EOF
-  > build: [
-  >   ["dune" "subst"] {dev}
-  >   [
-  >     "dune"
-  >     "build"
-  >     "-p"
-  >     name
-  >     "-j"
-  >     jobs
-  >     "@install"
-  >     "@runtest" {with-test}
-  >     "@doc" {with-doc}
-  >   ]
-  > ]
-  > url {
-  >  src: "http://0.0.0.0:$PORT"
-  >  checksum: [
-  >   "md5=$(md5sum foo.tar | cut -f1 -d' ')"
-  >  ]
-  > }
-  > EOF
+  $ make_foo_tarball_package
 
 Make a project that uses the library:
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.13)
-  > (package
-  >  (name bar)
-  >  (depends foo))
-  > EOF
-
-  $ cat > bar.ml <<EOF
-  > let () = print_endline Foo.foo
-  > EOF
-
-  $ cat > dune <<EOF
-  > (executable
-  >  (public_name bar)
-  >  (libraries foo))
-  > EOF
+  $ make_bar_executable_depends_foo_project
 
 Lock, build, and run the executable in the project:
 

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -102,6 +102,50 @@ make_foo_tarball() {
   rm -rf foo
 }
 
+make_foo_tarball_package() {
+  : "${PORT:?}"
+
+  mkpkg foo <<- EOF
+	build: [
+	  ["dune" "subst"] {dev}
+	  [
+	    "dune"
+	    "build"
+	    "-p"
+	    name
+	    "-j"
+	    jobs
+	    "@install"
+	    "@runtest" {with-test}
+	    "@doc" {with-doc}
+	  ]
+	]
+	url {
+	 src: "http://0.0.0.0:${PORT}"
+	 checksum: [
+	  "md5=$(md5sum foo.tar | cut -f1 -d' ')"
+	 ]
+	}
+	EOF
+}
+
+make_bar_executable_depends_foo_project() {
+  cat > dune-project <<-'EOF'
+	(lang dune 3.13)
+	(package
+	 (name bar)
+	 (depends foo))
+	EOF
+  cat > bar.ml <<-'EOF'
+	let () = print_endline Foo.foo
+	EOF
+  cat > dune <<-'EOF'
+	(executable
+	 (public_name bar)
+	 (libraries foo))
+	EOF
+}
+
 make_project_pinned_to_foo() {
   cat >dune-project <<- EOF
 	(lang dune 3.13)


### PR DESCRIPTION
Extract the repeated foo tarball opam package and bar executable
project setup used by pkg e2e tests into helpers.