### PR TITLE
test(pkg): share lockdir validation fixture

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -188,6 +188,33 @@ make_x_depends_bar_project() {
 	EOF
 }
 
+make_lockdir_validation_packages() {
+  mkpkg a 0.0.1 <<-'EOF'
+	depends: [ "c" "d" ]
+	EOF
+  mkpkg b 0.0.1 <<-'EOF'
+	EOF
+  mkpkg b 0.0.2 <<-'EOF'
+	EOF
+  mkpkg c <<-'EOF'
+	depends: [ "e" ]
+	EOF
+  mkpkg d <<-'EOF'
+	EOF
+  mkpkg e <<-'EOF'
+	EOF
+}
+
+make_lockdir_validation_project() {
+  local version="${1:?}"
+
+  cat >dune-project <<- EOF
+	(lang dune ${version})
+	(package (name foo) (depends a (b (>= 0.0.2))))
+	(package (name bar) (depends foo c))
+	EOF
+}
+
 make_bar_depends_foo_project() {
   cat > dune-project <<-'EOF'
 	(lang dune 3.10)

--- a/test/blackbox-tests/test-cases/pkg/lockdir-tampering.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-tampering.t
@@ -3,27 +3,10 @@ dependencies due to tampering with the lockdir. These are cases that won't be
 caught by checking the dependency hash.
 
   $ mkrepo
-  $ mkpkg a <<EOF
-  > depends: [ "c" "d" ]
-  > EOF
-  $ mkpkg b 0.0.1 <<EOF
-  > EOF
-  $ mkpkg b 0.0.2 <<EOF
-  > EOF
-  $ mkpkg c <<EOF
-  > depends: [ "e" ]
-  > EOF
-  $ mkpkg d <<EOF
-  > EOF
-  $ mkpkg e <<EOF
-  > EOF
+  $ make_lockdir_validation_packages
 
 Define some local packages.
-  $ cat >dune-project <<EOF
-  > (lang dune 3.11)
-  > (package (name foo) (depends a (b (>= 0.0.2))))
-  > (package (name bar) (depends foo c))
-  > EOF
+  $ make_lockdir_validation_project 3.11
   $ add_mock_repo_if_needed
 
 Without a lockdir this command prints a hint but exits successfully.

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-validation.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-validation.t
@@ -4,27 +4,10 @@ Exercise the `dune pkg validate-lockdir` command on portable lockdirs.
   $ add_mock_repo_if_needed
 
 Define some interdependent opam packages:
-  $ mkpkg a 0.0.1 <<EOF
-  > depends: [ "c" "d" ]
-  > EOF
-  $ mkpkg b 0.0.1 <<EOF
-  > EOF
-  $ mkpkg b 0.0.2 <<EOF
-  > EOF
-  $ mkpkg c <<EOF
-  > depends: [ "e" ]
-  > EOF
-  $ mkpkg d <<EOF
-  > EOF
-  $ mkpkg e <<EOF
-  > EOF
+  $ make_lockdir_validation_packages
 
 Define some local packages.
-  $ cat >dune-project <<EOF
-  > (lang dune 3.20)
-  > (package (name foo) (depends a (b (>= 0.0.2))))
-  > (package (name bar) (depends foo c))
-  > EOF
+  $ make_lockdir_validation_project 3.20
 
 Solve dependencies:
   $ dune pkg lock


### PR DESCRIPTION
Extract the repeated mock package graph and local package project used
by lockdir validation tests into pkg helpers.