### PR TITLE
test(stdlib): share mystdlib source fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -165,6 +165,21 @@ make_install_include_project() {
 	EOF
 }
 
+write_stdlib_mystdlib_sources() {
+  mkdir -p stdlib
+  cat > stdlib/other.ml <<-'EOF'
+	let other () = Mystdlib.defined_in_stdlib
+	EOF
+  cat > stdlib/one_module.ml <<-'EOF'
+	let foo = "foo"
+	EOF
+  cat > stdlib/mystdlib.ml <<-'EOF'
+	let defined_in_stdlib = "defined"
+	module One_module = One_module
+	module Other = Other
+	EOF
+}
+
 make_value_library() {
   local dir="$1"
   local name="$2"

--- a/test/blackbox-tests/test-cases/stdlib/stdlib-compilation-internal-modules.t
+++ b/test/blackbox-tests/test-cases/stdlib/stdlib-compilation-internal-modules.t
@@ -5,18 +5,7 @@ Compile a library with `(stdlib ..)` and multiple globs for internal_modules
   > (using experimental_building_ocaml_compiler_with_dune 0.1)
   > EOF
 
-  $ mkdir stdlib
-  $ cat > stdlib/other.ml <<EOF
-  > let other () = Mystdlib.defined_in_stdlib
-  > EOF
-  $ cat > stdlib/one_module.ml <<EOF
-  > let foo = "foo"
-  > EOF
-  $ cat > stdlib/mystdlib.ml <<EOF
-  > let defined_in_stdlib = "defined"
-  > module One_module = One_module
-  > module Other = Other
-  > EOF
+  $ write_stdlib_mystdlib_sources
 
   $ cat >stdlib/dune <<EOF
   > (library

--- a/test/blackbox-tests/test-cases/stdlib/stdlib-compilation-wrapping.t
+++ b/test/blackbox-tests/test-cases/stdlib/stdlib-compilation-wrapping.t
@@ -5,7 +5,7 @@ Compile a library with `(stdlib ..)` and wrapped settings
   > (using experimental_building_ocaml_compiler_with_dune 0.1)
   > EOF
 
-  $ mkdir stdlib
+  $ write_stdlib_mystdlib_sources
   $ runtest() {
   > cat >stdlib/dune <<EOF
   > (library
@@ -18,17 +18,6 @@ Compile a library with `(stdlib ..)` and wrapped settings
   > find _build/default/stdlib -iname '*.cmi' | sort;
   > }
 
-  $ cat > stdlib/other.ml <<EOF
-  > let other () = Mystdlib.defined_in_stdlib
-  > EOF
-  $ cat > stdlib/one_module.ml <<EOF
-  > let foo = "foo"
-  > EOF
-  $ cat > stdlib/mystdlib.ml <<EOF
-  > let defined_in_stdlib = "defined"
-  > module One_module = One_module
-  > module Other = Other
-  > EOF
 
 First we test wrapped:
 


### PR DESCRIPTION
Extract the repeated mystdlib source setup used by stdlib blackbox
tests into a shared helper.