### PR TITLE
test(directory-targets): share contents rule fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -542,6 +542,25 @@ make_empty_child_directory_target_project() {
 	EOF
 }
 
+write_directory_target_contents_rules() {
+  local deps="$1"
+
+  cat > dune <<- EOF
+	(rule
+	  (deps ${deps})
+	  (targets (dir output))
+	  (action (bash "\| echo running;
+	                "\| mkdir -p output/subdir;
+	                "\| cat src_a > output/new-a;
+	                "\| cat src_b > output/subdir/b
+	 )))
+	(rule
+	  (deps output)
+	  (target contents)
+	  (action (bash "echo running; echo 'new-a:' > contents; cat output/new-a >> contents; echo 'b:' >> contents; cat output/subdir/b >> contents")))
+	EOF
+}
+
 write_directory_diff_keep_rule() {
   cat > dune <<-'EOF'
 	(rule

--- a/test/blackbox-tests/test-cases/directory-targets/main.t
+++ b/test/blackbox-tests/test-cases/directory-targets/main.t
@@ -394,20 +394,7 @@ since the produced directory has the same contents.
 
 Check that Dune clears stale files from directory targets.
 
-  $ cat > dune <<EOF
-  > (rule
-  >   (deps src_a src_b src_c (sandbox always))
-  >   (targets (dir output))
-  >   (action (bash "\| echo running;
-  >                 "\| mkdir -p output/subdir;
-  >                 "\| cat src_a > output/new-a;
-  >                 "\| cat src_b > output/subdir/b
-  > )))
-  > (rule
-  >   (deps output)
-  >   (target contents)
-  >   (action (bash "echo running; echo 'new-a:' > contents; cat output/new-a >> contents; echo 'b:' >> contents; cat output/subdir/b >> contents")))
-  > EOF
+  $ write_directory_target_contents_rules "src_a src_b src_c (sandbox always)"
 
   $ dune build contents
   running

--- a/test/blackbox-tests/test-cases/directory-targets/no-sandboxing.t
+++ b/test/blackbox-tests/test-cases/directory-targets/no-sandboxing.t
@@ -48,20 +48,7 @@ When we fail to create the directory, dune complains:
 
 Check that Dune clears stale files from directory targets.
 
-  $ cat >dune <<EOF
-  > (rule
-  >   (deps src_a src_b src_c)
-  >   (targets (dir output))
-  >   (action (bash "\| echo running;
-  >                 "\| mkdir -p output/subdir;
-  >                 "\| cat src_a > output/new-a;
-  >                 "\| cat src_b > output/subdir/b
-  > )))
-  > (rule
-  >   (deps output)
-  >   (target contents)
-  >   (action (bash "echo running; echo 'new-a:' > contents; cat output/new-a >> contents; echo 'b:' >> contents; cat output/subdir/b >> contents")))
-  > EOF
+  $ write_directory_target_contents_rules "src_a src_b src_c"
 
   $ echo a > src_a
   $ echo b > src_b


### PR DESCRIPTION
Extract the repeated directory target plus contents rule pair into a shared helper
parameterized by the dependency list.