### PR TITLE
test(contexts): reuse two-context workspace helper

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -524,14 +524,17 @@ write_directory_diff_keep_rule() {
 }
 
 make_two_context_workspace() {
+  local version="${1:-3.13}"
+  local name="${2:-alt-context}"
+
   cat > dune-workspace <<- EOF
-	(lang dune 3.13)
+	(lang dune ${version})
 	
 	(context default)
 	
 	(context
 	 (default
-	  (name alt-context)))
+	  (name ${name})))
 	EOF
 }
 

--- a/test/blackbox-tests/test-cases/describe/describe-contexts.t
+++ b/test/blackbox-tests/test-cases/describe/describe-contexts.t
@@ -2,15 +2,7 @@ Showcase behavior of the `dune describe contexts` subcommand
 
   $ make_dune_project 3.14
 
-  $ cat > dune-workspace << EOF
-  > (lang dune 3.14)
-  > 
-  > (context default)
-  > 
-  > (context
-  >  (default
-  >   (name alt)))
-  > EOF
+  $ make_two_context_workspace 3.14 alt
 
   $ dune describe contexts
   alt

--- a/test/blackbox-tests/test-cases/merlin/alt-context.t
+++ b/test/blackbox-tests/test-cases/merlin/alt-context.t
@@ -2,15 +2,7 @@ Showcase behavior when passing the `--context` flag to ocaml-merlin
 
   $ make_dune_project 3.14
 
-  $ cat > dune-workspace << EOF
-  > (lang dune 3.14)
-  > 
-  > (context default)
-  > 
-  > (context
-  >  (default
-  >   (name alt)))
-  > EOF
+  $ make_two_context_workspace 3.14 alt
 
   $ lib1=foo
   $ lib2=bar


### PR DESCRIPTION
Parameterize the existing two-context workspace helper by language version and
context name, then use it in describe/merlin context tests.