### PR TITLE
test(cache): share copy rule project fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -844,6 +844,19 @@ write_cross_compilation_repro_project() {
   fi
 }
 
+make_dune_cache_copy_project() {
+  make_dune_project 2.1
+  cat > dune <<-'EOF'
+	(rule
+	  (deps source)
+	  (targets target)
+	  (action (copy source target)))
+	EOF
+  cat > source <<-'EOF'
+	\_o< COIN
+	EOF
+}
+
 make_two_context_workspace() {
   local version="${1:-3.13}"
   local name="${2:-alt-context}"

--- a/test/blackbox-tests/test-cases/dune-cache/config.t
+++ b/test/blackbox-tests/test-cases/dune-cache/config.t
@@ -10,16 +10,7 @@ Check that old cache configuration format works fine with an old language
   > (cache-trim-period 1h)
   > (cache-trim-size 1GB)
   > EOF
-  $ make_dune_project 2.1
-  $ cat > dune <<EOF
-  > (rule
-  >   (deps source)
-  >   (targets target)
-  >   (action (copy source target)))
-  > EOF
-  $ cat > source <<EOF
-  > \_o< COIN
-  > EOF
+  $ make_dune_cache_copy_project
 
 Test that DUNE_CACHE_ROOT can be used to control the cache location
 

--- a/test/blackbox-tests/test-cases/dune-cache/dedup.t
+++ b/test/blackbox-tests/test-cases/dune-cache/dedup.t
@@ -3,16 +3,7 @@ Test deduplication of build artifacts when using Dune cache with hard links.
   $ export DUNE_CACHE=enabled
   $ export DUNE_CACHE_ROOT=$(dune_cmd native-path $PWD/.cache)
 
-  $ make_dune_project 2.1
-  $ cat > dune <<EOF
-  > (rule
-  >   (deps source)
-  >   (targets target)
-  >   (action (copy source target)))
-  > EOF
-  $ cat > source <<EOF
-  > \_o< COIN
-  > EOF
+  $ make_dune_cache_copy_project
 
 Here we build [target], which is a copy of [source]. After the build, the same
 file will appear in the build directory twice: (i) as [_build/default/source],


### PR DESCRIPTION
Extract the repeated Dune cache test project with a copy rule and source file
into a shared blackbox-test helper.