### PR TITLE
test(per-module): share original_name update fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -209,6 +209,17 @@ make_mylib_consumer_executable() {
 	EOF
 }
 
+write_original_name_xy() {
+  cat > original_name.mli <<-'EOF'
+	val x : string
+	val y : int
+	EOF
+  cat > original_name.ml <<-'EOF'
+	let x = "hello"
+	let y = 42
+	EOF
+}
+
 make_melange_runtime_deps_lib() {
   local dir="${1:-lib}"
 

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/auto-wrapped-child-reexport.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/auto-wrapped-child-reexport.t
@@ -78,14 +78,7 @@ Edit [dep_lib]'s interface. [consumer] reaches [dep_lib]'s
 [Lib_re_export]). The cctx-wide compile-rule deps include
 [dep_lib], so [consumer] rebuilds:
 
-  $ cat > original_name.mli <<EOF
-  > val x : string
-  > val y : int
-  > EOF
-  $ cat > original_name.ml <<EOF
-  > let x = "hello"
-  > let y = 42
-  > EOF
+  $ write_original_name_xy
   $ dune build @check
   $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("consumer"))]'
   [

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/modules-without-implementation-cross-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/modules-without-implementation-cross-lib.t
@@ -53,14 +53,7 @@ Edit [dep_lib]'s interface. [consumer] reaches [Original_name]
 through [Foo.Re], so it must rebuild — and must rebuild cleanly,
 not error out with "inconsistent assumptions over interface":
 
-  $ cat > original_name.mli <<EOF
-  > val x : string
-  > val y : int
-  > EOF
-  $ cat > original_name.ml <<EOF
-  > let x = "hello"
-  > let y = 42
-  > EOF
+  $ write_original_name_xy
   $ dune build @check
   $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("consumer"))] | length'
   1

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-reexport-via-open-flag.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-reexport-via-open-flag.t
@@ -62,14 +62,7 @@ Edit [dep_lib]'s interface. [consumer] reaches [dep_lib]'s
 [Lib_re_export] wrapper. The cctx-wide compile-rule deps include
 [dep_lib], so [consumer] rebuilds:
 
-  $ cat > original_name.mli <<EOF
-  > val x : string
-  > val y : int
-  > EOF
-  $ cat > original_name.ml <<EOF
-  > let x = "hello"
-  > let y = 42
-  > EOF
+  $ write_original_name_xy
   $ dune build @check
   $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("consumer"))]'
   [


### PR DESCRIPTION
Extract the repeated original_name interface/implementation update used by
per-module reexport dependency tests into a shared helper.