### PR TITLE
test(melange): share installed app fixture

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -544,6 +544,25 @@ write_menhir_merge_into_sources() {
 	EOF
 }
 
+write_melange_app_using_foo() {
+  local dir="${1:-app}"
+
+  mkdir -p "$dir"
+  cat > "$dir/dune-project" <<-'EOF'
+	(lang dune 3.8)
+	(package (name app))
+	(using melange 0.1)
+	EOF
+  cat > "$dir/dune" <<-'EOF'
+	(melange.emit
+	 (target output)
+	 (alias mel)
+	 (emit_stdlib false)
+	 (libraries foo)
+	 (preprocess (pps melange.ppx)))
+	EOF
+}
+
 make_melange_virtual_time_project() {
   local vlib_public_name="$1"
   local impl_public_name="$2"

--- a/test/blackbox-tests/test-cases/melange/depend-on-installed-lib-with-dir-target-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/depend-on-installed-lib-with-dir-target-runtime-deps.t
@@ -36,19 +36,7 @@ Test `melange.runtime_deps` in a library that has been installed
 
   $ write_melange_asset_reader app
 
-  $ cat > app/dune-project <<EOF
-  > (lang dune 3.8)
-  > (package (name app))
-  > (using melange 0.1)
-  > EOF
-  $ cat > app/dune <<EOF
-  > (melange.emit
-  >  (target output)
-  >  (alias mel)
-  >  (emit_stdlib false)
-  >  (libraries foo)
-  >  (preprocess (pps melange.ppx)))
-  > EOF
+  $ write_melange_app_using_foo app
 
 
   $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root app @mel --debug-dependency-path

--- a/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps.t
@@ -30,19 +30,7 @@ Test `melange.runtime_deps` in a library that has been installed
 
   $ write_melange_asset_reader app
 
-  $ cat > app/dune-project <<EOF
-  > (lang dune 3.8)
-  > (package (name app))
-  > (using melange 0.1)
-  > EOF
-  $ cat > app/dune <<EOF
-  > (melange.emit
-  >  (target output)
-  >  (alias mel)
-  >  (emit_stdlib false)
-  >  (libraries foo)
-  >  (preprocess (pps melange.ppx)))
-  > EOF
+  $ write_melange_app_using_foo app
 
 
   $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root app @mel


### PR DESCRIPTION
Extract the repeated Melange app dune-project and emit stanza used by installed
runtime_deps tests into a shared helper.