### PR TITLE
test(melange): default dir target lib path

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -460,9 +460,9 @@ write_menhir_unit_parser_sources() {
 }
 
 write_melange_dir_target_runtime_deps_lib() {
-  local dir="${1:-lib}"
-  local runtime_deps="$2"
-  local file_path="$3"
+  local runtime_deps="$1"
+  local file_path="$2"
+  local dir="${3:-lib}"
 
   mkdir -p "$dir"
   cat > "$dir/dune" <<- EOF

--- a/test/blackbox-tests/test-cases/melange/depend-on-installed-lib-with-dir-target-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/depend-on-installed-lib-with-dir-target-runtime-deps.t
@@ -11,7 +11,6 @@ Test `melange.runtime_deps` in a library that has been installed
   $ mkdir -p lib
   $ echo "Some text" > lib/index.txt
   $ write_melange_dir_target_runtime_deps_lib \
-  >   lib \
   >   "./some_dir ./index.txt" \
   >   "./some_dir/inside-dir-target.txt"
 

--- a/test/blackbox-tests/test-cases/melange/installed-library-with-dir-target-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/installed-library-with-dir-target-runtime-deps.t
@@ -10,7 +10,6 @@ Test `melange.runtime_deps` in a library that has been installed
 
   $ echo 'hello' > lib/file.txt
   $ write_melange_dir_target_runtime_deps_lib \
-  >   lib \
   >   "./some_dir ./file.txt" \
   >   "./index.txt"
 
@@ -28,7 +27,6 @@ Test `melange.runtime_deps` in a library that has been installed
   $ rm -rf $PWD/prefix
   $ dune clean
   $ write_melange_dir_target_runtime_deps_lib \
-  >   lib \
   >   "./some_dir/inside-dir-target.txt ./some_dir ./file.txt" \
   >   "./index.txt"
 


### PR DESCRIPTION
Make the Melange directory-target runtime_deps helper default to writing the lib fixture under `lib`, shortening the current call sites.