### PR TITLE
Update head branch in backport.sh

### DIFF
--- a/doc/dev/releases/backport.sh
+++ b/doc/dev/releases/backport.sh
@@ -79,6 +79,6 @@ fi
 gh pr create \
     --repo ocaml/dune \
     --base "${rc_branch}" \
-    --head "${github_owner}:${rc_branch}" \
+    --head "${github_owner}:${backport_branch}" \
     --title "[${VERSION}] backport #${PR}" \
     --body "Backport #${PR} onto ${rc_branch}"


### PR DESCRIPTION
The commit to be backported gets cherry picked onto the `${backport_branch}`. Updating the script to make it the head branch of the PR to be generated by the script.