### PR TITLE
test(melange): combine installed app helpers

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -563,6 +563,13 @@ write_melange_app_using_foo() {
 	EOF
 }
 
+make_melange_app_with_asset_reader() {
+  local dir="${1:-app}"
+
+  write_melange_asset_reader "$dir"
+  write_melange_app_using_foo "$dir"
+}
+
 make_melange_virtual_time_project() {
   local vlib_public_name="$1"
   local impl_public_name="$2"

--- a/test/blackbox-tests/test-cases/melange/depend-on-installed-lib-with-dir-target-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/depend-on-installed-lib-with-dir-target-runtime-deps.t
@@ -33,9 +33,7 @@ Test `melange.runtime_deps` in a library that has been installed
 
   $ dune install --root lib --prefix $PWD/prefix
 
-  $ write_melange_asset_reader app
-
-  $ write_melange_app_using_foo app
+  $ make_melange_app_with_asset_reader app
 
 
   $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root app @mel --debug-dependency-path

--- a/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps.t
@@ -28,9 +28,7 @@ Test `melange.runtime_deps` in a library that has been installed
 
   $ dune install --root lib --prefix $PWD/prefix
 
-  $ write_melange_asset_reader app
-
-  $ write_melange_app_using_foo app
+  $ make_melange_app_with_asset_reader app
 
 
   $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root app @mel


### PR DESCRIPTION
Add a helper that writes both the installed-library Melange app project and its asset-reading main file, replacing repeated adjacent helper calls.