### PR TITLE
refactor(memo): split [Changed_or_not]

### DIFF
--- a/src/memo/changed_or_not.ml
+++ b/src/memo/changed_or_not.ml
@@ -1,0 +1,18 @@
+open! Import
+
+type 'cycle t =
+  | Unchanged
+  | Changed
+  | Cancelled of { dependency_cycle : 'cycle }
+
+let combine x y =
+  match x, y with
+  | Cancelled _, Cancelled _ ->
+    (* This is the only non-commutative case: we prefer the dependency cycle [x] here. We
+       could combine the two cycles into a set of cycles but it doesn't seems worth it. *)
+    x
+  | Cancelled _, _ -> x
+  | _, Cancelled _ -> y
+  | Changed, _ | _, Changed -> Changed
+  | Unchanged, Unchanged -> Unchanged
+;;

--- a/src/memo/changed_or_not.mli
+++ b/src/memo/changed_or_not.mli
@@ -1,0 +1,20 @@
+open! Import
+
+(** Checking dependencies of a Memo node can lead to one of these outcomes:
+
+    - [Unchanged]: All dependencies of the node are up to date. We can therefore skip
+      recomputing the node and can reuse the value computed in the previous run.
+
+    - [Changed]: One of the dependencies has changed since the previous run and the node
+      should therefore be recomputed.
+
+    - [Cancelled _]: One of the dependencies leads to a dependency cycle. In this case,
+      there is no point in recomputing the current node: it's impossible to bring its
+      dependencies up to date! *)
+type 'cycle t =
+  | Unchanged
+  | Changed
+  | Cancelled of { dependency_cycle : 'cycle }
+
+(** Prefers left dependency cycle errors in [Cancelled] but is otherwise commutative. *)
+val combine : 'cycle t -> 'cycle t -> 'cycle t

--- a/src/memo/deps.ml
+++ b/src/memo/deps.ml
@@ -13,13 +13,6 @@ let create ~deps_rev = Array.of_list deps_rev
 let length = Array.length
 let to_list t = Array.fold_left t ~init:[] ~f:(fun acc x -> x :: acc)
 
-module Changed_or_not = struct
-  type 'cycle t =
-    | Unchanged
-    | Changed
-    | Cancelled of { dependency_cycle : 'cycle }
-end
-
 let changed_or_not t ~f =
   let rec go index =
     if index < 0

--- a/src/memo/deps.mli
+++ b/src/memo/deps.mli
@@ -10,24 +10,6 @@ val create : deps_rev:'node list -> 'node t
 val length : 'node t -> int
 val to_list : 'node t -> 'node list
 
-(** Checking dependencies of a node can lead to one of these outcomes:
-
-    - [Unchanged]: All dependencies of the node are up to date. We can therefore skip
-      recomputing the node and can reuse the value computed in the previous run.
-
-    - [Changed]: One of the dependencies has changed since the previous run and the node
-      should therefore be recomputed.
-
-    - [Cancelled _]: One of the dependencies leads to a dependency cycle. In this case,
-      there is no point in recomputing the current node: it's impossible to bring its
-      dependencies up to date! *)
-module Changed_or_not : sig
-  type 'cycle t =
-    | Unchanged
-    | Changed
-    | Cancelled of { dependency_cycle : 'cycle }
-end
-
 val changed_or_not
   :  'node t
   -> f:('node -> 'cycle Changed_or_not.t Fiber.t)

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -494,8 +494,6 @@ module Computation0 = struct
   let create () = { ivar = Fiber.Ivar.create (); dag_node = Lazy_dag_node.create () }
 end
 
-module Changed_or_not = Deps.Changed_or_not
-
 (* For debugging *)
 let _print_dep_node ?prefix (dep_node : _ Dep_node.t) =
   let prefix =


### PR DESCRIPTION
Pure refactor with no behavior change: extract the `Changed_or_not` type out
of `memo.ml`/`deps.ml` into its own `Changed_or_not` module (with an `.mli`).

This is the first in a small series of internal `memo` refactors and
improvements; splitting it out on its own keeps each change easy to review.
No user-facing behavior changes, so no changelog entry.