### PR TITLE
Do not display misleading suggestion in 'conflicts' field

### DIFF
--- a/doc/changes/fixed/14956.md
+++ b/doc/changes/fixed/14956.md
@@ -1,0 +1,2 @@
+- Fixed wrong suggestion for duplicate entries in `conflicts` field (#14956,
+  fixes #14903, @Leonidas-from-XIV)

--- a/src/dune_lang/package.ml
+++ b/src/dune_lang/package.ml
@@ -15,16 +15,36 @@ type original_opam_file =
   }
 
 module Duplicate_dep_warning = struct
-  type joiner =
-    | And
-    | Or
+  type field =
+    | Depends
+    | Conflicts
+    | Depopts
 
   type t =
     { loc : Loc.t
     ; dep_string : string
-    ; field_name : string
-    ; joiner : joiner
+    ; field : field
     }
+
+  let field_name { field; _ } =
+    match field with
+    | Depends -> "depends"
+    | Conflicts -> "conflicts"
+    | Depopts -> "depopts"
+  ;;
+
+  let field_of_string = function
+    | "depends" -> Some Depends
+    | "conflicts" -> Some Conflicts
+    | "depopts" -> Some Depopts
+    | _ -> None
+  ;;
+
+  let combine_constraint_op { field; _ } =
+    match field with
+    | Conflicts -> "(or ...)"
+    | Depends | Depopts -> "(and ...)"
+  ;;
 end
 
 type t =
@@ -132,8 +152,6 @@ let decode_name ~version =
   if version >= (3, 11) then Name.decode_opam_compatible else Name.decode
 ;;
 
-let disjunction_fields = String.Set.of_list [ "conflicts" ]
-
 let decode =
   let enabled_if =
     String_with_vars.set_decoding_env
@@ -165,12 +183,15 @@ let decode =
         then (
           let dep_sexp = Package_dependency.encode dep in
           let dep_string = Dune_sexp.to_string dep_sexp in
-          let joiner =
-            match String.Set.mem disjunction_fields field_name with
-            | true -> Duplicate_dep_warning.Or
-            | false -> Duplicate_dep_warning.And
+          let field =
+            match Duplicate_dep_warning.field_of_string field_name with
+            | Some field -> field
+            | None ->
+              Code_error.raise
+                "Unsupported field name"
+                [ "field_name", Dyn.string field_name ]
           in
-          let warning = { Duplicate_dep_warning.loc; dep_string; field_name; joiner } in
+          let warning = { Duplicate_dep_warning.loc; dep_string; field } in
           warning :: warnings, (loc, dep) :: seen)
         else warnings, (loc, dep) :: seen)
     in

--- a/src/dune_lang/package.ml
+++ b/src/dune_lang/package.ml
@@ -15,10 +15,15 @@ type original_opam_file =
   }
 
 module Duplicate_dep_warning = struct
+  type joiner =
+    | And
+    | Or
+
   type t =
     { loc : Loc.t
     ; dep_string : string
     ; field_name : string
+    ; joiner : joiner
     }
 end
 
@@ -127,6 +132,8 @@ let decode_name ~version =
   if version >= (3, 11) then Name.decode_opam_compatible else Name.decode
 ;;
 
+let disjunction_fields = String.Set.of_list [ "conflicts" ]
+
 let decode =
   let enabled_if =
     String_with_vars.set_decoding_env
@@ -158,7 +165,12 @@ let decode =
         then (
           let dep_sexp = Package_dependency.encode dep in
           let dep_string = Dune_sexp.to_string dep_sexp in
-          let warning = { Duplicate_dep_warning.loc; dep_string; field_name } in
+          let joiner =
+            match String.Set.mem disjunction_fields field_name with
+            | true -> Duplicate_dep_warning.Or
+            | false -> Duplicate_dep_warning.And
+          in
+          let warning = { Duplicate_dep_warning.loc; dep_string; field_name; joiner } in
           warning :: warnings, (loc, dep) :: seen)
         else warnings, (loc, dep) :: seen)
     in

--- a/src/dune_lang/package.mli
+++ b/src/dune_lang/package.mli
@@ -79,10 +79,15 @@ val create
 val original_opam_file : t -> original_opam_file option
 
 module Duplicate_dep_warning : sig
+  type joiner =
+    | And
+    | Or
+
   type t =
     { loc : Loc.t
     ; dep_string : string
     ; field_name : string
+    ; joiner : joiner
     }
 end
 

--- a/src/dune_lang/package.mli
+++ b/src/dune_lang/package.mli
@@ -79,16 +79,20 @@ val create
 val original_opam_file : t -> original_opam_file option
 
 module Duplicate_dep_warning : sig
-  type joiner =
-    | And
-    | Or
+  type field =
+    | Depends
+    | Conflicts
+    | Depopts
 
   type t =
     { loc : Loc.t
     ; dep_string : string
-    ; field_name : string
-    ; joiner : joiner
+    ; field : field
     }
+
+  val field_of_string : string -> field option
+  val combine_constraint_op : t -> string
+  val field_name : t -> string
 end
 
 val duplicate_dep_warnings : t -> Duplicate_dep_warning.t list

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -451,15 +451,21 @@ let gen_project_rules =
                  duplicate_deps
                  (Warning_emit.Context.project project)
                  (fun () ->
+                    let joiner =
+                      match warning.joiner with
+                      | And -> "(and ...)"
+                      | Or -> "(or ...)"
+                    in
                     Memo.return
                       (User_message.make
                          ~loc:warning.loc
                          [ Pp.textf
                              "Duplicate dependency on package %s in '%s' field. If you \
                               want to specify multiple constraints, combine them using \
-                              (and ...)."
+                              %s."
                              warning.dep_string
                              warning.field_name
+                             joiner
                          ]))))
     in
     ()

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -442,31 +442,25 @@ let gen_project_rules =
     and+ () =
       (* Emit warnings for duplicate dependencies in packages *)
       let packages = Dune_project.packages project in
+      let module Duplicate_dep_warning = Dune_lang.Package.Duplicate_dep_warning in
       Dune_lang.Package.Name.Map.values packages
       |> Memo.parallel_iter ~f:(fun pkg ->
         Dune_lang.Package.duplicate_dep_warnings pkg
-        |> Memo.parallel_iter
-             ~f:(fun (warning : Dune_lang.Package.Duplicate_dep_warning.t) ->
-               Warning_emit.emit
-                 duplicate_deps
-                 (Warning_emit.Context.project project)
-                 (fun () ->
-                    let joiner =
-                      match warning.joiner with
-                      | And -> "(and ...)"
-                      | Or -> "(or ...)"
-                    in
-                    Memo.return
-                      (User_message.make
-                         ~loc:warning.loc
-                         [ Pp.textf
-                             "Duplicate dependency on package %s in '%s' field. If you \
-                              want to specify multiple constraints, combine them using \
-                              %s."
-                             warning.dep_string
-                             warning.field_name
-                             joiner
-                         ]))))
+        |> Memo.parallel_iter ~f:(fun (warning : Duplicate_dep_warning.t) ->
+          Warning_emit.emit
+            duplicate_deps
+            (Warning_emit.Context.project project)
+            (fun () ->
+               Memo.return
+                 (User_message.make
+                    ~loc:warning.loc
+                    [ Pp.textf
+                        "Duplicate dependency on package %s in '%s' field. If you want \
+                         to specify multiple constraints, combine them using %s."
+                        warning.dep_string
+                        (Duplicate_dep_warning.field_name warning)
+                        (Duplicate_dep_warning.combine_constraint_op warning)
+                    ]))))
     in
     ()
   in

--- a/test/blackbox-tests/test-cases/dune-project-meta/duplicate-dependencies.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/duplicate-dependencies.t
@@ -112,7 +112,7 @@ Duplicates in conflicts field
   6 |  (conflicts base base))
                        ^^^^
   Warning: Duplicate dependency on package base in 'conflicts' field. If you
-  want to specify multiple constraints, combine them using (and ...).
+  want to specify multiple constraints, combine them using (or ...).
   Hint: To disable this warning, add the following to your dune-project file:
   (warnings (duplicate_deps disabled))
 


### PR DESCRIPTION
Turns out we already had a repro case for `conflicts` but it was happily displaying the confusing error message that @raphael-proust reported.

Closes #14903.