### PR TITLE
Add Nix `result` symlinks to list of ignores

### DIFF
--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -1,3 +1,7 @@
 boot/libs.ml
 src/dune_rules/assets.ml
 src/dune_rules/setup.defaults.ml
+
+# nix
+result
+result-*


### PR DESCRIPTION
If there is a symlink to `result` or `result-1` etc then `dune fmt` goes haywire, trying to format everything in there (and failing). We shouldn't do that.