### PR TITLE
refactor(memo): move Spec/Debug into separate modules

### DIFF
--- a/src/memo/import.ml
+++ b/src/memo/import.ml
@@ -1,0 +1,1 @@
+include Stdune

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -4,13 +4,7 @@ module Metrics = Metrics0
 open Fiber.O
 module Graph = Dune_graph.Graph
 module Console = Console
-
-module Debug = struct
-  let track_locations_of_lazy_values = ref false
-  let check_invariants = ref false
-  let verbose_diagnostics = ref false
-end
-
+module Debug = Memo_debug
 include Fiber
 
 let when_ x y =
@@ -21,54 +15,13 @@ let when_ x y =
 
 let of_reproducible_fiber = Fun.id
 
-module Allow_cutoff = struct
-  type 'o t =
-    | No
-    | Yes of ('o -> 'o -> bool)
-end
+module Id = Id.Make ()
 
 module type Input = sig
   type t
 
   include Table.Key with type t := t
 end
-
-module Spec = struct
-  type ('i, 'o) t =
-    { name : string option
-    ; (* If the field [witness] precedes any of the functional values ([input]
-         and [f]), then polymorphic comparison actually works for [Spec.t]s. *)
-      witness : 'i Type_eq.Id.t
-    ; input : (module Store_intf.Input with type t = 'i)
-    ; allow_cutoff : 'o Allow_cutoff.t
-    ; f : 'i -> 'o Fiber.t
-    ; human_readable_description : ('i -> User_message.Style.t Pp.t) option
-    }
-
-  let create ~name ~input ~human_readable_description ~cutoff f =
-    let name =
-      match name with
-      | None when !Debug.track_locations_of_lazy_values ->
-        Option.map (Caller_id.get ~skip:[ __FILE__ ]) ~f:(fun loc ->
-          sprintf "lazy value created at %s" (Loc.to_file_colon_line loc))
-      | _ -> name
-    in
-    let allow_cutoff =
-      match cutoff with
-      | None -> Allow_cutoff.No
-      | Some equal -> Yes equal
-    in
-    { name
-    ; input
-    ; allow_cutoff
-    ; witness = Type_eq.Id.create ()
-    ; f
-    ; human_readable_description
-    }
-  ;;
-end
-
-module Id = Id.Make ()
 
 (* We can get rid of this once we use the memoization system more pervasively
    and all the dependencies are properly specified *)

--- a/src/memo/memo_debug.ml
+++ b/src/memo/memo_debug.ml
@@ -1,0 +1,3 @@
+let track_locations_of_lazy_values = ref false
+let check_invariants = ref false
+let verbose_diagnostics = ref false

--- a/src/memo/spec.ml
+++ b/src/memo/spec.ml
@@ -1,0 +1,40 @@
+open Import
+
+module Allow_cutoff = struct
+  type 'o t =
+    | No
+    | Yes of ('o -> 'o -> bool)
+end
+
+type ('i, 'o) t =
+  { name : string option
+  ; (* If the field [witness] precedes any of the functional values ([input]
+         and [f]), then polymorphic comparison actually works for [Spec.t]s. *)
+    witness : 'i Type_eq.Id.t
+  ; input : (module Store_intf.Input with type t = 'i)
+  ; allow_cutoff : 'o Allow_cutoff.t
+  ; f : 'i -> 'o Fiber.t
+  ; human_readable_description : ('i -> User_message.Style.t Pp.t) option
+  }
+
+let create ~name ~input ~human_readable_description ~cutoff f =
+  let name =
+    match name with
+    | None when !Memo_debug.track_locations_of_lazy_values ->
+      Option.map (Caller_id.get ~skip:[ __FILE__ ]) ~f:(fun loc ->
+        sprintf "lazy value created at %s" (Loc.to_file_colon_line loc))
+    | _ -> name
+  in
+  let allow_cutoff =
+    match cutoff with
+    | None -> Allow_cutoff.No
+    | Some equal -> Yes equal
+  in
+  { name
+  ; input
+  ; allow_cutoff
+  ; witness = Type_eq.Id.create ()
+  ; f
+  ; human_readable_description
+  }
+;;

--- a/src/memo/spec.mli
+++ b/src/memo/spec.mli
@@ -1,0 +1,28 @@
+(** A specification for a memoized function. *)
+
+open! Import
+
+module Allow_cutoff : sig
+  type 'o t =
+    | No
+    | Yes of ('o -> 'o -> bool)
+end
+
+type ('i, 'o) t =
+  { name : string option
+  ; (* If the field [witness] precedes any of the functional values ([input]
+         and [f]), then polymorphic comparison actually works for [Spec.t]s. *)
+    witness : 'i Type_eq.Id.t
+  ; input : (module Store_intf.Input with type t = 'i)
+  ; allow_cutoff : 'o Allow_cutoff.t
+  ; f : 'i -> 'o Fiber.t
+  ; human_readable_description : ('i -> User_message.Style.t Pp.t) option
+  }
+
+val create
+  :  name:string option
+  -> input:(module Store_intf.Input with type t = 'a)
+  -> human_readable_description:('a -> User_message.Style.t Pp.t) option
+  -> cutoff:('b -> 'b -> bool) option
+  -> ('a -> 'b Fiber.t)
+  -> ('a, 'b) t


### PR DESCRIPTION
Follow-up to #14955. Continues splitting `src/memo/memo.ml` into smaller
modules ahead of the larger memo improvements being upstreamed from Jane
Street's `dune_memo`.

This moves two self-contained pieces out of the monolithic `memo.ml`:

- **`Spec`** — the memoized-function spec (`Spec.t`, `register`/`find`) moves
  into `src/memo/spec.ml` + `spec.mli`.
- **`Debug`** — memo's debug toggles move into `src/memo/memo_debug.ml`. It is
  named `Memo_debug` rather than `Debug` so it cannot be shadowed by
  `Stdune.Debug` (which is in scope via `open Stdune`/`open Import`).

Pure code motion: no behavioural change. `dune build src/memo` and
`dune runtest test/expect-tests/memo` both pass.