### PR TITLE
Improve error for too-new dune-package language versions

### DIFF
--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -708,6 +708,43 @@ module Or_meta = struct
          Dune_package package)
   ;;
 
+  let unsupported_dune_language_version (message : User_message.t) =
+    let prefix = "Version " in
+    let suffix = " of the dune language is not supported." in
+    let is_newer_than_latest version =
+      match
+        Scanf.sscanf version "%u.%u%s" (fun major minor rest -> (major, minor), rest)
+      with
+      | Ok (version, "") -> Syntax.Version.compare version Stanza.latest_version = Gt
+      | Ok (_, _) | Error () -> false
+    in
+    match message.loc, String.split_lines (User_message.to_string message) with
+    | Some loc, line :: _ when (Loc.start loc).pos_lnum = 1 ->
+      (match String.drop_prefix line ~prefix with
+       | None -> None
+       | Some line ->
+         Option.bind (String.drop_suffix line ~suffix) ~f:(fun version ->
+           Option.some_if (is_newer_than_latest version) version))
+    | _ -> None
+  ;;
+
+  let clearer_unsupported_dune_language_version_error message =
+    match unsupported_dune_language_version message with
+    | None -> message
+    | Some version ->
+      User_error.make
+        ?loc:message.loc
+        ~hints:[ Pp.text "Upgrade your version of Dune." ]
+        [ Pp.textf
+            "The installed dune package was generated with dune language version %s, \
+             which this version of dune cannot read."
+            version
+        ; Pp.textf
+            "This version of Dune supports dune-package files up to version %s."
+            (Syntax.Version.to_string Stanza.latest_version)
+        ]
+  ;;
+
   let parse file lexbuf =
     let dir = Path.parent_exn file in
     let extensions = [ Dune_lang.Oxcaml.(syntax, latest_version) ] in
@@ -722,7 +759,8 @@ module Or_meta = struct
           (with_extensions (decode ~lang ~dir)))
     with
     | contents -> Ok contents
-    | exception User_error.E message -> Error message
+    | exception User_error.E message ->
+      Error (clearer_unsupported_dune_language_version_error message)
     | exception Sys_error msg ->
       Error
         (User_message.make

--- a/test/blackbox-tests/test-cases/invalid-dune-package.t
+++ b/test/blackbox-tests/test-cases/invalid-dune-package.t
@@ -20,3 +20,19 @@ Now we attempt to use an invalid dune-package library:
   -> required by _build/default/.foo.eobjs/native/dune__exe__Foo.cmx
   -> required by _build/default/foo.exe
   [1]
+
+Now we attempt to use a dune-package file produced by a future version of Dune:
+  $ cat >findlib/baz/dune-package <<EOF
+  > (lang dune 99.0)
+  > EOF
+  $ OCAMLPATH=$PWD/findlib dune exec ./foo.exe
+  File "$TESTCASE_ROOT/findlib/baz/dune-package", line 1, characters 11-15:
+  1 | (lang dune 99.0)
+                 ^^^^
+  Error: The installed dune package was generated with dune language version
+  99.0, which this version of dune cannot read.
+  This version of Dune supports dune-package files up to version 3.25.
+  -> required by _build/default/.foo.eobjs/native/dune__exe__Foo.cmx
+  -> required by _build/default/foo.exe
+  Hint: Upgrade your version of Dune.
+  [1]


### PR DESCRIPTION
Fixes #14560.

## Summary
- detect too-new `(lang dune X.Y)` errors while reading installed `dune-package` files
- replace the generic language-version error with a package-focused message and upgrade hint
- add a blackbox regression test for a future `dune-package` language version