### PR TITLE
feat(memo): add create_rec for self-recursive memoized functions

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1290,6 +1290,16 @@ end
 
 let exec (type i o) (t : (i, o) Table.t) i = Exec.exec_dep_node (dep_node t i)
 
+let create_rec name ~input ?cutoff ?human_readable_description f =
+  let rec table =
+    lazy
+      (create name ~input ?cutoff ?human_readable_description (fun input ->
+         let table = Stdlib.Lazy.force table in
+         f (exec table) input))
+  in
+  Stdlib.Lazy.force table
+;;
+
 let dump_cached_graph ?(on_not_cached = `Raise) ?(time_nodes = false) cell =
   let rec collect_graph (Dep_node.T dep_node) graph : Graph.t Fiber.t =
     let src_id = Id.to_int dep_node.id in

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -290,6 +290,27 @@ val create_with_store
   -> ('i -> 'o t)
   -> ('i, 'o) Table.t
 
+(** Like [create] but allows the memoized function to call itself recursively. The
+    function receives, as its first argument, the memoized version of itself.
+
+    {[
+      Memo.create_rec "fib" ~input:(module Int) (fun fib n ->
+        if n <= 1
+        then Memo.return n
+        else
+          let open Memo.O in
+          let* r1 = fib (n - 1) in
+          let+ r2 = fib (n - 2) in
+          r1 + r2)
+    ]} *)
+val create_rec
+  :  string
+  -> input:(module Input with type t = 'i)
+  -> ?cutoff:('o -> 'o -> bool)
+  -> ?human_readable_description:('i -> User_message.Style.t Pp.t)
+  -> (('i -> 'o t) -> 'i -> 'o t)
+  -> ('i, 'o) Table.t
+
 (** Execute a memoized function. *)
 val exec : ('i, 'o) Table.t -> 'i -> 'o t
 

--- a/test/expect-tests/memo/main.ml
+++ b/test/expect-tests/memo/main.ml
@@ -2305,3 +2305,36 @@ let%expect_test "Ensure that implicit output storage cell is not reused between 
   set_invalidate_print_run ();
   [%expect {| Some [ "x" ] |}]
 ;;
+
+let%expect_test "create_rec" =
+  let calls = ref 0 in
+  let fib =
+    Memo.create_rec
+      "fib"
+      ~input:(module Int)
+      (fun fib n ->
+         incr calls;
+         if n <= 1
+         then Memo.return n
+         else
+           let* r1 = fib (n - 1) in
+           let+ r2 = fib (n - 2) in
+           r1 + r2)
+  in
+  Format.printf "fib 10 = %d@." (run_memo fib 10);
+  (* Each input from 0 to 10 is computed exactly once thanks to memoization. *)
+  Format.printf "calls = %d@." !calls;
+  [%expect
+    {|
+    fib 10 = 55
+    calls = 11
+    |}];
+  (* A second evaluation reuses the cached results: no extra calls. *)
+  Format.printf "fib 10 = %d@." (run_memo fib 10);
+  Format.printf "calls = %d@." !calls;
+  [%expect
+    {|
+    fib 10 = 55
+    calls = 11
+    |}]
+;;


### PR DESCRIPTION
Follow-up to #14958, continuing the upstreaming of improvements from Jane
Street's `dune_memo`.

`Memo.create_rec` lets a memoized function call itself recursively by passing
it the memoized version of itself, tying the knot via a lazy table:

```ocaml
Memo.create_rec "fib" ~input:(module Int) (fun fib n ->
  if n <= 1
  then Memo.return n
  else
    let open Memo.O in
    let* r1 = fib (n - 1) in
    let+ r2 = fib (n - 2) in
    r1 + r2)
```

It mirrors the `create` signature (`?cutoff`, `?human_readable_description`), so
the change is purely additive. Ported without the oxcaml-only parameters from
the Jane Street version.

`dune build src/memo` and `dune runtest test/expect-tests/memo` both pass (the
new `create_rec` expect-test checks both memoization within a run and reuse
across runs).