### PR TITLE
Handle malformed package dependency variables

### DIFF
--- a/src/dune_lang/package_constraint.ml
+++ b/src/dune_lang/package_constraint.ml
@@ -157,9 +157,9 @@ let decode =
     in
     peek_exn
     >>= function
-    | Atom (_loc, A s) when String.starts_with ~prefix:":" s ->
-      let+ () = junk in
-      Bvar (Variable (Package_variable_name.of_string (String.drop s 1)))
+    | Atom (_, A s) when String.starts_with ~prefix:":" s ->
+      let+ variable = Package_variable_name.Project.decode in
+      Bvar (Variable variable)
     | _ -> sum (ops @ logops))
 ;;
 

--- a/src/dune_lang/package_dependency.ml
+++ b/src/dune_lang/package_dependency.ml
@@ -95,9 +95,12 @@ let decode =
      | None -> ());
     result
   in
-  enter constrained
-  <|> let+ name = Well_formed_name.decode in
-      { name; constraint_ = None }
+  peek_exn
+  >>= function
+  | List _ -> enter constrained
+  | _ ->
+    let+ name = Well_formed_name.decode in
+    { name; constraint_ = None }
 ;;
 
 let repr =

--- a/src/dune_lang/package_variable_name.ml
+++ b/src/dune_lang/package_variable_name.ml
@@ -131,9 +131,12 @@ module Project = struct
   let encode name = Encoder.string (":" ^ to_string name)
 
   let decode =
-    Decoder.atom_matching ~desc:"variable" (fun s ->
-      if String.starts_with ~prefix:":" s
-      then Some (of_string (String.drop s 1))
-      else None)
+    let open Decoder in
+    peek_exn
+    >>= function
+    | Atom (loc, A s) when String.starts_with ~prefix:":" s ->
+      let+ () = junk in
+      parse_string_exn (loc, String.drop s 1)
+    | sexp -> User_error.raise ~loc:(Ast.loc sexp) [ Pp.text "variable expected" ]
   ;;
 end

--- a/test/blackbox-tests/test-cases/dune-project-meta/operators.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/operators.t
@@ -36,6 +36,26 @@ Supported since 2.1:
     "conf-libX11" {os != "win32"}
 
 
+Malformed dependency variables are rejected:
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.20)
+  > (generate_opam_files)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends
+  >   (ocaml-lsp-server : with-dev-setup)))
+  > EOF
+
+  $ dune build
+  File "dune-project", line 7, characters 20-21:
+  7 |   (ocaml-lsp-server : with-dev-setup)))
+                          ^
+  Error: "" is an invalid variable name.
+  [1]
+
+
 Using negation operator for dependencies
 ----------------------------------------
 


### PR DESCRIPTION
Fixes #13230.

## Summary
- parse package variables through the checked decoder instead of constructing them directly
- avoid backtracking malformed constrained dependencies into plain dependency parsing
- add a regression for `(package (depends (pkg : with-dev-setup)))`