### PR TITLE
perf(memo): look up dep nodes with a single hash-table operation

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1016,12 +1016,7 @@ let make_dep_node ~spec ~input : _ Dep_node.t =
 ;;
 
 let dep_node (t : (_, _) Table.t) input =
-  match Store.find t.cache input with
-  | Some dep_node -> dep_node
-  | None ->
-    let dep_node = make_dep_node ~spec:t.spec ~input in
-    Store.set t.cache input dep_node;
-    dep_node
+  Store.find_or_add t.cache input ~f:(fun input -> make_dep_node ~spec:t.spec ~input)
 ;;
 
 let report_and_collect_errors f =

--- a/src/memo/store.ml
+++ b/src/memo/store.ml
@@ -11,6 +11,19 @@ let make (type k v) (module S : Store_intf.S with type key = k) : (k, v) t =
     let store = S.create ()
     let set = S.set
     let find = S.find
+
+    (* [S] only provides [find] and [set], so custom stores fall back to two lookups. The
+       default store ([of_table]) below overrides this with a single-lookup
+       implementation. *)
+    let find_or_add t key ~f =
+      match S.find t key with
+      | Some v -> v
+      | None ->
+        let v = f key in
+        S.set t key v;
+        v
+    ;;
+
     let clear = S.clear
     let iter = S.iter
   end)
@@ -19,6 +32,11 @@ let make (type k v) (module S : Store_intf.S with type key = k) : (k, v) t =
 let clear (type k v) ((module S) : (k, v) t) = S.clear S.store
 let set (type k v) ((module S) : (k, v) t) (k : k) (v : v) = S.set S.store k v
 let find (type k v) ((module S) : (k, v) t) (k : k) : v option = S.find S.store k
+
+let find_or_add (type k v) ((module S) : (k, v) t) (k : k) ~(f : k -> v) : v =
+  S.find_or_add S.store k ~f
+;;
+
 let iter (type k v) ((module S) : (k, v) t) ~(f : v -> unit) : unit = S.iter S.store ~f
 
 let of_table (type k v) (table : (k, v) Table.t) : (k, v) t =
@@ -32,6 +50,7 @@ let of_table (type k v) (table : (k, v) Table.t) : (k, v) t =
 
     let clear = Table.clear
     let find = Table.find
+    let find_or_add = Table.find_or_add
     let set = Table.set
     let iter = Table.iter
   end)

--- a/src/memo/store.mli
+++ b/src/memo/store.mli
@@ -6,5 +6,10 @@ val make : (module Store_intf.S with type key = 'a) -> ('a, 'b) t
 val set : ('a, 'b) t -> 'a -> 'b -> unit
 val clear : ('a, 'b) t -> unit
 val find : ('a, 'b) t -> 'a -> 'b option
+
+(** [find_or_add t key ~f] returns the value associated with [key], adding [f key] if it
+    is missing. A single hash-table lookup, unlike [find] then [set]. *)
+val find_or_add : ('a, 'b) t -> 'a -> f:('a -> 'b) -> 'b
+
 val iter : ('a, 'b) t -> f:('b -> unit) -> unit
 val of_table : ('a, 'b) Table.t -> ('a, 'b) t

--- a/src/memo/store_intf.ml
+++ b/src/memo/store_intf.ml
@@ -23,6 +23,12 @@ module type Instance = sig
   val clear : t -> unit
   val set : t -> key -> value -> unit
   val find : t -> key -> value option
+
+  (** [find_or_add t key ~f] returns the value associated with [key], or, if [key] is not
+      present, adds [f key] and returns it. This performs a single hash-table lookup,
+      unlike a [find] followed by a [set]. *)
+  val find_or_add : t -> key -> f:(key -> value) -> value
+
   val iter : t -> f:(value -> unit) -> unit
   val store : t
 end


### PR DESCRIPTION
`dep_node` is on the hot path — every memoized call resolves its node through
it — and previously did a `Store.find` followed, on a miss, by a `Store.set`:
two hash-table operations plus an intermediate `option` allocation.

This adds `Store.find_or_add`, implemented natively for the default
table-backed store via `Stdune.Table.find_or_add` (a single lookup), with a
`find`+`set` fallback for custom stores. The operation is added to the internal
`Store_intf.Instance` only, so the public `Store.S` interface is unchanged.

`dune build src/memo` and `dune runtest test/expect-tests/memo` both pass.