### PR TITLE
feat(memo): add Var.Unit for unit-valued variables

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1762,4 +1762,23 @@ module Var = struct
   ;;
 
   let read t = Cell.read t.cell
+
+  module Unit = struct
+    type t = (unit, unit) Cell.t
+
+    (* All [unit]-valued variables share a single spec; they only differ by node identity,
+       which is what invalidation acts on. *)
+    let spec =
+      Spec.create
+        ~name:(Some "Memo.Var.Unit")
+        ~input:(module Stdune.Unit)
+        ~human_readable_description:None
+        ~cutoff:None
+        (fun () -> return ())
+    ;;
+
+    let create () : t = make_dep_node ~spec ~input:()
+    let invalidate t ~reason = Cell.invalidate t ~reason
+    let read t = Cell.read t
+  end
 end

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -459,6 +459,22 @@ module Var : sig
   (** [read t] returns the value [t] and introduces a dependency on this node in the
       current Memo computation. *)
   val read : 'a t -> 'a memo
+
+  (** Like [Var] but specialized to the [unit] type, which makes the implementation
+      simpler and also allows sharing the underlying spec. Unlike [set], [invalidate]
+      takes a [reason], and unlike [create], it takes no [name]. *)
+  module Unit : sig
+    type t
+
+    (** Create a [unit]-valued variable.
+
+        Doesn't take a [cutoff] because there is no point: [unit]-valued variables can
+        only be useful if invalidating them causes downstream computations to rerun. *)
+    val create : unit -> t
+
+    val invalidate : t -> reason:Invalidation.Reason.t -> Invalidation.t
+    val read : t -> unit memo
+  end
 end
 
 (** Memoization of polymorphic functions ['a input -> 'a output t]. The provided

--- a/test/expect-tests/memo/main.ml
+++ b/test/expect-tests/memo/main.ml
@@ -2338,3 +2338,29 @@ let%expect_test "create_rec" =
     calls = 11
     |}]
 ;;
+
+let%expect_test "Var.Unit" =
+  let var = Memo.Var.Unit.create () in
+  let calls = ref 0 in
+  let downstream =
+    Memo.create
+      "var-unit-downstream"
+      ~input:(module Unit)
+      (fun () ->
+         incr calls;
+         Memo.Var.Unit.read var)
+  in
+  let run_downstream () = run (Memo.exec downstream ()) in
+  run_downstream ();
+  Format.printf "calls = %d@." !calls;
+  [%expect {| calls = 1 |}];
+  (* Without invalidation the result is cached, so there is no recomputation. *)
+  run_downstream ();
+  Format.printf "calls = %d@." !calls;
+  [%expect {| calls = 1 |}];
+  (* Invalidating the unit variable forces the downstream computation to rerun. *)
+  Memo.reset (Memo.Var.Unit.invalidate var ~reason:Test);
+  run_downstream ();
+  Format.printf "calls = %d@." !calls;
+  [%expect {| calls = 2 |}]
+;;


### PR DESCRIPTION
`Memo.Var.Unit` is a variable specialized to the `unit` type: it carries no
value and is used purely as an invalidation trigger. All unit variables share a
single spec and differ only by node identity. Unlike `Var.set`,
`Var.Unit.invalidate` takes an explicit `reason`.

Additive, with no API break. `dune build src/memo` and
`dune runtest test/expect-tests/memo` pass.