### PR TITLE
feat(memo): allow pre-sizing a memo table's store

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1001,12 +1001,13 @@ let create
       (type i)
       name
       ~input:(module Input : Input with type t = i)
+      ?(initial_store_size = 2)
       ?cutoff
       ?human_readable_description
       f
   =
   (* This mutable table is safe: the implementation tracks all dependencies. *)
-  let cache = Store.of_table (Stdune.Table.create (module Input) 2) in
+  let cache = Store.of_table (Stdune.Table.create (module Input) initial_store_size) in
   let input = (module Input : Store_intf.Input with type t = i) in
   create_with_cache name ~cache ~input ~cutoff ~human_readable_description f
 ;;
@@ -1306,12 +1307,18 @@ end
 
 let exec (type i o) (t : (i, o) Table.t) i = Exec.exec_dep_node (dep_node t i)
 
-let create_rec name ~input ?cutoff ?human_readable_description f =
+let create_rec name ~input ?initial_store_size ?cutoff ?human_readable_description f =
   let rec table =
     lazy
-      (create name ~input ?cutoff ?human_readable_description (fun input ->
-         let table = Stdlib.Lazy.force table in
-         f (exec table) input))
+      (create
+         name
+         ~input
+         ?initial_store_size
+         ?cutoff
+         ?human_readable_description
+         (fun input ->
+            let table = Stdlib.Lazy.force table in
+            f (exec table) input))
   in
   Stdlib.Lazy.force table
 ;;

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -263,6 +263,7 @@ end
 val create
   :  string
   -> input:(module Input with type t = 'i)
+  -> ?initial_store_size:int
   -> ?cutoff:('o -> 'o -> bool)
   -> ?human_readable_description:('i -> User_message.Style.t Pp.t)
   -> ('i -> 'o t)
@@ -306,6 +307,7 @@ val create_with_store
 val create_rec
   :  string
   -> input:(module Input with type t = 'i)
+  -> ?initial_store_size:int
   -> ?cutoff:('o -> 'o -> bool)
   -> ?human_readable_description:('i -> User_message.Style.t Pp.t)
   -> (('i -> 'o t) -> 'i -> 'o t)


### PR DESCRIPTION
`Memo.create` now takes an optional `?initial_store_size` (default 2), passed to
the backing hash table. Callers that know a table will hold many entries can
avoid repeated rehashing. Additive and non-breaking.

`dune build src/memo` and `dune runtest test/expect-tests/memo` pass.