### PR TITLE
fix(memo): stop adding cycle-detection edges after the first cycle

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -567,41 +567,73 @@ module Call_stack = struct
     Fiber.Var.set call_stack_var (Some stack) (fun () -> Implicit_output.forbid f)
   ;;
 
+  (* As soon as we hit a cycle error in the current run, we stop adding new edges to the
+     cycle detection DAG. Calling [Dag.add_assuming_missing] after a cycle has been
+     detected is unsafe: it can violate the DAG's internal invariants (and previously
+     caused Dune to hang). This holds the first (and only) cycle error we hit in the
+     current run; it is reset by [reset]. *)
+  let cycle_error_in_the_current_run : Cycle_error.t option ref = ref None
+  let reset_cycle_error_in_the_current_run () = cycle_error_in_the_current_run := None
+
+  (* Record a cycle error hit during the current run, returning the first cycle error
+     seen this run. Once any cycle is hit we report that same cycle for the rest of the
+     run (see [cycle_error_in_the_current_run]). *)
+  let note_cycle_error cycle =
+    match !cycle_error_in_the_current_run with
+    | Some first -> first
+    | None ->
+      cycle_error_in_the_current_run := Some cycle;
+      cycle
+  ;;
+
   (* Add all edges leading from the root of the call stack to [dag_node] to the cycle
      detection DAG. *)
   let add_path_to ~dag_node : (unit, Cycle_error.t) result Fiber.t =
     let+ stack = get_call_stack () in
-    let rec add_path_impl stack dag_node edges_added =
-      match stack with
-      | [] -> Ok (), edges_added
-      | frame :: stack ->
-        let dag_node_id = Dag.node_id dag_node in
-        let children_added_to_dag = Stack_frame_with_state.children_added_to_dag frame in
-        (match Dag.Id.Set.mem children_added_to_dag dag_node_id with
-         | true ->
-           (* Here we know that the current [frame] has already been traversed in
-              a previous [add_path_to] call. Therefore, the DAG already contains
-              all the edges that we will discover by continuing the recursive
-              traversal. We might as well stop here and save time. *)
-           Ok (), edges_added
-         | false ->
-           let caller_dag_node = Stack_frame_with_state.dag_node frame in
-           (match Dag.add_assuming_missing caller_dag_node dag_node with
-            | exception Dag.Cycle cycle ->
-              Error (List.map cycle ~f:Dag.value), edges_added
-            | () ->
-              let edges_added = edges_added + 1 in
-              let not_traversed_before = Dag.Id.Set.is_empty children_added_to_dag in
-              Stack_frame_with_state.record_child_added_to_dag frame ~dag_node_id;
-              (match not_traversed_before with
-               | true -> add_path_impl stack caller_dag_node edges_added
-               | false ->
-                 (* Same optimisation as above: no need to traverse again. *)
-                 Ok (), edges_added)))
-    in
-    let result, edges_added = add_path_impl stack dag_node 0 in
-    Counter.add Metrics.Cycle_detection.edges edges_added;
-    result
+    (match !cycle_error_in_the_current_run with
+     | Some _ ->
+       (* We already hit a cycle in this run, so we must not touch the DAG again (see the
+          comment on [cycle_error_in_the_current_run]). Report the first cycle below. *)
+       ()
+     | None ->
+       let rec add_path_impl stack dag_node edges_added =
+         match stack with
+         | [] -> Ok (), edges_added
+         | frame :: stack ->
+           let dag_node_id = Dag.node_id dag_node in
+           let children_added_to_dag =
+             Stack_frame_with_state.children_added_to_dag frame
+           in
+           (match Dag.Id.Set.mem children_added_to_dag dag_node_id with
+            | true ->
+              (* Here we know that the current [frame] has already been traversed in a
+                 previous [add_path_to] call. Therefore, the DAG already contains all the
+                 edges that we will discover by continuing the recursive traversal. We
+                 might as well stop here and save time. *)
+              Ok (), edges_added
+            | false ->
+              let caller_dag_node = Stack_frame_with_state.dag_node frame in
+              (match Dag.add_assuming_missing caller_dag_node dag_node with
+               | exception Dag.Cycle cycle ->
+                 Error (List.map cycle ~f:Dag.value), edges_added
+               | () ->
+                 let edges_added = edges_added + 1 in
+                 let not_traversed_before = Dag.Id.Set.is_empty children_added_to_dag in
+                 Stack_frame_with_state.record_child_added_to_dag frame ~dag_node_id;
+                 (match not_traversed_before with
+                  | true -> add_path_impl stack caller_dag_node edges_added
+                  | false ->
+                    (* Same optimisation as above: no need to traverse again. *)
+                    Ok (), edges_added)))
+       in
+       let result, edges_added = add_path_impl stack dag_node 0 in
+       Counter.add Metrics.Cycle_detection.edges edges_added;
+       (match result with
+        | Ok () -> ()
+        | Error cycle_error -> cycle_error_in_the_current_run := Some cycle_error));
+    match !cycle_error_in_the_current_run with
+    | None -> Ok ()
+    | Some cycle_error -> Error cycle_error
   ;;
 
   (* Add a dependency on the [dep_node] from the caller, if there is one. *)
@@ -723,7 +755,7 @@ module Computation = struct
         | Some callers -> Some (dep_node :: callers)
       in
       (match immediate_self_cycle with
-       | Some cycle -> Fiber.return (Error cycle)
+       | Some cycle -> Fiber.return (Error (Call_stack.note_cycle_error cycle))
        | None ->
          (match (phase : Stack_frame_with_state.phase) with
           | Restore_from_cache -> Counter.incr Metrics.Restore.blocked
@@ -1545,6 +1577,12 @@ let run t =
      non-toplevel [run] would be better. *)
   match is_top_level with
   | true ->
+    (* Start each top-level run with a clean cycle-detection state so that a cycle hit in
+       one run does not leak into independent later runs. In production Memo performs a
+       single run per build with a [reset] in between, so this matches resetting in
+       [reset]. (Concurrent top-level runs do not occur in Dune; if that ever changes,
+       this reset would need to be scoped to the individual run rather than shared.) *)
+    Call_stack.reset_cycle_error_in_the_current_run ();
     run_with_error_handler
       (fun () -> t)
       ~handle_error_no_raise:(fun _exn -> Fiber.return ())
@@ -1665,6 +1703,7 @@ let reset invalidation =
      justifies the [~reason:Unknown] below. *)
   let invalidate_current_run = Current_run.invalidate ~reason:Unknown in
   Invalidation.execute (Invalidation.combine invalidation invalidate_current_run);
+  Call_stack.reset_cycle_error_in_the_current_run ();
   Run.restart ()
 ;;
 

--- a/test/blackbox-tests/test-cases/inline-tests/alias-cycle.t
+++ b/test/blackbox-tests/test-cases/inline-tests/alias-cycle.t
@@ -29,15 +29,15 @@ turn depends on the inline-test-name alias of the inline tests of the library.
 This kind of cycle has a difficult to understand error message.
   $ dune build 2>&1 | grep -vwE "sed"
   Error: Dependency cycle between:
-     transitive deps of foo_simple__Bar.impl in _build/default
+     _build/default/bar.ml
+  -> transitive deps of foo_simple__Bar.impl in _build/default
   -> _build/default/.foo_simple.objs/byte/foo_simple__Bar.cmi
   -> _build/default/.foo_simple.inline-tests/.t.eobjs/native/dune__exe__Main.cmx
   -> _build/default/.foo_simple.inline-tests/inline-test-runner.exe
   -> alias runtest-foo_simple in dune:9
   -> _build/default/bar.ml
-  -> transitive deps of foo_simple__Bar.impl in _build/default
-  -> required by _build/default/.foo_simple.objs/byte/foo_simple__Bar.cmo
-  -> required by _build/default/foo_simple.cma
+  -> required by _build/default/.foo_simple.objs/native/foo_simple.cmx
+  -> required by _build/default/foo_simple.a
   -> required by alias all
   -> required by alias default
   [1]

--- a/test/expect-tests/memo/main.ml
+++ b/test/expect-tests/memo/main.ml
@@ -1254,10 +1254,6 @@ let%expect_test "cancelling a computing node wakes waiters" =
     Started evaluating B
     Started evaluating C
     Dependency cycle detected:
-    - ("B", ())
-    - called by ("C", ())
-    - called by ("A", ())
-    Dependency cycle detected:
     - ("C", ())
     - called by ("A", ())
     Dependency cycle detected:
@@ -1319,14 +1315,8 @@ let%expect_test "overlapping cycles with waiters can deadlock" =
     - called by ("inner_repro", ())
     - called by ("outer_repro", ())
     Dependency cycle detected:
-    - ("join_repro", ())
-    - called by ("inner_repro", ())
-    Dependency cycle detected:
     - ("inner_repro", ())
     - called by ("outer_repro", ())
-    - called by ("join_repro", ())
-    Dependency cycle detected:
-    - ("inner_repro", ())
     - called by ("join_repro", ())
     |}]
 ;;
@@ -1338,7 +1328,7 @@ let lazy_rec ~name f =
   node
 ;;
 
-let%expect_test "two similar, but not physically-equal, cycle errors" =
+let%expect_test "only the first cycle in a run is reported" =
   let cycle1 = lazy_rec ~name:"cycle" (fun node -> Memo.Lazy.force node) in
   let cycle2 = lazy_rec ~name:"cycle" (fun node -> Memo.Lazy.force node) in
   let both =
@@ -1348,16 +1338,12 @@ let%expect_test "two similar, but not physically-equal, cycle errors" =
         (fun () -> Memo.Lazy.force cycle2))
   in
   run_and_log_errors (Memo.Lazy.force both);
-  (* Even though these errors look similar, they are actually talking about two
-     different cycles which can be distinguished by the internal node ids, so
-     they are not deduplicated. *)
+  (* [cycle1] and [cycle2] are two physically distinct cycles. Once we hit the first cycle
+     in a run we stop adding edges to the cycle-detection graph (otherwise we risk
+     violating its invariants), so both branches report the same first cycle and the two
+     errors deduplicate into one. *)
   [%expect
     {|
-    Error: { exn =
-               "Memo.Error.E\n\
-               \  { exn = \"Cycle_error.E [ (\\\"cycle\\\", ()) ]\"; stack = [ (\"both\", ()) ] }"
-           ; backtrace = ""
-           }
     Error: { exn =
                "Memo.Error.E\n\
                \  { exn = \"Cycle_error.E [ (\\\"cycle\\\", ()) ]\"; stack = [ (\"both\", ()) ] }"


### PR DESCRIPTION
Once a dependency cycle is hit during a run, it is unsafe to keep calling
`Dag.add_assuming_missing`: it can violate the cycle-detection DAG's internal
invariants (which previously could make Dune hang). This tracks the first cycle
error seen in the current run and, once set, stops traversing the call stack and
reports that cycle for the rest of the run.

The state is cleared at the start of each top-level `run` (and in `reset`), so
independent runs stay isolated. In production Memo does a single run per build
with a `reset` in between, so the guard stays correctly scoped.

Consequence (intended): only the first cycle in a run is reported, so the "two
distinct cycles" test now sees a single, deduplicated error. Error messages for
cyclic builds may change.

`dune build src/memo` and `dune runtest test/expect-tests/memo` pass.