### PR TITLE
test(lib): clarify private package helper contract

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -563,7 +563,7 @@ make_melange_app_with_asset_reader() {
 	EOF
 }
 
-make_private_only_packages_project() {
+make_and_enter_private_only_packages_project() {
   local macro="$1"
   local lib1_extra="${2:-}"
 

--- a/test/blackbox-tests/test-cases/lib.t
+++ b/test/blackbox-tests/test-cases/lib.t
@@ -221,7 +221,7 @@ Testsuite for the %{lib...} and %{lib-private...} variable.
 In this test, two packages are defined in the same project, but we may not
 access the artifacts through %{lib-private}
 
-  $ make_private_only_packages_project lib-private
+  $ make_and_enter_private_only_packages_project lib-private
 
 The build works in development:
   $ dune build @install

--- a/test/blackbox-tests/test-cases/libexec.t
+++ b/test/blackbox-tests/test-cases/libexec.t
@@ -273,7 +273,7 @@ Testsuite for the %{libexec...} and %{libexec-private...} variable.
 In this test, two packages are defined in the same project, but we may not
 access the artifacts through %{libexec-private}
 
-  $ make_private_only_packages_project \
+  $ make_and_enter_private_only_packages_project \
   >   libexec-private \
   >   "(enabled_if (= %{context_name} host))"
   $ cat >dune <<EOF


### PR DESCRIPTION
Rename the helper for lib/libexec private --only-packages tests to make it clear that it creates the fixture and leaves the caller inside it.