### PR TITLE
Improve missing workspace pin name error

### DIFF
--- a/src/dune_lang/pin_stanza.ml
+++ b/src/dune_lang/pin_stanza.ml
@@ -46,8 +46,23 @@ let decode_with_name =
   fields
   @@
   let+ t = common_fields
-  and+ name = field "name" (located string) in
-  name, t
+  and+ loc = loc
+  and+ name = field_o "name" (located string) in
+  match name with
+  | Some name -> name, t
+  | None ->
+    User_error.raise
+      ~loc
+      [ Pp.text "Pin stanzas in dune-workspace must have a name."
+      ; Pp.text
+          "Workspace pins are named so lock_dir stanzas can choose which pins \
+           to use."
+      ]
+      ~hints:
+        [ Pp.text
+            "Add a (name <pin>) field to this pin and list the name in the \
+             relevant lock_dir's (pins ...) field."
+        ]
 ;;
 
 module Project = struct

--- a/src/dune_lang/pin_stanza.ml
+++ b/src/dune_lang/pin_stanza.ml
@@ -55,13 +55,12 @@ let decode_with_name =
       ~loc
       [ Pp.text "Pin stanzas in dune-workspace must have a name."
       ; Pp.text
-          "Workspace pins are named so lock_dir stanzas can choose which pins \
-           to use."
+          "Workspace pins are named so lock_dir stanzas can choose which pins to use."
       ]
       ~hints:
         [ Pp.text
-            "Add a (name <pin>) field to this pin and list the name in the \
-             relevant lock_dir's (pins ...) field."
+            "Add a (name <pin>) field to this pin and list the name in the relevant \
+             lock_dir's (pins ...) field."
         ]
 ;;
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/workspace.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/workspace.t
@@ -40,3 +40,35 @@ Note that sources in the projects are overriden by the workspace
   $ dune_pkg_lock_normalized
   Solution for dune.lock:
   - foo.dev
+
+Workspace pins need names so lock directories can refer to them explicitly.
+
+  $ mkdir missing-name
+  $ cd missing-name
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (package
+  >  (name main)
+  >  (allow_empty))
+  > EOF
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "file://$PWD/_foo")
+  >  (package (name foo)))
+  > EOF
+
+  $ dune pkg lock 2>&1 \
+  > | dune_cmd subst 'characters 0-[0-9]+:' 'characters 0-N:' \
+  > | dune_cmd subst "$PWD" '$PWD'
+  File "dune-workspace", lines 2-4, characters 0-N:
+  2 | (pin
+  3 |  (url "file://$PWD/_foo")
+  4 |  (package (name foo)))
+  Error: Pin stanzas in dune-workspace must have a name.
+  Workspace pins are named so lock_dir stanzas can choose which pins to use.
+  Hint: Add a (name <pin>) field to this pin and list the name in the relevant
+  lock_dir's (pins ...) field.
+  [1]


### PR DESCRIPTION
Fixes #10158.

This changes workspace pin decoding to report a targeted error when a workspace-level (pin ...) stanza omits (name ...), explaining that lock_dir stanzas refer to pins by name. It also adds a cram regression in pkg/pin-stanza/workspace.t.