### PR TITLE
feat(memo): add node life-cycle events (on_event)

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -5,6 +5,7 @@ open Fiber.O
 module Graph = Dune_graph.Graph
 module Console = Console
 module Debug = Memo_debug
+module Event = Spec.Event
 include Fiber
 
 let when_ x y =
@@ -1010,10 +1011,13 @@ let create_with_cache
       ~input
       ~cutoff
       ~human_readable_description
+      ~on_event
       (f : i -> o Fiber.t)
   : (i, o) Table.t
   =
-  let spec = Spec.create ~name:(Some name) ~input ~cutoff ~human_readable_description f in
+  let spec =
+    Spec.create ~name:(Some name) ~input ~cutoff ~human_readable_description ?on_event f
+  in
   Caches.register ~clear:(fun () ->
     Store.clear cache;
     invalidate_store cache);
@@ -1027,10 +1031,11 @@ let create_with_store
       ~input
       ?cutoff
       ?human_readable_description
+      ?on_event
       f
   =
   let cache = Store.make (module S) in
-  create_with_cache name ~cache ~input ~cutoff ~human_readable_description f
+  create_with_cache name ~cache ~input ~cutoff ~human_readable_description ~on_event f
 ;;
 
 let create
@@ -1040,12 +1045,13 @@ let create
       ?(initial_store_size = 2)
       ?cutoff
       ?human_readable_description
+      ?on_event
       f
   =
   (* This mutable table is safe: the implementation tracks all dependencies. *)
   let cache = Store.of_table (Stdune.Table.create (module Input) initial_store_size) in
   let input = (module Input : Store_intf.Input with type t = i) in
-  create_with_cache name ~cache ~input ~cutoff ~human_readable_description f
+  create_with_cache name ~cache ~input ~cutoff ~human_readable_description ~on_event f
 ;;
 
 let make_dep_node ~spec ~input : _ Dep_node.t =
@@ -1230,9 +1236,12 @@ end = struct
       let+ restore_result = restore_from_cache ~cached_value in
       Counter.incr Metrics.Restore.nodes;
       (match restore_result with
-       | Ok cached_value -> dep_node.state <- Cached_value cached_value
+       | Ok cached_value ->
+         dep_node.state <- Cached_value cached_value;
+         Spec.notify dep_node.spec dep_node.input Validated
        | Cancelled { dependency_cycle } ->
-         dep_node.state <- Cached_value (Cached_value.create_cancelled ~dependency_cycle)
+         dep_node.state <- Cached_value (Cached_value.create_cancelled ~dependency_cycle);
+         Spec.notify dep_node.spec dep_node.input Validated
        | Out_of_date { old_value } -> dep_node.state <- Out_of_date { old_value });
       restore_result)
 
@@ -1250,6 +1259,7 @@ end = struct
       Counter.incr Metrics.Compute.nodes;
       Counter.add Metrics.Compute.edges (Deps.length cached_value.deps);
       dep_node.state <- Cached_value cached_value;
+      Spec.notify dep_node.spec dep_node.input Validated;
       cached_value)
 
   and consider_and_restore_from_cache_without_adding_dep
@@ -1264,7 +1274,9 @@ end = struct
          [Run.is_current] check. We should try to find a shortcut. *)
       if Run.is_current (Cached_value.last_validated_at cached_value)
       then Fiber.return (Cache_lookup.Ok cached_value)
-      else start_restoring ~dep_node ~cached_value
+      else (
+        Spec.notify dep_node.spec dep_node.input Live;
+        start_restoring ~dep_node ~cached_value)
     | Restoring { restore_from_cache } ->
       Computation.read_but_first_check_for_cycles
         ~phase:Restore_from_cache
@@ -1299,7 +1311,12 @@ end = struct
           ];
       Fiber.return (Ok cached_value)
     | Restoring _ -> assert false
-    | Out_of_date { old_value } -> start_computing ~dep_node ~old_value >>| Result.ok
+    | Out_of_date { old_value } ->
+      (* Fire [Live] only for never-computed (fresh) nodes. A stale node ([old_value] is
+         set) has already fired [Live] when it started restoring, so we don't fire again. *)
+      if Option.Unboxed.is_none old_value
+      then Spec.notify dep_node.spec dep_node.input Live;
+      start_computing ~dep_node ~old_value >>| Result.ok
     | Computing { compute; _ } ->
       Computation.read_but_first_check_for_cycles ~phase:Compute compute ~dep_node
       >>= (function
@@ -1349,7 +1366,15 @@ end
 
 let exec (type i o) (t : (i, o) Table.t) i = Exec.exec_dep_node (dep_node t i)
 
-let create_rec name ~input ?initial_store_size ?cutoff ?human_readable_description f =
+let create_rec
+      name
+      ~input
+      ?initial_store_size
+      ?cutoff
+      ?human_readable_description
+      ?on_event
+      f
+  =
   let rec table =
     lazy
       (create
@@ -1358,6 +1383,7 @@ let create_rec name ~input ?initial_store_size ?cutoff ?human_readable_descripti
          ?initial_store_size
          ?cutoff
          ?human_readable_description
+         ?on_event
          (fun input ->
             let table = Stdlib.Lazy.force table in
             f (exec table) input))
@@ -1628,9 +1654,10 @@ let cell = dep_node
 
 module Implicit_output = Implicit_output
 
-let lazy_cell ?cutoff ?name ?human_readable_description f =
+let lazy_cell ?cutoff ?name ?human_readable_description ?on_event f =
+  let on_event = Option.map on_event ~f:(fun on_event () event -> on_event event) in
   let spec =
-    Spec.create ~name ~input:(module Unit) ~cutoff ~human_readable_description f
+    Spec.create ~name ~input:(module Unit) ~cutoff ~human_readable_description ?on_event f
   in
   make_dep_node ~spec ~input:()
 ;;
@@ -1645,14 +1672,14 @@ module Lazy = struct
   let of_val a () = Fiber.return a
 
   module Expert = struct
-    let create ?cutoff ?name ?human_readable_description f =
-      let cell = lazy_cell ?cutoff ?name ?human_readable_description f in
+    let create ?cutoff ?name ?human_readable_description ?on_event f =
+      let cell = lazy_cell ?cutoff ?name ?human_readable_description ?on_event f in
       cell, fun () -> Cell.read cell
     ;;
   end
 
-  let create ?cutoff ?name ?human_readable_description f =
-    let cell = lazy_cell ?cutoff ?name ?human_readable_description f in
+  let create ?cutoff ?name ?human_readable_description ?on_event f =
+    let cell = lazy_cell ?cutoff ?name ?human_readable_description ?on_event f in
     fun () -> Cell.read cell
   ;;
 

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -20,6 +20,16 @@ include S with type 'a t := 'a t
 module Option : Monad.Option with type 'a t := 'a t
 module Result : Monad.Result with type 'a t := 'a t
 
+(** Events in the life-cycle of a memoized node, for instrumentation (see the [?on_event]
+    arguments of [create] and friends). *)
+module Event : sig
+  type t =
+    | Live (** The node became live, i.e. used in the current run. *)
+    | Validated
+    (** The node's output has been validated for the current run, either by computing it
+        or by confirming that a cached value is still up to date. *)
+end
+
 (* CR-someday amokhov: Return the set of exceptions explicitly. *)
 val run : 'a t -> 'a Fiber.t
 
@@ -266,6 +276,7 @@ val create
   -> ?initial_store_size:int
   -> ?cutoff:('o -> 'o -> bool)
   -> ?human_readable_description:('i -> User_message.Style.t Pp.t)
+  -> ?on_event:('i -> Event.t -> unit)
   -> ('i -> 'o t)
   -> ('i, 'o) Table.t
 
@@ -288,6 +299,7 @@ val create_with_store
   -> input:(module Store.Input with type t = 'i)
   -> ?cutoff:('o -> 'o -> bool)
   -> ?human_readable_description:('i -> User_message.Style.t Pp.t)
+  -> ?on_event:('i -> Event.t -> unit)
   -> ('i -> 'o t)
   -> ('i, 'o) Table.t
 
@@ -310,6 +322,7 @@ val create_rec
   -> ?initial_store_size:int
   -> ?cutoff:('o -> 'o -> bool)
   -> ?human_readable_description:('i -> User_message.Style.t Pp.t)
+  -> ?on_event:('i -> Event.t -> unit)
   -> (('i -> 'o t) -> 'i -> 'o t)
   -> ('i, 'o) Table.t
 
@@ -364,6 +377,7 @@ val lazy_cell
   :  ?cutoff:('a -> 'a -> bool)
   -> ?name:string
   -> ?human_readable_description:(unit -> User_message.Style.t Pp.t)
+  -> ?on_event:(Event.t -> unit)
   -> (unit -> 'a t)
   -> (unit, 'a) Cell.t
 
@@ -383,6 +397,7 @@ module Lazy : sig
     :  ?cutoff:('a -> 'a -> bool)
     -> ?name:string
     -> ?human_readable_description:(unit -> User_message.Style.t Pp.t)
+    -> ?on_event:(Event.t -> unit)
     -> (unit -> 'a memo)
     -> 'a t
 
@@ -396,6 +411,7 @@ module Lazy : sig
       :  ?cutoff:('a -> 'a -> bool)
       -> ?name:string
       -> ?human_readable_description:(unit -> User_message.Style.t Pp.t)
+      -> ?on_event:(Event.t -> unit)
       -> (unit -> 'a memo)
       -> (unit, 'a) Cell.t * 'a t
   end
@@ -405,6 +421,7 @@ val lazy_
   :  ?cutoff:('a -> 'a -> bool)
   -> ?name:string
   -> ?human_readable_description:(unit -> User_message.Style.t Pp.t)
+  -> ?on_event:(Event.t -> unit)
   -> (unit -> 'a t)
   -> 'a Lazy.t
 

--- a/src/memo/spec.ml
+++ b/src/memo/spec.ml
@@ -6,6 +6,12 @@ module Allow_cutoff = struct
     | Yes of ('o -> 'o -> bool)
 end
 
+module Event = struct
+  type t =
+    | Live
+    | Validated
+end
+
 type ('i, 'o) t =
   { name : string option
   ; (* If the field [witness] precedes any of the functional values ([input]
@@ -15,9 +21,10 @@ type ('i, 'o) t =
   ; allow_cutoff : 'o Allow_cutoff.t
   ; f : 'i -> 'o Fiber.t
   ; human_readable_description : ('i -> User_message.Style.t Pp.t) option
+  ; on_event : ('i -> Event.t -> unit) option
   }
 
-let create ~name ~input ~human_readable_description ~cutoff f =
+let create ~name ~input ~human_readable_description ~cutoff ?on_event f =
   let name =
     match name with
     | None when !Memo_debug.track_locations_of_lazy_values ->
@@ -36,5 +43,12 @@ let create ~name ~input ~human_readable_description ~cutoff f =
   ; witness = Type_eq.Id.create ()
   ; f
   ; human_readable_description
+  ; on_event
   }
+;;
+
+let notify t input event =
+  match t.on_event with
+  | None -> ()
+  | Some f -> f input event
 ;;

--- a/src/memo/spec.mli
+++ b/src/memo/spec.mli
@@ -8,6 +8,14 @@ module Allow_cutoff : sig
     | Yes of ('o -> 'o -> bool)
 end
 
+(** Events in the life-cycle of a memoized node, used for instrumentation. *)
+module Event : sig
+  type t =
+    | Live (** The node became live, i.e. was used in the current run. *)
+    | Validated
+    (** The node's output was validated (confirmed up to date) in the current run. *)
+end
+
 type ('i, 'o) t =
   { name : string option
   ; (* If the field [witness] precedes any of the functional values ([input]
@@ -17,6 +25,7 @@ type ('i, 'o) t =
   ; allow_cutoff : 'o Allow_cutoff.t
   ; f : 'i -> 'o Fiber.t
   ; human_readable_description : ('i -> User_message.Style.t Pp.t) option
+  ; on_event : ('i -> Event.t -> unit) option
   }
 
 val create
@@ -24,5 +33,9 @@ val create
   -> input:(module Store_intf.Input with type t = 'a)
   -> human_readable_description:('a -> User_message.Style.t Pp.t) option
   -> cutoff:('b -> 'b -> bool) option
+  -> ?on_event:('a -> Event.t -> unit)
   -> ('a -> 'b Fiber.t)
   -> ('a, 'b) t
+
+(** [notify spec input event] runs [spec]'s [on_event] callback, if it has one. *)
+val notify : ('i, _) t -> 'i -> Event.t -> unit

--- a/test/expect-tests/memo/main.ml
+++ b/test/expect-tests/memo/main.ml
@@ -2388,3 +2388,38 @@ let%expect_test "Var: cutoff" =
   set_invalidate_print_run 202;
   [%expect {| var: 202 |}]
 ;;
+
+let%expect_test "on_event fires Live and Validated" =
+  let events = ref [] in
+  let f =
+    Memo.create
+      "ev"
+      ~input:(module Int)
+      ~on_event:(fun input (event : Memo.Event.t) ->
+        let tag =
+          match event with
+          | Live -> "live"
+          | Validated -> "validated"
+        in
+        events := Printf.sprintf "%d:%s" input tag :: !events)
+      (fun n -> Memo.return (n * 2))
+  in
+  let print_events () =
+    print_endline (String.concat ~sep:" " (List.rev !events));
+    events := []
+  in
+  (* First evaluation computes the node: [Live] then [Validated]. *)
+  ignore (run_memo f 1 : int);
+  print_events ();
+  [%expect {| 1:live 1:validated |}];
+  (* Re-running in the same build run hits the cache: no event. *)
+  ignore (run_memo f 1 : int);
+  print_events ();
+  [%expect {| |}];
+  (* In a fresh run with unchanged dependencies the node is revalidated:
+     [Live] (it became live again) then [Validated]. *)
+  Memo.reset Memo.Invalidation.empty;
+  ignore (run_memo f 1 : int);
+  print_events ();
+  [%expect {| 1:live 1:validated |}]
+;;


### PR DESCRIPTION
Adds an optional `?on_event` callback to the `Memo` node constructors
(`create`, `create_with_store`, `create_rec`, `lazy_`, `Lazy.create`,
`Lazy.Expert.create`) together with a `Memo.Event` type:

- `Live` — fired when a node becomes live in the current run: either a
  fresh node being computed, or a node cached in a previous run that
  starts being restored.
- `Validated` — fired when a node's cached output is confirmed up to
  date without being recomputed.

This lets callers instrument the memoization graph (for example, to
count how many nodes are recomputed vs. restored vs. validated in a
given run).

The callback is a plain `'i -> Event.t -> unit` stored on the node's
spec, reusing the existing `allow_cutoff` field, so nodes that do not
use it incur no extra cost.
