### PR TITLE
Reject misc install sections

### DIFF
--- a/src/dune_rules/stanzas/install_conf.ml
+++ b/src/dune_rules/stanzas/install_conf.ml
@@ -48,5 +48,11 @@ let decode =
          , Option.value dirs ~default:[]
          , Option.value source_trees ~default:[] )
      in
+     (match section with
+      | loc, Section Misc ->
+        User_error.raise
+          ~loc
+          [ Pp.text "The misc section is not supported by install stanzas." ]
+      | _ -> ());
      { section; dirs; files; source_trees; package; enabled_if })
 ;;

--- a/test/blackbox-tests/test-cases/install/misc-section.t
+++ b/test/blackbox-tests/test-cases/install/misc-section.t
@@ -12,11 +12,9 @@ The misc install section isn't supported:
   >  (files foo))
   > EOF
 
-  $ dune build xxx.install 2>&1 | awk '/Internal error/,/Raised/'
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
-  providing the file _build/trace.csexp, if possible. This includes build
-  commands, message logs, and file paths.
-  Description:
-    ("Install.Paths.get", {})
-  Raised at Stdune__Code_error.raise in file
+  $ dune build xxx.install
+  File "dune", line 2, characters 10-14:
+  2 |  (section misc)
+                ^^^^
+  Error: The misc section is not supported by install stanzas.
   [1]


### PR DESCRIPTION
Reject (install (section misc) ...) during stanza decoding instead of letting it reach Install.Paths.get and raise an internal error. The existing misc-section cram test now asserts the user-facing diagnostic at the section field.