### PR TITLE
Improve bytecode foreign stubs error hint

### DIFF
--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -100,16 +100,29 @@ let o_files
   if not (Executables.has_foreign exes)
   then Memo.return @@ Mode.Map.empty
   else (
+    let has_foreign_stubs = not (List.is_empty exes.buildable.foreign_stubs) in
     let what =
-      if List.is_empty exes.buildable.foreign_stubs then "archives" else "stubs"
+      if has_foreign_stubs then "stubs" else "archives"
+    in
+    let native_only_hint =
+      Pp.text "If you only need to build a native executable use \"(modes exe)\"."
+    in
+    let hints =
+      if has_foreign_stubs
+      then
+        [ native_only_hint
+        ; Pp.text
+            "To build a bytecode executable with foreign stubs, put the stubs \
+             in a library and depend on that library."
+        ]
+      else [ native_only_hint ]
     in
     if List.exists linkages ~f:Exe.Linkage.is_byte
     then
       User_error.raise
         ~loc:exes.buildable.loc
         [ Pp.textf "Pure bytecode executables cannot contain foreign %s." what ]
-        ~hints:
-          [ Pp.text "If you only need to build a native executable use \"(modes exe)\"." ];
+        ~hints;
     let* foreign_sources =
       let+ foreign_sources = Dir_contents.foreign_sources dir_contents in
       let first_exe = first_exe exes in

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -101,9 +101,7 @@ let o_files
   then Memo.return @@ Mode.Map.empty
   else (
     let has_foreign_stubs = not (List.is_empty exes.buildable.foreign_stubs) in
-    let what =
-      if has_foreign_stubs then "stubs" else "archives"
-    in
+    let what = if has_foreign_stubs then "stubs" else "archives" in
     let native_only_hint =
       Pp.text "If you only need to build a native executable use \"(modes exe)\"."
     in
@@ -112,8 +110,8 @@ let o_files
       then
         [ native_only_hint
         ; Pp.text
-            "To build a bytecode executable with foreign stubs, put the stubs \
-             in a library and depend on that library."
+            "To build a bytecode executable with foreign stubs, put the stubs in a \
+             library and depend on that library."
         ]
       else [ native_only_hint ]
     in

--- a/test/blackbox-tests/test-cases/foreign-stubs/exes-with-c.t/run.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/exes-with-c.t/run.t
@@ -23,5 +23,7 @@ Builds executables with C stubs and rejects pure bytecode ones.
   4 |  (foreign_stubs (language c) (names stubs)))
   Error: Pure bytecode executables cannot contain foreign stubs.
   Hint: If you only need to build a native executable use "(modes exe)".
+  Hint: To build a bytecode executable with foreign stubs, put the stubs in a
+  library and depend on that library.
   Leaving directory 'err'
   [1]


### PR DESCRIPTION
Pure bytecode executables with direct foreign stubs are rejected, but bytecode executables can still use foreign stubs through a library. Mention that supported layout in the error hints so users are not left thinking bytecode plus foreign stubs is impossible.

Fixes #6074.