### PR TITLE
fix: build on illumos

### DIFF
--- a/doc/changes/fixed/14980.md
+++ b/doc/changes/fixed/14980.md
@@ -1,0 +1,3 @@
+- Fix building Dune on Solaris/illumos by handling its `wait4` semantics
+  and retrying interrupted reads when spawning processes. (#14980, fixes #14182,
+  @jperkin)

--- a/otherlibs/stdune/src/wait4_stubs.c
+++ b/otherlibs/stdune/src/wait4_stubs.c
@@ -95,8 +95,14 @@ value dune_wait4(value v_pid, value flags) {
   struct rusage ru;
 
   caml_enter_blocking_section();
+  // On Solaris/illumos, wait4(-1, ...) semantics are different, so in
+  // that case use 0 and effectively act the same as wait3().
+#if defined(__sun)
+  pid = wait4(pid == -1 ? 0 : pid, &status, cv_flags, &ru);
+#else
   // returns the pid of the terminated process, or -1 on error
   pid = wait4(pid, &status, cv_flags, &ru);
+#endif
   int wait_errno = errno;
   time_ns = dune_clock_gettime_ns();
   caml_leave_blocking_section();

--- a/vendor/spawn/src/spawn_stubs.c
+++ b/vendor/spawn/src/spawn_stubs.c
@@ -750,7 +750,10 @@ CAMLprim value spawn_unix(value v_env,
     got_error = 1;
     set_error(&failure, errno_after_forking, "vfork", NOTHING);
   } else {
-    intnat res = read(result_pipe[0], &failure, sizeof(failure));
+    intnat res;
+    do {
+      res = read(result_pipe[0], &failure, sizeof(failure));
+    } while (res == -1 && errno == EINTR);
     /* If the sub-process exec successfully, the write end of the
        error pipe is closed (as it has the [O_CLOEXEC] flag set) and
        [read] returns [0].


### PR DESCRIPTION
Fixes #14182.

- Handle Solaris/illumos `wait4(-1, ...)` semantics by using `wait4(0, ...)`, matching `wait3` behavior.
- Retry the spawn error-pipe `read` when interrupted by `EINTR`.

Tests:
- `dune build @check`
- `dune fmt`