### PR TITLE
Reject nested paths in dirs stanzas

### DIFF
--- a/src/predicate_lang/predicate_lang.ml
+++ b/src/predicate_lang/predicate_lang.ml
@@ -254,10 +254,11 @@ module Glob = struct
       | Glob g -> Glob.test (unproxy g) s
     ;;
 
-    let decode =
+    let decode_validated ~f =
       let open Dune_sexp.Decoder in
       let+ glob =
         Decoder.plain_string (fun ~loc x ->
+          f ~loc x;
           let proxy = Proxy.of_string x in
           let (_ : Glob.t) =
             try unproxy proxy with
@@ -269,6 +270,8 @@ module Glob = struct
       in
       Glob glob
     ;;
+
+    let decode = decode_validated ~f:(fun ~loc:_ _ -> ())
   end
 
   type nonrec t = Element.t t
@@ -294,6 +297,7 @@ module Glob = struct
   let compare x y = compare Element.compare x y
   let equal x y = Ordering.is_eq (compare x y)
   let hash t = Poly.hash t
+  let decode_validated ~f = decode (Element.decode_validated ~f)
   let decode = decode Element.decode
   let encode t = encode Element.encode t
   let digest t = Dune_digest.repr repr t

--- a/src/predicate_lang/predicate_lang.mli
+++ b/src/predicate_lang/predicate_lang.mli
@@ -45,6 +45,10 @@ module Glob : sig
   val compare : t -> t -> Ordering.t
   val equal : t -> t -> bool
   val hash : t -> int
+  val decode_validated
+    :  f:(loc:Loc.t -> string -> unit)
+    -> t Dune_sexp.Decoder.t
+
   val decode : t Dune_sexp.Decoder.t
   val encode : t -> Dune_sexp.t
   val digest : t -> Dune_digest.t

--- a/src/source/dune_file.ml
+++ b/src/source/dune_file.ml
@@ -154,32 +154,36 @@ module Ast = struct
 
   open Dune_lang.Decoder
 
+  let validate_strict_subdir field_name ~loc dn =
+    let msg = [ Pp.textf "invalid sub-directory name %S" dn ] in
+    if Filename.dirname dn <> Filename.current_dir_name
+    then (
+      let msg = [ Pp.textf "only immediate sub-directories may be specified." ] in
+      let hints =
+        [ Pp.textf
+            "to ignore %s, write \"(%s %s)\" in %s/dune"
+            dn
+            field_name
+            (Filename.basename dn)
+            (Filename.dirname dn)
+        ]
+      in
+      User_error.raise ~loc ~hints msg)
+    else if
+      match dn with
+      | "" | "." ->
+        let hints = [ Pp.textf "did you mean (%s *)?" field_name ] in
+        User_error.raise ~loc ~hints msg
+      | ".." -> true
+      | _ -> false
+    then User_error.raise ~loc msg
+  ;;
+
   let strict_subdir field_name =
     let open Dune_lang.Decoder in
     plain_string (fun ~loc dn ->
-      let msg = [ Pp.textf "invalid sub-directory name %S" dn ] in
-      if Filename.dirname dn <> Filename.current_dir_name
-      then (
-        let msg = [ Pp.textf "only immediate sub-directories may be specified." ] in
-        let hints =
-          [ Pp.textf
-              "to ignore %s, write \"(%s %s)\" in %s/dune"
-              dn
-              field_name
-              (Filename.basename dn)
-              (Filename.dirname dn)
-          ]
-        in
-        User_error.raise ~loc ~hints msg)
-      else if
-        match dn with
-        | "" | "." ->
-          let hints = [ Pp.textf "did you mean (%s *)?" field_name ] in
-          User_error.raise ~loc ~hints msg
-        | ".." -> true
-        | _ -> false
-      then User_error.raise ~loc msg
-      else loc, dn)
+      validate_strict_subdir field_name ~loc dn;
+      loc, dn)
   ;;
 
   let ignored_sub_dirs =
@@ -230,9 +234,15 @@ module Ast = struct
   ;;
 
   let dirs =
+    let* dune_version = Dune_lang.Syntax.get_exn Stanza.syntax in
+    let decode =
+      if dune_version >= (3, 25)
+      then Predicate_lang.Glob.decode_validated ~f:(validate_strict_subdir "dirs")
+      else Predicate_lang.Glob.decode
+    in
     let+ loc, dirs =
       Dune_lang.Syntax.since Stanza.syntax (1, 6)
-      >>> Predicate_lang.Glob.decode
+      >>> decode
       |> located
     in
     Dirs (loc, dirs)

--- a/test/blackbox-tests/test-cases/dirs-with-subdir.t/run.t
+++ b/test/blackbox-tests/test-cases/dirs-with-subdir.t/run.t
@@ -41,13 +41,13 @@ Same for the other directory.
   [1]
   $ dune build A/C/c
 
-If we wish to exclude a subdirectory of A/, the following should error and Dune
-should suggest the correct course of action.
+In older dune language versions, nested paths in (dirs ...) are ignored.
   $ cat > dune << EOF
   > (dirs :standard \ A/C)
   > EOF
 
   $ dune build A/a
+  $ dune build A/C/c
 
 This should now only fail for the excluded directory.
   $ cat > dune << EOF
@@ -60,4 +60,23 @@ This should now only fail for the excluded directory.
   Error: Don't know how to build A/C/c
   Hint: directory A/C exists on disk but is excluded by a (dirs ...) stanza at
   dune:1
+  [1]
+
+Starting from dune 3.25, a nested path in (dirs ...) is rejected and Dune should
+suggest the correct course of action.
+  $ mkdir -p v325/A/C
+  $ touch v325/A/a v325/A/C/c
+  $ cat > v325/dune-project << EOF
+  > (lang dune 3.25)
+  > EOF
+  $ cat > v325/dune << EOF
+  > (dirs :standard \ A/C)
+  > EOF
+
+  $ (cd v325 && dune build A/a)
+  File "dune", line 1, characters 18-21:
+  1 | (dirs :standard \ A/C)
+                        ^^^
+  Error: only immediate sub-directories may be specified.
+  Hint: to ignore A/C, write "(dirs C)" in A/dune
   [1]


### PR DESCRIPTION
Starting in dune language 3.25, reject nested paths in `(dirs ...)` instead of silently ignoring them. Older language versions keep the existing behavior for compatibility.

When rejecting a nested path, Dune now gives the same style of hint as other strict subdirectory fields, pointing users to put the stanza in the immediate parent directory.

Fixes #5313.