### PR TITLE
fix(rpc-lwt): close input when closing output

### DIFF
--- a/doc/changes/fixed/14983.md
+++ b/doc/changes/fixed/14983.md
@@ -1,0 +1,3 @@
+- Fix `dune-rpc-lwt` clients so disconnecting shuts down socket output
+  without invalidating pending input reads, avoiding `EBADF` errors. (#14983,
+  fixes #7624, @rgrinberg)

--- a/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
+++ b/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
@@ -45,53 +45,46 @@ module V1 = struct
       (struct
         type t = Lwt_io.input_channel * Lwt_io.output_channel
 
-        let read (i, o) =
-          (* The input and output channels share the same file descriptor. If
-             the output channel has been closed, reading from the input channel
-             will result in an error. *)
-          let is_channel_closed () = Lwt_io.is_closed o in
+        let read (i, _) =
           let open Csexp.Parser in
           let lexer = Lexer.create () in
-          let rec loop depth stack =
-            if is_channel_closed ()
-            then (
-              Lexer.feed_eoi lexer;
-              Lwt.return_none)
-            else
-              let* res = Lwt_io.read_char_opt i in
-              match res with
-              | None ->
-                Lexer.feed_eoi lexer;
-                Lwt.return_none
-              | Some c ->
-                (match Lexer.feed lexer c with
-                 | Await -> loop depth stack
-                 | Lparen -> loop (depth + 1) (Stack.open_paren stack)
-                 | Rparen ->
-                   let stack = Stack.close_paren stack in
-                   let depth = depth - 1 in
-                   if depth = 0
-                   then (
-                     let sexps = Stack.to_list stack in
-                     sexps |> List.hd |> Lwt.return_some)
-                   else loop depth stack
-                 | Atom count ->
-                   if is_channel_closed ()
-                   then (
-                     Lexer.feed_eoi lexer;
-                     Lwt.return_none)
-                   else
-                     let* atom =
-                       let bytes = Bytes.create count in
-                       let+ () = Lwt_io.read_into_exactly i bytes 0 count in
-                       Bytes.to_string bytes
-                     in
-                     loop depth (Stack.add_atom atom stack))
+          let eoi () =
+            Lexer.feed_eoi lexer;
+            Lwt.return_none
           in
-          loop 0 Stack.Empty
+          let rec loop depth stack =
+            let open Lwt.Infix in
+            Lwt_io.read_char_opt i
+            >>= function
+            | None -> eoi ()
+            | Some c ->
+              (match Lexer.feed lexer c with
+               | Await -> loop depth stack
+               | Lparen -> loop (depth + 1) (Stack.open_paren stack)
+               | Rparen ->
+                 let stack = Stack.close_paren stack in
+                 let depth = depth - 1 in
+                 if depth = 0
+                 then Stack.to_list stack |> List.hd |> Lwt.return_some
+                 else loop depth stack
+               | Atom count ->
+                 let* atom =
+                   let bytes = Bytes.create count in
+                   let+ () = Lwt_io.read_into_exactly i bytes 0 count in
+                   Bytes.to_string bytes
+                 in
+                 loop depth (Stack.add_atom atom stack))
+          in
+          Lwt.catch
+            (fun () -> loop 0 Stack.Empty)
+            (function
+              | Lwt_io.Channel_closed _ -> eoi ()
+              | exn -> Lwt.fail exn)
         ;;
 
-        let close (_, o) = Lwt_io.close o
+        let close (i, o) =
+          Lwt.finalize (fun () -> Lwt_io.close o) (fun () -> Lwt_io.close i)
+        ;;
 
         let write (_, o) csexps =
           Lwt_list.iter_s (fun sexp -> Lwt_io.write o (Csexp.to_string sexp)) csexps
@@ -134,7 +127,15 @@ module V1 = struct
       let+ () = Lwt_unix.connect fd sockaddr in
       fd
     in
-    let fd mode = Lwt_io.of_fd fd ~mode in
-    fd Input, fd Output
+    let output =
+      Lwt_io.of_fd fd ~mode:Output ~close:(fun () ->
+        Lwt_unix.shutdown fd Unix.SHUTDOWN_SEND;
+        Lwt.return_unit)
+    in
+    let input =
+      Lwt_io.of_fd fd ~mode:Input ~close:(fun () ->
+        Lwt.finalize (fun () -> Lwt_io.close output) (fun () -> Lwt_unix.close fd))
+    in
+    input, output
   ;;
 end

--- a/otherlibs/dune-rpc-lwt/test/dune_rpc_lwt_tests.ml
+++ b/otherlibs/dune-rpc-lwt/test/dune_rpc_lwt_tests.ml
@@ -137,10 +137,10 @@ let%expect_test "run and connect" =
 
 let with_unix_socket_server f =
   let* dir = Lwt_io.create_temp_dir () in
-  let socket_path = Filename.concat dir "socket" in
   let server = Lwt_unix.socket Unix.PF_UNIX Unix.SOCK_STREAM 0 in
   Lwt.finalize
     (fun () ->
+       let socket_path = Filename.concat dir "socket" in
        let* () = Lwt_unix.bind server (Unix.ADDR_UNIX socket_path) in
        Lwt_unix.listen server 1;
        f ~socket_path ~server)
@@ -149,24 +149,21 @@ let with_unix_socket_server f =
 
 let%expect_test "closing output channel leaves input usable" =
   Sys.chdir initial_cwd;
-  (try
-     Lwt_main.run
-       (with_unix_socket_server (fun ~socket_path ~server ->
-          let server_conn =
-            let buffer = Bytes.create 1 in
-            let* client, _ = Lwt_unix.accept server in
-            let* _ = Lwt_unix.read client buffer 0 1 in
-            Lwt_unix.close client
-          in
-          let* input, output = connect_chan (`Unix socket_path) in
-          let* () = Lwt_io.close output in
-          let* () = server_conn in
-          let* res = Lwt_io.read_char_opt input in
-          printfn "input eof: %b" (Option.is_none res);
-          Lwt_io.close input))
-   with
-   | exn -> printfn "%s" (Printexc.to_string exn));
-  [%expect {| Unix.Unix_error(Unix.EBADF, "check_descriptor", "") |}]
+  Lwt_main.run
+    (with_unix_socket_server (fun ~socket_path ~server ->
+       let server_conn =
+         let buffer = Bytes.create 1 in
+         let* client, _ = Lwt_unix.accept server in
+         let* (_ : int) = Lwt_unix.read client buffer 0 1 in
+         Lwt_unix.close client
+       in
+       let* input, output = connect_chan (`Unix socket_path) in
+       let* () = Lwt_io.close output in
+       let* () = server_conn in
+       let* res = Lwt_io.read_char_opt input in
+       printfn "input eof: %b" (Option.is_none res);
+       Lwt_io.close input));
+  [%expect {| input eof: true |}]
 ;;
 
 let%expect_test "closing input channel closes output channel" =
@@ -174,14 +171,14 @@ let%expect_test "closing input channel closes output channel" =
   Lwt_main.run
     (with_unix_socket_server (fun ~socket_path ~server ->
        let server_conn =
-         let* client, _ = Lwt_unix.accept server in
+         let* client, (_ : Unix.sockaddr) = Lwt_unix.accept server in
          Lwt_unix.close client
        in
        let* input, output = connect_chan (`Unix socket_path) in
        let* () = Lwt_io.close input in
        printfn "output closed: %b" (Lwt_io.is_closed output);
        server_conn));
-  [%expect {| output closed: false |}]
+  [%expect {| output closed: true |}]
 ;;
 
 module Logger = struct


### PR DESCRIPTION
Fixes #7624.

`connect_chan` now uses the socket half-close primitive for the output channel: closing the output channel calls `shutdown(SHUTDOWN_SEND)` instead of closing the shared descriptor. This lets pending input reads finish cleanly without racing on a closed fd.

The input channel owns the actual fd close. Its close hook first closes the output channel, so code cannot keep writing on a descriptor that is about to be closed.
