### PR TITLE
feat(rpc): report rule progress as built vs total rules

### DIFF
--- a/bin/util.ml
+++ b/bin/util.ml
@@ -64,13 +64,13 @@ let setup () =
   Console.Status_line.set
     (Live
        (fun () ->
-         match Fiber.Svar.read Build_system.state with
+         match !Build_system.state with
          | Initializing
          | Restarting_current_build
          | Build_succeeded__now_waiting_for_changes
          | Build_failed__now_waiting_for_changes -> Pp.nop
          | Building
-             { Build_system.Progress.number_of_rules_executed = done_
+             { Build_system.Progress.number_of_rules_validated = done_
              ; number_of_rules_discovered = total
              ; number_of_rules_failed = failed
              } ->

--- a/doc/changes/changed/14985.md
+++ b/doc/changes/changed/14985.md
@@ -1,0 +1,4 @@
+- Report rule build progress as the number of rules built against the total
+  number of live rules, rather than rules executed against rules discovered
+  during the current run. This affects both the status line and the progress
+  reported over RPC. (#14985, @snowleopard, @pwhite)

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -5,7 +5,7 @@ module Error = Build_system_error
 module Progress = struct
   type t =
     { number_of_rules_discovered : int
-    ; number_of_rules_executed : int
+    ; number_of_rules_validated : int
     ; number_of_rules_failed : int
     }
 
@@ -14,8 +14,8 @@ module Progress = struct
       "Progress"
       [ Repr.field "number_of_rules_discovered" Repr.int ~get:(fun t ->
           t.number_of_rules_discovered)
-      ; Repr.field "number_of_rules_executed" Repr.int ~get:(fun t ->
-          t.number_of_rules_executed)
+      ; Repr.field "number_of_rules_validated" Repr.int ~get:(fun t ->
+          t.number_of_rules_validated)
       ; Repr.field "number_of_rules_failed" Repr.int ~get:(fun t ->
           t.number_of_rules_failed)
       ]
@@ -29,9 +29,14 @@ module Progress = struct
 
   let init =
     { number_of_rules_discovered = 0
-    ; number_of_rules_executed = 0
+    ; number_of_rules_validated = 0
     ; number_of_rules_failed = 0
     }
+  ;;
+
+  (* Rules that have become live but whose value has not yet been validated this run. *)
+  let number_of_rules_in_progress t =
+    t.number_of_rules_discovered - t.number_of_rules_validated
   ;;
 end
 
@@ -89,45 +94,57 @@ module State = struct
       let repr = repr
     end)
 
-  let t = Fiber.Svar.create Initializing
+  (* The build progress lives in a plain [ref], not a [Fiber.Svar.t], so that [on_rule_event]
+     (a synchronous Memo callback) can update it. Observers (the status line, the RPC server)
+     read it directly or poll it; see [Rpc.Server.Source.Computed]. *)
+  let t = ref Initializing
 
   (* This mutable table is safe: it maps paths to lazily created mutexes. *)
   let locks : (Path.t, Fiber.Mutex.t) Table.t = Table.create (module Path) 32
 
   (* This mutex ensures that at most one [run] is running in parallel. *)
   let build_mutex = Fiber.Mutex.create ()
-  let reset_progress () = Svar.write t (Building Progress.init)
-  let set what = Svar.write t what
+  let reset_progress () = t := Building Progress.init
+  let set what = t := what
 
   let update_build_progress_exn ~f =
-    let current = Svar.read t in
-    match current with
-    | Building current -> Svar.write t @@ Building (f current)
+    match !t with
+    | Building current -> t := Building (f current)
     | other ->
       Code_error.raise
         "Unexpected build progress state (expected [Building _])"
         [ "current", to_dyn other ]
   ;;
 
-  let incr_rule_done_exn () =
-    update_build_progress_exn ~f:(fun p ->
-      { p with number_of_rules_executed = p.number_of_rules_executed + 1 })
+  (* Like [update_build_progress_exn] but a no-op outside of a running build. Used by
+     [on_rule_event], which can fire from tests that drive the build engine directly. *)
+  let update_build_progress ~f =
+    match !t with
+    | Building progress -> t := Building (f progress)
+    | Initializing
+    | Restarting_current_build
+    | Build_succeeded__now_waiting_for_changes
+    | Build_failed__now_waiting_for_changes -> ()
   ;;
 
-  let start_rule_exn () =
-    update_build_progress_exn ~f:(fun p ->
-      { p with number_of_rules_discovered = p.number_of_rules_discovered + 1 })
+  (* Fired by Memo for rule and anonymous-action nodes. [Live] fires when a node becomes
+     live in the current run, so [number_of_rules_discovered] counts every live rule,
+     including ones restored from the cache - the true total. [Validated] fires when a
+     node's value is established for the run, advancing [number_of_rules_validated]. *)
+  let on_rule_event _input (event : Memo.Event.t) =
+    update_build_progress ~f:(fun p ->
+      match event with
+      | Live -> { p with number_of_rules_discovered = p.number_of_rules_discovered + 1 }
+      | Validated ->
+        { p with number_of_rules_validated = p.number_of_rules_validated + 1 })
   ;;
 
   let errors = Svar.create Error.Set.empty
   let reset_errors () = Svar.write errors Error.Set.empty
 
   let add_errors error_list =
-    let open Fiber.O in
-    let* () =
-      update_build_progress_exn ~f:(fun p ->
-        { p with number_of_rules_failed = p.number_of_rules_failed + 1 })
-    in
+    update_build_progress_exn ~f:(fun p ->
+      { p with number_of_rules_failed = p.number_of_rules_failed + 1 });
     List.fold_left error_list ~init:(Svar.read errors) ~f:Error.Set.add
     |> Svar.write errors
   ;;
@@ -278,7 +295,7 @@ module Internal = struct
   let report_evaluated_rule_exn () =
     Dune_trace.emit Debug (fun () ->
       let rule_total =
-        match Fiber.Svar.read State.t with
+        match !State.t with
         | Building progress -> progress.number_of_rules_discovered
         | _ -> assert false
       in
@@ -506,11 +523,6 @@ module Internal = struct
 
   and execute_rule_impl ~rule_kind rule =
     let { Rule.id = _; targets; mode; action; info = _; loc } = rule in
-    (* We run [State.start_rule_exn ()] entirely for its side effect, so one
-       might be tempted to use [Memo.of_non_reproducible_fiber] here but that is
-       wrong, because that would force us to rerun [execute_rule_impl] on every
-       incremental build. *)
-    let* () = Memo.of_reproducible_fiber (State.start_rule_exn ()) in
     let head_target = Targets.Validated.head targets in
     let* execution_parameters =
       match Dpath.Target_dir.of_target targets.root with
@@ -694,13 +706,12 @@ module Internal = struct
             ~targets_digest:(Targets.Produced.digest produced_targets);
           Fiber.return produced_targets
       in
-      let* () =
+      let+ () =
         promote_targets
           ~rule_mode:mode
           ~targets:produced_targets
           ~promote_source:config.promote_source
       in
-      let+ () = State.incr_rule_done_exn () in
       produced_targets)
     (* jeremidimino: We need to include the dependencies discovered while
        running the action here. Otherwise, package dependencies are broken in
@@ -983,6 +994,7 @@ module Internal = struct
          "execute-action"
          ~input:(module Anonymous_action)
          ~cutoff:String.equal
+         ~on_event:State.on_rule_event
          execute_action_generic_stage2_impl)
 
   and eval_pred_memo =
@@ -1016,6 +1028,7 @@ module Internal = struct
       (Memo.create
          "execute-rule"
          ~input:(module Rule)
+         ~on_event:State.on_rule_event
          (execute_rule_impl ~rule_kind:Normal_rule))
   ;;
 
@@ -1157,7 +1170,7 @@ let run_with_error_collection ?restart_started_at ~build collect_errors =
        in the [_build] directory. For now, it's unclear if optimising this is
        worth the effort. *)
     Fs_memo.invalidate_cached_timestamps ();
-    let* () = State.reset_progress () in
+    State.reset_progress ();
     let* () = State.reset_errors () in
     let* outcome = collect_errors () in
     Dtemp.clear ();
@@ -1170,8 +1183,8 @@ let run_with_error_collection ?restart_started_at ~build collect_errors =
       match outcome with
       | Ok res ->
         finalize_diff_promotion ();
-        let+ () = State.set Build_succeeded__now_waiting_for_changes in
-        Ok res
+        State.set Build_succeeded__now_waiting_for_changes;
+        Fiber.return (Ok res)
       | Error exns ->
         handle_final_exns exns;
         finalize_diff_promotion ();
@@ -1180,8 +1193,8 @@ let run_with_error_collection ?restart_started_at ~build collect_errors =
           then State.Restarting_current_build
           else Build_failed__now_waiting_for_changes
         in
-        let+ () = State.set final_status in
-        Error `Already_reported
+        State.set final_status;
+        Fiber.return (Error `Already_reported)
     in
     Metrics.reset ();
     let+ () = Scheduler.flush_file_watcher () in

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -87,12 +87,16 @@ module Progress : sig
 
   type t =
     { number_of_rules_discovered : int
-    ; number_of_rules_executed : int
+    ; number_of_rules_validated : int
     ; number_of_rules_failed : int
     }
 
   (** Initialize with zeros on all measures. *)
   val init : t
+
+  (** Rules that have become live but are not yet validated this run
+      ([number_of_rules_discovered - number_of_rules_validated]). *)
+  val number_of_rules_in_progress : t -> int
 end
 
 module State : sig
@@ -106,7 +110,7 @@ module State : sig
   val equal : t -> t -> bool
 end
 
-val state : State.t Fiber.Svar.t
+val state : State.t ref
 
 (** The current set of active errors. *)
 val errors : Build_system_error.Set.t Fiber.Svar.t

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -25,6 +25,7 @@ end
 
 module Session = Rpc.Server.Session
 module Handler = Rpc.Server.Handler
+module Source = Rpc.Server.Source
 module Csexp_rpc = Rpc.Csexp_rpc
 
 type build_request =
@@ -197,7 +198,7 @@ let handler (t : t Fdecl.t) action_runner_server : unit Handler.t =
     Handler.implement_long_poll
       rpc
       Procedures.Poll.diagnostic
-      Build_system.errors
+      (Source.Svar Build_system.errors)
       ~equal:Error.Set.equal
       ~diff
   in
@@ -232,7 +233,7 @@ let handler (t : t Fdecl.t) action_runner_server : unit Handler.t =
     Handler.implement_long_poll
       rpc
       Procedures.Poll.running_jobs
-      Running_jobs.jobs
+      (Source.Svar Running_jobs.jobs)
       ~equal:Running_jobs.equal
       ~diff
   in
@@ -245,15 +246,16 @@ let handler (t : t Fdecl.t) action_runner_server : unit Handler.t =
       | Build_failed__now_waiting_for_changes -> Failed
       | Building now ->
         In_progress
-          { complete = now.number_of_rules_executed
-          ; remaining = now.number_of_rules_discovered - now.number_of_rules_executed
+          { complete = now.number_of_rules_validated
+          ; remaining = Build_system.Progress.number_of_rules_in_progress now
           ; failed = now.number_of_rules_failed
           }
     in
     Handler.implement_long_poll
       rpc
       Procedures.Poll.progress
-      Build_system.state
+      (Source.Computed
+         { get = (fun () -> !Build_system.state); poll_every = Time.Span.of_secs 0.2 })
       ~equal:Build_system.State.equal
       ~diff
   in

--- a/src/rpc/server.ml
+++ b/src/rpc/server.ml
@@ -24,6 +24,37 @@ module Poller = struct
   let compare x y = Id.compare x.id y.id
 end
 
+(* A source of state observed by long polling. [Svar] uses [Fiber.Svar.wait] to block until
+   the value changes; [Computed] reads the value from a thunk and polls it periodically (for
+   state that lives in a plain [ref] and cannot wake waiters itself). *)
+module Source = struct
+  type 'a t =
+    | Svar of 'a Fiber.Svar.t
+    | Computed of
+        { get : unit -> 'a
+        ; poll_every : Time.Span.t
+        }
+
+  let read = function
+    | Svar svar -> Fiber.Svar.read svar
+    | Computed { get; poll_every = _ } -> get ()
+  ;;
+
+  let wait t ~until =
+    match t with
+    | Svar svar -> Fiber.Svar.wait svar ~until
+    | Computed { get; poll_every } ->
+      let rec loop () =
+        if until (get ())
+        then Fiber.return ()
+        else
+          let* () = Dune_scheduler.Scheduler.sleep poll_every in
+          loop ()
+      in
+      loop ()
+  ;;
+end
+
 module V = Versioned.Make (struct
     include Fiber
 
@@ -750,16 +781,16 @@ module H = struct
         Fiber.return ()
       ;;
 
-      let make_on_poll map svar ~equal ~diff _session poller =
+      let make_on_poll map source ~equal ~diff _session poller =
         let send last =
           let* () =
             match last with
             | None -> Fiber.return ()
             | Some last ->
               let until x = not (equal x last) in
-              Fiber.Svar.wait svar ~until
+              Source.wait source ~until
           in
-          let now = Fiber.Svar.read svar in
+          let now = Source.read source in
           map := Map.set !map poller (Status.Active now);
           let to_send = diff ~last ~now in
           Fiber.return (Some to_send)
@@ -772,13 +803,13 @@ module H = struct
           Fiber.never
       ;;
 
-      let implement_long_poll (rpc : _ t) proc svar ~equal ~diff =
+      let implement_long_poll (rpc : _ t) proc source ~equal ~diff =
         let map = ref Map.empty in
         implement_poll
           rpc
           proc
           ~on_cancel:(on_cancel map)
-          ~on_poll:(make_on_poll map svar ~equal ~diff)
+          ~on_poll:(make_on_poll map source ~equal ~diff)
       ;;
     end
 

--- a/src/rpc/server.mli
+++ b/src/rpc/server.mli
@@ -72,6 +72,21 @@ module Session : sig
   end
 end
 
+(** A source of state observed by long polling. [Svar] blocks in [wait] until the value
+    changes; [Computed] reads the value from a thunk and polls it every [poll_every] (used
+    for state held in a plain [ref], which cannot wake waiters on its own). *)
+module Source : sig
+  type 'a t =
+    | Svar of 'a Fiber.Svar.t
+    | Computed of
+        { get : unit -> 'a
+        ; poll_every : Time.Span.t
+        }
+
+  val read : 'a t -> 'a
+  val wait : 'a t -> until:('a -> bool) -> unit Fiber.t
+end
+
 module Handler : sig
   (** A handler defines everything necessary to serve a session. It contains
 
@@ -126,14 +141,14 @@ module Handler : sig
       according to the metadata [decl]. *)
   val declare_request : 's t -> ('a, 'b) Decl.request -> unit
 
-  (** [implement_long_poll t proc_diff svar ~equal ~diff] will implement long
-      polling routines to sync the state variable [svar]. [equal] is used to
+  (** [implement_long_poll t proc_diff source ~equal ~diff] will implement long
+      polling routines to sync the state observed through [source]. [equal] is used to
       prevent updates that do not modify the state. [diff] is used to generate
       efficient operations to bring the state up to date. *)
   val implement_long_poll
     :  _ t
     -> 'diff Procedures.Poll.t
-    -> 'state Fiber.Svar.t
+    -> 'state Source.t
     -> equal:('state -> 'state -> bool)
     -> diff:(last:'state option -> now:'state -> 'diff)
     -> unit

--- a/test/expect-tests/dune_rpc/long_polling.ml
+++ b/test/expect-tests/dune_rpc/long_polling.ml
@@ -46,7 +46,7 @@ let server_long_poll svar =
     Rpc.Server.Handler.implement_long_poll
       rpc
       sub_proc
-      svar
+      (Rpc.Server.Source.Svar svar)
       ~equal:Int.equal
       ~diff:(fun ~last ~now ->
         match last with
@@ -107,6 +107,45 @@ let%expect_test "long polling - client side termination" =
     client: received 1
     client: received 2
     server: polling cancelled
+    server: finished. |}]
+;;
+
+(* A long poll backed by a [Computed] source reads its state from a plain [ref] and polls
+   it for changes. Here we mutate the ref before asking for the next value, so the poll's
+   predicate is already satisfied and the source returns immediately without sleeping. *)
+let server_long_poll_computed r =
+  let rpc = rpc () in
+  let () =
+    Rpc.Server.Handler.implement_long_poll
+      rpc
+      sub_proc
+      (Rpc.Server.Source.Computed
+         { get = (fun () -> !r); poll_every = Time.Span.of_secs 0.01 })
+      ~equal:Int.equal
+      ~diff:(fun ~last ~now ->
+        match last with
+        | None -> now
+        | Some last -> now - last)
+  in
+  rpc
+;;
+
+let%expect_test "long polling - computed (poll/ref) source" =
+  let r = ref 0 in
+  let handler = server_long_poll_computed r in
+  let client client =
+    let* poller = poll_exn client in
+    r := 1;
+    let* () = print_next "first" poller in
+    r := 5;
+    let* () = print_next "second" poller in
+    Client.Stream.cancel poller
+  in
+  test ~init ~client ~handler ~private_menu:[ Poll sub_proc ] ();
+  [%expect
+    {|
+    client: first received 1
+    client: second received 4
     server: finished. |}]
 ;;
 


### PR DESCRIPTION
Rule progress now reports **built vs total rules**: the number of rules whose
value has been established this run, against the true total number of live
rules — instead of the previous "executed vs discovered", which counted only
the rules rebuilt this run (so an incremental build that was mostly cache hits
never approached 100%).

### How

The counts are driven by Memo's `on_event` callback, wired into the rule and
anonymous-action memo nodes:

- `Live` (a node becomes live this run) → `number_of_rules_discovered`. Because
  `Live` fires for every live rule, including cache-restored ones, this is now
  the *true* total.
- `Validated` (its value established for the run) → the new
  `number_of_rules_validated` ("built").

`in_progress = discovered - validated`. The previous `number_of_rules_executed`
counter is no longer used and is removed.

### Plumbing

`on_event` is a synchronous callback, so the build progress moves from a
`Fiber.Svar.t` to a plain `ref`. To keep the RPC server able to observe it,
`Rpc.Server` gains a long-poll `Source`: `Svar` (blocks on `Svar.wait`, as
before) or `Computed` (reads a thunk, polled every `poll_every`). The progress
poll uses a `Computed` source over the `ref`; errors and running-jobs keep
their `Svar`s. The RPC wire type (`{ complete; remaining; failed }`) is
unchanged — only the values improve.
