### PR TITLE
feat(memo): add Invalidation.custom and to_reason_list

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1452,6 +1452,23 @@ module Invalidation = struct
       | Test -> Some "Rebuild initiated by an internal testsuite"
       | Variable_changed v -> Some (sprintf "Variable %s changed" v)
     ;;
+
+    let equal a b =
+      match a, b with
+      | Unknown, Unknown
+      | Event_queue_overflow, Event_queue_overflow
+      | Upgrade, Upgrade
+      | Test, Test -> true
+      | Path_changed a, Path_changed b -> Path.equal a b
+      | Variable_changed a, Variable_changed b -> String.equal a b
+      | ( ( Unknown
+          | Path_changed _
+          | Event_queue_overflow
+          | Upgrade
+          | Test
+          | Variable_changed _ )
+        , _ ) -> false
+    ;;
   end
 
   module Leaf = struct
@@ -1459,6 +1476,7 @@ module Invalidation = struct
       | Invalidate_node : _ Dep_node.t -> kind
       | Clear_cache : ('input, ('input, 'output) Dep_node.t) Store.t -> kind
       | Clear_caches
+      | Custom of (unit -> unit)
 
     type t =
       { kind : kind
@@ -1492,6 +1510,7 @@ module Invalidation = struct
     | Invalidate_node dep_node -> invalidate_dep_node dep_node
     | Clear_cache store -> invalidate_store store
     | Clear_caches -> Caches.clear ()
+    | Custom f -> f ()
   ;;
 
   let rec execute x xs =
@@ -1575,6 +1594,16 @@ module Invalidation = struct
 
   let invalidate_node ~reason (dep_node : _ Dep_node.t) =
     Leaf { kind = Invalidate_node dep_node; reason }
+  ;;
+
+  (* For out-of-band caching mechanisms that need to run an arbitrary action when the build
+     is invalidated. *)
+  let custom ~reason ~f = Leaf { kind = Custom f; reason }
+
+  let to_reason_list t =
+    List.fold_left (to_list t) ~init:[] ~f:(fun acc ({ Leaf.reason; _ } : Leaf.t) ->
+      if List.mem acc reason ~equal:Reason.equal then acc else reason :: acc)
+    |> List.rev
   ;;
 end
 

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -231,9 +231,16 @@ module Invalidation : sig
   (** Invalidate all computations stored in a given [memo] table. *)
   val invalidate_cache : reason:Reason.t -> _ Table.t -> t
 
-  (** A list of human-readable strings explaining the reasons for invalidation.
-      The list is truncated to [max_elements] elements, with [max_elements = 1]
-      by default. Raises if [max_elements <= 0]. *)
+  (** A custom invalidation, for use by out-of-band caching mechanisms: [f] is run when the
+      invalidation is applied. *)
+  val custom : reason:Reason.t -> f:(unit -> unit) -> t
+
+  (** All reasons contributing to an invalidation, deduplicated and in first-seen order. *)
+  val to_reason_list : t -> Reason.t list
+
+  (** A list of human-readable strings explaining the reasons for invalidation. The list
+      is truncated to [max_elements] elements, with [max_elements = 1] by default. Raises
+      if [max_elements <= 0]. *)
   val details_hum : ?max_elements:int -> t -> string list
 
   (** The list of changed paths that contributed [Path_changed] invalidations.

--- a/test/expect-tests/memo/main.ml
+++ b/test/expect-tests/memo/main.ml
@@ -2325,6 +2325,36 @@ let%expect_test "create_rec" =
     |}]
 ;;
 
+let%expect_test "Invalidation.custom runs its action on reset" =
+  let ran = ref 0 in
+  let inv = Memo.Invalidation.custom ~reason:Test ~f:(fun () -> incr ran) in
+  printf "before: %d\n" !ran;
+  Memo.reset inv;
+  printf "after: %d\n" !ran;
+  [%expect
+    {|
+    before: 0
+    after: 1
+    |}]
+;;
+
+let%expect_test "Invalidation.to_reason_list deduplicates reasons" =
+  let open Memo.Invalidation in
+  let inv =
+    combine
+      (combine (custom ~reason:Test ~f:ignore) (custom ~reason:Test ~f:ignore))
+      (custom ~reason:(Variable_changed "x") ~f:ignore)
+  in
+  printf "%d reasons\n" (List.length (to_reason_list inv));
+  List.iter (details_hum ~max_elements:10 inv) ~f:print_endline;
+  [%expect
+    {|
+    2 reasons
+    Rebuild initiated by an internal testsuite
+    Variable x changed
+    |}]
+;;
+
 let%expect_test "Var.Unit" =
   let var = Memo.Var.Unit.create () in
   let calls = ref 0 in


### PR DESCRIPTION
Adds two additive helpers to `Memo.Invalidation`:

- `Invalidation.custom ~reason ~f` builds an invalidation that runs an arbitrary action `f` when applied — for out-of-band caching mechanisms that need to hook into a build invalidation.
- `Invalidation.to_reason_list` returns all reasons contributing to an invalidation, deduplicated and in first-seen order.

Both are additive; the existing `reset` / `details_hum` behaviour is unchanged.
