### PR TITLE
feat(memo): add reset_if_necessary and track non-reproducible errors

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1079,6 +1079,11 @@ let report_and_collect_errors f =
 
 let check_point = ref (Fiber.return ())
 
+(* The run in which we last computed a non-reproducible error. [reset_if_necessary]
+   uses it to force a new run even when the invalidation is empty, so that
+   non-reproducible errors (which are never restored from the cache) get recomputed. *)
+let last_saw_non_reproducible_exn_at = ref Run.invalid
+
 module Exec : sig
   val exec_dep_node : ('i, 'o) Dep_node.t -> 'o Fiber.t
 end = struct
@@ -1191,6 +1196,10 @@ end = struct
       | Ok res -> Value.Ok res
       | Error errors -> Error errors
     in
+    (match res with
+     | Error { reproducible = false; _ } ->
+       last_saw_non_reproducible_exn_at := Run.current ()
+     | Ok _ | Error { reproducible = true; _ } -> ());
     let deps_rev = Stack_frame_with_state.deps_rev stack_frame in
     Option.Unboxed.match_
       old_value
@@ -1771,6 +1780,17 @@ let reset invalidation =
   Invalidation.execute (Invalidation.combine invalidation invalidate_current_run);
   Call_stack.reset_cycle_error_in_the_current_run ();
   Run.restart ()
+;;
+
+(* Like [reset], but a no-op when nothing can have changed: the [invalidation] is empty and
+   no non-reproducible error was computed in the current run. This lets a caller (e.g. a
+   file-watcher waking up with no relevant changes) avoid advancing the run and discarding
+   the whole cache. *)
+let reset_if_necessary invalidation =
+  if
+    (not (Invalidation.is_empty invalidation))
+    || Run.is_current !last_saw_non_reproducible_exn_at
+  then reset invalidation
 ;;
 
 module For_tests = struct

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -253,6 +253,11 @@ end
     and advances the current run. *)
 val reset : Invalidation.t -> unit
 
+(** Like [reset], but does nothing when [invalidation] is empty and no non-reproducible
+    error was produced during the current run. Use this to avoid advancing the run (and
+    thus invalidating the whole cache) when nothing relevant has changed. *)
+val reset_if_necessary : Invalidation.t -> unit
+
 module type Input = sig
   type t
 

--- a/src/memo/run.ml
+++ b/src/memo/run.ml
@@ -8,6 +8,7 @@ let current = ref 0
 let is_current t = Int.equal !current t
 let restart () = incr current
 let current () = !current
+let invalid = -1
 
 module Pair = struct
   (* The high [63 - delta_bits] bits store [last_validated_at + 1] (so that a pair of two

--- a/src/memo/run.mli
+++ b/src/memo/run.mli
@@ -26,6 +26,10 @@ val compare : t -> t -> Ordering.t
 (** End the current run and start a new one. *)
 val restart : unit -> unit
 
+(** A run that is never current: [is_current invalid] is always [false]. Used as the
+    initial value of trackers that record "the run in which X last happened". *)
+val invalid : t
+
 (** A pair of [t]s representing the [(last_changed_at, last_validated_at)]
     timestamps of a memoized value, with the invariant
     [last_changed_at <= last_validated_at], packed into a single immediate.

--- a/test/expect-tests/memo/main.ml
+++ b/test/expect-tests/memo/main.ml
@@ -2355,6 +2355,63 @@ let%expect_test "Invalidation.to_reason_list deduplicates reasons" =
     |}]
 ;;
 
+let%expect_test "reset_if_necessary" =
+  let calls = ref 0 in
+  let cell =
+    Memo.lazy_cell (fun () ->
+      incr calls;
+      Memo.return ())
+  in
+  let eval () = run (Memo.Cell.read cell) in
+  eval ();
+  printf "calls = %d\n" !calls;
+  [%expect {| calls = 1 |}];
+  (* An empty invalidation is a no-op: the run is not advanced, so the cached value is
+     reused and the computation does not run again. *)
+  Memo.reset_if_necessary Memo.Invalidation.empty;
+  eval ();
+  printf "calls = %d\n" !calls;
+  [%expect {| calls = 1 |}];
+  (* A non-empty invalidation forces a reset, so the cell is recomputed. *)
+  Memo.reset_if_necessary (Memo.Cell.invalidate ~reason:Test cell);
+  eval ();
+  printf "calls = %d\n" !calls;
+  [%expect {| calls = 2 |}]
+;;
+
+let%expect_test "reset_if_necessary retries non-reproducible errors" =
+  let calls = ref 0 in
+  let cell =
+    Memo.lazy_cell (fun () ->
+      incr calls;
+      raise (Memo.Non_reproducible (Failure "boom")))
+  in
+  run_and_log_errors (Memo.Cell.read cell);
+  printf "calls = %d\n" !calls;
+  [%expect
+    {|
+    Error: { exn =
+               "Memo.Error.E { exn = \"Failure(\\\"boom\\\")\"; stack = [ (\"<unnamed>\", ()) ] }"
+           ; backtrace = ""
+           }
+    calls = 1
+    |}];
+  (* The invalidation is empty, but a non-reproducible error was produced in the current
+     run, so [reset_if_necessary] still advances the run and the computation is retried
+     instead of being served stale from the cache. *)
+  Memo.reset_if_necessary Memo.Invalidation.empty;
+  run_and_log_errors (Memo.Cell.read cell);
+  printf "calls = %d\n" !calls;
+  [%expect
+    {|
+    Error: { exn =
+               "Memo.Error.E { exn = \"Failure(\\\"boom\\\")\"; stack = [ (\"<unnamed>\", ()) ] }"
+           ; backtrace = ""
+           }
+    calls = 2
+    |}]
+;;
+
 let%expect_test "Var.Unit" =
   let var = Memo.Var.Unit.create () in
   let calls = ref 0 in


### PR DESCRIPTION
Adds `Memo.reset_if_necessary` and tracks non-reproducible errors.

`reset_if_necessary invalidation` advances the build run only when doing so would actually change something:

- the invalidation is non-empty, **or**
- a non-reproducible error was produced during the current run (which must be retried rather than served stale from the cache).

Otherwise it is a no-op, so an empty invalidation with no errors reuses the cached values and does not re-run the computation.

To support the second case, Memo records the run in which it last saw a non-reproducible error (`last_saw_non_reproducible_exn_at`), and `Run` gains a `Run.invalid` sentinel for "never". The existing `reset` behaviour is unchanged.
