### PR TITLE
fix(vcs): contextualize missing git errors

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -228,7 +228,11 @@ module File_ops_real (W : sig
       in
       match packages with
       | None -> Fiber.return None
-      | Some vcs -> Memo.run (Vcs.describe vcs)
+      | Some vcs ->
+        Memo.run
+          (Vcs.describe
+             vcs
+             ~needed_for:"to infer package versions while installing files")
     in
     try f ~get_version ic ~src oc with
     | _ (* XXX should we really be catching everything here? *) ->

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -341,9 +341,10 @@ let subst vcs =
   let open Memo.O in
   (match vcs with
    | Some vcs ->
-     let+ version = Vcs.describe vcs
-     and+ commit_id = Vcs.commit_id vcs
-     and+ files = Vcs.files vcs in
+     let needed_for = "by 'dune subst' to infer version information and list files" in
+     let+ version = Vcs.describe ~needed_for vcs
+     and+ commit_id = Vcs.commit_id ~needed_for vcs
+     and+ files = Vcs.files ~needed_for vcs in
      Some (version, commit_id, files)
    | None ->
      let* root = Source_tree.root () in

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -449,6 +449,8 @@ let env =
   |> Env.add ~var:"GIT_TERMINAL_PROMPT" ~value:"0"
 ;;
 
+let git () = Vcs.git_for ~needed_for:"by dune package management to fetch git sources"
+
 let with_specified_git_dir ~dir env =
   (* prevent Git from walking up the file system to find a potentially
      unrelated git directory, so we disable the walk up by setting
@@ -465,7 +467,7 @@ module Git_error = struct
     }
 
   let raise_code_error { dir; args; exit_code; output } =
-    let git = Lazy.force Vcs.git in
+    let git = git () in
     Code_error.raise
       "git returned non-zero exit code"
       [ "exit code", Dyn.int exit_code
@@ -484,7 +486,7 @@ end
 
 let run_with_exit_code ~env { dir; _ } ~allow_codes ~display args =
   let stdout_to = make_stdout () in
-  let git = Lazy.force Vcs.git in
+  let git = git () in
   let+ stderr, exit_code =
     Fiber.Temp.with_temp_file
       ~prefix:"dune"
@@ -522,7 +524,7 @@ let run t ~display args =
 ;;
 
 let run_capture_lines { dir; _ } ~display args =
-  let git = Lazy.force Vcs.git in
+  let git = git () in
   let+ output, exit_code =
     Process.run_capture_lines ~dir ~display ~env failure_mode git args
   in
@@ -530,7 +532,7 @@ let run_capture_lines { dir; _ } ~display args =
 ;;
 
 let run_capture_zero_separated_lines { dir; _ } args =
-  let git = Lazy.force Vcs.git in
+  let git = git () in
   let+ output, exit_code =
     Process.run_capture_zero_separated ~dir ~display:Quiet ~env failure_mode git args
   in
@@ -538,7 +540,7 @@ let run_capture_zero_separated_lines { dir; _ } args =
 ;;
 
 let cat_file { dir; _ } command =
-  let git = Lazy.force Vcs.git in
+  let git = git () in
   let failure_mode = Vcs.git_accept () in
   let stderr_to = make_stderr () in
   let stdout_to = make_stdout () in
@@ -548,7 +550,7 @@ let cat_file { dir; _ } command =
 ;;
 
 let rev_parse { dir; _ } rev =
-  let git = Lazy.force Vcs.git in
+  let git = git () in
   let+ lines, code =
     Process.run_capture_lines
       ~dir
@@ -574,7 +576,7 @@ let escape_url_for_ref url = Re.replace_string url_escape_re ~by:"_" url
    refs relevant to the remote being fetched from. *)
 let add_object_ref { dir; _ } ~negotiation_ref_prefix obj =
   let hex = Object.to_hex obj in
-  let git = Lazy.force Vcs.git in
+  let git = git () in
   let env = with_specified_git_dir ~dir env in
   Process.run
     ~dir
@@ -592,7 +594,7 @@ let add_object_ref { dir; _ } ~negotiation_ref_prefix obj =
 ;;
 
 let object_exists_no_lock { dir; _ } obj =
-  let git = Lazy.force Vcs.git in
+  let git = git () in
   let+ (), code =
     Process.run
       ~dir
@@ -628,7 +630,7 @@ let mem_path repo obj path =
 
 let show =
   let show { dir; _ } revs_and_paths =
-    let git = Lazy.force Vcs.git in
+    let git = git () in
     let failure_mode = Vcs.git_accept () in
     let command =
       "show"
@@ -644,7 +646,7 @@ let show =
       (if Sys.win32 then 8191 else 2097152)
       - String.length "show"
       - 1 (* space *)
-      - String.length (Path.to_string (Lazy.force Vcs.git))
+      - String.length (Path.to_string (git ()))
       - 100 (* some extra safety *)
     in
     let rec loop acc batch cmd_len_remaining = function
@@ -1109,7 +1111,7 @@ module At_rev = struct
         }
         ~target
     =
-    let git = Lazy.force Vcs.git in
+    let git = git () in
     let temp_dir =
       Temp_dir.dir_for_target ~target ~prefix:"rev-store" ~suffix:(Object.to_hex revision)
     in

--- a/src/dune_rules/artifact_substitution.ml
+++ b/src/dune_rules/artifact_substitution.ml
@@ -207,7 +207,10 @@ let eval t ~(conf : Conf.t) =
        >>= function
        | None -> Memo.return ""
        | Some vcs ->
-         let+ res = Vcs.describe vcs in
+         let needed_for =
+           "to infer version information for artifact substitution and build info"
+         in
+         let+ res = Vcs.describe ~needed_for vcs in
          Option.value res ~default:"")
   | Location (name, lib_name) ->
     conf.get_location name lib_name |> relocatable |> Memo.run

--- a/src/dune_vcs/vcs.ml
+++ b/src/dune_vcs/vcs.ml
@@ -66,23 +66,30 @@ end
 
 include T
 
-let git, hg =
-  let get prog =
-    lazy
-      (match Bin.which ~path:(Env_path.path Env.initial) prog with
-       | Some x -> x
-       | None ->
-         let hint =
-           match prog with
-           | "git" ->
-             Some
-               "Git is required for version information in 'dune subst', build info, and \
-                package management. Install git or add it to your PATH."
-           | _ -> None
-         in
-         Utils.program_not_found prog ~loc:None ?hint)
-  in
-  get "git", get "hg"
+let git_path = lazy (Bin.which ~path:(Env_path.path Env.initial) "git")
+
+let git_for ~needed_for =
+  match Lazy.force git_path with
+  | Some x -> x
+  | None ->
+    Utils.program_not_found
+      "git"
+      ~loc:None
+      ~hint:(sprintf "Git is required %s. Install git or add it to your PATH." needed_for)
+;;
+
+let git =
+  lazy
+    (git_for
+       ~needed_for:
+         "for version information in 'dune subst', build info, and package management")
+;;
+
+let hg =
+  lazy
+    (match Bin.which ~path:(Env_path.path Env.initial) "hg" with
+     | Some x -> x
+     | None -> Utils.program_not_found "hg" ~loc:None)
 ;;
 
 let select git hg t =
@@ -157,26 +164,35 @@ let make_fun name ~git ~hg =
   Staged.stage (Memo.exec memo)
 ;;
 
+let with_git_hint ?needed_for t f =
+  (match needed_for, t.kind with
+   | Some needed_for, Git ->
+     let (_ : Path.t) = git_for ~needed_for in
+     ()
+   | None, Git | _, Hg -> ());
+  f t
+;;
+
 let describe =
-  Staged.unstage
-  @@ make_fun
-       "vcs-describe"
-       ~git:(fun t -> run_git t [ "describe"; "--always"; "--dirty"; "--abbrev=7" ])
-       ~hg:(fun x ->
-         let open Fiber.O in
-         let+ res = hg_describe x in
-         Some res)
+  let describe =
+    Staged.unstage
+    @@ make_fun
+         "vcs-describe"
+         ~git:(fun t -> run_git t [ "describe"; "--always"; "--dirty"; "--abbrev=7" ])
+         ~hg:(fun x -> Fiber.O.(hg_describe x >>| Option.some))
+  in
+  fun t ~needed_for -> with_git_hint ~needed_for t describe
 ;;
 
 let commit_id =
-  Staged.unstage
-  @@ make_fun
-       "vcs-commit-id"
-       ~git:(fun t -> run_git t [ "rev-parse"; "HEAD" ])
-       ~hg:(fun t ->
-         let open Fiber.O in
-         let+ res = run t [ "id"; "-i" ] in
-         Some res)
+  let commit_id =
+    Staged.unstage
+    @@ make_fun
+         "vcs-commit-id"
+         ~git:(fun t -> run_git t [ "rev-parse"; "HEAD" ])
+         ~hg:(fun t -> Fiber.O.(run t [ "id"; "-i" ] >>| Option.some))
+  in
+  fun t ~needed_for -> with_git_hint ~needed_for t commit_id
 ;;
 
 let git_sha_short =
@@ -240,9 +256,12 @@ let files =
     in
     run t args >>| List.filter_map ~f
   in
-  Staged.unstage
-  @@ make_fun
-       "vcs-files"
-       ~git:(f run_zero_separated_git [ "ls-tree"; "-z"; "-r"; "--name-only"; "HEAD" ])
-       ~hg:(f run_zero_separated_hg [ "files"; "-0" ])
+  let files =
+    Staged.unstage
+    @@ make_fun
+         "vcs-files"
+         ~git:(f run_zero_separated_git [ "ls-tree"; "-z"; "-r"; "--name-only"; "HEAD" ])
+         ~hg:(f run_zero_separated_hg [ "files"; "-0" ])
+  in
+  fun t ~needed_for -> with_git_hint ~needed_for t files
 ;;

--- a/src/dune_vcs/vcs.mli
+++ b/src/dune_vcs/vcs.mli
@@ -24,20 +24,21 @@ val equal : t -> t -> bool
 val to_dyn : t -> Dyn.t
 
 (** Nice description of the current tip *)
-val describe : t -> string option Memo.t
+val describe : t -> needed_for:string -> string option Memo.t
 
 (** String uniquely identifying the current head commit *)
-val commit_id : t -> string option Memo.t
+val commit_id : t -> needed_for:string -> string option Memo.t
 
 (** Short git SHA of the current head commit, or [None] if unavailable *)
 val git_sha_short : t -> string option Memo.t
 
 (** List of files committed in the repo *)
-val files : t -> Path.Source.t list Memo.t
+val files : t -> needed_for:string -> Path.Source.t list Memo.t
 
 (** VCS commands *)
 val git : Path.t Lazy.t
 
+val git_for : needed_for:string -> Path.t
 val hg : Path.t Lazy.t
 
 (** Valid git exit codes *)

--- a/test/blackbox-tests/test-cases/subst/subst.t
+++ b/test/blackbox-tests/test-cases/subst/subst.t
@@ -135,3 +135,22 @@ Test subst and files with unicode (#3879)
   $ dune subst
 
   $ rm -rf .git
+
+Missing git
+-----------
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > (name foo)
+  > EOF
+
+  $ git init --quiet
+  $ git add .
+  $ git commit -am _ --quiet
+  $ git tag -a 1.0 -m 1.0
+
+  $ PATH=$(dirname $(which dune)) dune subst
+  Error: Program git not found in the tree or in PATH
+  Hint: Git is required by 'dune subst' to infer version information and list
+  files. Install git or add it to your PATH.
+  [1]

--- a/test/expect-tests/vcs/vcs_tests.ml
+++ b/test/expect-tests/vcs/vcs_tests.ml
@@ -89,7 +89,7 @@ let run_action (vcs : Vcs.t) action =
       | Hg when not has_hg -> { vcs with kind = Git }
       | _ -> vcs
     in
-    let+ s = Memo.run (Vcs.describe vcs) in
+    let+ s = Memo.run (Vcs.describe vcs ~needed_for:"unit test") in
     let s = Option.value s ~default:"n/a" in
     let processed =
       String.split s ~on:'-'


### PR DESCRIPTION
Fixes #10393.

Missing `git` errors now include context about the Dune feature that required Git, such as `dune subst`, build-info/artifact substitution, or package management.