### PR TITLE
doc(changes): mention diff promotion fix for #8073

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -323,8 +323,8 @@
 
 - `$ dune promotion list` writes output to stdout rather than stderr (#13462)
 
-- Improve handling of empty files in the `diff` action. These are now correctly
-  distinguished from *empty* files. (#13696, @rgrinberg)
+- Improve handling of empty files in the `diff` action. Missing files are now
+  correctly distinguished from empty files. (#13696, fixes #8073, @rgrinberg)
 - Pass `/dev/null` to `--diff-command` instead of non-existent files (#13696,
   @rgrinberg)
 


### PR DESCRIPTION
The behavior reported in #8073 was fixed by #13696 and released in Dune 3.22.0. Update the changelog entry to mention the issue explicitly.

Closes #8073.