### PR TITLE
refactor(memo): move Value into its own module

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -173,43 +173,6 @@ module M = struct
     exception E of t
   end
 
-  and Exn_comparable : (Comparable_intf.S with type key := Exn_with_backtrace.t) =
-  Comparable.Make (struct
-      type t = Exn_with_backtrace.t
-
-      let unwrap = function
-        | Error.E { exn; _ } -> exn
-        | exn -> exn
-      ;;
-
-      let compare { Exn_with_backtrace.exn; backtrace = _ } (t : t) =
-        Poly.compare (unwrap exn) (unwrap t.exn)
-      ;;
-
-      let to_dyn = Exn_with_backtrace.to_dyn
-    end)
-
-  and Exn_set : (Set.S with type elt := Exn_with_backtrace.t) = Exn_comparable.Set
-
-  and Collect_errors_monoid : sig
-    type t =
-      { exns : Exn_set.t
-      ; reproducible : bool
-      }
-  end =
-    Collect_errors_monoid
-
-  (* Restoring or computing a value can fail when the user-supplied function raises one or
-     more exceptions, recorded in the [Collect_errors_monoid.t]. A computation cancelled due
-     to a dependency cycle is recorded as a non-reproducible [Error] whose exception set
-     holds the corresponding [Cycle_error.E]. *)
-  and Value : sig
-    type 'a t =
-      | Ok of 'a
-      | Error of Collect_errors_monoid.t
-  end =
-    Value
-
   and Cache_lookup : sig
     (* Looking up a value cached in a previous run can fail in three possible ways:
 
@@ -359,6 +322,15 @@ module Error = struct
   ;;
 end
 
+(* Now that [Error] is defined, teach [Value]'s error-set comparison to unwrap [Error.E]
+   (see the comment on [Value.unwrap_exn]). *)
+let () =
+  Value.unwrap_exn
+  := function
+     | Error.E { exn; _ } -> exn
+     | exn -> exn
+;;
+
 let () =
   Printexc.register_printer (fun exn ->
     let dyn =
@@ -373,39 +345,8 @@ let () =
     Option.map dyn ~f:Dyn.to_string)
 ;;
 
-module Exn_set = M.Exn_set
-
-module Collect_errors_monoid = struct
-  module T = struct
-    include M.Collect_errors_monoid
-
-    let empty = { exns = Exn_set.empty; reproducible = true }
-
-    let combine
-          { exns = exns1; reproducible = reproducible1 }
-          { exns = exns2; reproducible = reproducible2 }
-      =
-      { exns = Exn_set.union exns1 exns2; reproducible = reproducible1 && reproducible2 }
-    ;;
-  end
-
-  include T
-  include Monoid.Make (T)
-end
-
-module Value = struct
-  include M.Value
-
-  let get_exn t ~stack_frame =
-    match t with
-    | Ok a -> Fiber.return a
-    | Error { exns; _ } ->
-      Fiber.reraise_all
-        (Exn_set.to_list_map exns ~f:(fun exn ->
-           { exn with exn = Error.extend_stack exn.exn ~stack_frame }))
-  ;;
-end
-
+module Exn_set = Value.Exn_set
+module Collect_errors_monoid = Value.Collect_errors_monoid
 module Cache_lookup = M.Cache_lookup
 module Dag = M.Dag
 
@@ -1341,7 +1282,8 @@ end = struct
            [consider_and_restore_from_cache_without_adding_dep], is a measurable win. *)
         let* () = Call_stack.add_dep_from_caller dep_node in
         let stack_frame = Dep_node.T dep_node in
-        Value.get_exn cached_value.value ~stack_frame
+        Value.get_exn cached_value.value ~map_exn:(fun exn ->
+          Error.extend_stack exn ~stack_frame)
       | _ ->
         let* result =
           consider_and_restore_from_cache_without_adding_dep dep_node
@@ -1363,7 +1305,8 @@ end = struct
          | Ok res ->
            let* () = Call_stack.add_dep_from_caller dep_node in
            let stack_frame = Dep_node.T dep_node in
-           Value.get_exn res.value ~stack_frame
+           Value.get_exn res.value ~map_exn:(fun exn ->
+             Error.extend_stack exn ~stack_frame)
          | Error cycle_error -> raise (Cycle_error.E cycle_error)))
   ;;
 end

--- a/src/memo/value.ml
+++ b/src/memo/value.ml
@@ -1,0 +1,57 @@
+open! Import
+
+(* [Error.E] (defined in memo.ml) wraps an exception together with a memoized call stack.
+   To deduplicate errors we compare the underlying exceptions, but [Error] depends on the
+   node graph and so cannot be referenced here. The unwrapping function is therefore
+   installed by memo.ml at startup via [unwrap_exn]. *)
+let unwrap_exn = ref (fun (exn : exn) -> exn)
+
+module Exn_comparable = Comparable.Make (struct
+    type t = Exn_with_backtrace.t
+
+    let compare { Exn_with_backtrace.exn; backtrace = _ } (t : t) =
+      Poly.compare (!unwrap_exn exn) (!unwrap_exn t.exn)
+    ;;
+
+    let to_dyn = Exn_with_backtrace.to_dyn
+  end)
+
+module Exn_set = Exn_comparable.Set
+
+module Collect_errors_monoid = struct
+  module T = struct
+    type t =
+      { exns : Exn_set.t
+      ; reproducible : bool
+      }
+
+    let empty = { exns = Exn_set.empty; reproducible = true }
+
+    let combine
+          { exns = exns1; reproducible = reproducible1 }
+          { exns = exns2; reproducible = reproducible2 }
+      =
+      { exns = Exn_set.union exns1 exns2; reproducible = reproducible1 && reproducible2 }
+    ;;
+  end
+
+  include T
+  include Monoid.Make (T)
+end
+
+(* Restoring or computing a value can fail when the user-supplied function raises one or
+   more exceptions, recorded in the [Collect_errors_monoid.t]. A computation cancelled due
+   to a dependency cycle is recorded as a non-reproducible [Error] whose exception set holds
+   the corresponding cycle error. *)
+type 'a t =
+  | Ok of 'a
+  | Error of Collect_errors_monoid.t
+
+let get_exn t ~map_exn =
+  match t with
+  | Ok a -> Fiber.return a
+  | Error { Collect_errors_monoid.exns; reproducible = _ } ->
+    Fiber.reraise_all
+      (Exn_set.to_list_map exns ~f:(fun (exn : Exn_with_backtrace.t) ->
+         { exn with exn = map_exn exn.exn }))
+;;

--- a/src/memo/value.mli
+++ b/src/memo/value.mli
@@ -1,0 +1,28 @@
+open! Import
+
+(** The function used to unwrap an exception before errors are deduplicated by their
+    underlying exception. It is installed by [memo.ml] so that the [Error.E] wrapper
+    (defined there) is unwrapped; the default is the identity. *)
+val unwrap_exn : (exn -> exn) ref
+
+module Exn_set : Set.S with type elt := Exn_with_backtrace.t
+
+module Collect_errors_monoid : sig
+  type t =
+    { exns : Exn_set.t
+    ; reproducible : bool
+    }
+
+  include Monoid.S with type t := t
+end
+
+(** Restoring or computing a value can fail when the user-supplied function raises one or
+    more exceptions, recorded in the [Collect_errors_monoid.t]. A computation cancelled by a
+    dependency cycle is recorded as a non-reproducible [Error] whose exception set holds the
+    cycle error. *)
+type 'a t =
+  | Ok of 'a
+  | Error of Collect_errors_monoid.t
+
+(** Get the value, or reraise the contained errors after remapping each one with [map_exn]. *)
+val get_exn : 'a t -> map_exn:(exn -> exn) -> 'a Fiber.t


### PR DESCRIPTION
Extract `Value` into its own module `src/memo/value.ml` (+ `.mli`).

Now that cancellations are represented as non-reproducible errors, `Value.t` is a leaf type (`Ok | Error`) with no dependency on the node graph, so it can live in its own module. To break the one remaining dependency — `Value`'s error-set comparison unwraps `Error.E`, which is defined in `memo.ml` — the unwrapping function is installed by `memo.ml` at startup via a `Value.unwrap_exn` ref.

Pure code motion; behaviour is unchanged.
