### PR TITLE
doc: add executable test example

### DIFF
--- a/doc/quick-start.rst
+++ b/doc/quick-start.rst
@@ -463,7 +463,8 @@ And run the tests with:
   $ dune runtest
 
 It will run the test program (the main module is ``my_test_program.ml``) and
-error if it exits with a nonzero code.
+error if it exits with a nonzero code. See :ref:`writing-tests` for a more
+complete guide to testing with Dune.
 
 In addition, if a ``my_test_program.expected`` file exists, it will be compared
 to the standard output of the test program and the differences will be

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -482,25 +482,35 @@ build, as this would cause portability problems.
 Custom Tests
 ============
 
-We said in `Running tests`_ that to run tests, Dune simply builds
-the ``runtest`` alias. As a result, you simply need to add an action 
-to this alias in any directory in order to define custom tests. For instance, if
-you have a binary ``tests.exe`` that you want to run as part of
-running your test suite, simply add this to a ``dune`` file:
+For the common case of running an executable as a test, write a
+:ref:`test stanza <tests-stanza>` in your ``dune`` file:
+
+.. code:: dune
+
+   (test
+    (name my_test_program))
+
+This declares a test executable whose main module is
+``my_test_program.ml`` and arranges for ``dune runtest`` to run it. Dune will
+report a test failure if the executable exits with a nonzero status.
+
+The :ref:`tests-stanza` stanza is the multi-test form of ``test``:
+
+.. code:: dune
+
+   (tests (names test1 test2))
+
+More generally, we said in `Running tests`_ that to run tests, Dune simply
+builds the ``runtest`` alias. As a result, you can also add an action to this
+alias in any directory in order to define custom tests. For instance, if you
+have a binary ``tests.exe`` that you want to run as part of running your test
+suite, simply add this to a ``dune`` file:
 
 .. code:: dune
 
    (rule
     (alias  runtest)
     (action (run ./tests.exe)))
-
-Hence to define a test, a pair of alias and executable stanzas are required.
-To simplify this common pattern, Dune provides a :ref:`tests-stanza` stanza to
-define multiple tests and their aliases at once:
-
-.. code:: dune
-
-   (tests (names test1 test2))
 
 
 Diffing the Result


### PR DESCRIPTION
Add the simple `(test (name ...))` example to the testing guide and link to the guide from the quick start.

Fixes #10037.