### PR TITLE
fix: clarify unsupported dune language version error

### DIFF
--- a/src/dune_sexp/syntax.ml
+++ b/src/dune_sexp/syntax.ml
@@ -461,22 +461,51 @@ let check_supported ~dune_lang_ver t (loc, ver) =
        else Pp.textf "Supported versions of this extension in %s:")
         (dune_ver_text dune_lang_ver)
     in
-    let message =
-      [ Pp.textf
-          "Version %s of %s is not supported%s."
-          (Version.to_string ver)
-          t.desc
-          until
-      ; supported
-      ; Pp.enumerate supported_ranges ~f:(fun (a, b) ->
-          let open Version.Infix in
-          if a = b
-          then Pp.text (Version.to_string a)
-          else Pp.textf "%s to %s" (Version.to_string a) (Version.to_string b))
-      ]
+    let supported_ranges_pp =
+      Pp.enumerate supported_ranges ~f:(fun (a, b) ->
+        let open Version.Infix in
+        if a = b
+        then Pp.text (Version.to_string a)
+        else Pp.textf "%s to %s" (Version.to_string a) (Version.to_string b))
     in
-    let is_error = String.is_empty until || dune_lang_ver >= (2, 6) in
-    User_warning.emit ~is_error ~loc message
+    if String.equal t.name Name.dune
+    then
+      User_error.raise
+        ~loc
+        ~hints:
+          [ Pp.textf
+              "Upgrade Dune to a version that supports (lang dune %s)."
+              (Version.to_string ver)
+          ; Pp.text
+              "If this file is part of your project, you can instead lower the dune \
+               language version."
+          ]
+        [ Pp.textf
+            "Version %s of the dune language is not supported by this version of Dune."
+            (Version.to_string ver)
+        ; (if List.is_empty supported_ranges
+           then
+             Pp.text
+               "This version of Dune does not support any version of the dune language."
+           else
+             Pp.text
+               "This version of Dune supports the following versions of the dune \
+                language:")
+        ; supported_ranges_pp
+        ]
+    else (
+      let message =
+        [ Pp.textf
+            "Version %s of %s is not supported%s."
+            (Version.to_string ver)
+            t.desc
+            until
+        ; supported
+        ; supported_ranges_pp
+        ]
+      in
+      let is_error = String.is_empty until || dune_lang_ver >= (2, 6) in
+      User_warning.emit ~is_error ~loc message)
 ;;
 
 let greatest_supported_version t =

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/unknown-dune-version.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/unknown-dune-version.t
@@ -26,9 +26,13 @@ We are unable to pin projects that the version of dune doesn't understand.
   File "dune-project", line 1, characters 11-16:
   1 | (lang dune 3.XX)
                  ^^^^^
-  Error: Version 100.1 of the dune language is not supported.
-  Supported versions of this extension in version 100.1 of the dune language:
+  Error: Version 100.1 of the dune language is not supported by this version of
+  Dune.
+  This version of Dune supports the following versions of the dune language:
   - 1.0 to 1.12
   - 2.0 to 2.9
   - 3.XX to 3.XX
+  Hint: Upgrade Dune to a version that supports (lang dune 100.1).
+  Hint: If this file is part of your project, you can instead lower the dune
+  language version.
   [1]


### PR DESCRIPTION
Avoid describing the dune language as an extension when the requested `(lang dune ...)` version is unsupported, and add upgrade/lower-version hints.

Tested with:

```sh
dune runtest test/blackbox-tests/test-cases/pkg/pin-stanza/unknown-dune-version.t
dune build @check
```

Fixes #14560.