### PR TITLE
doc: mention @doc-json in documentation guide

### DIFF
--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -60,6 +60,16 @@ But these libraries will not be in the main HTML listing above, since they
 don't belong to any particular package, but the generated HTML will still be
 found in ``_build/default/_doc/_html/<library>``.
 
+Documentation for public libraries can also be generated as JSON files with the
+:doc:`/reference/aliases/doc-json` alias:
+
+.. code:: console
+
+  $ dune build @doc-json
+
+These files are produced by ``odoc`` and can be used by external tools or
+custom documentation websites.
+
 
 Documentation Stanza: Examples
 ------------------------------

--- a/doc/reference/aliases/doc-json.rst
+++ b/doc/reference/aliases/doc-json.rst
@@ -4,3 +4,9 @@
 This alias builds documentation for public libraries as JSON files. These are
 produced by ``odoc``'s option ``--as-json`` and can be consumed by external
 tools.
+
+The generated files mirror the HTML documentation hierarchy and use the
+``.html.json`` suffix. For example, the package index is generated at
+``_build/default/_doc/_html/index.html.json``.
+
+.. seealso:: :doc:`/documentation`


### PR DESCRIPTION
Improve discoverability of `@doc-json` by linking it from the documentation guide and describing where the generated JSON files are written.

Fixes #10557.