### PR TITLE
test(init): reproduce abandoned project directory

### DIFF
--- a/test/blackbox-tests/test-cases/dune-init/invalid-module-name-github8252.t
+++ b/test/blackbox-tests/test-cases/dune-init/invalid-module-name-github8252.t
@@ -8,3 +8,8 @@
   Hint: M01_module would be a correct module name
   Leaving directory '01_module'
   [1]
+
+The aborted init should not leave behind the project directory (#9963).
+
+  $ dune_cmd exists 01_module
+  true


### PR DESCRIPTION
Adds a regression test for #9963 showing that an aborted `dune init project` with an invalid module name leaves the project directory behind.