### PR TITLE
doc: mention dependencies that force linkall

### DIFF
--- a/doc/reference/dune/executable.rst
+++ b/doc/reference/dune/executable.rst
@@ -70,6 +70,10 @@ files for executables. See
 - ``(link_flags <flags>)`` specifies additional flags to pass to the linker.
   This field supports ``(:include ...)`` forms.
 
+  Some dependencies require Dune to link executables with ``-linkall`` even if
+  it is not present in ``link_flags``. This is currently the case for
+  ``dune-site``, ``dune-site.plugins``, and ``findlib.dynload``.
+
 - ``(link_deps (<deps-conf list>))`` specifies the dependencies used only by the
   linker, i.e., when using a version script. See
   :doc:`/concepts/dependency-spec` for more details.

--- a/doc/sites.rst
+++ b/doc/sites.rst
@@ -100,8 +100,9 @@ by Dune. As such, the dependency on ``dune-site`` must be specified explicitly.
 
 .. warning::
 
-   An executable that depends (even transitively) on `dune-site` will be compiled with
-   `linkall`, regardless of other options.
+   An executable that depends, even transitively, on ``dune-site`` or
+   ``dune-site.plugins`` will be compiled with ``-linkall``, regardless of
+   other options.
 
 .. note::
 


### PR DESCRIPTION
Document that some dependencies cause Dune to link executables with `-linkall`, and clarify the dune-site warning.

Fixes #12749.