### PR TITLE
doc: add foreign flag examples

### DIFF
--- a/doc/foreign-code.rst
+++ b/doc/foreign-code.rst
@@ -58,6 +58,39 @@ source files or in the same directory group when using
 
 The header files must have the ``.h`` extension.
 
+For headers that are part of the current project, use ``include_dirs`` to add
+an include directory that Dune can track as a dependency:
+
+.. code:: dune
+
+   (library
+    (name mylib)
+    (foreign_stubs
+     (language c)
+     (names mystubs)
+     (include_dirs include)))
+
+For headers and libraries installed by the operating system, prefer querying
+``pkg-config`` with ``dune-configurator`` and passing the discovered compiler
+and linker flags to Dune. This is useful on systems where libraries are
+installed in non-standard locations, such as Homebrew prefixes.
+
+.. code:: dune
+
+   (library
+    (name lz4)
+    (foreign_stubs
+     (language c)
+     (names lz4_stubs)
+     (flags (:standard (:include c_flags.sexp))))
+    (c_library_flags (:standard (:include c_library_flags.sexp))))
+
+The generated ``c_flags.sexp`` file should contain the C compilation flags,
+such as ``-I`` include paths, and ``c_library_flags.sexp`` should contain link
+flags, such as ``-L`` and ``-l`` flags. See the quick-start section on
+:ref:`defining a library with C stubs using pkg-config
+<defining-library-with-c-stubs-pkg-config>` for a complete example.
+
 Installing Header Files
 -----------------------
 

--- a/doc/quick-start.rst
+++ b/doc/quick-start.rst
@@ -378,6 +378,8 @@ this ``dune`` file:
       (flags -I/blah/include))
      (c_library_flags (-lblah)))
 
+.. _defining-library-with-c-stubs-pkg-config:
+
 Defining a Library with C Stubs using ``pkg-config``
 ====================================================
 

--- a/doc/reference/foreign-flags.rst
+++ b/doc/reference/foreign-flags.rst
@@ -20,3 +20,36 @@ one in its `:standard` set:
 
 The ``%{cc}`` :doc:`variable <../concepts/variables>` will contain the flags
 from the first three levels only.
+
+For example, to add a flag to all C stubs in the ``dev`` profile, write:
+
+.. code:: dune
+
+   (env
+    (dev
+     (c_flags (:standard -DMY_DEBUG_STUBS))))
+
+To add flags only to one ``foreign_stubs`` field, write:
+
+.. code:: dune
+
+   (library
+    (name mylib)
+    (foreign_stubs
+     (language c)
+     (names mystubs)
+     (flags (:standard -DMYLIB_STUBS))))
+
+If the flags come from a generated file, for example from a
+``dune-configurator`` script that queried ``pkg-config``, include them with
+``(:include ...)``:
+
+.. code:: dune
+
+   (library
+    (name mylib)
+    (foreign_stubs
+     (language c)
+     (names mystubs)
+     (flags (:standard (:include c_flags.sexp))))
+    (c_library_flags (:standard (:include c_library_flags.sexp))))


### PR DESCRIPTION
Add concrete examples for foreign flags, including project-local include directories and `dune-configurator`/`pkg-config` generated compiler and linker flags.

Fixes #10727.
Fixes #8412.