### PR TITLE
doc: define source files for source_tree

### DIFF
--- a/doc/concepts/dependency-spec.rst
+++ b/doc/concepts/dependency-spec.rst
@@ -23,7 +23,15 @@ Dependencies in ``dune`` files can be specified using one of the following:
 - ``(glob_files_rec <glob>)`` is the recursive version of
   ``(glob_files <glob>)``. See the :ref:`glob <glob>` for details.
 - ``(source_tree <dir>)`` depends on all source files in the subtree with root
-  ``<dir>``.
+  ``<dir>``. A source file is a file that exists in the source tree rather than
+  a target produced by Dune. Source files may still be raw data: for example,
+  files in :doc:`/reference/dune/data_only_dirs` directories are source files,
+  even though Dune does not interpret ``dune`` files in those directories.
+
+  Dune does not traverse directories excluded by the
+  :doc:`/reference/dune/dirs` stanza. In addition, files and directories whose
+  names begin with ``.`` are
+  ignored by ``source_tree`` by default; see :ref:`source-tree-hidden-files`.
 - ``(universe)`` depends on everything in the universe. This is for
   cases where dependencies are too hard to specify. Note that Dune
   will not be able to cache the result of actions that depend on the

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -171,6 +171,8 @@ directory - not the project root. If the library defines a ``name`` distinct fro
 its ``public_name`` then that can be used interchangeably with the ``public_name``
 in this command.
 
+.. _source-tree-hidden-files:
+
 Why does ``source_tree`` ignore files and directories when they begin with a "." (period)?
 ==========================================================================================
 


### PR DESCRIPTION
Clarify what `source_tree` means by source files and link to the FAQ entry about hidden files and directories.

Fixes #9055.