### PR TITLE
feat(memo): restore parallel dependencies concurrently

### DIFF
--- a/doc/changes/fixed/15012.md
+++ b/doc/changes/fixed/15012.md
@@ -1,0 +1,5 @@
+- Dune now restores dependency cutoffs concurrently when they were originally
+  computed in parallel, instead of recomputing them one at a time. The
+  `cutoffs_that_reduce_concurrency_in_watch_mode` setting, which existed to
+  avoid this serialisation, is no longer needed and has been removed.
+  (#15012, @snowleopard)

--- a/otherlibs/stdune/src/config.ml
+++ b/otherlibs/stdune/src/config.ml
@@ -116,13 +116,6 @@ let make_toggle ~name ~default =
 let make ~name ~of_string ~default = make ~lazy_init:false ~name ~of_string ~default
 let global_lock = make ~name:"global_lock" ~of_string:Toggle.of_string ~default:`Enabled
 
-let cutoffs_that_reduce_concurrency_in_watch_mode =
-  make
-    ~name:"cutoffs_that_reduce_concurrency_in_watch_mode"
-    ~of_string:Toggle.of_string
-    ~default:`Disabled
-;;
-
 let copy_file =
   make
     ~name:"copy_file"

--- a/otherlibs/stdune/src/config.mli
+++ b/otherlibs/stdune/src/config.mli
@@ -37,10 +37,6 @@ val get : 'a t -> 'a
 (** should dune acquire the global lock before building *)
 val global_lock : Toggle.t t
 
-(** whether dune should add cutoff to various memoized functions where it
-    reduces concurrency *)
-val cutoffs_that_reduce_concurrency_in_watch_mode : Toggle.t t
-
 (** whether dune should optimize file copying on Linux/MacOS *)
 val copy_file : [ `Portable | `Best ] t
 

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -970,16 +970,11 @@ module Internal = struct
 
   and build_file_memo =
     lazy
-      (let cutoff =
-         match Config.(get cutoffs_that_reduce_concurrency_in_watch_mode) with
-         | `Disabled -> None
-         | `Enabled -> Some (Tuple.T2.equal Digest.equal target_kind_equal)
-       in
-       Memo.create_with_store
+      (Memo.create_with_store
          "build-file"
          ~store:(module Path.Table)
          ~input:(module Path)
-         ?cutoff
+         ~cutoff:(Tuple.T2.equal Digest.equal target_kind_equal)
          build_file_impl)
 
   and build_alias_memo =

--- a/src/memo/deps.ml
+++ b/src/memo/deps.ml
@@ -3,29 +3,117 @@ open Stdune
 module Metrics = M
 open Fiber.O
 
-(* The array is stored reversed to avoid reversing the list in [create]. We need to be
-   careful about traversing the array in the right order in the functions [to_list] and
-   [changed_or_not]. *)
-type 'node t = 'node array
+(* Dependencies form a series-parallel graph. We alternate between sequential sections
+   ([Seq], whose children are checked in order) and parallel sections ([Par], whose
+   children are checked concurrently). [Seq]/[Par] arrays always have at least two
+   elements; single elements are represented as [Singleton], and empty sections as
+   [Empty]. *)
+module Static = struct
+  type 'node t =
+    | Empty
+    | Singleton of 'node
+    | Seq of 'node t array
+    | Par of 'node t array
 
-let empty = [||]
-let create ~deps_rev = Array.of_list deps_rev
-let length = Array.length
-let to_list t = Array.fold_left t ~init:[] ~f:(fun acc x -> x :: acc)
+  (* Flatten a chronological list of sections into a sequence, flattening nested [Seq]s:
+     (x ; (y ; z)) = (x ; y ; z). *)
+  let flatten_seqs (sections : 'node t list) : 'node t =
+    let flat =
+      List.concat_map sections ~f:(function
+        | Empty -> []
+        | Seq arr -> Array.to_list arr
+        | (Singleton _ | Par _) as t -> [ t ])
+    in
+    match flat with
+    | [] -> Empty
+    | [ t ] -> t
+    | _ :: _ :: _ -> Seq (Array.of_list flat)
+  ;;
 
-let changed_or_not t ~f =
-  let rec go index =
-    if index < 0
-    then (
-      Counter.add Metrics.Restore.edges (Array.length t);
-      Fiber.return Changed_or_not.Unchanged)
-    else
-      f t.(index)
+  (* Flatten a list of parallel threads into a parallel section, flattening nested [Par]s:
+     (x | (y | z)) = (x | y | z). *)
+  let flatten_pars (threads : 'node t list) : 'node t =
+    let flat =
+      List.concat_map threads ~f:(function
+        | Empty -> []
+        | Par arr -> Array.to_list arr
+        | (Singleton _ | Seq _) as t -> [ t ])
+    in
+    match flat with
+    | [] -> Empty
+    | [ t ] -> t
+    | _ :: _ :: _ -> Par (Array.of_list flat)
+  ;;
+end
+
+type 'node t = 'node Static.t
+
+let empty = Static.Empty
+
+module Dynamic = struct
+  (* The most recently discovered section is at the head of the list. *)
+  type 'node t = 'node Static.t list
+
+  let empty = []
+
+  let append_seq t ~node =
+    Counter.incr Metrics.Compute.edges;
+    Static.Singleton node :: t
+  ;;
+
+  let append_par t ~threads =
+    match Static.flatten_pars threads with
+    | Static.Empty -> t
+    | section -> section :: t
+  ;;
+
+  (* The list is most-recent-first, so reverse it to chronological order before flattening
+     the sequence. *)
+  let to_static (t : 'node t) : 'node Static.t = Static.flatten_seqs (List.rev t)
+end
+
+(* Note that dependencies should be checked in the order in which they were depended on to
+   avoid recomputations of dependencies that are no longer relevant, and to eliminate
+   spurious dependency cycles. This is why [changed_or_not] checks sequential sections in
+   order rather than in parallel. *)
+let changed_or_not (t : 'node t) ~f =
+  let rec loop ~ok_to_recompute_eagerly (t : 'node Static.t) =
+    match t with
+    | Empty -> Fiber.return Changed_or_not.Unchanged
+    | Singleton node ->
+      Counter.add Metrics.Restore.edges 1;
+      f ~ok_to_recompute_eagerly node
+    | Seq arr -> seq arr 0
+    | Par arr ->
+      Fiber.map_reduce_array
+        arr
+        ~empty:Changed_or_not.Unchanged
+        ~combine:Changed_or_not.combine
+        ~f:(fun section ->
+          match section with
+          | Static.Singleton node ->
+            Counter.add Metrics.Restore.edges 1;
+            f ~ok_to_recompute_eagerly:true node
+          | other -> loop ~ok_to_recompute_eagerly:false other)
+  and seq arr index =
+    if index < Array.length arr
+    then
+      loop ~ok_to_recompute_eagerly:false arr.(index)
       >>= function
-      | Changed_or_not.Unchanged -> go (index - 1)
-      | (Changed | Cancelled _) as res ->
-        Counter.add Metrics.Restore.edges (Array.length t - index);
-        Fiber.return res
+      | Changed_or_not.Unchanged -> seq arr (index + 1)
+      | (Changed | Cancelled _) as res -> Fiber.return res
+    else Fiber.return Changed_or_not.Unchanged
   in
-  go (Array.length t - 1)
+  loop ~ok_to_recompute_eagerly:false t
 ;;
+
+module For_debugging = struct
+  let to_list (t : 'node t) =
+    let rec loop acc = function
+      | Static.Empty -> acc
+      | Singleton node -> node :: acc
+      | Seq arr | Par arr -> Array.fold_right arr ~init:acc ~f:(fun t acc -> loop acc t)
+    in
+    loop [] t
+  ;;
+end

--- a/src/memo/deps.mli
+++ b/src/memo/deps.mli
@@ -1,16 +1,45 @@
-(** Dependencies of a Memo node. *)
+(** A series-parallel graph representing the dependencies of a Memo node.
+
+    Dependencies discovered sequentially (via [let*]/[>>=]) form a sequence; dependencies
+    discovered through a parallel combinator (e.g. [fork_and_join]) form a parallel
+    section. This lets [changed_or_not] check independent dependencies concurrently while
+    still checking sequential ones in order. *)
+
+open! Stdune
 
 type 'node t
 
 val empty : 'node t
 
-(* CR-soon amokhov: Push accumulation of dependencies inside this module to avoid dealing
-   with reversed lists in [memo.ml]. *)
-val create : deps_rev:'node list -> 'node t
-val length : 'node t -> int
-val to_list : 'node t -> 'node list
+(** Like [t] but supports cheap appending of new dependencies. *)
+module Dynamic : sig
+  type 'node static := 'node t
+  type 'node t
 
+  val empty : 'node t
+
+  (** Append a dependency discovered after the existing ones. *)
+  val append_seq : 'node t -> node:'node -> 'node t
+
+  (** Append a parallel section consisting of the dependencies of [threads], each captured
+      independently. *)
+  val append_par : 'node t -> threads:'node static list -> 'node t
+
+  val to_static : 'node t -> 'node static
+end
+
+(** [changed_or_not t ~f] checks each dependency with [f]. Sequential sections are checked
+    in order and the check stops early at the first [Changed]/[Cancelled]; parallel
+    sections are checked concurrently and their results combined.
+
+    [ok_to_recompute_eagerly] is [true] when the dependency is a direct child of a parallel
+    section, telling [f] that it may eagerly recompute a dependency without a cutoff in
+    parallel with its siblings (instead of deferring the recomputation). *)
 val changed_or_not
   :  'node t
-  -> f:('node -> 'cycle Changed_or_not.t Fiber.t)
+  -> f:(ok_to_recompute_eagerly:bool -> 'node -> 'cycle Changed_or_not.t Fiber.t)
   -> 'cycle Changed_or_not.t Fiber.t
+
+module For_debugging : sig
+  val to_list : 'node t -> 'node list
+end

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -66,11 +66,6 @@ module Stack_frame_with_state : sig
   val create : dag_node:Lazy_dag_node.t -> phase -> dep_node:_ Dep_node.t -> t
   val dep_node : t -> Dep_node.packed
   val dag_node : t -> Dag.node
-
-  (* This function accumulates dependencies of frames in the [Compute] phase.
-     Calling it in the [Restore_from_cache] frame raises an exception. *)
-  val add_dep : t -> dep_node:_ Dep_node.t -> unit
-  val deps_rev : t -> Dep_node.packed list
   val children_added_to_dag : t -> Dag.Id.Set.t
   val record_child_added_to_dag : t -> dag_node_id:Dag.Id.t -> unit
 end = struct
@@ -98,36 +93,16 @@ end = struct
          and in these cases [Set] is fast enough; (ii) we don't have hash sets
          in Stdune and using [unit] hash maps is disturbing. *)
       mutable children_added_to_dag : Dag.Id.Set.t
-    ; (* The only purpose of storing [phase] is to ensure (via an [assert]) that
-         we are accumulating dependencies only during the [Compute] phase. We
-         can drop it if we find a way to statically guarantee this property. *)
-      phase : phase
-    ; (* [deps_rev] are accumulated only when [phase = Compute], see
-         [add_dep]. *)
-      mutable deps_rev : Dep_node.packed list
     }
 
   let to_dyn t = Dep_node.Packed.to_dyn_without_state t.dep_node
 
-  let create ~dag_node phase ~dep_node =
-    { dep_node = Dep_node.T dep_node
-    ; phase
-    ; deps_rev = []
-    ; dag_node
-    ; children_added_to_dag = Dag.Id.Set.empty
-    }
+  let create ~dag_node (_ : phase) ~dep_node =
+    { dep_node = Dep_node.T dep_node; dag_node; children_added_to_dag = Dag.Id.Set.empty }
   ;;
 
   let dep_node t = t.dep_node
   let dag_node t = Lazy_dag_node.force t.dag_node ~dep_node:t.dep_node
-
-  let add_dep t ~dep_node =
-    match t.phase with
-    | Restore_from_cache -> assert false
-    | Compute -> t.deps_rev <- Dep_node.T dep_node :: t.deps_rev
-  ;;
-
-  let deps_rev t = t.deps_rev
 
   let record_child_added_to_dag t ~dag_node_id =
     t.children_added_to_dag <- Dag.Id.Set.add t.children_added_to_dag dag_node_id
@@ -141,6 +116,128 @@ module To_open = struct
 end
 
 open To_open
+
+module Deps_collector = struct
+  (* The dependencies discovered by the currently running computation. We keep it in
+     fiber-local storage (rather than on the call-stack frame) so that parallel branches
+     can each collect into their own sub-collector. *)
+  type t = Dep_node.packed Deps.Dynamic.t ref
+
+  let var : t option Fiber.Var.t = Fiber.Var.create None
+  let create () : t = ref Deps.Dynamic.empty
+  let run (t : t) ~f = Fiber.Var.set var (Some t) f
+  let get (t : t) : Dep_node.packed Deps.t = Deps.Dynamic.to_static !t
+  let add (t : t) dep_node = t := Deps.Dynamic.append_seq !t ~node:(Dep_node.T dep_node)
+
+  (* Add a dependency on [dep_node] to the currently running computation, if there is one. *)
+  let add_dep_from_caller dep_node =
+    Fiber.Var.get var
+    >>| function
+    | None -> ()
+    | Some t -> add t dep_node
+  ;;
+
+  (* A way to run a parallel thread while collecting its dependencies separately. *)
+  type run_thread = { run : 'a. f:(unit -> 'a Fiber.t) -> 'a Fiber.t } [@@unboxed]
+
+  (* Run [num_threads] parallel threads, collecting each thread's dependencies into its own
+     sub-collector (via fiber-local storage) and recording them as a single parallel section
+     in the caller's collector. [k] is called with [None] when [num_threads < 2] or when
+     there is no active collector, in which case dependencies are collected sequentially as
+     usual.
+
+     Dependencies are recorded even when a thread raises, because some errors are cached; we
+     reraise after recording. *)
+  let run_parallel ~num_threads k =
+    if num_threads < 2
+    then k None
+    else
+      Fiber.Var.get var
+      >>= function
+      | None -> k None
+      | Some t ->
+        let threads = Array.init num_threads ~f:(fun _ -> create ()) in
+        let thread_index = ref 0 in
+        let run_thread =
+          { run =
+              (fun ~f ->
+                (* The scheduler is cooperative and single-threaded, so reading and bumping
+                   [thread_index] is atomic and each thread gets a distinct sub-collector. *)
+                let i = !thread_index in
+                incr thread_index;
+                Fiber.Var.set var (Some threads.(i)) f)
+          }
+        in
+        let* result = Fiber.collect_errors (fun () -> k (Some run_thread)) in
+        t
+        := Deps.Dynamic.append_par
+             !t
+             ~threads:
+               (List.init num_threads ~f:(fun i -> Deps.Dynamic.to_static !(threads.(i))));
+        (match result with
+         | Ok res -> Fiber.return res
+         | Error exns -> Fiber.reraise_all exns)
+  ;;
+end
+
+(* The parallel combinators below shadow the ones brought in by [include Fiber] above so
+   that, while a Memo computation runs, dependencies discovered by independent parallel
+   branches are recorded as a parallel section (rather than sequentially). This lets
+   [restore_from_cache] check those dependencies concurrently. When no computation is
+   running (no active collector) they behave exactly like the [Fiber] versions.
+
+   Combinators that are not overridden (e.g. [both], [parallel_iter_seq]) simply collect
+   their dependencies sequentially, which is always correct -- overriding only adds the
+   parallel-restore optimisation. *)
+
+let fork_and_join x y =
+  Deps_collector.run_parallel ~num_threads:2 (function
+    | None -> Fiber.fork_and_join x y
+    | Some { Deps_collector.run } ->
+      Fiber.fork_and_join (fun () -> run ~f:x) (fun () -> run ~f:y))
+;;
+
+let fork_and_join_unit x y =
+  Deps_collector.run_parallel ~num_threads:2 (function
+    | None -> Fiber.fork_and_join_unit x y
+    | Some { Deps_collector.run } ->
+      Fiber.fork_and_join_unit (fun () -> run ~f:x) (fun () -> run ~f:y))
+;;
+
+let all_concurrently l =
+  Deps_collector.run_parallel ~num_threads:(List.length l) (function
+    | None -> Fiber.all_concurrently l
+    | Some { Deps_collector.run } ->
+      Fiber.parallel_map l ~f:(fun x -> run ~f:(fun () -> x)))
+;;
+
+let parallel_map l ~f =
+  Deps_collector.run_parallel ~num_threads:(List.length l) (function
+    | None -> Fiber.parallel_map l ~f
+    | Some { Deps_collector.run } ->
+      Fiber.parallel_map l ~f:(fun value -> run ~f:(fun () -> f value)))
+;;
+
+let parallel_iter l ~f =
+  Deps_collector.run_parallel ~num_threads:(List.length l) (function
+    | None -> Fiber.parallel_iter l ~f
+    | Some { Deps_collector.run } ->
+      Fiber.parallel_iter l ~f:(fun value -> run ~f:(fun () -> f value)))
+;;
+
+let map_reduce l ~f ~empty ~combine =
+  Deps_collector.run_parallel ~num_threads:(List.length l) (function
+    | None -> Fiber.map_reduce l ~f ~empty ~combine
+    | Some { Deps_collector.run } ->
+      Fiber.map_reduce l ~f:(fun x -> run ~f:(fun () -> f x)) ~empty ~combine)
+;;
+
+let map_reduce_array arr ~f ~empty ~combine =
+  Deps_collector.run_parallel ~num_threads:(Array.length arr) (function
+    | None -> Fiber.map_reduce_array arr ~f ~empty ~combine
+    | Some { Deps_collector.run } ->
+      Fiber.map_reduce_array arr ~f:(fun x -> run ~f:(fun () -> f x)) ~empty ~combine)
+;;
 
 module Call_stack = struct
   type t = Stack_frame_with_state.t list
@@ -229,14 +326,6 @@ module Call_stack = struct
   ;;
 
   (* Add a dependency on the [dep_node] from the caller, if there is one. *)
-  let add_dep_from_caller =
-    let get_call_stack_tip () = get_call_stack () >>| List.hd_opt in
-    fun dep_node ->
-      let+ caller = get_call_stack_tip () in
-      match caller with
-      | None -> ()
-      | Some caller -> Stack_frame_with_state.add_dep caller ~dep_node
-  ;;
 end
 
 (* This module contains the essence of our cycle detection algorithm. Briefly,
@@ -449,10 +538,10 @@ module Cached_value = struct
   let last_changed_at t = Run.Pair.last_changed_at t.runs
   let last_validated_at t = Run.Pair.last_validated_at t.runs
 
-  let capture_deps ~deps_rev =
+  let capture_deps ~deps =
     if !Debug.check_invariants
     then
-      List.iter deps_rev ~f:(function Dep_node.T dep_node ->
+      List.iter (Deps.For_debugging.to_list deps) ~f:(function Dep_node.T dep_node ->
           (match get_cached_value_in_current_run dep_node with
            | None ->
              let reason =
@@ -466,14 +555,14 @@ module Cached_value = struct
                ("Attempted to create a cached value based on some stale inputs " ^ reason)
                []
            | Some _up_to_date_cached_value -> ()));
-    Deps.create ~deps_rev
+    deps
   ;;
 
-  let create x ~deps_rev =
+  let create x ~deps =
     let now = Run.current () in
     { value = x
     ; runs = Run.Pair.create ~last_changed_at:now ~last_validated_at:now
-    ; deps = capture_deps ~deps_rev
+    ; deps = capture_deps ~deps
     }
   ;;
 
@@ -494,9 +583,9 @@ module Cached_value = struct
     }
   ;;
 
-  let confirm_old_value t ~deps_rev =
+  let confirm_old_value t ~deps =
     t.runs <- Run.Pair.with_last_validated_at t.runs ~last_validated_at:(Run.current ());
-    t.deps <- capture_deps ~deps_rev;
+    t.deps <- capture_deps ~deps;
     t
   ;;
 
@@ -704,62 +793,73 @@ end = struct
       let+ deps_changed =
         (* Make sure [f] gets inlined to avoid unnecessary closure allocations and improve
            stack traces in profiling. *)
-        Deps.changed_or_not cached_value.deps ~f:(fun[@inline] (Dep_node.T dep) ->
-          match dep.state with
-          | Cached_value dep_cached_value
-            when Run.is_current (Cached_value.last_validated_at dep_cached_value) ->
-            (* Fast path: [dep] is already up to date in the current run, so there is no
+        Deps.changed_or_not
+          cached_value.deps
+          ~f:(fun[@inline] ~ok_to_recompute_eagerly (Dep_node.T dep) ->
+            match dep.state with
+            | Cached_value dep_cached_value
+              when Run.is_current (Cached_value.last_validated_at dep_cached_value) ->
+              (* Fast path: [dep] is already up to date in the current run, so there is no
                need to restore it (which would allocate a fiber). We can compare the
                timestamps directly. *)
-            (match
-               Run.compare
-                 (Cached_value.last_changed_at dep_cached_value)
-                 (Cached_value.last_validated_at cached_value)
-             with
-             | Gt -> Fiber.return Changed_or_not.Changed
-             | Eq | Lt -> Fiber.return Changed_or_not.Unchanged)
-          | _ ->
-            consider_and_restore_from_cache_without_adding_dep dep
-            >>= (function
-             | Ok cached_value_of_dep ->
-               (* The [Changed] branch will be taken if [cached_value]'s node was skipped
+              (match
+                 Run.compare
+                   (Cached_value.last_changed_at dep_cached_value)
+                   (Cached_value.last_validated_at cached_value)
+               with
+               | Gt -> Fiber.return Changed_or_not.Changed
+               | Eq | Lt -> Fiber.return Changed_or_not.Unchanged)
+            | _ ->
+              consider_and_restore_from_cache_without_adding_dep dep
+              >>= (function
+               | Ok cached_value_of_dep ->
+                 (* The [Changed] branch will be taken if [cached_value]'s node was skipped
                   in the previous run (it was unreachable), while [dep] wasn't skipped and
                   [cached_value_of_dep] changed. *)
-               (match
-                  Run.compare
-                    (Cached_value.last_changed_at cached_value_of_dep)
-                    (Cached_value.last_validated_at cached_value)
-                with
-                | Gt -> Fiber.return Changed_or_not.Changed
-                | Eq | Lt -> Fiber.return Changed_or_not.Unchanged)
-             | Cancelled { dependency_cycle } ->
-               Fiber.return (Changed_or_not.Cancelled { dependency_cycle })
-             | Out_of_date _old_value ->
-               (match dep.spec.allow_cutoff with
-                | No ->
-                  (* If [dep] has no cutoff, it is sufficient to check whether it is up to
+                 (match
+                    Run.compare
+                      (Cached_value.last_changed_at cached_value_of_dep)
+                      (Cached_value.last_validated_at cached_value)
+                  with
+                  | Gt -> Fiber.return Changed_or_not.Changed
+                  | Eq | Lt -> Fiber.return Changed_or_not.Unchanged)
+               | Cancelled { dependency_cycle } ->
+                 Fiber.return (Changed_or_not.Cancelled { dependency_cycle })
+               | Out_of_date _old_value ->
+                 (match dep.spec.allow_cutoff with
+                  | No when not ok_to_recompute_eagerly ->
+                    (* If [dep] has no cutoff, it is sufficient to check whether it is up to
                      date. If not, we must recompute the [cached_value]. *)
-                  Fiber.return Changed_or_not.Changed
-                | Yes _equal ->
-                  (* If [dep] has a cutoff predicate, it is not sufficient to check
+                    Fiber.return Changed_or_not.Changed
+                  | No ->
+                    (* [dep] is a direct child of a parallel section, so recompute it eagerly
+                     (in parallel with its siblings) rather than deferring. It has no
+                     cutoff, so the outcome is [Changed] regardless of the new value. *)
+                    consider_and_compute_without_adding_dep dep
+                    >>| (function
+                     | Ok (_ : _ Cached_value.t) -> Changed_or_not.Changed
+                     | Error dependency_cycle ->
+                       Changed_or_not.Cancelled { dependency_cycle })
+                  | Yes _equal ->
+                    (* If [dep] has a cutoff predicate, it is not sufficient to check
                      whether it is up to date: even if it isn't, after we recompute it,
                      the resulting value may remain unchanged, allowing us to skip
                      recomputing the [cached_value]. *)
-                  consider_and_compute_without_adding_dep dep
-                  >>| (function
-                   | Ok cached_value_of_dep ->
-                     (* Note: [cached_value_of_dep.value] will be [Cancelled _] if [dep]
+                    consider_and_compute_without_adding_dep dep
+                    >>| (function
+                     | Ok cached_value_of_dep ->
+                       (* Note: [cached_value_of_dep.value] will be [Cancelled _] if [dep]
                         itself doesn't introduce a dependency cycle but one of its
                         transitive dependencies does. In this case, the value will be new,
                         so we will take the [Changed] branch. *)
-                     (match
-                        Run.compare
-                          (Cached_value.last_changed_at cached_value_of_dep)
-                          (Cached_value.last_validated_at cached_value)
-                      with
-                      | Gt -> Changed_or_not.Changed
-                      | Eq | Lt -> Unchanged)
-                   | Error dependency_cycle -> Cancelled { dependency_cycle }))))
+                       (match
+                          Run.compare
+                            (Cached_value.last_changed_at cached_value_of_dep)
+                            (Cached_value.last_validated_at cached_value)
+                        with
+                        | Gt -> Changed_or_not.Changed
+                        | Eq | Lt -> Unchanged)
+                     | Error dependency_cycle -> Cancelled { dependency_cycle }))))
       in
       (match deps_changed with
        | Unchanged ->
@@ -778,11 +878,12 @@ end = struct
     -> stack_frame:Stack_frame_with_state.t
     -> 'o Cached_value.t Fiber.t
     =
-    fun ~dep_node ~old_value ~stack_frame ->
+    fun ~dep_node ~old_value ~stack_frame:_ ->
+    let deps_collector = Deps_collector.create () in
     let+ res =
       report_and_collect_errors (fun () ->
         let* () = !check_point in
-        dep_node.spec.f dep_node.input)
+        Deps_collector.run deps_collector ~f:(fun () -> dep_node.spec.f dep_node.input))
     in
     let value =
       match res with
@@ -793,14 +894,14 @@ end = struct
      | Error { reproducible = false; _ } ->
        last_saw_non_reproducible_exn_at := Run.current ()
      | Ok _ | Error { reproducible = true; _ } -> ());
-    let deps_rev = Stack_frame_with_state.deps_rev stack_frame in
+    let deps = Deps_collector.get deps_collector in
     Option.Unboxed.match_
       old_value
-      ~none:(fun () -> Cached_value.create value ~deps_rev)
+      ~none:(fun () -> Cached_value.create value ~deps)
       ~some:(fun old_cv ->
         match Cached_value.value_changed dep_node old_cv.value value with
-        | true -> Cached_value.create value ~deps_rev
-        | false -> Cached_value.confirm_old_value ~deps_rev old_cv)
+        | true -> Cached_value.create value ~deps
+        | false -> Cached_value.confirm_old_value ~deps old_cv)
 
   and cancel_due_to_dependency_cycle
     :  'i 'o.
@@ -859,7 +960,6 @@ end = struct
     Computation.force computation ~phase:Compute ~dep_node (fun stack_frame ->
       let+ cached_value = compute ~dep_node ~old_value ~stack_frame in
       Counter.incr Metrics.Compute.nodes;
-      Counter.add Metrics.Compute.edges (Deps.length cached_value.deps);
       dep_node.state <- Cached_value cached_value;
       Spec.notify dep_node.spec dep_node.input Validated;
       cached_value)
@@ -937,7 +1037,7 @@ end = struct
         (* Fast path: the value is already up to date in the current run. Doing this check
            here, before allocating the fibers needed by
            [consider_and_restore_from_cache_without_adding_dep], is a measurable win. *)
-        let* () = Call_stack.add_dep_from_caller dep_node in
+        let* () = Deps_collector.add_dep_from_caller dep_node in
         let stack_frame = Dep_node.T dep_node in
         Value.get_exn cached_value.value ~map_exn:(fun exn ->
           Error.extend_stack exn ~stack_frame)
@@ -960,7 +1060,7 @@ end = struct
         in
         (match result with
          | Ok res ->
-           let* () = Call_stack.add_dep_from_caller dep_node in
+           let* () = Deps_collector.add_dep_from_caller dep_node in
            let stack_frame = Dep_node.T dep_node in
            Value.get_exn res.value ~map_exn:(fun exn ->
              Error.extend_stack exn ~stack_frame)
@@ -1015,7 +1115,7 @@ let dump_cached_graph ?(on_not_cached = `Raise) ?(time_nodes = false) cell =
       in
       let graph = Graph.add_node graph ~id:src_id ?label:dep_node.spec.name ~attributes in
       List.fold_left
-        (Deps.to_list cached.deps)
+        (Deps.For_debugging.to_list cached.deps)
         ~init:(Fiber.return graph)
         ~f:(fun graph (Dep_node.T dst_node as packed) ->
           let* graph = graph in
@@ -1397,7 +1497,7 @@ module For_tests = struct
        | None -> None
        | Some cv ->
          Some
-           (Deps.to_list cv.deps
+           (Deps.For_debugging.to_list cv.deps
             |> List.map ~f:(fun (Dep_node.T dep) ->
               dep.spec.name, Dep_node.input_to_dyn dep)))
   ;;

--- a/test/blackbox-tests/test-cases/enabled_if/eif-simple.t/run.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-simple.t/run.t
@@ -30,5 +30,6 @@ Test the enabled_if field for libraries:
   Error: Library "foo" in _build/default is hidden (unsatisfied 'enabled_if').
   -> required by library "bar" in _build/default
   -> required by executable main in dune:44
+  -> required by _build/default/.main.eobjs/native/main.cmx
   -> required by _build/default/main.exe
   [1]

--- a/test/blackbox-tests/test-cases/exec/exec-missing.t/run.t
+++ b/test/blackbox-tests/test-cases/exec/exec-missing.t/run.t
@@ -5,5 +5,6 @@ When using dune exec, the external-lib-deps command refers to the executable:
   3 |  (libraries does-not-exist))
                   ^^^^^^^^^^^^^^
   Error: Library "does-not-exist" not found.
+  -> required by _build/default/.x.eobjs/native/x.cmx
   -> required by _build/default/x.exe
   [1]

--- a/test/blackbox-tests/test-cases/odoc/conflicting-modules-github1645/legacy.t
+++ b/test/blackbox-tests/test-cases/odoc/conflicting-modules-github1645/legacy.t
@@ -34,7 +34,6 @@ built. See #1645.
   _build/default/_doc/_odocls/l/module.odocl:
   - <internal location>
   - <internal location>
-  -> required by _build/default/_doc/_html/l/db.js
   -> required by _build/default/_doc/_html/l/index.html
   -> required by alias _doc/_html/l/doc
   -> required by alias doc

--- a/test/blackbox-tests/test-cases/oxcaml/instantiate-parameterised.t
+++ b/test/blackbox-tests/test-cases/oxcaml/instantiate-parameterised.t
@@ -71,6 +71,7 @@ It's an error for the binary to partially instantiate `lib_ab`:
   3 |   (libraries (instantiate lib_ab b_impl))) ; missing a_impl
                                 ^^^^^^
   Error: Missing argument for parameter "project.a".
+  -> required by _build/default/bin/.bin.eobjs/native/dune__exe__Bin.cmx
   -> required by _build/default/bin/bin.exe
   Hint: Pass an argument implementing "project.a" to the dependency.
   [1]

--- a/test/blackbox-tests/test-cases/rocq/config-no-coqc.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/config-no-coqc.t/run.t
@@ -128,6 +128,7 @@ Coq package should fail:
   $ (unset INSIDE_DUNE; PATH=_path dune build -p example-coq)
   Couldn't find Rocq Corelib, and the theory does not disable automatic Corelib
   inclusion with (no_corelib).
+  -> required by _build/default/coq/Common/.Common.theory.d
   -> required by _build/default/coq/Common/Foo.glob
   -> required by _build/install/default/lib/coq/user-contrib/Common/Foo.glob
   -> required by _build/default/example-coq.install

--- a/test/blackbox-tests/test-cases/virtual-libraries/double-implementation.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/double-implementation.t/run.t
@@ -7,6 +7,7 @@ Executable that tries to use two implementations for the same virtual lib
   - "impl2" in _build/default/impl2
   This cannot work.
   -> required by executable foo in dune:2
+  -> required by _build/default/.foo.eobjs/native/foo.cmx
   -> required by _build/default/foo.exe
   -> required by alias default in dune:11
   [1]

--- a/test/blackbox-tests/test-cases/virtual-libraries/missing-implementation.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/missing-implementation.t/run.t
@@ -3,6 +3,7 @@ Executable that tries to build against a virtual library without an implementati
   Error: No implementation found for virtual library "vlib" in
   _build/default/vlib.
   -> required by executable foo in dune:2
+  -> required by _build/default/.foo.eobjs/native/foo.cmx
   -> required by _build/default/foo.exe
   -> required by alias default in dune:5
   [1]

--- a/test/expect-tests/memo/main.ml
+++ b/test/expect-tests/memo/main.ml
@@ -2216,14 +2216,121 @@ let%expect_test "loss of concurrency" =
     (Memo.Invalidation.combine
        (Memo.Cell.invalidate a ~reason:Test)
        (Memo.Cell.invalidate b ~reason:Test));
-  (* Now we recompute [c]. Notice that [a] and [b] are no longer computed concurrently *)
+  (* Now we recompute [c]. Because [c] recorded [a] and [b] as a parallel section (via
+     [fork_and_join]), restoring [c] from the cache checks them concurrently, so the
+     cutoff-driven recomputations of [a] and [b] also run concurrently. *)
   read c;
   [%expect
     {|
     start a
-    finish a
     start b
-    finish b |}]
+    finish a
+    finish b
+    |}]
+;;
+
+(* A memoized node that prints ["<name>+ "] when it starts computing, yields (so that
+   nodes computing in parallel interleave observably in the output), then prints
+   ["<name>- "] -- or ["<name>! "] and raises, when [fail] is set. Reading [var] makes the
+   node depend on it, so invalidating [var] forces a recomputation; the [Unit.equal] cutoff
+   means that recomputation produces the same value and so does not invalidate callers. *)
+let yielding_node ?(fail = false) ~name () =
+  let var = Memo.Var.Unit.create () in
+  let table =
+    Memo.create
+      name
+      ~input:(module Unit)
+      ~cutoff:Unit.equal
+      (fun () ->
+         let* () = Memo.Var.Unit.read var in
+         Memo.of_reproducible_fiber
+         @@ Fiber.of_thunk (fun () ->
+           let open Fiber.O in
+           printf "%s+ " name;
+           let+ () = Scheduler.yield () in
+           if fail
+           then (
+             printf "%s! " name;
+             raise_notrace (Failure name))
+           else printf "%s- " name))
+  in
+  table, var
+;;
+
+let%expect_test "fork_and_join: parallel cutoff restore" =
+  let a, a_var = yielding_node ~name:"a" () in
+  let b, b_var = yielding_node ~name:"b" () in
+  let top =
+    Memo.lazy_cell (fun () ->
+      printf "top* ";
+      Memo.fork_and_join (fun () -> Memo.exec a ()) (fun () -> Memo.exec b ()))
+  in
+  let evaluate () = run (Memo.map ~f:ignore (Memo.Cell.read top)) in
+  printf "1st run: ";
+  evaluate ();
+  Memo.reset
+    (Memo.Invalidation.combine
+       (Memo.Var.Unit.invalidate a_var ~reason:Test)
+       (Memo.Var.Unit.invalidate b_var ~reason:Test));
+  printf "\n2nd run: ";
+  evaluate ();
+  printf "\n";
+  (* On the 2nd run [top] is restored from the cache thanks to the cutoffs on [a] and [b]
+     (note the absence of ["top* "]); because [top] recorded [a] and [b] as a parallel
+     section, they are re-checked -- and hence recomputed -- concurrently (["a+ b+ a- b-"],
+     not the sequential ["a+ a- b+ b-"]). *)
+  [%expect
+    {|
+    1st run: top* a+ b+ a- b-
+    2nd run: a+ b+ a- b-
+    |}]
+;;
+
+let%expect_test "parallel_map: parallel cutoff restore" =
+  let a, a_var = yielding_node ~name:"a" () in
+  let b, b_var = yielding_node ~name:"b" () in
+  let top =
+    Memo.lazy_cell (fun () ->
+      printf "top* ";
+      Memo.parallel_map [ a; b ] ~f:(fun node -> Memo.exec node ()))
+  in
+  let evaluate () = run (Memo.map ~f:ignore (Memo.Cell.read top)) in
+  printf "1st run: ";
+  evaluate ();
+  Memo.reset
+    (Memo.Invalidation.combine
+       (Memo.Var.Unit.invalidate a_var ~reason:Test)
+       (Memo.Var.Unit.invalidate b_var ~reason:Test));
+  printf "\n2nd run: ";
+  evaluate ();
+  printf "\n";
+  (* As above, but the parallel section is recorded by [parallel_map] rather than
+     [fork_and_join]. *)
+  [%expect
+    {|
+    1st run: top* a+ b+ a- b-
+    2nd run: a+ b+ a- b-
+    |}]
+;;
+
+let%expect_test "fork_and_join: a failing thread still lets its sibling run" =
+  let a, _ = yielding_node ~name:"a" ~fail:true () in
+  let b, _ = yielding_node ~name:"b" () in
+  let top =
+    Memo.lazy_cell (fun () ->
+      Memo.fork_and_join (fun () -> Memo.exec a ()) (fun () -> Memo.exec b ()))
+  in
+  run_and_log_errors (Memo.map ~f:ignore (Memo.Cell.read top));
+  (* [a] raises, but [b] still runs to completion ([a+ b+ a! b-]) and the error from [a]
+     propagates. *)
+  [%expect
+    {|
+    a+ b+ a! b- Error: { exn =
+               "Memo.Error.E\n\
+               \  { exn = \"Failure(\\\"a\\\")\"; stack = [ (\"a\", ()); (\"<unnamed>\", ()) ] }"
+           ; backtrace = ""
+           }
+    |}]
 ;;
 
 let%expect_test "variables - print new" =


### PR DESCRIPTION
Represent a node's dependencies as a **series-parallel graph** instead of a flat
list. Dependencies discovered sequentially (via `let*`/`>>=`) form a sequence;
dependencies discovered through a parallel combinator (e.g. `fork_and_join`,
`parallel_map`) form a parallel section.

When restoring a node from the cache, sequential dependencies are still checked
in order (with early exit), but parallel sections are now checked
**concurrently**. This matters for dependencies with cutoffs: a cutoff
dependency must be recomputed to find out whether its value changed, and
previously those cutoff-driven recomputations ran one at a time even when the
dependencies had originally been computed in parallel. They now run
concurrently again, matching the structure of the original computation.

### Implementation

- `Deps` becomes a series-parallel graph (`Empty`/`Singleton`/`Seq`/`Par`),
  built up via a `Dynamic` builder and flattened to a static form.
  `changed_or_not` walks it, running `Par` sections through
  `Fiber.map_reduce_array`.
- `Deps_collector` is kept in fiber-local storage so that parallel branches each
  collect into their own sub-collector; `run_parallel` runs N threads, collects
  each thread's dependencies separately, and records them as one parallel
  section.
- The parallel combinators (`fork_and_join`, `fork_and_join_unit`,
  `all_concurrently`, `parallel_map`, `parallel_iter`, `map_reduce`,
  `map_reduce_array`) are overridden to record parallel sections while a
  computation runs, and behave exactly like the `Fiber` versions otherwise.
  Combinators that are not overridden simply collect dependencies sequentially,
  which is always correct — overriding only adds the concurrent-restore
  optimisation.

### Removing `cutoffs_that_reduce_concurrency_in_watch_mode`

This setting gated a cutoff on the `build-file` node. That cutoff used to
*serialise* watch-mode restoration, because cutoff dependencies were restored
one at a time — which is exactly the limitation this PR removes. Now that those
restorations run concurrently, the cutoff no longer reduces concurrency, so the
setting is dropped and the cutoff is enabled unconditionally.

A handful of error messages accordingly gain or lose one intermediate
`-> required by …` entry (the root errors are unchanged); those golden outputs
are updated in this PR.

Concurrency is just `Fiber`; correctness relies on the cooperative,
single-threaded scheduler (each dependency-collector read/write is atomic with
respect to other fibers because no `await` occurs between them).
