### PR TITLE
Print a separator before the twice error summary

### DIFF
--- a/doc/changes/changed/15016.md
+++ b/doc/changes/changed/15016.md
@@ -1,0 +1,4 @@
+- With `--error-reporting=twice`, print an `==== Error Summary ====` separator
+  before the deterministic list of errors reported at the end of the build. The
+  separator is omitted when there are no errors to report.
+  (#15016, fixes #14757, @yussypu)

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1092,11 +1092,15 @@ let report_early_exn exn =
 let handle_final_exns exns =
   match !Clflags.report_errors_config with
   | Early -> ()
-  | Twice | Deterministic ->
-    let report exn =
-      if not (caused_by_cancellation exn) then Dune_util.Report_error.report exn
-    in
-    List.iter exns ~f:report
+  | Deterministic ->
+    List.iter exns ~f:(fun exn ->
+      if not (caused_by_cancellation exn) then Dune_util.Report_error.report exn)
+  | Twice ->
+    (match List.filter exns ~f:(fun exn -> not (caused_by_cancellation exn)) with
+     | [] -> ()
+     | exns ->
+       Console.print [ Pp.verbatim "==== Error Summary ====" ];
+       List.iter exns ~f:Dune_util.Report_error.report)
 ;;
 
 let run ?restart_started_at ?(run_id = Run_id.Batch) f =

--- a/test/blackbox-tests/test-cases/error-reporting-twice-separator.t
+++ b/test/blackbox-tests/test-cases/error-reporting-twice-separator.t
@@ -1,0 +1,34 @@
+Separator before the deterministic error summary
+================================================
+
+With `--error-reporting=twice`, each error is reported once as soon as it
+is discovered and once more at the end of the build, in a deterministic
+order. The second batch is preceded by a separator so the summary is easy
+to find (issue #14757).
+
+  $ echo '(lang dune 3.0)' > dune-project
+  $ cat >dune<<EOF
+  > (rule (with-stdout-to x (run ./fail.exe)))
+  > (executable (name fail))
+  > EOF
+  $ echo 'exit 1' > fail.ml
+
+  $ dune build x --error-reporting=twice
+  File "dune", line 1, characters 0-42:
+  1 | (rule (with-stdout-to x (run ./fail.exe)))
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Command exited with code 1.
+  ==== Error Summary ====
+  File "dune", line 1, characters 0-42:
+  1 | (rule (with-stdout-to x (run ./fail.exe)))
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Command exited with code 1.
+  [1]
+
+When the build succeeds there are no errors to report, so the separator
+is not printed.
+
+  $ cat >dune<<EOF
+  > (rule (with-stdout-to x (system "printf ok")))
+  > EOF
+  $ dune build x --error-reporting=twice


### PR DESCRIPTION
Fixes #14757.

With `--error-reporting=twice`, the deterministic error list printed at the end of the build ran straight into the build output with nothing marking where it began. This adds an `==== Error Summary ====` separator before that list, and omits it when there are no errors to report.

Header form is your call. I shipped the form the issue floated:

```
==== Error Summary ====
```

The alternative is a full width rule, e.g.:

```
================================================================
```

Happy to switch to whichever you prefer. It's a one line change in `handle_final_exns` plus a test re-run.

**Testing.** Added a cram test (`test/blackbox-tests/test-cases/error-reporting-twice-separator.t`) covering three cases: a failing build (early report, separator, deterministic re-report), a successful build (no separator), and `--error-reporting=deterministic` (single report, no header). Verified against the real harness with `dune runtest`.
