### PR TITLE
fix(cram): sanitize output paths containing spaces

### DIFF
--- a/doc/changes/fixed/14943.md
+++ b/doc/changes/fixed/14943.md
@@ -1,0 +1,4 @@
+- Fix cram test output sanitization when the project path contains a space.
+  Absolute paths are now rewritten to `$TESTCASE_ROOT` even when the path
+  contains spaces, and lines with multiple paths have every path sanitized.
+  (#<PR>, fixes #14943, @yussypu)

--- a/doc/changes/fixed/15017.md
+++ b/doc/changes/fixed/15017.md
@@ -1,4 +1,4 @@
 - Fix cram test output sanitization when the project path contains a space.
   Absolute paths are now rewritten to `$TESTCASE_ROOT` even when the path
   contains spaces, and lines with multiple paths have every path sanitized.
-  (#<PR>, fixes #14943, @yussypu)
+  (#15017, fixes #14943, @yussypu)

--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -287,9 +287,26 @@ let rewrite_paths ~build_path_prefix_map ~parent_script ~command_script s =
       "Cannot decode build prefix map"
       [ "build_path_prefix_map", String build_path_prefix_map; "msg", String msg ]
   | Ok map ->
-    let abs_path_re =
-      let not_dir = Printf.sprintf " \n\r\t%c" Bin.path_sep in
-      Re.(compile (seq [ char '/'; rep1 (diff any (set not_dir)) ]))
+    let s =
+      (* Match map sources literally, longest first, so spaced paths match. *)
+      match
+        (* Drop None and empty sources: [Re.str ""] would match everywhere. *)
+        List.filter_map map ~f:(function
+          | None | Some { Build_path_prefix_map.source = ""; _ } -> None
+          | Some { Build_path_prefix_map.source; target = _ } -> Some source)
+      with
+      | [] -> s
+      | sources ->
+        let abs_path_re =
+          sources
+          |> List.sort ~compare:(fun a b ->
+            Int.compare (String.length b) (String.length a))
+          |> List.map ~f:Re.str
+          |> Re.alt
+          |> Re.compile
+        in
+        Re.replace abs_path_re s ~f:(fun g ->
+          Build_path_prefix_map.rewrite map (Re.Group.get g 0))
     in
     let error_msg =
       let open Re in
@@ -302,9 +319,7 @@ let rewrite_paths ~build_path_prefix_map ~parent_script ~command_script s =
       let b = seq [ command_script; str ": line "; line_number; str ": " ] in
       [ a; b ] |> List.map ~f:(fun re -> seq [ bol; re ]) |> alt |> compile
     in
-    Re.replace abs_path_re s ~f:(fun g ->
-      Build_path_prefix_map.rewrite map (Re.Group.get g 0))
-    |> Re.replace_string error_msg ~by:""
+    Re.replace_string error_msg ~by:"" s
 ;;
 
 type command_out =

--- a/test/blackbox-tests/test-cases/cram/path-rewriting-spaces-gh14943.t
+++ b/test/blackbox-tests/test-cases/cram/path-rewriting-spaces-gh14943.t
@@ -1,0 +1,53 @@
+Regression test for cram path sanitization when the project path contains a
+space.
+
+When the absolute path of a cram test contains a space, the volatile prefix
+that should be rewritten to $TESTCASE_ROOT itself contains a space. The old
+tokenizer cut path tokens at the first space, so the prefix no longer matched a
+map source and was left unsanitized. See
+https://github.com/ocaml/dune/issues/14943
+
+  $ mkdir "aaa bbb" && cd "aaa bbb"
+  $ cat >dune-project <<EOF
+  > (lang dune 3.0)
+  > (cram enable)
+  > EOF
+
+A single path is sanitized, and a line with two paths has both occurrences
+sanitized:
+
+  $ cat >foo.t <<'EOF'
+  >   $ echo $(pwd)/bla
+  >   $ echo "$(pwd)/foo and $(pwd)/bar"
+  > EOF
+
+  $ dune build @foo
+  File "foo.t", line 1, characters 0-0:
+  --- foo.t
+  +++ foo.t.corrected
+  @@ -1,2 +1,4 @@
+     $ echo $(pwd)/bla
+  +  $TESTCASE_ROOT/bla
+     $ echo "$(pwd)/foo and $(pwd)/bar"
+  +  $TESTCASE_ROOT/foo and $TESTCASE_ROOT/bar
+  [1]
+
+The reporter's exact repro: prepending a lower-precedence source that is a
+prefix-superset of $TESTCASE_ROOT must still resolve to $TESTCASE_ROOT. The
+regex matches the longest source, then rewrite re-derives right-to-left
+precedence on it, so the higher-precedence $TESTCASE_ROOT rule still wins:
+
+  $ cat >bar.t <<'EOF'
+  >   $ export BUILD_PATH_PREFIX_MAP="FOO=$(pwd)/bla:$BUILD_PATH_PREFIX_MAP"
+  >   $ echo $(pwd)/bla
+  > EOF
+
+  $ dune build @bar
+  File "bar.t", line 1, characters 0-0:
+  --- bar.t
+  +++ bar.t.corrected
+  @@ -1,2 +1,3 @@
+     $ export BUILD_PATH_PREFIX_MAP="FOO=$(pwd)/bla:$BUILD_PATH_PREFIX_MAP"
+     $ echo $(pwd)/bla
+  +  $TESTCASE_ROOT/bla
+  [1]


### PR DESCRIPTION
## Problem

When a project path contains a space, cram output is not sanitized: absolute paths are printed raw instead of being rewritten to `$TESTCASE_ROOT`.

Repro:

```
mkdir "a b" && cd "a b"
dune init proj p1
# add a cram test containing:  $ echo $(pwd)/bla
(cd p1 && dune runtest)
```

The output shows the raw absolute sandbox path rather than `$TESTCASE_ROOT/bla`.

## Root cause

In `src/dune_rules/cram/cram_exec.ml`, `rewrite_paths` tokenized paths with:

```ocaml
let not_dir = Printf.sprintf " \n\r\t%c" Bin.path_sep in
Re.(compile (seq [ char '/'; rep1 (diff any (set not_dir)) ]))
```

`not_dir` includes a space, so a path token ends at the first space. The volatile prefix that should be rewritten to `$TESTCASE_ROOT` is the map `source`, the absolute cwd. When that path contains a space, the token is cut mid prefix, the truncated string no longer has any map `source` as a prefix, and `Build_path_prefix_map.rewrite` returns it unchanged. With no space the whole path is one token, matches a source, and works, which is why this went unnoticed.

Note the naive fix of dropping the space from `not_dir` is wrong: the token regex then runs greedily across spaces, so a line with two paths (`/a/foo and /a/bar`) is captured as one token and only the leading prefix is rewritten.

## Fix

Build the match regex from the actual `source` strings in the decoded map: `Re.str` each source so spaces and regex metacharacters are literal, combine with `Re.alt`, sorted longest first. The existing `Build_path_prefix_map.rewrite map (Re.Group.get g 0)` call is kept, so the right to left precedence logic is reused: the regex decides how much text to hand to `rewrite`, and `rewrite` re-derives precedence on that substring. The path suffix outside the match is preserved by the global `Re.replace`. The `error_msg` stripping is untouched.

`None` and empty sources are filtered before building the alternation, because `Re.str ""` would match at every position (and an empty source is also a prefix of everything, so it would not be caught by `rewrite`).

This is space safe and multi path safe.

## Tests

`test/blackbox-tests/test-cases/cram/path-rewriting-spaces-gh14943.t` covers, all under a project path containing a space:

- a single path is sanitized to `$TESTCASE_ROOT`;
- a line with two paths has both occurrences sanitized;
- the reporter's exact repro: prepending a lower precedence source (`FOO=$(pwd)/bla`) that is a prefix superset of the `$TESTCASE_ROOT` source still resolves to `$TESTCASE_ROOT/bla`. The regex matches the longest source and `rewrite` re-derives right to left precedence on it, so the higher precedence rule wins. This demonstrates that longest first regex selection and `rewrite` precedence agree for prefix nested sources.

`dune build @check` (scoped to the source tree) is clean, the full `cram` test directory passes, and `dune fmt` produces no changes.

Fixes #14943
