### PR TITLE
Honor :standard in included ordered sets

### DIFF
--- a/src/dune_lang/ordered_set_lang.ml
+++ b/src/dune_lang/ordered_set_lang.ml
@@ -135,6 +135,17 @@ let is_standard t =
   | _ -> false
 ;;
 
+let has_standard t =
+  let rec loop ast =
+    match (ast : ast_expanded) with
+    | Standard -> true
+    | Element _ -> false
+    | Union l -> List.exists ~f:loop l
+    | Diff (l, r) -> loop l || loop r
+  in
+  loop t.ast
+;;
+
 module Eval = struct
   let of_ast ~diff ~singleton ~union t ~parse ~standard =
     let rec loop (t : ast_expanded) =

--- a/src/dune_lang/ordered_set_lang.mli
+++ b/src/dune_lang/ordered_set_lang.mli
@@ -36,6 +36,7 @@ val standard : t
 val replace_standard_with_empty : t -> t
 
 val is_standard : t -> bool
+val has_standard : t -> bool
 val field : ?check:unit Decoder.t -> string -> t Decoder.fields_parser
 val equal : t -> t -> bool
 

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -1081,11 +1081,10 @@ let expand_ordered_set_lang =
 ;;
 
 let expand_and_eval_set t set ~standard =
+  let* set = expand_ordered_set_lang t set in
   let+ standard =
-    if Ordered_set_lang.Unexpanded.has_standard set
-    then standard
-    else Action_builder.return []
-  and+ set = expand_ordered_set_lang t set in
+    if Ordered_set_lang.has_standard set then standard else Action_builder.return []
+  in
   Ordered_set_lang.eval set ~standard ~eq:String.equal ~parse:(fun ~loc:_ s -> s)
 ;;
 

--- a/test/blackbox-tests/test-cases/stanzas/env/standard-in-include.t
+++ b/test/blackbox-tests/test-cases/stanzas/env/standard-in-include.t
@@ -1,7 +1,6 @@
-:standard in :include'd files is ignored (issue #13225)
+:standard in :include'd files is honored (issue #13225)
 
-When :standard is used inside an :include'd file, environment flags are not
-applied.
+When :standard is used inside an :include'd file, environment flags are applied.
 
   $ make_dune_project 3.18
 
@@ -42,8 +41,8 @@ Direct :standard correctly picks up the environment flag:
   $ show_flags direct.ml | grep -o '\-w -8'
   -w -8
 
-But :include containing :standard silently ignores environment flags:
+:include containing :standard also picks up the environment flag:
 
   $ dune build included.cma
-  $ show_flags included.ml | grep -o '\-w -8' || echo "flag missing"
-  flag missing
+  $ show_flags included.ml | grep -o '\-w -8'
+  -w -8


### PR DESCRIPTION
When an ordered set uses (:include ...), expand_and_eval_set decided whether to evaluate the caller-provided :standard value before expanding the include. As a result, :standard inside the included file was treated as an empty standard value. This expands includes first and checks the expanded ordered set for :standard, so included sets behave like its contents were written inline. Fixes #13225.