### PR TITLE
Do not enable ReScript dialect for Melange 1.0

### DIFF
--- a/doc/reference/dune-project/dialect.rst
+++ b/doc/reference/dune-project/dialect.rst
@@ -89,5 +89,5 @@ Dune ships with two dialects pre-configured and enabled:
 * ``reason`` for the Reason syntax and enabled in `.re`/`.rei` files. ``refmt``
   is used for formatting.
 
-A third dialect, ``rescript``, is added when Melange support (see :doc:`/melange`)
-is enabled in the project.
+A third dialect, ``rescript``, is added when version 0.1 of Melange support
+(see :doc:`/melange`) is enabled in the project.

--- a/src/dune_lang/dune_project.ml
+++ b/src/dune_lang/dune_project.ml
@@ -1074,8 +1074,9 @@ let parse ~dir ~(lang : Lang.Instance.t) ~file =
     let dialects =
       let dialects =
         match Syntax.Name.Map.find explicit_extensions_map Melange_syntax.name with
-        | Some extension -> (extension.loc, Dialect.rescript) :: dialects
-        | None -> dialects
+        | Some extension when extension.version < (1, 0) ->
+          (extension.loc, Dialect.rescript) :: dialects
+        | Some _ | None -> dialects
       in
       List.fold_left dialects ~init:Dialect.DB.builtin ~f:(fun dialects (loc, dialect) ->
         Dialect.DB.add dialects ~loc dialect)

--- a/test/blackbox-tests/test-cases/melange/melange-stanza-version.t
+++ b/test/blackbox-tests/test-cases/melange/melange-stanza-version.t
@@ -50,3 +50,28 @@ Using `(module_system es6)` is deprecated in `(using melange 1.0)`
                                                   ^^^
   Warning: 'es6' was deprecated in version 1.0 of the Melange extension. Use
   `esm' instead.
+
+Melange 1.0 does not implicitly enable the ReScript dialect
+
+  $ mkdir rescript
+  $ cat > rescript/dune-project <<EOF
+  > (lang dune 3.20)
+  > (using melange 1.0)
+  > EOF
+  $ cat > rescript/dune <<EOF
+  > (library
+  >  (name app)
+  >  (modes melange)
+  >  (modules app))
+  > EOF
+  $ cat > rescript/app.res <<EOF
+  > let x = "hello"
+  > EOF
+  $ dune build --root rescript
+  Entering directory 'rescript'
+  File "dune", line 4, characters 10-13:
+  4 |  (modules app))
+                ^^^
+  Error: Module App doesn't exist.
+  Leaving directory 'rescript'
+  [1]


### PR DESCRIPTION
Do not register the built-in ReScript dialect for projects using Melange 1.0.