### PR TITLE
doc: document lint field

### DIFF
--- a/doc/melange.rst
+++ b/doc/melange.rst
@@ -233,6 +233,10 @@ The resulting layout in ``_build/default/output`` will be as follows:
   needed. The default is ``no_preprocessing``. Additional options are described
   in the :doc:`reference/preprocessing-spec` section.
 
+- ``(lint <preprocess-spec>)`` specifies how to lint source files when building
+  the :doc:`reference/aliases/lint` alias. The default is
+  ``no_preprocessing``. The syntax is described in :ref:`lint-field`.
+
 - ``(preprocessor_deps (<deps-conf list>))`` specifies extra preprocessor
   dependencies, e.g., if the preprocessor reads a generated file.
   The dependency specification is described in the :doc:`concepts/dependency-spec`

--- a/doc/reference/aliases/lint.rst
+++ b/doc/reference/aliases/lint.rst
@@ -1,4 +1,8 @@
 @lint
 =====
 
-This alias runs linting tools.
+This alias runs the linters configured by :ref:`lint field <lint-field>`.
+
+For example, ``dune build @lint`` runs linters in the current directory and its
+subdirectories. If a PPX linter reports corrections, Dune displays them as
+diffs that can be applied with ``dune promote``.

--- a/doc/reference/dune/executable.rst
+++ b/doc/reference/dune/executable.rst
@@ -94,7 +94,11 @@ files for executables. See
 - ``(preprocess <preprocess-spec>)`` is the same as the ``(preprocess ...)``
   field of :doc:`library`.
 
-- ``(preprocessor_deps (<deps-conf list>))`` is the same as the ``(preprocessor_deps ...)`` field of :doc:`library`.
+- ``(lint <preprocess-spec>)`` is the same as the ``(lint ...)`` field of
+  :doc:`library`.
+
+- ``(preprocessor_deps (<deps-conf list>))`` is the same as the
+  ``(preprocessor_deps ...)`` field of :doc:`library`.
 
 - ``js_of_ocaml``: See the section about :ref:`jsoo-field`
 

--- a/doc/reference/dune/library.rst
+++ b/doc/reference/dune/library.rst
@@ -104,6 +104,14 @@ order to declare a multi-directory library, you need to use the
    The default is ``no_preprocessing``, and other options are described
    in :doc:`/reference/preprocessing-spec`.
 
+.. describe:: (lint <preprocess-spec>)
+
+   Specifies how to lint source files when building the
+   :doc:`/reference/aliases/lint` alias.
+
+   The default is ``no_preprocessing``. The syntax is described in
+   :ref:`lint-field`.
+
 .. describe:: (preprocessor_deps (<deps-conf list>))
 
    Specifies extra preprocessor dependencies preprocessor, i.e., if the

--- a/doc/reference/dune/library_parameter.rst
+++ b/doc/reference/dune/library_parameter.rst
@@ -58,12 +58,20 @@ you need to add ``(using oxcaml 0.1)`` :doc:`extension
 
     See :doc:`/reference/library-dependencies` for more details.
 
-  .. describe:: (preprocesss <preprocess-spec>)
+  .. describe:: (preprocess <preprocess-spec>)
 
     Specifies how to preprocess files when needed.
 
     The default is ``no_preprocessing``, and other options are described
     in :doc:`/reference/preprocessing-spec`.
+
+  .. describe:: (lint <preprocess-spec>)
+
+    Specifies how to lint source files when building the
+    :doc:`/reference/aliases/lint` alias.
+
+    The default is ``no_preprocessing``. The syntax is described in
+    :ref:`lint-field`.
 
   .. describe:: (preprocessor_deps (<deps-conf list>))
 

--- a/doc/reference/preprocessing-spec.rst
+++ b/doc/reference/preprocessing-spec.rst
@@ -122,3 +122,32 @@ If your preprocessor needs extra dependencies, you should use the
 ``preprocessor_deps`` field available in the ``library``, ``executable``, and
 ``executables`` stanzas. It uses the :doc:`../concepts/dependency-spec` to
 declare what the preprocessor needs.
+
+.. _lint-field:
+
+Linting
+-------
+
+The ``lint`` field available in ``library``, ``executable``, ``executables``,
+``test``, ``tests``, ``library_parameter``, and ``melange.emit`` stanzas uses
+syntax similar to ``preprocess``:
+
+.. code:: dune
+
+   (lint <preprocess-spec>)
+
+The default is ``no_preprocessing``. Linting actions are attached to the
+:doc:`aliases/lint` alias and are run by building it, for example with
+``dune build @lint``.
+
+The ``future_syntax`` and ``staged_pps`` forms are not supported in ``lint``
+fields. The ``(per_module ...)`` form is supported, as with ``preprocess``.
+
+With ``(lint (action <action>))``, Dune runs ``<action>`` for each matching
+implementation and interface source. The ``%{input-file}`` variable is bound to
+the source file, as for preprocessing actions. The action should report lint
+errors in the usual way, such as by exiting with a non-zero status.
+
+With ``(lint (pps ...))``, Dune runs the PPX driver in lint mode. Corrections
+registered by the PPX, for example through ppxlib, are displayed as diffs
+against the source files and can be applied with ``dune promote``.


### PR DESCRIPTION
Document the `lint` field for library, executable(s), library_parameter, and melange.emit stanzas.

This also expands the `@lint` alias page and describes the supported syntax, limitations, and promotion behavior for PPX lint corrections.

Fixes #5021.