### PR TITLE
doc: clarify package version sources

### DIFF
--- a/doc/advanced/package-version.rst
+++ b/doc/advanced/package-version.rst
@@ -4,13 +4,30 @@ Package Version
 .. TODO(diataxis)
    - reference: environment - packages
 
-Dune determines a package's version by looking at the ``version`` field in the
-:doc:`/reference/dune-project/package`. If the version field isn't set,
-it looks at the toplevel ``version`` field in the ``dune-project`` field. If
-neither are set, Dune assumes that we are in development mode and reads the
-version from the VCS, if any. The way it obtains the version from the VCS is
-described in :ref:`the build-info section <build-info>`.
+Dune records package versions in generated metadata such as generated opam
+files, ``META`` files, and ``dune-package`` files. The same version is
+available in Dune files with the ``%{version:<package>}`` variable.
 
-When installing the files of a package on the system, Dune
-automatically inserts the package version into various metadata files
-such as ``META`` and ``dune-package`` files.
+For packages declared with a :doc:`/reference/dune-project/package` stanza,
+Dune determines the version in this order:
+
+1. The package-specific ``version`` field in the ``(package ...)`` stanza.
+2. The top-level :doc:`/reference/dune-project/version` field in
+   ``dune-project``.
+3. No version.
+
+When a package is declared in ``dune-project``, Dune does not read the version
+from an existing ``<package>.opam`` file for generated metadata. If you want
+Dune to manage opam files, use
+:doc:`/reference/dune-project/generate_opam_files` and keep the version in
+``dune-project``.
+
+For projects without any ``(package ...)`` stanzas, Dune can infer packages
+from existing opam files. In that case, the version from ``<package>.opam`` is
+used first; if the opam file has no version, Dune falls back to the top-level
+``(version ...)`` field in ``dune-project``.
+
+Ordinary builds do not use the VCS version as a fallback for generated package
+metadata. VCS-derived versions are used by ``dune subst`` and by the
+``dune-build-info`` library. The way Dune obtains the version from the VCS is
+described in :ref:`the build-info section <build-info>`.

--- a/doc/reference/dune-project/package.rst
+++ b/doc/reference/dune-project/package.rst
@@ -22,6 +22,16 @@ is used when generating OPAM files (see :doc:`generate_opam_files`).
 
       A longer package description.
 
+   .. describe:: (version <version>)
+
+      .. versionadded:: 2.5
+
+      The version of this package. This overrides the top-level
+      :doc:`version` field for this package.
+
+      See :doc:`/advanced/package-version` for details on how Dune determines
+      package versions.
+
    .. describe:: (depends <dep-specification>)
 
       Package dependencies, as :token:`~pkg-dep:dep_specification`.

--- a/test/blackbox-tests/test-cases/dune-project-meta/version.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/version.t
@@ -54,3 +54,100 @@ With package stanzas and generating the opam files
 
   $ grep ^version _build/default/META.foo
   version = "1.0"
+
+Version source precedence without dune subst
+--------------------------------------------
+
+The previous tests cover versions written by ``dune subst``. Without
+substitution, generated package metadata uses the package version stored in
+Dune's package description. In particular, Dune does not read the VCS version
+when generating META files during an ordinary build.
+
+  $ show_meta_version() {
+  >   dir=$1
+  >   dune build --root "$dir" META.foo
+  >   grep '^version' "$dir/_build/default/META.foo" || echo "no version"
+  > }
+
+When there are no ``(package ...)`` stanzas, Dune infers the package from the
+opam file and uses the opam file's version before the top-level project version.
+
+  $ mkdir opam-only
+  $ cat > opam-only/dune-project <<EOF
+  > (lang dune 3.24)
+  > (name foo)
+  > (version 2.0.0)
+  > EOF
+  $ cat > opam-only/foo.opam <<EOF
+  > opam-version: "2.0"
+  > version: "1.0.0"
+  > EOF
+  $ cat > opam-only/dune <<EOF
+  > (library (public_name foo))
+  > EOF
+  $ touch opam-only/foo.ml
+  $ show_meta_version opam-only
+  version = "1.0.0"
+
+When a ``(package ...)`` stanza exists, Dune uses that package description. A
+package-specific version overrides the top-level project version and any version
+in an existing opam file.
+
+  $ mkdir package-version
+  $ cat > package-version/dune-project <<EOF
+  > (lang dune 3.24)
+  > (name foo)
+  > (version 2.0.0)
+  > (package
+  >  (name foo)
+  >  (version 3.0.0))
+  > EOF
+  $ cat > package-version/foo.opam <<EOF
+  > opam-version: "2.0"
+  > version: "1.0.0"
+  > EOF
+  $ cat > package-version/dune <<EOF
+  > (library (public_name foo))
+  > EOF
+  $ touch package-version/foo.ml
+  $ show_meta_version package-version
+  version = "3.0.0"
+
+If the package stanza has no version, the top-level project version is used.
+The opam file's version is not used for packages declared in ``dune-project``.
+
+  $ mkdir project-version
+  $ cat > project-version/dune-project <<EOF
+  > (lang dune 3.24)
+  > (name foo)
+  > (version 2.0.0)
+  > (package (name foo))
+  > EOF
+  $ cat > project-version/foo.opam <<EOF
+  > opam-version: "2.0"
+  > version: "1.0.0"
+  > EOF
+  $ cat > project-version/dune <<EOF
+  > (library (public_name foo))
+  > EOF
+  $ touch project-version/foo.ml
+  $ show_meta_version project-version
+  version = "2.0.0"
+
+If neither the package nor the project has a version, ordinary builds don't fall
+back to the VCS version for generated package metadata.
+
+  $ mkdir vcs-only
+  $ cat > vcs-only/dune-project <<EOF
+  > (lang dune 3.24)
+  > (name foo)
+  > (package (name foo))
+  > EOF
+  $ cat > vcs-only/dune <<EOF
+  > (library (public_name foo))
+  > EOF
+  $ touch vcs-only/foo.ml
+  $ (cd vcs-only && git init -q && git add . && git commit -qm _ && \
+  >  git tag -a 9.0.0 -m 9.0.0)
+  $ show_meta_version vcs-only
+  no version


### PR DESCRIPTION
Clarify how Dune determines package versions for generated metadata.

This documents the current precedence for packages declared in `dune-project`, packages inferred from opam files, and the fact that ordinary builds do not fall back to the VCS version for package metadata.

The PR also adds cram coverage for the documented precedence to avoid duplicating/contradicting the existing `dune subst` version tests.

Fixes #4457.