### PR TITLE
refactor(memo): move the parallel combinators into parallel.ml

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -117,65 +117,7 @@ module To_open = struct
 end
 
 open To_open
-
-(* The parallel combinators below shadow the ones brought in by [include Fiber] above so
-   that, while a Memo computation runs, dependencies discovered by independent parallel
-   branches are recorded as a parallel section (rather than sequentially). This lets
-   [restore_from_cache] check those dependencies concurrently. When no computation is
-   running (no active collector) they behave exactly like the [Fiber] versions.
-
-   Combinators that are not overridden (e.g. [both], [parallel_iter_seq]) simply collect
-   their dependencies sequentially, which is always correct -- overriding only adds the
-   parallel-restore optimisation. *)
-
-let fork_and_join x y =
-  Deps_collector.run_parallel ~num_threads:2 (function
-    | None -> Fiber.fork_and_join x y
-    | Some { Deps_collector.run } ->
-      Fiber.fork_and_join (fun () -> run ~f:x) (fun () -> run ~f:y))
-;;
-
-let fork_and_join_unit x y =
-  Deps_collector.run_parallel ~num_threads:2 (function
-    | None -> Fiber.fork_and_join_unit x y
-    | Some { Deps_collector.run } ->
-      Fiber.fork_and_join_unit (fun () -> run ~f:x) (fun () -> run ~f:y))
-;;
-
-let all_concurrently l =
-  Deps_collector.run_parallel ~num_threads:(List.length l) (function
-    | None -> Fiber.all_concurrently l
-    | Some { Deps_collector.run } ->
-      Fiber.parallel_map l ~f:(fun x -> run ~f:(fun () -> x)))
-;;
-
-let parallel_map l ~f =
-  Deps_collector.run_parallel ~num_threads:(List.length l) (function
-    | None -> Fiber.parallel_map l ~f
-    | Some { Deps_collector.run } ->
-      Fiber.parallel_map l ~f:(fun value -> run ~f:(fun () -> f value)))
-;;
-
-let parallel_iter l ~f =
-  Deps_collector.run_parallel ~num_threads:(List.length l) (function
-    | None -> Fiber.parallel_iter l ~f
-    | Some { Deps_collector.run } ->
-      Fiber.parallel_iter l ~f:(fun value -> run ~f:(fun () -> f value)))
-;;
-
-let map_reduce l ~f ~empty ~combine =
-  Deps_collector.run_parallel ~num_threads:(List.length l) (function
-    | None -> Fiber.map_reduce l ~f ~empty ~combine
-    | Some { Deps_collector.run } ->
-      Fiber.map_reduce l ~f:(fun x -> run ~f:(fun () -> f x)) ~empty ~combine)
-;;
-
-let map_reduce_array arr ~f ~empty ~combine =
-  Deps_collector.run_parallel ~num_threads:(Array.length arr) (function
-    | None -> Fiber.map_reduce_array arr ~f ~empty ~combine
-    | Some { Deps_collector.run } ->
-      Fiber.map_reduce_array arr ~f:(fun x -> run ~f:(fun () -> f x)) ~empty ~combine)
-;;
+include Parallel
 
 module Call_stack = struct
   type t = Stack_frame_with_state.t list

--- a/src/memo/parallel.ml
+++ b/src/memo/parallel.ml
@@ -1,0 +1,60 @@
+open! Import
+
+(* These mirror the parallel combinators in [Fiber], but while a Memo computation is running
+   they record the dependencies discovered by independent parallel branches as a parallel
+   section (via [Deps_collector.run_parallel]) rather than sequentially, so that
+   [restore_from_cache] can later check those dependencies concurrently. When no computation
+   is running (no active collector) they behave exactly like the [Fiber] versions.
+
+   Combinators that are not overridden here (e.g. [both], [parallel_iter_seq]) simply collect
+   their dependencies sequentially, which is always correct -- overriding only adds the
+   parallel-restore optimisation. *)
+
+let fork_and_join x y =
+  Deps_collector.run_parallel ~num_threads:2 (function
+    | None -> Fiber.fork_and_join x y
+    | Some { Deps_collector.run } ->
+      Fiber.fork_and_join (fun () -> run ~f:x) (fun () -> run ~f:y))
+;;
+
+let fork_and_join_unit x y =
+  Deps_collector.run_parallel ~num_threads:2 (function
+    | None -> Fiber.fork_and_join_unit x y
+    | Some { Deps_collector.run } ->
+      Fiber.fork_and_join_unit (fun () -> run ~f:x) (fun () -> run ~f:y))
+;;
+
+let all_concurrently l =
+  Deps_collector.run_parallel ~num_threads:(List.length l) (function
+    | None -> Fiber.all_concurrently l
+    | Some { Deps_collector.run } ->
+      Fiber.parallel_map l ~f:(fun x -> run ~f:(fun () -> x)))
+;;
+
+let parallel_map l ~f =
+  Deps_collector.run_parallel ~num_threads:(List.length l) (function
+    | None -> Fiber.parallel_map l ~f
+    | Some { Deps_collector.run } ->
+      Fiber.parallel_map l ~f:(fun value -> run ~f:(fun () -> f value)))
+;;
+
+let parallel_iter l ~f =
+  Deps_collector.run_parallel ~num_threads:(List.length l) (function
+    | None -> Fiber.parallel_iter l ~f
+    | Some { Deps_collector.run } ->
+      Fiber.parallel_iter l ~f:(fun value -> run ~f:(fun () -> f value)))
+;;
+
+let map_reduce l ~f ~empty ~combine =
+  Deps_collector.run_parallel ~num_threads:(List.length l) (function
+    | None -> Fiber.map_reduce l ~f ~empty ~combine
+    | Some { Deps_collector.run } ->
+      Fiber.map_reduce l ~f:(fun x -> run ~f:(fun () -> f x)) ~empty ~combine)
+;;
+
+let map_reduce_array arr ~f ~empty ~combine =
+  Deps_collector.run_parallel ~num_threads:(Array.length arr) (function
+    | None -> Fiber.map_reduce_array arr ~f ~empty ~combine
+    | Some { Deps_collector.run } ->
+      Fiber.map_reduce_array arr ~f:(fun x -> run ~f:(fun () -> f x)) ~empty ~combine)
+;;


### PR DESCRIPTION
Move the parallel combinators (`fork_and_join`, `fork_and_join_unit`,
`all_concurrently`, `parallel_map`, `parallel_iter`, `map_reduce`,
`map_reduce_array`) from `memo.ml` into `src/memo/parallel.ml`.

These shadow the `Fiber` combinators so that, while a computation runs,
dependencies discovered by independent parallel branches are recorded as a
parallel section (enabling concurrent restore). They depend only on
`Deps_collector` and `Fiber`, so they move out cleanly; `memo.ml` keeps
exposing them via `include Parallel`.

Pure code motion; behaviour is unchanged.
