### PR TITLE
refactor(memo): add interfaces for deps_collector, parallel and exec

### DIFF
--- a/src/memo/deps_collector.mli
+++ b/src/memo/deps_collector.mli
@@ -1,0 +1,26 @@
+open! Import
+open Node
+
+(** Collects the dependencies discovered by a running computation. Kept in fiber-local
+    storage so that parallel branches can each collect into their own sub-collector. *)
+type t
+
+val create : unit -> t
+
+(** Run [f] with [t] as the active collector. *)
+val run : t -> f:(unit -> 'a Fiber.t) -> 'a Fiber.t
+
+(** The dependencies collected so far, as a series-parallel graph. *)
+val get : t -> Dep_node.packed Deps.t
+
+(** Record a dependency on [dep_node] in the active collector, if there is one. *)
+val add_dep_from_caller : ('i, 'o) Dep_node.t -> unit Fiber.t
+
+(** A way to run one parallel thread while collecting its dependencies separately. *)
+type run_thread = { run : 'a. f:(unit -> 'a Fiber.t) -> 'a Fiber.t } [@@unboxed]
+
+(** Run [num_threads] parallel threads, recording their dependencies as a single parallel
+    section in the active collector. [k] is called with [None] when [num_threads < 2] or
+    when there is no active collector, in which case dependencies are collected
+    sequentially. *)
+val run_parallel : num_threads:int -> (run_thread option -> 'a Fiber.t) -> 'a Fiber.t

--- a/src/memo/exec.mli
+++ b/src/memo/exec.mli
@@ -1,0 +1,21 @@
+open! Import
+open Node
+
+(** Wrap an exception in [Non_reproducible] to tell Memo not to cache it. We catch it,
+    unwrap, and re-raise without the wrapper. *)
+exception Non_reproducible of exn
+
+(** A hook run at the start of each computation, used for cooperative cancellation. *)
+val check_point : unit Fiber.t ref
+
+(** The run in which a non-reproducible error was last computed. [reset_if_necessary] reads
+    it to force a new run even on an empty invalidation. *)
+val last_saw_non_reproducible_exn_at : Run.t ref
+
+(** Run [f], reporting its errors to the active handler and collecting them. *)
+val report_and_collect_errors
+  :  (unit -> 'a Fiber.t)
+  -> ('a, Collect_errors_monoid.t) result Fiber.t
+
+(** Restore-or-compute a memoized node, returning its value (reraising cached errors). *)
+val exec_dep_node : ('i, 'o) Dep_node.t -> 'o Fiber.t

--- a/src/memo/parallel.mli
+++ b/src/memo/parallel.mli
@@ -1,0 +1,26 @@
+open! Import
+
+(** Parallel combinators that, while a Memo computation is running, record the dependencies
+    discovered by independent branches as a parallel section (so that restoring from the
+    cache can check them concurrently). With no running computation they behave exactly like
+    the corresponding [Fiber] combinators. *)
+
+val fork_and_join : (unit -> 'a Fiber.t) -> (unit -> 'b Fiber.t) -> ('a * 'b) Fiber.t
+val fork_and_join_unit : (unit -> unit Fiber.t) -> (unit -> 'a Fiber.t) -> 'a Fiber.t
+val all_concurrently : 'a Fiber.t list -> 'a list Fiber.t
+val parallel_map : 'a list -> f:('a -> 'b Fiber.t) -> 'b list Fiber.t
+val parallel_iter : 'a list -> f:('a -> unit Fiber.t) -> unit Fiber.t
+
+val map_reduce
+  :  'a list
+  -> f:('a -> 'b Fiber.t)
+  -> empty:'b
+  -> combine:('b -> 'b -> 'b)
+  -> 'b Fiber.t
+
+val map_reduce_array
+  :  'a array
+  -> f:('a -> 'b Fiber.t)
+  -> empty:'b
+  -> combine:('b -> 'b -> 'b)
+  -> 'b Fiber.t


### PR DESCRIPTION
Add interfaces for the three implementation-only modules extracted in the
preceding commits: `deps_collector.mli`, `parallel.mli`, and `exec.mli`. The
modules were moved out of `memo.ml` without interfaces; the `.mli`s now
constrain and document the surface each one exposes.

This completes the split of `memo.ml` into focused modules — `node`, `value`,
`deps`, `deps_collector`, `parallel`, `error_handler`, `exec` — each behind an
interface.

Interface-only change; behaviour is unchanged.
