### PR TITLE
doc: clarify dirs and data_only_dirs

### DIFF
--- a/doc/reference/dune/data_only_dirs.rst
+++ b/doc/reference/dune/data_only_dirs.rst
@@ -7,8 +7,27 @@ Dune allows the user to treat directories as *data only*. ``dune`` files in
 these directories won't be evaluated for their rules, but the contents of these
 directories will still be usable as dependencies for other rules.
 
-The syntax is the same as for the ``dirs`` stanza except that ``:standard`` is
-empty by default.
+The syntax is a list of immediate subdirectory names or globs. Unlike the
+:doc:`dirs` stanza, this field doesn't support the full predicate language:
+``:standard``, ``\``, and other set operations aren't available here.
+
+``data_only_dirs`` only changes the status of directories that Dune would
+otherwise include. If a directory is excluded by ``dirs``, then Dune ignores it
+rather than treating it as data-only. For example, this marks ``vendor`` as
+ignored, not data-only, because it isn't included by ``dirs``:
+
+.. code:: dune
+
+   (dirs src)
+   (data_only_dirs vendor)
+
+To make ``vendor`` data-only while excluding another generated directory, keep
+``vendor`` in ``dirs`` and mark it with ``data_only_dirs``:
+
+.. code:: dune
+
+   (dirs :standard \ target)
+   (data_only_dirs vendor)
 
 Example:
 

--- a/doc/reference/dune/dirs.rst
+++ b/doc/reference/dune/dirs.rst
@@ -24,9 +24,15 @@ Examples:
    (dirs :standard \ test* foo*) ;; exclude all dirs that start with test or foo
 
 Dune will not scan a directory that isn't included in this stanza. Any contained
-``dune`` (or other special) files won't be interpreted either and will be
-treated as raw data. It is however possible to depend on files inside ignored
-subdirectories.
+``dune`` (or other special) files won't be interpreted either. It is still
+possible to depend on a specific file inside an excluded subdirectory by naming
+that file explicitly, but Dune won't discover files there by traversing the
+subdirectory.
+
+Use :doc:`/reference/dune/data_only_dirs` when Dune should ignore ``dune`` files
+inside a subdirectory but still treat the subdirectory's files as source files
+for dependency discovery. A data-only directory must still be included by
+``dirs``; if ``dirs`` excludes it, it is ignored rather than data-only.
 
 .. warning::
 


### PR DESCRIPTION
Clarify that `data_only_dirs` takes immediate subdirectory names/globs rather than the full predicate language, and that data-only directories must still be included by `dirs`.

Closes #9759.
Closes #2144.