### PR TITLE
feat(configurator): expose pkg-config variable queries

### DIFF
--- a/otherlibs/configurator/src/v1.ml
+++ b/otherlibs/configurator/src/v1.ml
@@ -696,6 +696,35 @@ module Pkg_config = struct
     ; cflags : string list
     }
 
+  let pkg_config_env t ~package =
+    let c = t.configurator in
+    let dir = c.dest_dir in
+    match ocaml_config_var c "system" with
+    | Some "macosx" ->
+      let open Option.O in
+      which c "brew"
+      >>= fun brew ->
+      let new_pkg_config_path =
+        let prefix = String.trim (Process.run_capture_exn c ~dir brew [ "--prefix" ]) in
+        let p = sprintf "%s/opt/%s/lib/pkgconfig" (quote_if_needed prefix) package in
+        Option.some_if
+          (match Sys.is_directory p with
+           | s -> s
+           | exception Sys_error _ -> false)
+          p
+      in
+      new_pkg_config_path
+      >>| fun new_pkg_config_path ->
+      let _PKG_CONFIG_PATH = "PKG_CONFIG_PATH" in
+      let pkg_config_path =
+        match Sys.getenv _PKG_CONFIG_PATH with
+        | s -> s ^ ":"
+        | exception Not_found -> ""
+      in
+      [ sprintf "%s=%s%s" _PKG_CONFIG_PATH pkg_config_path new_pkg_config_path ]
+    | _ -> None
+  ;;
+
   let gen_query t ~package ~expr =
     let c = t.configurator in
     let dir = c.dest_dir in
@@ -714,32 +743,7 @@ module Pkg_config = struct
             package;
         package
     in
-    let env =
-      match ocaml_config_var c "system" with
-      | Some "macosx" ->
-        let open Option.O in
-        which c "brew"
-        >>= fun brew ->
-        let new_pkg_config_path =
-          let prefix = String.trim (Process.run_capture_exn c ~dir brew [ "--prefix" ]) in
-          let p = sprintf "%s/opt/%s/lib/pkgconfig" (quote_if_needed prefix) package in
-          Option.some_if
-            (match Sys.is_directory p with
-             | s -> s
-             | exception Sys_error _ -> false)
-            p
-        in
-        new_pkg_config_path
-        >>| fun new_pkg_config_path ->
-        let _PKG_CONFIG_PATH = "PKG_CONFIG_PATH" in
-        let pkg_config_path =
-          match Sys.getenv _PKG_CONFIG_PATH with
-          | s -> s ^ ":"
-          | exception Not_found -> ""
-        in
-        [ sprintf "%s=%s%s" _PKG_CONFIG_PATH pkg_config_path new_pkg_config_path ]
-      | _ -> None
-    in
+    let env = pkg_config_env t ~package in
     let pc_flags = "--print-errors" in
     let { Process.exit_code; stderr; _ } =
       Process.run_process c ~dir ?env t.pkg_config (t.pkg_config_args @ [ pc_flags; expr ])
@@ -770,6 +774,21 @@ module Pkg_config = struct
   ;;
 
   let query_expr_err t ~package ~expr = gen_query t ~package ~expr:(Some expr)
+
+  let query_variable t ~package ~variable =
+    let c = t.configurator in
+    let dir = c.dest_dir in
+    let env = pkg_config_env t ~package in
+    let { Process.exit_code; stdout; _ } =
+      Process.run_process
+        c
+        ~dir
+        ?env
+        t.pkg_config
+        (t.pkg_config_args @ [ sprintf "--variable=%s" variable; package ])
+    in
+    if exit_code = 0 then Some (String.trim stdout) else None
+  ;;
 end
 
 let main ?(args = []) ~name f =

--- a/otherlibs/configurator/src/v1.mli
+++ b/otherlibs/configurator/src/v1.mli
@@ -118,6 +118,10 @@ module Pkg_config : sig
       -> package:string
       -> expr:string
       -> (package_conf, string) result
+
+    (** [query_variable t ~package ~variable] query pkg-config for [variable]
+        from [package]. Returns [None] if [package] is not available. *)
+    val query_variable : t -> package:string -> variable:string -> string option
   end
   with type configurator := t
 

--- a/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/config_test.ml
+++ b/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/config_test.ml
@@ -10,4 +10,8 @@ let () =
     in
     let query package = ignore (C.Pkg_config.query pkg_config ~package) in
     query "dummy-pkg";
+    (match C.Pkg_config.query_variable pkg_config ~package:"dummy-pkg" ~variable:"prefix" with
+     | Some "value-for-prefix" -> ()
+     | Some value -> failwith ("unexpected pkg-config variable value: " ^ value)
+     | None -> failwith "pkg-config variable query failed")
   )

--- a/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/pkgconf.ml
+++ b/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/pkgconf.ml
@@ -1,8 +1,26 @@
 (* We'd like to use String.equal but that's OCaml >= 4.03 *)
 let not_flag x = not ("--print-errors" = x)
 
+let variable_prefix = "--variable="
+
+let variable_arg args =
+  let prefix_len = String.length variable_prefix in
+  let rec loop = function
+    | [] -> None
+    | arg :: args ->
+      if String.length arg >= prefix_len
+         && String.sub arg 0 prefix_len = variable_prefix
+      then Some (String.sub arg prefix_len (String.length arg - prefix_len))
+      else loop args
+  in
+  loop args
+;;
+
 let () =
   let args = List.tl (Array.to_list Sys.argv) in
-  let args = List.filter not_flag args in
-  Format.printf "@[<v>%a@]@."
-    (Format.pp_print_list Format.pp_print_string) args
+  match variable_arg args with
+  | Some variable -> Printf.printf "value-for-%s\n" variable
+  | None ->
+    let args = List.filter not_flag args in
+    Format.printf "@[<v>%a@]@."
+      (Format.pp_print_list Format.pp_print_string) args

--- a/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/run.t
+++ b/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/run.t
@@ -24,6 +24,10 @@ These tests show that setting `PKG_CONFIG_ARGN` passes extra args to `pkg-config
    | $TARGET
    | --libs
    | dummy-pkg
+  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --personality $TARGET --variable=prefix dummy-pkg
+  -> process exited with code 0
+  -> stdout:
+   | value-for-prefix
 
   $ dune clean
   $ PKG_CONFIG_ARGN="--static" dune build 2>&1 | awk '/run:.*bin\/pkgconf/{a=1}/stderr/{a=0}a'
@@ -44,3 +48,7 @@ These tests show that setting `PKG_CONFIG_ARGN` passes extra args to `pkg-config
    | --static
    | --libs
    | dummy-pkg
+  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --static --variable=prefix dummy-pkg
+  -> process exited with code 0
+  -> stdout:
+   | value-for-prefix


### PR DESCRIPTION
Add C.Pkg_config.query_variable to query pkg-config --variable=<name> and return the trimmed value when the package is available. Reuse the pkg-config environment setup for regular and variable queries, and extend the pkg-config arguments blackbox test to cover the new API.

Fixes #3332 