### PR TITLE
Improve deleted extension migration hints

### DIFF
--- a/src/dune_sexp/syntax.ml
+++ b/src/dune_sexp/syntax.ml
@@ -407,13 +407,13 @@ let check_supported ~dune_lang_ver t (loc, ver) =
   match Supported_versions.status t.supported_versions ver ~dune_lang_ver with
   | `Supported -> ()
   | `Deleted_in deleted_in ->
-    let min_ext_ver, min_dune_lang_ver =
+    let min_dune_lang_ver =
       match Supported_versions.minimum_versions t.supported_versions with
-      | None -> None, None
-      | Some (x, y) -> Some x, Some y
+      | None -> None
+      | Some (_, y) -> Some y
     in
     let please_port_message =
-      match min_ext_ver with
+      match Supported_versions.greatest_supported_version t.supported_versions with
       | None -> ""
       | Some min_ext_ver ->
         let open Version.Infix in

--- a/test/expect-tests/dune_sexp/dune_sexp_tests.ml
+++ b/test/expect-tests/dune_sexp/dune_sexp_tests.ml
@@ -87,3 +87,26 @@ let%expect_test "parsing TiB suffix" =
   test_bytes_hex "1TiB" ~check:(long_power 1024L 4);
   [%expect {| 0x10_000_000_000 |}]
 ;;
+
+let%expect_test "deleted extension version" =
+  let supported_versions =
+    [ (0, 1), `Since (1, 0); (0, 1), `Deleted_in (3, 25); (0, 2), `Since (3, 25) ]
+  in
+  let syntax =
+    Dune_sexp.Syntax.create
+      ~name:(Dune_sexp.Syntax.Name.parse "test-extension")
+      ~desc:"the test extension"
+      supported_versions
+  in
+  Dune_sexp.Syntax.check_supported ~dune_lang_ver:(3, 24) syntax (Loc.none, (0, 1));
+  (try
+     Dune_sexp.Syntax.check_supported ~dune_lang_ver:(3, 25) syntax (Loc.none, (0, 1))
+   with
+   | User_error.E message -> User_message.print message);
+  [%expect
+    {|
+    File "<none>", line 1, characters 0-0:
+    Error: Version 0.1 of the test-extension extension has been deleted in Dune
+    3.25. Please port this project to a newer version of the extension, such as
+    0.2. |}]
+;;


### PR DESCRIPTION
Make deleted extension errors suggest the latest supported extension version. Split out from #14574.