### PR TITLE
doc: clarify build profile semantics

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -82,7 +82,8 @@ non-fatal:
 - You can pass ``--profile release`` to ``dune``. It will set up different
   compilation options that usually make sense for release builds, including
   making warnings non-fatal. This is done by default when installing packages
-  from opam.
+  from opam. See :doc:`/reference/dune-workspace/profile` for the exact
+  defaults associated with each standard profile.
 - You can change the flags used by the ``dev`` profile by adding the following
   stanza to a ``dune`` file:
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -130,11 +130,10 @@ Terminology
    build profile
      A global setting that influences various defaults. It can be set from the
      command line using ``--profile <profile>`` or from ``dune-workspace``
-     files. The following profiles are standard:
-
-     -  ``release`` which is the profile used for opam releases
-     -  ``dev`` which is the default profile when none is set explicitly, and
-        which has warnings-as-errors turned on.
+     files. The standard profiles are ``dev`` and ``release``. ``dev`` is the
+     default profile when none is set explicitly, and ``release`` is the profile
+     used for opam releases. See :doc:`reference/dune-workspace/profile` for the
+     exact defaults associated with these profiles.
 
    dialect
      An alternative frontend to OCaml (such as ReasonML). It is described

--- a/doc/reference/dune-workspace/profile.rst
+++ b/doc/reference/dune-workspace/profile.rst
@@ -10,6 +10,31 @@ The build profile can be selected in the ``dune-workspace`` file by writing a
 
 Note that the command line option ``--profile`` has precedence over this stanza.
 
+Profile Names and Environment Stanzas
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Profiles do not need to be defined before they are selected. Any valid profile
+name can be passed to ``--profile`` or used in a workspace ``(profile ...)``
+field. The selected profile name is then used to choose matching entries in
+:doc:`/reference/dune/env` stanzas.
+
+For example, this workspace context selects the profile ``dbg``:
+
+.. code:: dune
+
+    (context
+     (default
+      (name dbg)
+      (profile dbg)))
+
+A ``dune`` file in the project can provide settings for that profile with:
+
+.. code:: dune
+
+    (env
+     (dbg
+      (flags (:standard -w +a))))
+
 Standard Profiles
 ~~~~~~~~~~~~~~~~~
 
@@ -34,3 +59,24 @@ artifacts that will be distributed or published.
 User-defined profiles are not aliases for ``dev`` or ``release``. They select
 matching :doc:`/reference/dune/env` stanzas by name and otherwise use Dune's
 defaults for profiles that are neither ``dev`` nor ``release``.
+
+Default OCaml Flags
+~~~~~~~~~~~~~~~~~~~
+
+For projects using Dune language 3.21 or later, Dune's default OCaml flags are:
+
+- all profiles add ``-g`` to the default ``ocamlc_flags`` and
+  ``ocamlopt_flags``;
+- the ``dev`` profile adds ``-short-paths -keep-locs -warn-error +a`` to the
+  default common ``flags``;
+- ``release`` and user-defined profiles add no default common ``flags``;
+- no profile adds optimization flags such as ``-O2`` or ``-O3`` by default.
+
+These defaults are the ``:standard`` set for the corresponding flag fields.
+They can be extended with ``(:standard ...)`` or replaced by omitting
+``:standard``. For example, ``(ocamlc_flags ())`` and ``(ocamlopt_flags ())``
+remove the default ``-g`` flags.
+
+For projects using older Dune language versions, the ``dev`` profile uses
+Dune's historical warning set. See the ``%{dune-warnings}`` variable in
+:doc:`/concepts/variables` for details.

--- a/doc/reference/dune/env.rst
+++ b/doc/reference/dune/env.rst
@@ -16,6 +16,12 @@ The first form ``(<profile> <settings>)`` that corresponds to the selected build
 profile will be used to modify the environment in this directory. You can use
 ``_`` to match any build profile.
 
+Profiles are not declared by ``env`` stanzas. Any valid profile name can be
+selected on the command line or in ``dune-workspace``. ``env`` stanzas only
+provide settings that are looked up later when a context is built with a
+matching profile. For example, a workspace context using ``(profile dbg)`` can
+pick up settings from an ``(env (dbg ...))`` stanza in the project.
+
 Fields supported in ``<settings>`` are:
 
 - any OCaml flags field. See :doc:`/concepts/ocaml-flags` for more details.

--- a/test/blackbox-tests/test-cases/cmdline/profile.t
+++ b/test/blackbox-tests/test-cases/cmdline/profile.t
@@ -31,3 +31,144 @@ Bug #4632
     "User_defined",
     "cmdline"
   ]
+
+Profiles selected in dune-workspace can match env stanzas from dune files. The
+profile name is not defined by the env stanza; it is just selected by the
+context and looked up when computing the directory environment.
+
+  $ mkdir profile-scope
+  $ cat > profile-scope/dune-project <<EOF
+  > (lang dune 3.24)
+  > EOF
+  $ cat > profile-scope/dune <<EOF
+  > (env
+  >  (dbg
+  >   (flags (:standard -DDBG)))
+  >  (dbg-opt
+  >   (flags (:standard -DDBGOPT))))
+  > EOF
+  $ cat > profile-scope/dune-workspace <<EOF
+  > (lang dune 3.24)
+  > (context (default (name dbg) (profile dbg)))
+  > (context (default (name dbg-opt) (profile dbg-opt)))
+  > EOF
+  $ (cd profile-scope && dune printenv --field flags)
+  Environment for context dbg:
+    (flags (-DDBG))
+  
+  Environment for context dbg-opt:
+    (flags (-DDBGOPT))
+  
+
+Default profile flags for projects using the current dune language.
+
+  $ mkdir profile-defaults
+  $ cat > profile-defaults/dune-project <<EOF
+  > (lang dune 3.24)
+  > EOF
+  $ cat > profile-defaults/dune <<EOF
+  > (library (name x))
+  > EOF
+  $ cat > profile-defaults/x.ml <<EOF
+  > let x = 1
+  > EOF
+  $ show_env() {
+  >   (cd profile-defaults && dune printenv --profile "$1" \
+  >      --field flags --field ocamlc_flags --field ocamlopt_flags)
+  > }
+
+The dev profile adds development-oriented common flags. The release profile and
+user-defined profiles do not add common flags. All profiles add -g to ocamlc and
+ocamlopt flags by default.
+
+  $ show_env dev
+  (flags
+   (-short-paths -keep-locs -warn-error +a))
+  (ocamlc_flags (-g))
+  (ocamlopt_flags (-g))
+  $ show_env release
+  (flags ())
+  (ocamlc_flags (-g))
+  (ocamlopt_flags (-g))
+  $ show_env custom
+  (flags ())
+  (ocamlc_flags (-g))
+  (ocamlopt_flags (-g))
+
+The -g flags are part of the standard ocamlc/ocamlopt flags and can be replaced
+by overriding those fields.
+
+  $ mkdir profile-no-g
+  $ cat > profile-no-g/dune-project <<EOF
+  > (lang dune 3.24)
+  > EOF
+  $ cat > profile-no-g/dune <<EOF
+  > (env
+  >  (_
+  >   (ocamlc_flags ())
+  >   (ocamlopt_flags ())))
+  > EOF
+  $ (cd profile-no-g && dune printenv --profile release \
+  >    --field ocamlc_flags --field ocamlopt_flags)
+  (ocamlc_flags ())
+  (ocamlopt_flags ())
+
+Dune enables -opaque for local modules in the dev profile when the compiler
+supports it. It does not enable -opaque in release or user-defined profiles, and
+it does not add -O2 or -O3 optimization flags by default.
+
+  $ show_compile_summary() {
+  >   profile="$1"
+  >   root="compile-$profile"
+  >   mkdir "$root"
+  >   cat > "$root/dune-project" <<EOF
+  > (lang dune 3.24)
+  > EOF
+  >   cat > "$root/dune" <<EOF
+  > (library (name x))
+  > EOF
+  >   cat > "$root/x.ml" <<EOF
+  > let x = 1
+  > EOF
+  >   (cd "$root" && dune build x.cma --profile "$profile" >/dev/null && \
+  >    dune trace cat | jq_dune -r '
+  >      processes
+  >      | select(.args.process_args | index("x.ml"))
+  >      | .args.process_args as $args
+  >      | [ "g=\($args | index("-g") != null)"
+  >        , "opaque=\($args | index("-opaque") != null)"
+  >        , "O2=\($args | index("-O2") != null)"
+  >        , "O3=\($args | index("-O3") != null)"
+  >        ]
+  >      | join(" ")' \
+  >    | sort -u)
+  > }
+  $ show_compile_summary dev
+  g=true opaque=true O2=false O3=false
+  $ show_compile_summary release
+  g=true opaque=false O2=false O3=false
+  $ show_compile_summary custom
+  g=true opaque=false O2=false O3=false
+
+The %{inline_tests} variable is disabled in release and enabled otherwise.
+
+  $ mkdir inline-tests-profile
+  $ cat > inline-tests-profile/dune-project <<EOF
+  > (lang dune 3.24)
+  > EOF
+  $ cat > inline-tests-profile/dune <<EOF
+  > (rule
+  >  (target inline-tests-value)
+  >  (action (with-stdout-to %{target} (echo "%{inline_tests}"))))
+  > EOF
+  $ show_inline_tests() {
+  >   profile="$1"
+  >   (cd inline-tests-profile && dune build inline-tests-value --profile "$profile" >/dev/null && \
+  >    printf "%s=" "$profile" && cat _build/default/inline-tests-value)
+  > }
+  $ show_inline_tests dev
+  dev=enabled
+  $ show_inline_tests release
+  release=disabled
+  $ show_inline_tests custom
+  custom=enabled


### PR DESCRIPTION
Clarify how profile names are selected and matched against `(env ...)` stanzas, including the fact that profiles do not need to be defined before use.

Also document the exact OCaml flag defaults for current Dune language versions: `-g`, dev-only `-short-paths -keep-locs -warn-error +a`, dev-only `-opaque`, and the absence of default `-O2`/`-O3` optimization flags. The accompanying cram coverage witnesses these documented defaults, including `%{inline_tests}` defaults and overriding `ocamlc_flags`/`ocamlopt_flags` to remove `-g`.

Closes #3279.
Closes #3359.
Closes #5562.

Validated with:

- `dune runtest test/blackbox-tests/test-cases/cmdline/profile.t`
- `dune build @doc`
- `dune build @check`
- `dune fmt`