### PR TITLE
test: cross-library .cmi baseline for dotted -open path

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-open-flag-chained.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-open-flag-chained.t
@@ -1,0 +1,55 @@
+Like `cross-lib-open-flag-barrier.t`, but the intermediate library uses
+two chained opens, `(flags (:standard -open Prelude -open Color))`. The
+second open resolves through the first: `Color` is the `Color` submodule
+of `prelude`, brought into scope by `-open Prelude`, rather than a
+top-level module. Pins that the consumer's compile tracks `prelude`'s
+`.cmi`s as sandbox-required deps.
+
+  $ make_dune_project 3.24
+
+`prelude` is a wrapped library whose `Color` submodule exposes a sum
+type:
+
+  $ mkdir prelude
+  $ cat > prelude/dune <<EOF
+  > (library (name prelude))
+  > EOF
+  $ cat > prelude/color.ml <<EOF
+  > type t = Red | Green | Blue
+  > EOF
+
+`middle` depends on `prelude` and is compiled with
+`(flags (:standard -open Prelude -open Color))`, exposing
+`val pick : unit -> t` whose `t` resolves through the chained opens to
+`Prelude.Color.t`. Its source names neither `Prelude` nor `Color`:
+
+  $ mkdir middle
+  $ cat > middle/dune <<EOF
+  > (library
+  >  (name middle)
+  >  (libraries prelude)
+  >  (flags (:standard -open Prelude -open Color)))
+  > EOF
+  $ cat > middle/middle.mli <<EOF
+  > val pick : unit -> t
+  > EOF
+  $ cat > middle/middle.ml <<EOF
+  > let pick () = Green
+  > EOF
+
+`consumer` depends on `middle` and `prelude` and pattern-matches on the
+result of `Middle.pick` against the bare constructors `Green`, `Red`,
+`Blue`. `ocamldep` reports no `Prelude` token on any of `middle.{ml,mli}`
+or `consumer.ml`:
+
+  $ mkdir consumer
+  $ cat > consumer/dune <<EOF
+  > (executable (name consumer) (libraries middle prelude))
+  > EOF
+  $ cat > consumer/consumer.ml <<EOF
+  > let () = match Middle.pick () with
+  >   | Green -> print_endline "g"
+  >   | Red | Blue -> print_endline "nb"
+  > EOF
+
+  $ dune build --sandbox=copy consumer/consumer.exe

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-open-flag-module-path.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-open-flag-module-path.t
@@ -1,0 +1,54 @@
+Like `cross-lib-open-flag-barrier.t`, but the intermediate library
+opens a *dotted* module path, `(flags (:standard -open Prelude.Color))`,
+rather than a bare top-level module. `Prelude.Color` names the `Color`
+submodule of the wrapped library `prelude`. Pins that the consumer's
+compile tracks `prelude`'s `.cmi`s as sandbox-required deps.
+
+  $ make_dune_project 3.24
+
+`prelude` is a wrapped library whose `Color` submodule exposes a sum
+type:
+
+  $ mkdir prelude
+  $ cat > prelude/dune <<EOF
+  > (library (name prelude))
+  > EOF
+  $ cat > prelude/color.ml <<EOF
+  > type t = Red | Green | Blue
+  > EOF
+
+`middle` depends on `prelude` and is compiled with
+`(flags (:standard -open Prelude.Color))`, exposing
+`val pick : unit -> t` whose `t` resolves through the open to
+`Prelude.Color.t`. Its source never names `Prelude`:
+
+  $ mkdir middle
+  $ cat > middle/dune <<EOF
+  > (library
+  >  (name middle)
+  >  (libraries prelude)
+  >  (flags (:standard -open Prelude.Color)))
+  > EOF
+  $ cat > middle/middle.mli <<EOF
+  > val pick : unit -> t
+  > EOF
+  $ cat > middle/middle.ml <<EOF
+  > let pick () = Green
+  > EOF
+
+`consumer` depends on `middle` and `prelude` and pattern-matches on the
+result of `Middle.pick` against the bare constructors `Green`, `Red`,
+`Blue`. `ocamldep` reports no `Prelude` token on any of `middle.{ml,mli}`
+or `consumer.ml`:
+
+  $ mkdir consumer
+  $ cat > consumer/dune <<EOF
+  > (executable (name consumer) (libraries middle prelude))
+  > EOF
+  $ cat > consumer/consumer.ml <<EOF
+  > let () = match Middle.pick () with
+  >   | Green -> print_endline "g"
+  >   | Red | Blue -> print_endline "nb"
+  > EOF
+
+  $ dune build --sandbox=copy consumer/consumer.exe


### PR DESCRIPTION
## Summary

A fifth sibling to the cross-library `.cmi` regression baselines from #14584, covering an intermediate library compiled with `(flags (-open Prelude.Color))` — a *dotted* module path naming a submodule of a wrapped dependency, rather than a bare top-level module.

The fixture asserts build success under `--sandbox=copy`. It builds on `main` today (no per-module narrowing) and pins behaviour that the per-module narrowing work in #14492 must preserve: the effective-`-open` detection has to key on the head component of the path (`Prelude` from `Prelude.Color`), since only top-level module names map to libraries. Without that, the dotted open is dropped from the cross-library frontier and the sandboxed build regresses.

Test-only; no changelog.
