### PR TITLE
refactor: move compilation mode to dune_lang

### DIFF
--- a/bin/import.ml
+++ b/bin/import.ml
@@ -76,6 +76,7 @@ include struct
   module Section = Section
   module Dune_project_name = Dune_project_name
   module Dune_project = Dune_project
+  module Compilation_mode = Compilation_mode
 end
 
 include struct

--- a/src/dune_lang/compilation_mode.ml
+++ b/src/dune_lang/compilation_mode.ml
@@ -43,8 +43,8 @@ let of_mode_set (modes : Lib_mode.Map.Set.t) =
 ;;
 
 let default_sandbox = function
-  | Ocaml -> Sandbox_config.no_special_requirements
-  | Melange -> Sandbox_config.needs_sandboxing
+  | Ocaml -> Dune_engine.Sandbox_config.no_special_requirements
+  | Melange -> Dune_engine.Sandbox_config.needs_sandboxing
 ;;
 
 module By_mode = struct

--- a/src/dune_lang/compilation_mode.mli
+++ b/src/dune_lang/compilation_mode.mli
@@ -1,5 +1,3 @@
-open Import
-
 type t =
   | Ocaml
   | Melange
@@ -14,7 +12,7 @@ type modes =
 
 val of_lib_mode : Lib_mode.t -> t
 val of_mode_set : Lib_mode.Map.Set.t -> modes
-val default_sandbox : t -> Sandbox_config.t
+val default_sandbox : t -> Dune_engine.Sandbox_config.t
 
 module By_mode : sig
   type mode := t

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -41,6 +41,7 @@ module Package_info = Package_info
 module Section = Section
 module Package = Package
 module Dune_project_name = Dune_project_name
+module Compilation_mode = Compilation_mode
 module Dialect = Dialect
 module Lib_mode = Lib_mode
 module Melange = Melange

--- a/src/dune_rules/dune_rules.ml
+++ b/src/dune_rules/dune_rules.ml
@@ -13,7 +13,6 @@ module Foreign_rules = Foreign_rules
 module Jsoo_rules = Jsoo_rules
 module Super_context = Super_context
 module Compilation_context = Compilation_context
-module Compilation_mode = Compilation_mode
 module Colors = Colors
 module Dune_package = Dune_package
 module Alias_rec = Alias_rec

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -113,6 +113,7 @@ include struct
   module Package_constraint = Package_constraint
   module Dune_project_name = Dune_project_name
   module Package = Package
+  module Compilation_mode = Compilation_mode
   module Dialect = Dialect
   module Lib_mode = Lib_mode
   module Module_name = Module_name


### PR DESCRIPTION
Moves `Compilation_mode` into `dune_lang` and aliases it from `dune_rules`.

Split out from #15057.