### PR TITLE
refactor: rename compilation mode map to per mode

### DIFF
--- a/src/dune_lang/compilation_mode.ml
+++ b/src/dune_lang/compilation_mode.ml
@@ -47,7 +47,7 @@ let default_sandbox = function
   | Melange -> Dune_engine.Sandbox_config.needs_sandboxing
 ;;
 
-module By_mode = struct
+module Per_mode = struct
   type nonrec 'a t =
     { ocaml : 'a
     ; melange : 'a

--- a/src/dune_lang/compilation_mode.mli
+++ b/src/dune_lang/compilation_mode.mli
@@ -14,7 +14,7 @@ val of_lib_mode : Lib_mode.t -> t
 val of_mode_set : Lib_mode.Map.Set.t -> modes
 val default_sandbox : t -> Dune_engine.Sandbox_config.t
 
-module By_mode : sig
+module Per_mode : sig
   type mode := t
 
   type 'a t =

--- a/src/dune_lang/dialect.ml
+++ b/src/dune_lang/dialect.ml
@@ -301,7 +301,7 @@ module DB = struct
   type t =
     { by_name : dialect String.Map.t
     ; by_extension : dialect Filename.Extension.Map.t
-    ; for_merlin : for_merlin Compilation_mode.By_mode.t Lazy.t
+    ; for_merlin : for_merlin Compilation_mode.Per_mode.t Lazy.t
     }
 
   and for_merlin =
@@ -315,7 +315,7 @@ module DB = struct
     let for_merlin = { extensions = []; readers = String.Map.empty } in
     { by_name = String.Map.empty
     ; by_extension = Filename.Extension.Map.empty
-    ; for_merlin = lazy (Compilation_mode.By_mode.both for_merlin)
+    ; for_merlin = lazy (Compilation_mode.Per_mode.both for_merlin)
     }
   ;;
 
@@ -384,10 +384,10 @@ module DB = struct
           extensions = melange_source_suffixes (source_suffixes by_name) @ extensions
         }
       in
-      { Compilation_mode.By_mode.ocaml; melange }
+      { Compilation_mode.Per_mode.ocaml; melange }
   ;;
 
-  let for_merlin t ~for_ = Compilation_mode.By_mode.get ~for_ (Lazy.force t.for_merlin)
+  let for_merlin t ~for_ = Compilation_mode.Per_mode.get ~for_ (Lazy.force t.for_merlin)
 
   let add { by_name; by_extension; for_merlin = _ } ~loc dialect =
     let by_name =

--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -313,12 +313,12 @@ module Lib = struct
          let foreign_objects = Lib_info.Source.External foreign_objects in
          let public_headers = Lib_info.File_deps.External public_headers in
          let preprocess =
-           Compilation_mode.By_mode.both (Preprocess.Per_module.no_preprocessing ())
+           Compilation_mode.Per_mode.both (Preprocess.Per_module.no_preprocessing ())
          in
          let virtual_deps = [] in
          let dune_version = None in
          let modules =
-           { Compilation_mode.By_mode.ocaml = modules
+           { Compilation_mode.Per_mode.ocaml = modules
            ; melange =
                (match modes.melange, melange_modules with
                 | true, Some _ -> melange_modules
@@ -328,12 +328,12 @@ module Lib = struct
            }
          in
          let entry_modules =
-           Compilation_mode.By_mode.map modules ~f:(fun ~for_:_ modules ->
+           Compilation_mode.Per_mode.map modules ~f:(fun ~for_:_ modules ->
              Option.map modules ~f:(fun modules ->
                Modules.entry_modules modules |> List.map ~f:Module.name))
          in
          let modules =
-           Compilation_mode.By_mode.map modules ~f:(fun ~for_:_ modules ->
+           Compilation_mode.Per_mode.map modules ~f:(fun ~for_:_ modules ->
              Option.map modules ~f:(fun modules -> Modules.With_vlib.modules modules))
          in
          let wrapped =
@@ -348,7 +348,7 @@ module Lib = struct
          let modules = Lib_info.Source.External modules in
          let melange_runtime_deps = Lib_info.File_deps.External melange_runtime_deps in
          let requires =
-           { Compilation_mode.By_mode.ocaml = requires
+           { Compilation_mode.Per_mode.ocaml = requires
            ; melange =
                (match modes.melange, melange_requires with
                 | true, Some melange_requires -> melange_requires
@@ -358,7 +358,7 @@ module Lib = struct
            }
          in
          let ppx_runtime_deps =
-           { Compilation_mode.By_mode.ocaml = ppx_runtime_deps
+           { Compilation_mode.Per_mode.ocaml = ppx_runtime_deps
            ; melange =
                (match modes.melange, melange_ppx_runtime_deps with
                 | _, Some melange_ppx_runtime_deps -> melange_ppx_runtime_deps

--- a/src/dune_rules/findlib.ml
+++ b/src/dune_rules/findlib.ml
@@ -141,10 +141,10 @@ let to_dune_library (t : Findlib.Package.t) ~dir_contents ~ext_lib ~external_loc
           in
           lib_dep (add_loc name))
       in
-      { Compilation_mode.By_mode.ocaml; melange = [] }
+      { Compilation_mode.Per_mode.ocaml; melange = [] }
     in
     let ppx_runtime_deps =
-      { Compilation_mode.By_mode.ocaml =
+      { Compilation_mode.Per_mode.ocaml =
           List.map (Findlib.Package.ppx_runtime_deps t) ~f:add_loc
       ; melange = []
       }
@@ -163,7 +163,7 @@ let to_dune_library (t : Findlib.Package.t) ~dir_contents ~ext_lib ~external_loc
     let wasmoo_runtime = Findlib.Package.wasmoo_runtime t in
     let melange_runtime_deps = Lib_info.File_deps.External [] in
     let preprocess =
-      Compilation_mode.By_mode.both (Preprocess.Per_module.no_preprocessing ())
+      Compilation_mode.Per_mode.both (Preprocess.Per_module.no_preprocessing ())
     in
     let default_implementation = None in
     let wrapped = None in
@@ -206,7 +206,7 @@ let to_dune_library (t : Findlib.Package.t) ~dir_contents ~ext_lib ~external_loc
         (match Vars.get_words t.vars "main_modules" Ps.empty with
          | _ :: _ as modules ->
            Ok
-             (Compilation_mode.By_mode.just
+             (Compilation_mode.Per_mode.just
                 ~for_:Ocaml
                 (List.map ~f:Module_name.of_checked_string modules))
          | [] ->
@@ -239,9 +239,9 @@ let to_dune_library (t : Findlib.Package.t) ~dir_contents ~ext_lib ~external_loc
                     with
                     | Ok s -> Ok (Some s)
                     | Error e -> Error e))
-              |> Result.map ~f:(Compilation_mode.By_mode.just ~for_:Ocaml)))
+              |> Result.map ~f:(Compilation_mode.Per_mode.just ~for_:Ocaml)))
     in
-    let modules = Lib_info.Source.External (Compilation_mode.By_mode.both None) in
+    let modules = Lib_info.Source.External (Compilation_mode.Per_mode.both None) in
     let name = t.name in
     let lib_id = Lib_id.External (loc, name) in
     Lib_info.create

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -39,7 +39,7 @@ module For_stanza : sig
 
   val of_stanzas
     :  Stanza.t list
-    -> cctxs:Compilation_context.t option Compilation_mode.By_mode.t Loc.Map.t
+    -> cctxs:Compilation_context.t option Compilation_mode.Per_mode.t Loc.Map.t
     -> sctx:Super_context.t
     -> src_dir:Path.Source.t
     -> ctx_dir:Path.Build.t
@@ -47,7 +47,7 @@ module For_stanza : sig
     -> dir_contents:Dir_contents.t
     -> expander:Expander.t
     -> ( Merlin.t list
-         , Compilation_context.t option Compilation_mode.By_mode.t Loc.Map.t
+         , Compilation_context.t option Compilation_mode.Per_mode.t Loc.Map.t
          , Path.Build.t list
          , Path.Source.t list )
          t
@@ -69,13 +69,13 @@ end = struct
       Loc.Map.update tl loc ~f:(function
         | None ->
           Some
-            (Compilation_mode.By_mode.of_list
+            (Compilation_mode.Per_mode.of_list
                ~init:None
                [ Compilation_context.for_ hd, Some hd ])
         | Some e ->
-          let current = Compilation_mode.By_mode.to_list e in
+          let current = Compilation_mode.Per_mode.to_list e in
           Some
-            (Compilation_mode.By_mode.of_list
+            (Compilation_mode.Per_mode.of_list
                ~init:None
                ((Compilation_context.for_ hd, Some hd)
                 :: List.map current ~f:(fun (k, v) -> k, Some v))))
@@ -133,7 +133,7 @@ end = struct
         ~loc:lib.buildable.loc
         (fun () ->
            Lib_rules.rules lib ~sctx ~scope ~dir_contents ~expander
-           >>| Compilation_mode.By_mode.choose
+           >>| Compilation_mode.Per_mode.choose
            >>| Option.value_exn)
         enabled_if
     | Foreign_library.T lib ->
@@ -356,7 +356,7 @@ let gen_rules_source_only sctx ~dir source_dir =
 ;;
 
 let gen_rules_group_part_or_root sctx dir_contents cctxs ~source_dir ~dir
-  : Compilation_context.t option Compilation_mode.By_mode.t Loc.Map.t Memo.t
+  : Compilation_context.t option Compilation_mode.Per_mode.t Loc.Map.t Memo.t
   =
   let+ () = gen_format_and_cram_rules sctx ~dir source_dir
   and+ () = Revdep_rules.add ~sctx ~dir
@@ -544,7 +544,7 @@ let gen_rules_standalone_or_root sctx ~dir ~source_dir =
       Dir_contents.Standalone_or_root.subdirs standalone_or_root
       >>= Memo.parallel_iter ~f:(fun dc ->
         let source_dir = Option.value_exn (Dir_contents.source_dir dc) in
-        let+ (_ : Compilation_context.t option Compilation_mode.By_mode.t Loc.Map.t) =
+        let+ (_ : Compilation_context.t option Compilation_mode.Per_mode.t Loc.Map.t) =
           gen_rules_group_part_or_root
             sctx
             dir_contents

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -838,7 +838,7 @@ end = struct
                 in
                 for_, Some modules)
             in
-            Compilation_mode.By_mode.of_list modules ~init:None
+            Compilation_mode.Per_mode.of_list modules ~init:None
           and* melange_runtime_deps =
             if lib_modes.melange
             then file_deps (Lib_info.melange_runtime_deps info)

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -379,14 +379,14 @@ module T = struct
     { info : Lib_info.external_
     ; name : Lib_name.t
     ; unique_id : Id.t
-    ; re_exports : t list Resolve.t Compilation_mode.By_mode.t
+    ; re_exports : t list Resolve.t Compilation_mode.Per_mode.t
     ; (* [requires] is contains all required libraries, including the ones
          mentioned in [re_exports]. *)
-      requires : t list Resolve.t Compilation_mode.By_mode.t
-    ; user_written_requires : (Loc.t * t) list Resolve.Memo.t Compilation_mode.By_mode.t
-    ; ppx_runtime_deps : t list Resolve.t Compilation_mode.By_mode.t
-    ; pps : t list Resolve.t Compilation_mode.By_mode.t
-    ; resolved_selects : Resolved_select.t list Resolve.t Compilation_mode.By_mode.t
+      requires : t list Resolve.t Compilation_mode.Per_mode.t
+    ; user_written_requires : (Loc.t * t) list Resolve.Memo.t Compilation_mode.Per_mode.t
+    ; ppx_runtime_deps : t list Resolve.t Compilation_mode.Per_mode.t
+    ; pps : t list Resolve.t Compilation_mode.Per_mode.t
+    ; resolved_selects : Resolved_select.t list Resolve.t Compilation_mode.Per_mode.t
     ; allow_unused_libraries : t list Resolve.t
     ; parameters : (Loc.t * t) list Resolve.t
     ; arguments : t option list
@@ -491,14 +491,14 @@ let info t = t.info
 let project t = t.project
 let implements t = Option.map ~f:Memo.return t.implements
 let parameters t = Resolve.Memo.lift (Resolve.map ~f:(List.map ~f:snd) t.parameters)
-let requires t ~for_ = Memo.return (Compilation_mode.By_mode.get ~for_ t.requires)
-let re_exports t ~for_ = Memo.return (Compilation_mode.By_mode.get ~for_ t.re_exports)
+let requires t ~for_ = Memo.return (Compilation_mode.Per_mode.get ~for_ t.requires)
+let re_exports t ~for_ = Memo.return (Compilation_mode.Per_mode.get ~for_ t.re_exports)
 
 let ppx_runtime_deps t ~for_ =
-  Memo.return (Compilation_mode.By_mode.get ~for_ t.ppx_runtime_deps)
+  Memo.return (Compilation_mode.Per_mode.get ~for_ t.ppx_runtime_deps)
 ;;
 
-let pps t ~for_ = Memo.return (Compilation_mode.By_mode.get ~for_ t.pps)
+let pps t ~for_ = Memo.return (Compilation_mode.Per_mode.get ~for_ t.pps)
 
 let is_local t =
   match Lib_info.obj_dir t.info |> Obj_dir.byte_dir with
@@ -678,7 +678,7 @@ module Parameterised = struct
   let requires (lib : lib) ~for_ =
     let open Resolve.O in
     let+ deps =
-      Compilation_mode.By_mode.get lib.requires ~for_
+      Compilation_mode.Per_mode.get lib.requires ~for_
       >>= Resolve.List.map ~f:(complement_arguments ~parent:lib)
     in
     let deps = List.filter_opt lib.arguments @ deps in
@@ -1470,12 +1470,12 @@ end = struct
           |> Instrumentation.with_instrumentation ~instrumentation_backend
           >>| fun pps -> for_, Preprocess.Per_module.pps pps)
         |> Memo.map ~f:Resolve.all
-        >>| Compilation_mode.By_mode.of_list ~init:[]
+        >>| Compilation_mode.Per_mode.of_list ~init:[]
       in
       let* parameters = Resolve.Memo.lift parameters in
       let dune_version = Lib_info.dune_version info in
       let resolved =
-        Compilation_mode.By_mode.map pps ~f:(fun ~for_ pps ->
+        Compilation_mode.Per_mode.map pps ~f:(fun ~for_ pps ->
           let open Memo.O in
           let+ resolved =
             Lib_info.requires info ~for_
@@ -1492,7 +1492,7 @@ end = struct
       let open Memo.O in
       let+ ocaml = resolved.ocaml
       and+ melange = resolved.melange in
-      Resolve.return { Compilation_mode.By_mode.ocaml; melange }
+      Resolve.return { Compilation_mode.Per_mode.ocaml; melange }
     in
     let* implements =
       match Lib_info.implements info with
@@ -1554,10 +1554,10 @@ end = struct
                    ])))
     in
     let* requires =
-      Compilation_mode.By_mode.Memo.from_fun (fun ~for_ ->
+      Compilation_mode.Per_mode.Memo.from_fun (fun ~for_ ->
         let open Resolve.Memo.O in
         let* resolved = Memo.return resolved in
-        let { Resolved.requires; _ } = Compilation_mode.By_mode.get ~for_ resolved in
+        let { Resolved.requires; _ } = Compilation_mode.Per_mode.get ~for_ resolved in
         let* requires = Memo.return requires in
         let+ requires_params = Memo.return parameters
         and+ requires_implements =
@@ -1593,12 +1593,12 @@ end = struct
     in
     let* ppx_runtime_deps =
       let ppx_runtime_deps = Lib_info.ppx_runtime_deps info in
-      Compilation_mode.By_mode.Memo.from_fun (fun ~for_ ->
-        let deps = Compilation_mode.By_mode.get ppx_runtime_deps ~for_ in
+      Compilation_mode.Per_mode.Memo.from_fun (fun ~for_ ->
+        let deps = Compilation_mode.Per_mode.get ppx_runtime_deps ~for_ in
         resolve_simple_deps db ~private_deps deps)
     in
     let user_written_requires =
-      Compilation_mode.By_mode.from_fun (fun ~for_ ->
+      Compilation_mode.Per_mode.from_fun (fun ~for_ ->
         let open Memo.O in
         let+ complex =
           Lib_info.requires info ~for_
@@ -1611,7 +1611,7 @@ end = struct
     in
     let src_dir = Lib_info.src_dir info in
     let map_error =
-      Compilation_mode.By_mode.map ~f:(fun ~for_:_ x ->
+      Compilation_mode.Per_mode.map ~f:(fun ~for_:_ x ->
         Resolve.push_stack_frame x ~human_readable_description:(fun () ->
           Dep_path.Entry.Lib.pp { name; path = src_dir }))
     in
@@ -1629,19 +1629,19 @@ end = struct
     let rec t =
       lazy
         (let resolved_selects =
-           Compilation_mode.By_mode.from_fun (fun ~for_ ->
+           Compilation_mode.Per_mode.from_fun (fun ~for_ ->
              let open Resolve.O in
-             resolved >>| Compilation_mode.By_mode.get ~for_ >>| fun r -> r.selects)
+             resolved >>| Compilation_mode.Per_mode.get ~for_ >>| fun r -> r.selects)
          in
          let pps =
-           Compilation_mode.By_mode.from_fun (fun ~for_ ->
+           Compilation_mode.Per_mode.from_fun (fun ~for_ ->
              let open Resolve.O in
-             resolved >>| Compilation_mode.By_mode.get ~for_ >>= fun r -> r.pps)
+             resolved >>| Compilation_mode.Per_mode.get ~for_ >>= fun r -> r.pps)
          in
          let re_exports =
-           Compilation_mode.By_mode.from_fun (fun ~for_ ->
+           Compilation_mode.Per_mode.from_fun (fun ~for_ ->
              let open Resolve.O in
-             resolved >>| Compilation_mode.By_mode.get ~for_ >>= fun r -> r.re_exports)
+             resolved >>| Compilation_mode.Per_mode.get ~for_ >>= fun r -> r.re_exports)
          in
          { info
          ; name
@@ -1976,7 +1976,7 @@ end = struct
         let* pps = pps in
         Resolve.List.concat_map pps ~f:(fun pp ->
           let open Resolve.O in
-          Compilation_mode.By_mode.get pp.ppx_runtime_deps ~for_
+          Compilation_mode.Per_mode.get pp.ppx_runtime_deps ~for_
           >>= Resolve.List.map ~f:(fun dep ->
             check_private_deps ~loc ~private_deps dep |> Resolve.of_result))
         |> Memo.return
@@ -2236,14 +2236,14 @@ let descriptive_closure (l : lib list) ~with_pps ~for_ : lib list Memo.t =
         and acc = Set.add acc lib in
         let* todo =
           if with_pps
-          then register_work todo (Compilation_mode.By_mode.get ~for_:Ocaml lib.pps)
+          then register_work todo (Compilation_mode.Per_mode.get ~for_:Ocaml lib.pps)
           else Memo.return todo
         in
         let* todo =
-          register_work todo (Compilation_mode.By_mode.get lib.ppx_runtime_deps ~for_)
+          register_work todo (Compilation_mode.Per_mode.get lib.ppx_runtime_deps ~for_)
         in
         let* todo =
-          let requires = Compilation_mode.By_mode.get lib.requires ~for_ in
+          let requires = Compilation_mode.Per_mode.get lib.requires ~for_ in
           register_work todo requires
         in
         work todo acc ~for_)
@@ -2258,18 +2258,18 @@ module Compile = struct
   module Resolved_select = Resolved_select
 
   type nonrec t =
-    { direct_requires : t list Resolve.Memo.t Compilation_mode.By_mode.t
-    ; user_written_requires : (Loc.t * t) list Resolve.Memo.t Compilation_mode.By_mode.t
-    ; requires_link : t list Resolve.t Memo.Lazy.t Compilation_mode.By_mode.t
-    ; pps : t list Resolve.Memo.t Compilation_mode.By_mode.t
-    ; resolved_selects : Resolved_select.t list Resolve.Memo.t Compilation_mode.By_mode.t
+    { direct_requires : t list Resolve.Memo.t Compilation_mode.Per_mode.t
+    ; user_written_requires : (Loc.t * t) list Resolve.Memo.t Compilation_mode.Per_mode.t
+    ; requires_link : t list Resolve.t Memo.Lazy.t Compilation_mode.Per_mode.t
+    ; pps : t list Resolve.Memo.t Compilation_mode.Per_mode.t
+    ; resolved_selects : Resolved_select.t list Resolve.Memo.t Compilation_mode.Per_mode.t
     ; allow_unused_libraries : t list Resolve.Memo.t
     ; sub_systems : Sub_system0.Instance.t Memo.Lazy.t Sub_system_name.Map.t
     }
 
   let for_lib ~allow_overlaps db (t : lib) =
     let requires =
-      Compilation_mode.By_mode.map t.requires ~f:(fun ~for_:_ requires ->
+      Compilation_mode.Per_mode.map t.requires ~f:(fun ~for_:_ requires ->
         (* This makes sure that the default implementation belongs to the same
          package before we build the virtual library *)
         let* () =
@@ -2281,9 +2281,9 @@ module Compile = struct
         in
         Memo.return requires)
     in
-    let requires_link : lib list Resolve.t Memo.Lazy.t Compilation_mode.By_mode.t =
+    let requires_link : lib list Resolve.t Memo.Lazy.t Compilation_mode.Per_mode.t =
       let db = Option.some_if (not allow_overlaps) db in
-      Compilation_mode.By_mode.map requires ~f:(fun ~for_ requires ->
+      Compilation_mode.Per_mode.map requires ~f:(fun ~for_ requires ->
         Memo.lazy_ (fun () ->
           let open Resolve.Memo.O in
           requires
@@ -2296,22 +2296,22 @@ module Compile = struct
     ; user_written_requires = t.user_written_requires
     ; requires_link
     ; resolved_selects =
-        Compilation_mode.By_mode.map t.resolved_selects ~f:(fun ~for_:_ -> Memo.return)
-    ; pps = Compilation_mode.By_mode.map t.pps ~f:(fun ~for_:_ -> Memo.return)
+        Compilation_mode.Per_mode.map t.resolved_selects ~f:(fun ~for_:_ -> Memo.return)
+    ; pps = Compilation_mode.Per_mode.map t.pps ~f:(fun ~for_:_ -> Memo.return)
     ; allow_unused_libraries = Memo.return t.allow_unused_libraries
     ; sub_systems = t.sub_systems
     }
   ;;
 
-  let direct_requires t ~for_ = Compilation_mode.By_mode.get t.direct_requires ~for_
+  let direct_requires t ~for_ = Compilation_mode.Per_mode.get t.direct_requires ~for_
 
   let user_written_requires t ~for_ =
-    Compilation_mode.By_mode.get t.user_written_requires ~for_
+    Compilation_mode.Per_mode.get t.user_written_requires ~for_
   ;;
 
-  let requires_link t ~for_ = Compilation_mode.By_mode.get t.requires_link ~for_
-  let resolved_selects t ~for_ = Compilation_mode.By_mode.get t.resolved_selects ~for_
-  let pps t ~for_ = Compilation_mode.By_mode.get t.pps ~for_
+  let requires_link t ~for_ = Compilation_mode.Per_mode.get t.requires_link ~for_
+  let resolved_selects t ~for_ = Compilation_mode.Per_mode.get t.resolved_selects ~for_
+  let pps t ~for_ = Compilation_mode.Per_mode.get t.pps ~for_
   let allow_unused_libraries t = t.allow_unused_libraries
 
   let sub_systems t =
@@ -2525,7 +2525,7 @@ module DB = struct
           ~dune_version:(Some dune_version)
           ~for_)
     in
-    let requires_link : lib list Resolve.t Memo.Lazy.t Compilation_mode.By_mode.t =
+    let requires_link : lib list Resolve.t Memo.Lazy.t Compilation_mode.Per_mode.t =
       let requires_link =
         Memo.Lazy.create (fun () ->
           let* forbidden_libraries =
@@ -2567,28 +2567,28 @@ module DB = struct
                   (Loc.to_file_colon_line loc)))
       in
       let init = Memo.lazy_ (fun () -> Resolve.Memo.return []) in
-      Compilation_mode.By_mode.of_list ~init [ for_, requires_link ]
+      Compilation_mode.Per_mode.of_list ~init [ for_, requires_link ]
     in
-    let pps : lib list Resolve.Memo.t Compilation_mode.By_mode.t =
+    let pps : lib list Resolve.Memo.t Compilation_mode.Per_mode.t =
       let pps =
         let open Memo.O in
         let+ resolved = Memo.Lazy.force resolved in
         resolved.pps
       in
       let init = Resolve.Memo.return [] in
-      Compilation_mode.By_mode.of_list ~init [ for_, pps ]
+      Compilation_mode.Per_mode.of_list ~init [ for_, pps ]
     in
-    let direct_requires : lib list Resolve.Memo.t Compilation_mode.By_mode.t =
+    let direct_requires : lib list Resolve.Memo.t Compilation_mode.Per_mode.t =
       let direct_requires =
         let open Memo.O in
         let+ resolved = Memo.Lazy.force resolved in
         resolved.requires
       in
       let init = Resolve.Memo.return [] in
-      Compilation_mode.By_mode.of_list ~init [ for_, direct_requires ]
+      Compilation_mode.Per_mode.of_list ~init [ for_, direct_requires ]
     in
     let resolved_selects
-      : Resolved_select.t list Resolve.Memo.t Compilation_mode.By_mode.t
+      : Resolved_select.t list Resolve.Memo.t Compilation_mode.Per_mode.t
       =
       let resolved_selects =
         let open Memo.O in
@@ -2596,13 +2596,13 @@ module DB = struct
         Resolve.return resolved.selects
       in
       let init = Resolve.Memo.return [] in
-      Compilation_mode.By_mode.of_list ~init [ for_, resolved_selects ]
+      Compilation_mode.Per_mode.of_list ~init [ for_, resolved_selects ]
     in
     let allow_unused_libraries =
       Resolve_names.resolve_simple_deps t ~private_deps:Allow_all allow_unused_libraries
     in
     let user_written_requires
-      : (Loc.t * lib) list Resolve.Memo.t Compilation_mode.By_mode.t
+      : (Loc.t * lib) list Resolve.Memo.t Compilation_mode.Per_mode.t
       =
       let resolved_user_written_requires =
         Memo.lazy_ (fun () ->
@@ -2616,7 +2616,7 @@ module DB = struct
         |> Memo.Lazy.force
       in
       let init = Resolve.Memo.return [] in
-      Compilation_mode.By_mode.of_list ~init [ for_, resolved_user_written_requires ]
+      Compilation_mode.Per_mode.of_list ~init [ for_, resolved_user_written_requires ]
     in
     { Compile.direct_requires
     ; user_written_requires
@@ -2656,14 +2656,14 @@ module DB = struct
 end
 
 let to_resolve_memo
-  :  lib list Resolve.t Compilation_mode.By_mode.t
-  -> lib list Compilation_mode.By_mode.t Resolve.Memo.t
+  :  lib list Resolve.t Compilation_mode.Per_mode.t
+  -> lib list Compilation_mode.Per_mode.t Resolve.Memo.t
   =
   fun t ->
   let open Resolve.Memo.O in
   let+ ocaml = Resolve.Memo.lift t.ocaml
   and+ melange = Resolve.Memo.lift t.melange in
-  { Compilation_mode.By_mode.ocaml; melange }
+  { Compilation_mode.Per_mode.ocaml; melange }
 ;;
 
 let to_dune_lib
@@ -2684,7 +2684,7 @@ let to_dune_lib
     | _ -> lib.name
   in
   let add_loc =
-    Compilation_mode.By_mode.map ~f:(fun ~for_:_ ->
+    Compilation_mode.Per_mode.map ~f:(fun ~for_:_ ->
       List.map ~f:(fun x -> loc, mangled_name x))
   in
   let obj_dir =
@@ -2696,7 +2696,7 @@ let to_dune_lib
   in
   let modules =
     let install_dir = Obj_dir.dir obj_dir in
-    Compilation_mode.By_mode.map modules ~f:(fun ~for_:_for_ modules ->
+    Compilation_mode.Per_mode.map modules ~f:(fun ~for_:_for_ modules ->
       Option.map modules ~f:(fun modules ->
         Modules.With_vlib.version_installed
           modules
@@ -2731,10 +2731,10 @@ let to_dune_lib
   and+ re_exports = to_resolve_memo lib.re_exports in
   let ppx_runtime_deps = add_loc ppx_runtime_deps in
   let requires =
-    Compilation_mode.By_mode.map requires ~f:(fun ~for_ requires ->
+    Compilation_mode.Per_mode.map requires ~f:(fun ~for_ requires ->
       List.map requires ~f:(fun lib ->
         if
-          List.exists (Compilation_mode.By_mode.get re_exports ~for_) ~f:(fun r ->
+          List.exists (Compilation_mode.Per_mode.get re_exports ~for_) ~f:(fun r ->
             r = lib)
         then Lib_dep.Re_export (loc, mangled_name lib)
         else (

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -265,7 +265,7 @@ end
 val to_dune_lib
   :  t
   -> modes:Lib_mode.Map.Set.t
-  -> modules:Modules.With_vlib.t option Compilation_mode.By_mode.t
+  -> modules:Modules.With_vlib.t option Compilation_mode.Per_mode.t
   -> foreign_objects:Path.t list
   -> melange_runtime_deps:Path.t list
   -> public_headers:Path.t list

--- a/src/dune_rules/lib_info.ml
+++ b/src/dune_rules/lib_info.ml
@@ -317,18 +317,19 @@ type 'path t =
   ; foreign_dll_files : 'path list
   ; jsoo_runtime : 'path list
   ; wasmoo_runtime : 'path list
-  ; requires : Lib_dep.t list Compilation_mode.By_mode.t
+  ; requires : Lib_dep.t list Compilation_mode.Per_mode.t
   ; parameters : (Loc.t * Lib_name.t) list
-  ; ppx_runtime_deps : (Loc.t * Lib_name.t) list Compilation_mode.By_mode.t
+  ; ppx_runtime_deps : (Loc.t * Lib_name.t) list Compilation_mode.Per_mode.t
   ; allow_unused_libraries : (Loc.t * Lib_name.t) list
   ; preprocess :
-      Preprocess.With_instrumentation.t Preprocess.Per_module.t Compilation_mode.By_mode.t
+      Preprocess.With_instrumentation.t Preprocess.Per_module.t
+        Compilation_mode.Per_mode.t
   ; enabled : Enabled_status.t Memo.t
   ; virtual_deps : (Loc.t * Lib_name.t) list
   ; dune_version : Dune_lang.Syntax.Version.t option
   ; sub_systems : Sub_system_info.t Sub_system_name.Map.t
   ; entry_modules :
-      (Module_name.t list option Compilation_mode.By_mode.t, User_message.t) result
+      (Module_name.t list option Compilation_mode.Per_mode.t, User_message.t) result
         Source.t
   ; implements : (Loc.t * Lib_name.t) option
   ; default_implementation : (Loc.t * Lib_name.t) option
@@ -336,7 +337,7 @@ type 'path t =
   ; main_module_name : Main_module_name.t
   ; local_main_module_name : Module_name.t option
   ; modes : Lib_mode.Map.Set.t
-  ; modules : Modules.With_vlib.t option Compilation_mode.By_mode.t Source.t
+  ; modules : Modules.With_vlib.t option Compilation_mode.Per_mode.t Source.t
   ; special_builtin_support : (Loc.t * Special_builtin_support.t) option
   ; exit_module : Module_name.t option
   ; instrumentation_backend : (Loc.t * Lib_name.t) option
@@ -351,14 +352,14 @@ let version t = t.version
 let dune_version t = t.dune_version
 let loc t = t.loc
 let parameters t = t.parameters
-let requires t ~for_ = Compilation_mode.By_mode.get t.requires ~for_
+let requires t ~for_ = Compilation_mode.Per_mode.get t.requires ~for_
 let requires_by_mode t = t.requires
-let preprocess t ~for_ = Compilation_mode.By_mode.get t.preprocess ~for_
+let preprocess t ~for_ = Compilation_mode.Per_mode.get t.preprocess ~for_
 let ppx_runtime_deps t = t.ppx_runtime_deps
 let allow_unused_libraries t = t.allow_unused_libraries
 let sub_systems t = t.sub_systems
 let modes t = t.modes
-let modules t ~for_ = Source.map t.modules ~f:(Compilation_mode.By_mode.get ~for_)
+let modules t ~for_ = Source.map t.modules ~f:(Compilation_mode.Per_mode.get ~for_)
 let modules_by_mode t = t.modules
 let archives t = t.archives
 let foreign_archives t = t.foreign_archives
@@ -393,7 +394,7 @@ let set_version t version = { t with version }
 let entry_modules t ~for_ =
   Source.map t.entry_modules ~f:(fun entry_modules ->
     Result.map entry_modules ~f:(fun entry_modules ->
-      Compilation_mode.By_mode.get entry_modules ~for_ |> Option.value_exn))
+      Compilation_mode.Per_mode.get entry_modules ~for_ |> Option.value_exn))
 ;;
 
 let dynlink_supported t = Mode.Dict.get t.plugins Native <> []
@@ -615,16 +616,16 @@ let to_dyn
     ; "jsoo_runtime", list path jsoo_runtime
     ; "wasmoo_runtime", list path wasmoo_runtime
     ; "parameters", list (snd Lib_name.to_dyn) parameters
-    ; "requires", Compilation_mode.By_mode.to_dyn (list Lib_dep.to_dyn) requires
+    ; "requires", Compilation_mode.Per_mode.to_dyn (list Lib_dep.to_dyn) requires
     ; ( "ppx_runtime_deps"
-      , Compilation_mode.By_mode.to_dyn (list (snd Lib_name.to_dyn)) ppx_runtime_deps )
+      , Compilation_mode.Per_mode.to_dyn (list (snd Lib_name.to_dyn)) ppx_runtime_deps )
     ; "virtual_deps", list (snd Lib_name.to_dyn) virtual_deps
     ; "dune_version", option Dune_lang.Syntax.Version.to_dyn dune_version
     ; "sub_systems", Sub_system_name.Map.to_dyn Dyn.opaque sub_systems
     ; ( "entry_modules"
       , Source.to_dyn
           (Result.to_dyn
-             (Compilation_mode.By_mode.to_dyn (option (list Module_name.to_dyn)))
+             (Compilation_mode.Per_mode.to_dyn (option (list Module_name.to_dyn)))
              string)
           (Source.map entry_modules ~f:(Result.map_error ~f:User_message.to_string)) )
     ; "implements", option (snd Lib_name.to_dyn) implements
@@ -635,7 +636,7 @@ let to_dyn
     ; "modes", Lib_mode.Map.Set.to_dyn modes
     ; ( "modules"
       , Source.to_dyn
-          (Compilation_mode.By_mode.to_dyn (option Modules.With_vlib.to_dyn))
+          (Compilation_mode.Per_mode.to_dyn (option Modules.With_vlib.to_dyn))
           modules )
     ; ( "special_builtin_support"
       , option (snd Special_builtin_support.to_dyn) special_builtin_support )
@@ -667,7 +668,7 @@ let for_dune_package
       ~melange_runtime_deps
       ~public_headers
       ~modes
-      ~(modules : Modules.With_vlib.t option Compilation_mode.By_mode.t)
+      ~(modules : Modules.With_vlib.t option Compilation_mode.Per_mode.t)
   =
   let foreign_objects = Source.External foreign_objects in
   let orig_src_dir =
@@ -742,7 +743,7 @@ let for_instance ~dir ~ext_lib t =
     obj_dir
   ; archives
   ; native_archives
-  ; modules = External (Compilation_mode.By_mode.both None)
+  ; modules = External (Compilation_mode.Per_mode.both None)
   ; src_dir = dir
   ; orig_src_dir = None
   ; plugins = Mode.Dict.make ~byte:[] ~native:[]

--- a/src/dune_rules/lib_info.mli
+++ b/src/dune_rules/lib_info.mli
@@ -156,13 +156,13 @@ val modules : _ t -> for_:Compilation_mode.t -> Modules.With_vlib.t option Sourc
 
 val modules_by_mode
   :  _ t
-  -> Modules.With_vlib.t option Compilation_mode.By_mode.t Source.t
+  -> Modules.With_vlib.t option Compilation_mode.Per_mode.t Source.t
 
 val implements : _ t -> (Loc.t * Lib_name.t) option
 val requires : _ t -> for_:Compilation_mode.t -> Lib_dep.t list
-val requires_by_mode : _ t -> Lib_dep.t list Compilation_mode.By_mode.t
+val requires_by_mode : _ t -> Lib_dep.t list Compilation_mode.Per_mode.t
 val parameters : _ t -> (Loc.t * Lib_name.t) list
-val ppx_runtime_deps : _ t -> (Loc.t * Lib_name.t) list Compilation_mode.By_mode.t
+val ppx_runtime_deps : _ t -> (Loc.t * Lib_name.t) list Compilation_mode.Per_mode.t
 val allow_unused_libraries : _ t -> (Loc.t * Lib_name.t) list
 
 val preprocess
@@ -191,8 +191,8 @@ val set_version : 'a t -> Package_version.t option -> 'a t
 val for_dune_package
   :  Path.t t
   -> name:Lib_name.t
-  -> ppx_runtime_deps:(Loc.t * Lib_name.t) list Compilation_mode.By_mode.t
-  -> requires:Lib_dep.t list Compilation_mode.By_mode.t
+  -> ppx_runtime_deps:(Loc.t * Lib_name.t) list Compilation_mode.Per_mode.t
+  -> requires:Lib_dep.t list Compilation_mode.Per_mode.t
   -> foreign_objects:Path.t list
   -> obj_dir:Path.t Obj_dir.t
   -> implements:(Loc.t * Lib_name.t) option
@@ -202,7 +202,7 @@ val for_dune_package
   -> melange_runtime_deps:Path.t list
   -> public_headers:Path.t list
   -> modes:Lib_mode.Map.Set.t
-  -> modules:Modules.With_vlib.t option Compilation_mode.By_mode.t
+  -> modules:Modules.With_vlib.t option Compilation_mode.Per_mode.t
   -> Path.t t
 
 type 'a path =
@@ -224,13 +224,13 @@ val create
   -> main_module_name:Main_module_name.t
   -> local_main_module_name:Module_name.t option
   -> sub_systems:Sub_system_info.t Sub_system_name.Map.t
-  -> requires:Lib_dep.t list Compilation_mode.By_mode.t
+  -> requires:Lib_dep.t list Compilation_mode.Per_mode.t
   -> parameters:(Loc.t * Lib_name.t) list
   -> foreign_objects:'a list Source.t
   -> public_headers:'a File_deps.t
   -> plugins:'a list Mode.Dict.t
   -> archives:'a list Mode.Dict.t
-  -> ppx_runtime_deps:(Loc.t * Lib_name.t) list Compilation_mode.By_mode.t
+  -> ppx_runtime_deps:(Loc.t * Lib_name.t) list Compilation_mode.Per_mode.t
   -> allow_unused_libraries:(Loc.t * Lib_name.t) list
   -> foreign_archives:'a Mode.Map.Multi.t
   -> native_archives:'a native_archives
@@ -239,17 +239,17 @@ val create
   -> wasmoo_runtime:'a list
   -> preprocess:
        Preprocess.With_instrumentation.t Preprocess.Per_module.t
-         Compilation_mode.By_mode.t
+         Compilation_mode.Per_mode.t
   -> enabled:Enabled_status.t Memo.t
   -> virtual_deps:(Loc.t * Lib_name.t) list
   -> dune_version:Dune_lang.Syntax.Version.t option
   -> entry_modules:
-       (Module_name.t list option Compilation_mode.By_mode.t, User_message.t) result
+       (Module_name.t list option Compilation_mode.Per_mode.t, User_message.t) result
          Source.t
   -> implements:(Loc.t * Lib_name.t) option
   -> default_implementation:(Loc.t * Lib_name.t) option
   -> modes:Lib_mode.Map.Set.t
-  -> modules:Modules.With_vlib.t option Compilation_mode.By_mode.t Source.t
+  -> modules:Modules.With_vlib.t option Compilation_mode.Per_mode.t Source.t
   -> wrapped:Wrapped.t Inherited.t option
   -> special_builtin_support:(Loc.t * Special_builtin_support.t) option
   -> exit_module:Module_name.t option

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -786,5 +786,5 @@ let rules (lib : Library.t) ~sctx ~dir_contents ~expander ~scope =
       in
       for_, Some r)
   in
-  Compilation_mode.By_mode.of_list cctxs ~init:None
+  Compilation_mode.Per_mode.of_list cctxs ~init:None
 ;;

--- a/src/dune_rules/lib_rules.mli
+++ b/src/dune_rules/lib_rules.mli
@@ -23,4 +23,4 @@ val rules
   -> dir_contents:Dir_contents.t
   -> expander:Expander.t
   -> scope:Scope.t
-  -> (Compilation_context.t * Merlin.t) option Compilation_mode.By_mode.t Memo.t
+  -> (Compilation_context.t * Merlin.t) option Compilation_mode.Per_mode.t Memo.t

--- a/src/dune_rules/obj_dir.ml
+++ b/src/dune_rules/obj_dir.ml
@@ -31,31 +31,31 @@ end
 
 module External = struct
   type t =
-    { public_dir : Path.t Compilation_mode.By_mode.t
-    ; private_dir : Path.t option Compilation_mode.By_mode.t
-    ; public_cmi_dir : Path.t option Compilation_mode.By_mode.t
+    { public_dir : Path.t Compilation_mode.Per_mode.t
+    ; private_dir : Path.t option Compilation_mode.Per_mode.t
+    ; public_cmi_dir : Path.t option Compilation_mode.Per_mode.t
     }
 
   let equal : t -> t -> bool = Poly.equal
 
   let make ~dir ~has_private_modules ~private_lib =
     let public_dir =
-      { Compilation_mode.By_mode.ocaml = dir
+      { Compilation_mode.Per_mode.ocaml = dir
       ; melange = Path.relative dir Melange.Install.dir
       }
     in
     let private_dir =
       match has_private_modules with
-      | false -> Compilation_mode.By_mode.both None
+      | false -> Compilation_mode.Per_mode.both None
       | true ->
-        Compilation_mode.By_mode.map public_dir ~f:(fun ~for_:_ public_dir ->
+        Compilation_mode.Per_mode.map public_dir ~f:(fun ~for_:_ public_dir ->
           Some (Path.relative public_dir ".private"))
     in
     let public_cmi_dir =
       match private_lib with
-      | false -> Compilation_mode.By_mode.both None
+      | false -> Compilation_mode.Per_mode.both None
       | true ->
-        Compilation_mode.By_mode.map public_dir ~f:(fun ~for_ public_dir ->
+        Compilation_mode.Per_mode.map public_dir ~f:(fun ~for_ public_dir ->
           let segment =
             match for_ with
             | Ocaml -> ".public_cmi"
@@ -77,20 +77,20 @@ module External = struct
   let to_dyn { public_dir; private_dir; public_cmi_dir } =
     let open Dyn in
     record
-      [ "public_dir", Compilation_mode.By_mode.to_dyn Path.to_dyn public_dir
-      ; "private_dir", Compilation_mode.By_mode.to_dyn (option Path.to_dyn) private_dir
+      [ "public_dir", Compilation_mode.Per_mode.to_dyn Path.to_dyn public_dir
+      ; "private_dir", Compilation_mode.Per_mode.to_dyn (option Path.to_dyn) private_dir
       ; ( "public_cmi_dir"
-        , Compilation_mode.By_mode.to_dyn (option Path.to_dyn) public_cmi_dir )
+        , Compilation_mode.Per_mode.to_dyn (option Path.to_dyn) public_cmi_dir )
       ]
   ;;
 
   let cm_dir t (cm_kind : Lib_mode.Cm_kind.t) (visibility : Visibility.t) =
     match cm_kind, visibility, t.private_dir with
-    | Ocaml Cmi, Private, { Compilation_mode.By_mode.ocaml = Some p; melange = _ } -> p
-    | Ocaml Cmi, Private, { Compilation_mode.By_mode.ocaml = None; melange = _ } ->
+    | Ocaml Cmi, Private, { Compilation_mode.Per_mode.ocaml = Some p; melange = _ } -> p
+    | Ocaml Cmi, Private, { Compilation_mode.Per_mode.ocaml = None; melange = _ } ->
       Code_error.raise "External.cm_dir" [ "t", to_dyn t ]
-    | Melange Cmi, Private, { Compilation_mode.By_mode.melange = Some p; ocaml = _ } -> p
-    | Melange Cmi, Private, { Compilation_mode.By_mode.melange = None; ocaml = _ } ->
+    | Melange Cmi, Private, { Compilation_mode.Per_mode.melange = Some p; ocaml = _ } -> p
+    | Melange Cmi, Private, { Compilation_mode.Per_mode.melange = None; ocaml = _ } ->
       Code_error.raise "External.cm_dir" [ "t", to_dyn t ]
     | Ocaml Cmi, Public, _ -> public_cmi_ocaml_dir t
     | Melange Cmi, Public, _ -> public_cmi_melange_dir t
@@ -115,7 +115,7 @@ module External = struct
 
   let decode ~dir =
     let public_dir =
-      { Compilation_mode.By_mode.ocaml = dir
+      { Compilation_mode.Per_mode.ocaml = dir
       ; melange = Path.relative dir Melange.Install.dir
       }
     in
@@ -125,7 +125,7 @@ module External = struct
        and+ public_cmi_ocaml_dir = field_o "public_cmi_ocaml_dir" string
        and+ public_cmi_melange_dir = field_o "public_cmi_melange_dir" string in
        let private_dir =
-         { Compilation_mode.By_mode.ocaml = Option.map ~f:(Path.relative dir) private_dir
+         { Compilation_mode.Per_mode.ocaml = Option.map ~f:(Path.relative dir) private_dir
          ; melange =
              Option.map
                ~f:(fun _ -> Path.relative public_dir.melange ".private")
@@ -139,7 +139,7 @@ module External = struct
          Option.map ~f:(Path.relative dir) public_cmi_melange_dir
        in
        let public_cmi_dir =
-         { Compilation_mode.By_mode.ocaml = public_cmi_ocaml_dir
+         { Compilation_mode.Per_mode.ocaml = public_cmi_ocaml_dir
          ; melange = public_cmi_melange_dir
          }
        in

--- a/src/dune_rules/stanzas/library.ml
+++ b/src/dune_rules/stanzas/library.ml
@@ -476,7 +476,7 @@ let library_deps ~modes (buildable : Buildable.t) =
     in
     ocaml_libraries, melange_libraries
   in
-  { Compilation_mode.By_mode.ocaml; melange }
+  { Compilation_mode.Per_mode.ocaml; melange }
 ;;
 
 let to_lib_info
@@ -615,10 +615,10 @@ let to_lib_info
     let melange =
       Option.value conf.melange_ppx_runtime_libraries ~default:conf.ppx_runtime_libraries
     in
-    { Compilation_mode.By_mode.ocaml = conf.ppx_runtime_libraries; melange }
+    { Compilation_mode.Per_mode.ocaml = conf.ppx_runtime_libraries; melange }
   in
   let preprocess =
-    { Compilation_mode.By_mode.ocaml = conf.buildable.preprocess.config
+    { Compilation_mode.Per_mode.ocaml = conf.buildable.preprocess.config
     ; melange = conf.buildable.melange_preprocess.config
     }
   in

--- a/src/dune_rules/top_module.ml
+++ b/src/dune_rules/top_module.ml
@@ -47,7 +47,7 @@ let find_module sctx src =
          | Tests tests -> Exe_rules.rules ~sctx ~dir_contents ~scope ~expander tests.exes
          | Library lib ->
            Lib_rules.rules lib ~sctx ~dir_contents ~expander ~scope
-           >>| Compilation_mode.By_mode.get ~for_
+           >>| Compilation_mode.Per_mode.get ~for_
            >>| Option.value_exn
          | Melange mel ->
            Melange_rules.setup_emit_cmj_rules ~sctx ~dir_contents ~expander ~scope mel


### PR DESCRIPTION
Renames `Compilation_mode.By_mode` to `Compilation_mode.Per_mode`.

Follow-up to #15058.