### PR TITLE
refactor(memo): store the dependency graph in immutable arrays

### DIFF
--- a/otherlibs/stdune/src/array.ml
+++ b/otherlibs/stdune/src/array.ml
@@ -58,6 +58,7 @@ module Immutable = struct
   include T
 
   let of_array_unsafe a = a
+  let to_array_unsafe a = a
   let of_array a = copy a
   let to_list_map t ~f = to_list_map t ~f
   let of_list_map t ~f = of_list_map t ~f

--- a/otherlibs/stdune/src/array.mli
+++ b/otherlibs/stdune/src/array.mli
@@ -11,6 +11,11 @@ module Immutable : sig
   type 'a t
 
   val of_array_unsafe : 'a array -> 'a t
+
+  (** [to_array_unsafe t] returns [t]'s underlying array without copying; the
+      caller must not mutate it, as it is shared with [t]. *)
+  val to_array_unsafe : 'a t -> 'a array
+
   val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
   val get : 'a t -> int -> 'a
   val of_array : 'a array -> 'a t

--- a/src/memo/deps.ml
+++ b/src/memo/deps.ml
@@ -12,8 +12,8 @@ module Static = struct
   type 'node t =
     | Empty
     | Singleton of 'node
-    | Seq of 'node t array
-    | Par of 'node t array
+    | Seq of 'node t Array.Immutable.t
+    | Par of 'node t Array.Immutable.t
 
   (* Flatten a chronological list of sections into a sequence, flattening nested [Seq]s:
      (x ; (y ; z)) = (x ; y ; z). *)
@@ -21,13 +21,13 @@ module Static = struct
     let flat =
       List.concat_map sections ~f:(function
         | Empty -> []
-        | Seq arr -> Array.to_list arr
+        | Seq arr -> Array.Immutable.to_list arr
         | (Singleton _ | Par _) as t -> [ t ])
     in
     match flat with
     | [] -> Empty
     | [ t ] -> t
-    | _ :: _ :: _ -> Seq (Array.of_list flat)
+    | _ :: _ :: _ -> Seq (Array.Immutable.of_list flat)
   ;;
 
   (* Flatten a list of parallel threads into a parallel section, flattening nested [Par]s:
@@ -36,13 +36,13 @@ module Static = struct
     let flat =
       List.concat_map threads ~f:(function
         | Empty -> []
-        | Par arr -> Array.to_list arr
+        | Par arr -> Array.Immutable.to_list arr
         | (Singleton _ | Seq _) as t -> [ t ])
     in
     match flat with
     | [] -> Empty
     | [ t ] -> t
-    | _ :: _ :: _ -> Par (Array.of_list flat)
+    | _ :: _ :: _ -> Par (Array.Immutable.of_list flat)
   ;;
 end
 
@@ -86,7 +86,7 @@ let changed_or_not (t : 'node t) ~f =
     | Seq arr -> seq arr 0
     | Par arr ->
       Fiber.map_reduce_array
-        arr
+        (Array.Immutable.to_array_unsafe arr)
         ~empty:Changed_or_not.Unchanged
         ~combine:Changed_or_not.combine
         ~f:(fun section ->
@@ -96,9 +96,9 @@ let changed_or_not (t : 'node t) ~f =
             f ~ok_to_recompute_eagerly:true node
           | other -> loop ~ok_to_recompute_eagerly:false other)
   and seq arr index =
-    if index < Array.length arr
+    if index < Array.Immutable.length arr
     then
-      loop ~ok_to_recompute_eagerly:false arr.(index)
+      loop ~ok_to_recompute_eagerly:false (Array.Immutable.get arr index)
       >>= function
       | Changed_or_not.Unchanged -> seq arr (index + 1)
       | (Changed | Cancelled _) as res -> Fiber.return res
@@ -112,7 +112,8 @@ module For_debugging = struct
     let rec loop acc = function
       | Static.Empty -> acc
       | Singleton node -> node :: acc
-      | Seq arr | Par arr -> Array.fold_right arr ~init:acc ~f:(fun t acc -> loop acc t)
+      | Seq arr | Par arr ->
+        Array.Immutable.fold_right arr ~init:acc ~f:(fun t acc -> loop acc t)
     in
     loop [] t
   ;;


### PR DESCRIPTION
The series-parallel dependency graph in `Deps` keeps its `Seq` and `Par`
sections in arrays that are built once (from a flattened list) and never
mutated afterwards. This stores them as `Stdune.Array.Immutable.t` instead of
regular mutable arrays, so the type enforces that the dependency arrays shared
inside every cached value cannot be mutated.

`changed_or_not`'s parallel case hands its section array to
`Fiber.map_reduce_array`, which operates on a regular array, so
`Array.Immutable` gains a zero-copy `to_array_unsafe` — the inverse of the
existing `of_array_unsafe`, safe here because `map_reduce_array` only reads.

Pure type-level change; behaviour is unchanged.
