### PR TITLE
perf(memo): pool the per-thread collector arrays in run_parallel

### DIFF
--- a/src/memo/deps_collector.ml
+++ b/src/memo/deps_collector.ml
@@ -24,6 +24,99 @@ let add_dep_from_caller dep_node =
 (* A way to run a parallel thread while collecting its dependencies separately. *)
 type run_thread = { run : 'a. f:(unit -> 'a Fiber.t) -> 'a Fiber.t } [@@unboxed]
 
+(* A pool of large per-thread sub-collector arrays, keyed by power-of-two size, to avoid
+   repeated major-heap allocations of the outer thread array in [run_parallel] when the
+   parallel fan-out is large. Not thread- or domain-safe. *)
+module Pool : sig
+  type collector := t
+  type t
+
+  val acquire : int -> t
+  val get : t -> int -> collector
+  val release : t -> unit
+end = struct
+  type nonrec collector = t
+
+  type t =
+    { arr : collector Array.Immutable.t
+    ; size : int
+    }
+
+  (* [Max_young_wosize] is OCaml's minor-heap allocation limit (in words): arrays at or
+     below it are allocated cheaply in the minor heap and reclaimed by the next minor
+     collection, so pooling them is pointless. We only pool larger arrays, which would
+     otherwise pay a major-heap allocation on every [run_parallel] call. *)
+  external max_young_wosize_stub : unit -> int = "dune_memo_max_young_wosize" [@@noalloc]
+
+  let max_young_wosize = max_young_wosize_stub ()
+
+  (* The smallest power of two that is at least [n] (for [n >= 1]). *)
+  let ceil_pow2 n =
+    let p = ref 1 in
+    while !p < n do
+      p := !p * 2
+    done;
+    !p
+  ;;
+
+  (* [floor (log2 n)] for [n >= 1]. *)
+  let floor_log2 n =
+    let n = ref n in
+    let r = ref 0 in
+    while !n > 1 do
+      n := !n / 2;
+      incr r
+    done;
+    !r
+  ;;
+
+  (* One queue of recycled arrays per power-of-two size class, indexed by
+     [floor_log2 array_size]. *)
+  let num_size_classes = 64
+
+  let table =
+    Array.Immutable.of_array_unsafe
+      (Array.init num_size_classes ~f:(fun _ -> Queue.create ()))
+  ;;
+
+  let make ~array_size =
+    Array.Immutable.of_array_unsafe (Array.init array_size ~f:(fun _ -> create ()))
+  ;;
+
+  let acquire size =
+    let array_size = ceil_pow2 size in
+    let arr =
+      if array_size <= max_young_wosize
+      then make ~array_size
+      else (
+        match Queue.pop (Array.Immutable.get table (floor_log2 array_size)) with
+        | None -> make ~array_size
+        | Some arr -> arr)
+    in
+    { arr; size }
+  ;;
+
+  let get { arr; size } i =
+    if i >= size (* [Array.Immutable.get] checks [i >= 0]. *)
+    then
+      Code_error.raise
+        "Pool.get: index outside active range"
+        [ "i", Dyn.int i; "size", Dyn.int size ];
+    Array.Immutable.get arr i
+  ;;
+
+  let release { arr; size } =
+    let array_size = Array.Immutable.length arr in
+    if array_size <= max_young_wosize
+    then (* Let the minor GC reclaim it. *) ()
+    else (
+      for i = 0 to size - 1 do
+        Array.Immutable.get arr i := Deps.Dynamic.empty
+      done;
+      Queue.push (Array.Immutable.get table (floor_log2 array_size)) arr)
+  ;;
+end
+
 (* Run [num_threads] parallel threads, collecting each thread's dependencies into its own
      sub-collector (via fiber-local storage) and recording them as a single parallel section
      in the caller's collector. [k] is called with [None] when [num_threads < 2] or when
@@ -40,7 +133,7 @@ let run_parallel ~num_threads k =
     >>= function
     | None -> k None
     | Some t ->
-      let threads = Array.init num_threads ~f:(fun _ -> create ()) in
+      let threads = Pool.acquire num_threads in
       let thread_index = ref 0 in
       let run_thread =
         { run =
@@ -49,7 +142,7 @@ let run_parallel ~num_threads k =
                    [thread_index] is atomic and each thread gets a distinct sub-collector. *)
               let i = !thread_index in
               incr thread_index;
-              Fiber.Var.set var (Some threads.(i)) f)
+              Fiber.Var.set var (Some (Pool.get threads i)) f)
         }
       in
       let* result = Fiber.collect_errors (fun () -> k (Some run_thread)) in
@@ -57,7 +150,9 @@ let run_parallel ~num_threads k =
       := Deps.Dynamic.append_par
            !t
            ~threads:
-             (List.init num_threads ~f:(fun i -> Deps.Dynamic.to_static !(threads.(i))));
+             (List.init num_threads ~f:(fun i ->
+                Deps.Dynamic.to_static !(Pool.get threads i)));
+      Pool.release threads;
       (match result with
        | Ok res -> Fiber.return res
        | Error exns -> Fiber.reraise_all exns)

--- a/src/memo/dune
+++ b/src/memo/dune
@@ -1,4 +1,7 @@
 (library
  (name memo)
  (libraries stdune dyn dune_graph dag fiber unix)
+ (foreign_stubs
+  (language c)
+  (names dune_memo_stubs))
  (synopsis "Incremental computation library that powers Dune"))

--- a/src/memo/dune_memo_stubs.c
+++ b/src/memo/dune_memo_stubs.c
@@ -1,0 +1,9 @@
+#include <caml/mlvalues.h>
+#include <caml/config.h>
+
+/* [Max_young_wosize] is OCaml's minor-heap allocation limit, in words. */
+CAMLprim value dune_memo_max_young_wosize(value unit)
+{
+  (void)unit;
+  return Val_long(Max_young_wosize);
+}


### PR DESCRIPTION
When collecting dependencies in parallel, `run_parallel` allocates an array of
`num_threads` sub-collectors so each parallel thread can gather its dependencies
independently. For a large parallel fan-out that outer array is a fresh
major-heap allocation on every call.

This pools those arrays: they are keyed by power-of-two size class and recycled
across `run_parallel` calls (each thread's collector is reset to empty on
release). Arrays small enough to be minor-heap allocated (at or below
`Max_young_wosize`) are not pooled — the minor GC reclaims them cheaply, so
pooling would only add bookkeeping. `Max_young_wosize` is read from the runtime
through a small C stub (`dune_memo_max_young_wosize`). The threads buffer is held
as an immutable array (`Stdune.Array.Immutable`).
