### PR TITLE
Add a testcase for 'dune describe pkg lock' with autolocking

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/describe-pkg-lock-autolock.t
+++ b/test/blackbox-tests/test-cases/pkg/describe-pkg-lock-autolock.t
@@ -1,0 +1,29 @@
+Test `dune describe pkg lock` with autolocking (no committed lock dir).
+
+  $ mkrepo
+  $ mkpkg A 1.2.0
+  > mkpkg B 2.1+rc1
+
+  $ add_mock_repo_if_needed
+  $ enable_pkg
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.20)
+  > (package
+  >  (name x)
+  >  (depends A B))
+  > EOF
+
+Before any build there is no lock dir, so describe reports none rather than
+failing:
+  $ dune describe pkg lock
+  Error: dune.lock/lock.dune: No such file or directory
+  [1]
+
+Trigger autolocking with a build:
+  $ dune build @pkg-install 2>&1
+
+After the build, describe reads the internal autolocked lock:
+  $ dune describe pkg lock
+  Error: dune.lock/lock.dune: No such file or directory
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/describe-pkg-lock-autolock.t
+++ b/test/blackbox-tests/test-cases/pkg/describe-pkg-lock-autolock.t
@@ -14,8 +14,8 @@ Test `dune describe pkg lock` with autolocking (no committed lock dir).
   >  (depends A B))
   > EOF
 
-Before any build there is no lock dir, so describe reports none rather than
-failing:
+Before any build there is no lock dir, so describe reports it can't find a
+lockfile:
   $ dune describe pkg lock
   Error: dune.lock/lock.dune: No such file or directory
   [1]
@@ -23,7 +23,8 @@ failing:
 Trigger autolocking with a build:
   $ dune build @pkg-install 2>&1
 
-After the build, describe reads the internal autolocked lock:
+After the build the lockdir is still not read because the command is looking for
+a lockfile in the source directory:
   $ dune describe pkg lock
   Error: dune.lock/lock.dune: No such file or directory
   [1]


### PR DESCRIPTION
Prequel to #15062.

This adds the testcase for when we run `dune describe pkg lock` in a project with `pkg enabled`.