### PR TITLE
perf(memo): build parallel dependency sections without an intermediate list

### DIFF
--- a/src/memo/deps.ml
+++ b/src/memo/deps.ml
@@ -30,19 +30,26 @@ module Static = struct
     | _ :: _ :: _ -> Seq (Array.Immutable.of_list flat)
   ;;
 
-  (* Flatten a list of parallel threads into a parallel section, flattening nested [Par]s:
-     (x | (y | z)) = (x | y | z). *)
-  let flatten_pars (threads : 'node t list) : 'node t =
-    let flat =
-      List.concat_map threads ~f:(function
-        | Empty -> []
-        | Par arr -> Array.Immutable.to_list arr
-        | (Singleton _ | Seq _) as t -> [ t ])
+  (* Flatten a parallel section of [num_threads] threads, where thread [i]'s section is
+     [f i], flattening nested [Par]s: (x | (y | z)) = (x | y | z). Building the flattened
+     list directly from [f] avoids allocating an intermediate list of the threads' sections. *)
+  let flatten_pars_init num_threads ~f =
+    let rec loop i acc =
+      if i < 0
+      then acc
+      else (
+        let elements =
+          match f i with
+          | Empty -> []
+          | Par arr -> Array.Immutable.to_list arr
+          | (Singleton _ | Seq _) as t -> [ t ]
+        in
+        loop (i - 1) (elements @ acc))
     in
-    match flat with
+    match loop (num_threads - 1) [] with
     | [] -> Empty
     | [ t ] -> t
-    | _ :: _ :: _ -> Par (Array.Immutable.of_list flat)
+    | _ :: _ :: _ as flat -> Par (Array.Immutable.of_list flat)
   ;;
 end
 
@@ -61,8 +68,8 @@ module Dynamic = struct
     Static.Singleton node :: t
   ;;
 
-  let append_par t ~threads =
-    match Static.flatten_pars threads with
+  let append_par_init t ~num_threads ~f =
+    match Static.flatten_pars_init num_threads ~f with
     | Static.Empty -> t
     | section -> section :: t
   ;;

--- a/src/memo/deps.mli
+++ b/src/memo/deps.mli
@@ -21,9 +21,10 @@ module Dynamic : sig
   (** Append a dependency discovered after the existing ones. *)
   val append_seq : 'node t -> node:'node -> 'node t
 
-  (** Append a parallel section consisting of the dependencies of [threads], each captured
-      independently. *)
-  val append_par : 'node t -> threads:'node static list -> 'node t
+  (** Append a parallel section of [num_threads] threads, where thread [i]'s dependencies
+      are [f i], each captured independently. Builds the section directly from [f], avoiding
+      an intermediate list of the threads' dependencies. *)
+  val append_par_init : 'node t -> num_threads:int -> f:(int -> 'node static) -> 'node t
 
   val to_static : 'node t -> 'node static
 end

--- a/src/memo/deps_collector.ml
+++ b/src/memo/deps_collector.ml
@@ -147,11 +147,8 @@ let run_parallel ~num_threads k =
       in
       let* result = Fiber.collect_errors (fun () -> k (Some run_thread)) in
       t
-      := Deps.Dynamic.append_par
-           !t
-           ~threads:
-             (List.init num_threads ~f:(fun i ->
-                Deps.Dynamic.to_static !(Pool.get threads i)));
+      := Deps.Dynamic.append_par_init !t ~num_threads ~f:(fun i ->
+           Deps.Dynamic.to_static !(Pool.get threads i));
       Pool.release threads;
       (match result with
        | Ok res -> Fiber.return res


### PR DESCRIPTION
When recording a node's parallel dependencies, `run_parallel` passed a list of
the `num_threads` threads' sections to `Deps.Dynamic.append_par`. Materialising
that list (`List.init num_threads …`) is a per-call allocation on the hot
parallel dependency-collection path.

This replaces `append_par` (and `Static.flatten_pars`) with `append_par_init`
(and `flatten_pars_init`), which build the parallel section directly from `f i`
— thread `i`'s section — without first allocating the list of sections.
`run_parallel` now calls `append_par_init ~num_threads ~f:(fun i -> …)`.

`append_par`'s only caller was `run_parallel`, so it is removed.

Pure allocation reduction; behaviour is unchanged.
