### PR TITLE
doc: mention display command-line option

### DIFF
--- a/doc/reference/config/display.rst
+++ b/doc/reference/config/display.rst
@@ -1,11 +1,15 @@
 display
 -------
 
-Specify the amount of Dune’s verbosity.
+Specify the amount of Dune's verbosity.
 
 .. code:: dune
 
     (display <setting>)
+
+The display mode can also be selected for a single invocation with the
+``--display <setting>`` command-line option. The ``--verbose`` option is
+equivalent to ``--display verbose``.
 
 where ``<setting>`` is one of:
 
@@ -18,4 +22,6 @@ where ``<setting>`` is one of:
 - ``short`` prints a line for each program executed with the binary name on the
   left and the targets of the action on the right.
 
-- ``quiet`` only display errors.
+- ``quiet`` only displays errors.
+
+- ``tui`` uses Dune's terminal UI.


### PR DESCRIPTION
Document that the `display` setting can be selected with `--display`, mention the relation to `--verbose`, and list the currently accepted `tui` value.

Fixes #3044.