### PR TITLE
fix: hint package field for private library deps

### DIFF
--- a/doc/changes/fixed/15070.md
+++ b/doc/changes/fixed/15070.md
@@ -1,0 +1,3 @@
+- Improve the error message for private libraries that cannot be dependencies of
+  public libraries by mentioning the `(package ...)` field as an alternative to
+  giving the private library a public name (#10230, @rgrinberg).

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -209,7 +209,7 @@ module Error = struct
       ~loc
       [ Pp.textf
           "Library %S is private, it cannot be a dependency of a %s. You need to give %S \
-           a public name."
+           a public name or add a (package ...) field to its stanza."
           (Lib_name.to_string name)
           (match kind with
            | `Private_package -> "private library attached to a package"

--- a/test/blackbox-tests/test-cases/default-implementation/package-mismatch2.t
+++ b/test/blackbox-tests/test-cases/default-implementation/package-mismatch2.t
@@ -22,5 +22,6 @@ A default implementation of a library must belong to the same package
   4 |  (implements vlib))
                    ^^^^
   Error: Library "vlib" is private, it cannot be a dependency of a public
-  library. You need to give "vlib" a public name.
+  library. You need to give "vlib" a public name or add a (package ...) field
+  to its stanza.
   [1]

--- a/test/blackbox-tests/test-cases/oxcaml/implements-parameter.t
+++ b/test/blackbox-tests/test-cases/oxcaml/implements-parameter.t
@@ -185,7 +185,8 @@ But it's an error for a public library to implement a private parameter:
   3 |  (implements bar))
                    ^^^
   Error: Library "bar" is private, it cannot be a dependency of a public
-  library. You need to give "bar" a public name.
+  library. You need to give "bar" a public name or add a (package ...) field to
+  its stanza.
   [1]
 
 It's impossible for a library to implement two parameters:

--- a/test/blackbox-tests/test-cases/oxcaml/library-field-parameters.t
+++ b/test/blackbox-tests/test-cases/oxcaml/library-field-parameters.t
@@ -160,7 +160,8 @@ It's an error for a public library to depend on a private parameter:
   1 | (library (public_name project.lib) (name lib) (parameters project.a b))
                                                                           ^
   Error: Library "b" is private, it cannot be a dependency of a public library.
-  You need to give "b" a public name.
+  You need to give "b" a public name or add a (package ...) field to its
+  stanza.
   [1]
 
 Giving a public name to `b` fixes the error:

--- a/test/blackbox-tests/test-cases/oxcaml/vendor-parameterised.t
+++ b/test/blackbox-tests/test-cases/oxcaml/vendor-parameterised.t
@@ -186,7 +186,8 @@ The parameter itself could be private too,
   5 |    (implements param))
                      ^^^^^
   Error: Library "param" is private, it cannot be a dependency of a public
-  library. You need to give "param" a public name.
+  library. You need to give "param" a public name or add a (package ...) field
+  to its stanza.
   [1]
 
 But only if there are no public stanza depending on it:

--- a/test/blackbox-tests/test-cases/private-package-lib/private-public-overlap.t
+++ b/test/blackbox-tests/test-cases/private-package-lib/private-public-overlap.t
@@ -19,5 +19,6 @@ private library
   3 |  (libraries bar)
                   ^^^
   Error: Library "bar" is private, it cannot be a dependency of a private
-  library attached to a package. You need to give "bar" a public name.
+  library attached to a package. You need to give "bar" a public name or add a
+  (package ...) field to its stanza.
   [1]

--- a/test/blackbox-tests/test-cases/private-public-overlap/private-dep.t/run.t
+++ b/test/blackbox-tests/test-cases/private-public-overlap/private-dep.t/run.t
@@ -5,5 +5,6 @@ public libraries may not have private dependencies
   8 |  (libraries privatelib)
                   ^^^^^^^^^^
   Error: Library "privatelib" is private, it cannot be a dependency of a public
-  library. You need to give "privatelib" a public name.
+  library. You need to give "privatelib" a public name or add a (package ...)
+  field to its stanza.
   [1]

--- a/test/blackbox-tests/test-cases/private-public-overlap/private-runtime-deps.t/run.t
+++ b/test/blackbox-tests/test-cases/private-public-overlap/private-runtime-deps.t/run.t
@@ -4,5 +4,6 @@ Unless they introduce private runtime dependencies:
   16 |   (pps private_ppx))
               ^^^^^^^^^^^
   Error: Library "private_runtime_dep" is private, it cannot be a dependency of
-  a public library. You need to give "private_runtime_dep" a public name.
+  a public library. You need to give "private_runtime_dep" a public name or add
+  a (package ...) field to its stanza.
   [1]


### PR DESCRIPTION
When rejecting a private library dependency from a public library or a private library attached to a package, mention that adding a `(package ...)` field to the private dependency is also a valid fix.

Closes #10230.