### PR TITLE
fix: clarify empty package error

### DIFF
--- a/doc/changes/fixed/15071.md
+++ b/doc/changes/fixed/15071.md
@@ -1,0 +1,4 @@
+- Clarify the error shown for packages that do not define anything to install.
+  The message now avoids the confusing phrase "user defined stanzas" and points
+  users to `public_name`, `package`, or `allow_empty` as appropriate (#8352,
+  #5789, @rgrinberg).

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -1481,9 +1481,10 @@ let gen_package_install_file_rules sctx (package : Package.t) =
           User_warning.emit
             ~is_error
             [ Pp.textf
-                "The package %s does not have any user defined stanzas attached to it. \
-                 If this is intentional, add (allow_empty) to the package definition in \
-                 the dune-project file"
+                "The package %s does not define anything to install. If this is \
+                 intentional, add (allow_empty) to the package definition in the \
+                 dune-project file. Otherwise, add a public_name or package field to \
+                 stanzas that should install files as part of this package."
                 (Package.Name.to_string package_name)
             ]);
       List.rev_map entries ~f:(fun (e : Install.Entry.Sourced.Expanded.t) ->

--- a/test/blackbox-tests/test-cases/long-lines.t
+++ b/test/blackbox-tests/test-cases/long-lines.t
@@ -9,9 +9,10 @@ lines appear. For example, with a short project name, the line wraps later:
   >  (name short))
   > EOF
   $ dune build
-  Error: The package short does not have any user defined stanzas attached to
-  it. If this is intentional, add (allow_empty) to the package definition in
-  the dune-project file
+  Error: The package short does not define anything to install. If this is
+  intentional, add (allow_empty) to the package definition in the dune-project
+  file. Otherwise, add a public_name or package field to stanzas that should
+  install files as part of this package.
   -> required by _build/default/short.install
   -> required by alias all
   -> required by alias default
@@ -26,9 +27,10 @@ a different position:
   >  (name verylongnamethatcauseslinewrappingincases))
   > EOF
   $ dune build
-  Error: The package verylongnamethatcauseslinewrappingincases does not have
-  any user defined stanzas attached to it. If this is intentional, add
-  (allow_empty) to the package definition in the dune-project file
+  Error: The package verylongnamethatcauseslinewrappingincases does not define
+  anything to install. If this is intentional, add (allow_empty) to the package
+  definition in the dune-project file. Otherwise, add a public_name or package
+  field to stanzas that should install files as part of this package.
   -> required by
      _build/default/verylongnamethatcauseslinewrappingincases.install
   -> required by alias all
@@ -40,7 +42,7 @@ line breaks in the input and not when the line gets too long.
 
   $ export DUNE_CONFIG__SKIP_LINE_BREAK=enabled
   $ dune build
-  Error: The package verylongnamethatcauseslinewrappingincases does not have any user defined stanzas attached to it. If this is intentional, add (allow_empty) to the package definition in the dune-project file
+  Error: The package verylongnamethatcauseslinewrappingincases does not define anything to install. If this is intentional, add (allow_empty) to the package definition in the dune-project file. Otherwise, add a public_name or package field to stanzas that should install files as part of this package.
   -> required by _build/default/verylongnamethatcauseslinewrappingincases.install
   -> required by alias all
   -> required by alias default


### PR DESCRIPTION
Reword the empty-package diagnostic to avoid the confusing phrase “user defined stanzas” and explain that the package has nothing to install. Also point users toward `public_name`/`package` fields when they expected stanzas to contribute installable files.

Closes #8352.
Closes #5789.