### PR TITLE
fix: clarify module conflict errors

### DIFF
--- a/doc/changes/fixed/15072.md
+++ b/doc/changes/fixed/15072.md
@@ -1,0 +1,3 @@
+- Clarify the module conflict error shown when a module is used in multiple
+  stanzas. The message now explains implicit module ownership and lists all
+  relevant stanza kinds (#6598, @rgrinberg).

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -415,10 +415,10 @@ let raise_module_conflict_error ~module_path origins =
     [ main_message
     ; Pp.enumerate locs ~f:(fun loc -> Pp.verbatim (Loc.to_file_colon_line loc))
     ; Pp.text
-        "To fix this error, you must specify an explicit \"modules\" field in every \
-         library, executable, and executables stanzas in this dune file. Note that each \
-         module cannot appear in more than one \"modules\" field - it must belong to a \
-         single library or executable."
+        "To fix this error, you must specify explicit \"modules\" fields so that each \
+         module belongs to only one stanza. Stanzas without an explicit \"modules\" \
+         field use all modules in the directory by default. This applies to library, \
+         executable, executables, test, tests, and melange.emit stanzas."
     ]
 ;;
 

--- a/test/blackbox-tests/test-cases/melange/reused-module.t
+++ b/test/blackbox-tests/test-cases/melange/reused-module.t
@@ -21,8 +21,8 @@ Test error message for modules belonging to melange.emit and another stanza
   Error: Module "Main" is used in several stanzas:
   - dune:1
   - dune:4
-  To fix this error, you must specify an explicit "modules" field in every
-  library, executable, and executables stanzas in this dune file. Note that
-  each module cannot appear in more than one "modules" field - it must belong
-  to a single library or executable.
+  To fix this error, you must specify explicit "modules" fields so that each
+  module belongs to only one stanza. Stanzas without an explicit "modules"
+  field use all modules in the directory by default. This applies to library,
+  executable, executables, test, tests, and melange.emit stanzas.
   [1]

--- a/test/blackbox-tests/test-cases/ocamldep/ocamldep-multi-stanzas.t/run.t
+++ b/test/blackbox-tests/test-cases/ocamldep/ocamldep-multi-stanzas.t/run.t
@@ -5,10 +5,10 @@ Reports modules that are claimed by multiple stanzas.
   Error: Module "Lib" is used in several stanzas:
   - dune:1
   - dune:5
-  To fix this error, you must specify an explicit "modules" field in every
-  library, executable, and executables stanzas in this dune file. Note that
-  each module cannot appear in more than one "modules" field - it must belong
-  to a single library or executable.
+  To fix this error, you must specify explicit "modules" fields so that each
+  module belongs to only one stanza. Stanzas without an explicit "modules"
+  field use all modules in the directory by default. This applies to library,
+  executable, executables, test, tests, and melange.emit stanzas.
   [1]
 
   $ dune build src/a.cma --debug-dep
@@ -16,8 +16,8 @@ Reports modules that are claimed by multiple stanzas.
   Error: Module "X" is used in several stanzas:
   - src/dune:1
   - src/dune:2
-  To fix this error, you must specify an explicit "modules" field in every
-  library, executable, and executables stanzas in this dune file. Note that
-  each module cannot appear in more than one "modules" field - it must belong
-  to a single library or executable.
+  To fix this error, you must specify explicit "modules" fields so that each
+  module belongs to only one stanza. Stanzas without an explicit "modules"
+  field use all modules in the directory by default. This applies to library,
+  executable, executables, test, tests, and melange.emit stanzas.
   [1]


### PR DESCRIPTION
Clarify the diagnostic shown when a module is claimed by multiple stanzas. The new wording explains that stanzas without explicit `(modules ...)` fields claim modules by default and lists all affected stanza kinds, including `test`, `tests`, and `melange.emit`.

Closes #6598.