### PR TITLE
fix(doc): ignore invalid opam file package names

### DIFF
--- a/doc/changes/fixed/15075.md
+++ b/doc/changes/fixed/15075.md
@@ -1,0 +1,2 @@
+- Avoid crashing `dune build @doc` when a project contains a secondary `.opam`
+  file whose basename is not a valid opam package name (#8281, @rgrinberg).

--- a/src/dune_lang/package_name.ml
+++ b/src/dune_lang/package_name.ml
@@ -81,7 +81,8 @@ let decode_opam_compatible =
 let of_opam_file_basename basename =
   let open Option.O in
   let* name = String.drop_suffix (Filename.to_string basename) ~suffix:opam_ext in
-  of_string_opt name
+  let+ name = Opam_compatible.of_string_opt name in
+  Opam_compatible.to_package_name name
 ;;
 
 let digest_feed = Dune_digest.Feed.string

--- a/test/blackbox-tests/test-cases/invalid-opam-file-name-github8281.t
+++ b/test/blackbox-tests/test-cases/invalid-opam-file-name-github8281.t
@@ -1,6 +1,7 @@
 Reproduce #8281
 
-Whenever an invalid package name is used, dune crashes when building @doc
+When a secondary .opam file has an invalid package name, dune should not crash
+when building @doc.
 
   $ make_dune_project 2.4
   $ touch x.opam x.y.opam
@@ -21,21 +22,4 @@ Whenever an invalid package name is used, dune crashes when building @doc
 
   $ cd ..
 
-  $ dune build @doc 2>&1 | awk '/Internal error/,/Raised/'
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
-  providing the file _build/trace.csexp, if possible. This includes build
-  commands, message logs, and file paths.
-  Description:
-    ("[gen_rules] returned rules in a directory that is not a descendant of the directory it was called for",
-     { dir = In_build_dir "default/_doc/_html/x.y"
-     ; example =
-         Rule
-           { targets =
-               { root = In_build_dir "default/_doc/_html/x"
-               ; files = set { "db.js" }
-               ; dirs = set {}
-               }
-           }
-     })
-  Raised at Stdune__Code_error.raise in file
-  [1]
+  $ dune build @doc


### PR DESCRIPTION
Only infer project packages from `.opam` files whose basename is a valid opam package name. This prevents invalid secondary opam filenames such as `x.y.opam` from being treated as packages and crashing `@doc` rule generation.

Closes #8281.