### PR TITLE
fix: locate failing copy actions

### DIFF
--- a/doc/changes/fixed/15076.md
+++ b/doc/changes/fixed/15076.md
@@ -1,0 +1,2 @@
+- Report the rule location when Unix errors occur while executing copy actions
+  or releasing redirected action IO (#11506, @rgrinberg).

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -240,15 +240,22 @@ let rec exec t ~ectx ~eenv : Done_or_more_deps.t Produce.t =
     in
     let+ () =
       maybe_async (fun () ->
-        (* NOTE(anmonteiro): we may reconsider relaxing the directory target
-           constraint (see [test/blackbox-tests/test-cases/pkg/source-with-directory-symlink.t]).
+        match
+          (* NOTE(anmonteiro): we may reconsider relaxing the directory target
+             constraint (see [test/blackbox-tests/test-cases/pkg/source-with-directory-symlink.t]).
 
-           [Copy] stays file-oriented by default. We only use recursive copying
-           when [dst] is a directory target. *)
-        match ectx.targets with
-        | Some { dirs; _ } when Filename.Set.mem dirs (Path.basename dst) ->
-          Tree_copy.copy ~src ~dst ~copy_file ~mkdir ~on_unsupported ()
-        | _ -> copy_file ~src ~dst)
+             [Copy] stays file-oriented by default. We only use recursive copying
+             when [dst] is a directory target. *)
+          match ectx.targets with
+          | Some { dirs; _ } when Filename.Set.mem dirs (Path.basename dst) ->
+            Tree_copy.copy ~src ~dst ~copy_file ~mkdir ~on_unsupported ()
+          | _ -> copy_file ~src ~dst
+        with
+        | () -> ()
+        | exception Unix.Unix_error (error, syscall, arg) ->
+          User_error.raise
+            ~loc:ectx.rule_loc
+            [ Unix_error.Detailed.pp (error, syscall, arg) ])
     in
     Done
   | Symlink (src, dst) ->
@@ -320,9 +327,15 @@ and redirect t ~ectx ~eenv ?in_ ?out () =
       in
       stdout_to, stderr_to, fun () -> Process.Io.release out
   in
+  let release_io release =
+    match release () with
+    | () -> ()
+    | exception Unix.Unix_error (error, syscall, arg) ->
+      User_error.raise ~loc:ectx.rule_loc [ Unix_error.Detailed.pp (error, syscall, arg) ]
+  in
   let+ result = exec t ~ectx ~eenv:{ eenv with stdin_from; stdout_to; stderr_to } in
-  release_in ();
-  release_out ();
+  release_io release_in;
+  release_io release_out;
   result
 
 and exec_list ts ~ectx ~eenv : Done_or_more_deps.t Produce.t =

--- a/test/blackbox-tests/test-cases/unreadable-target.t
+++ b/test/blackbox-tests/test-cases/unreadable-target.t
@@ -17,3 +17,30 @@ Reports unreadable or broken targets after a rule runs.
   - a: open(_build/default/a): Permission denied
   - b: Broken symbolic link
   [1]
+
+Report the rule location for copy actions that fail while executing.
+
+  $ mkdir copy-error
+  $ cd copy-error
+  $ make_dune_project 3.24
+  $ mkdir -p sub
+  $ echo '{}' > sub/file.json
+  $ cat > dune <<EOF
+  > (rule
+  >  (target f.json)
+  >  (action
+  >   (with-stdout-to %{target}
+  >    (copy sub/file.json f.json))))
+  > EOF
+
+  $ dune build 2>&1 \
+  > | sed -E 's#_build/\.sandbox/[0-9a-f]+#_build/.sandbox/$SANDBOX#'
+  File "dune", lines 1-5, characters 0-93:
+  1 | (rule
+  2 |  (target f.json)
+  3 |  (action
+  4 |   (with-stdout-to %{target}
+  5 |    (copy sub/file.json f.json))))
+  Error:
+  open(_build/.sandbox/$SANDBOX/default/f.json): Permission denied
+  [1]


### PR DESCRIPTION
Report the rule location when Unix errors occur while executing copy actions or releasing redirected action IO. This makes failures such as a `(copy ...)` nested under `(with-stdout-to ...)` point back to the responsible dune rule instead of only printing a bare `open(...)` error.

Closes #11506.