### PR TITLE
fix: relativize installed artifacts from external build dirs

### DIFF
--- a/doc/changes/fixed/15077.md
+++ b/doc/changes/fixed/15077.md
@@ -1,0 +1,3 @@
+- Emit relative artifact references in installed `dune-package` files when using
+  an absolute external `DUNE_BUILD_DIR`, avoiding build-directory-dependent
+  archive and module paths (#15077, fixes #11774, @rgrinberg).

--- a/otherlibs/stdune/src/io.ml
+++ b/otherlibs/stdune/src/io.ml
@@ -456,7 +456,15 @@ let portable_symlink ~src ~dst =
     let src =
       match Path.parent dst with
       | None -> Path.to_string src
-      | Some from -> Path.reach ~from src
+      | Some from ->
+        (* A relative symlink target is resolved from the real directory that
+           contains [dst], not necessarily from the lexical spelling of [from].
+           External paths may contain symlinked prefixes (for example
+           /var -> /private/var on macOS), so keep external-to-external symlink
+           targets absolute. *)
+        (match Path.as_external src, Path.as_external from with
+         | Some _, Some _ -> Path.to_string src
+         | _ -> Path.reach ~from src)
     in
     let dst = Path.to_string dst in
     match Unix.readlink dst with

--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -538,6 +538,7 @@ let external_of_in_source_tree x = external_of_local x ~root:(Lazy.force abs_roo
 
 let reach t ~from =
   match t, from with
+  | External t, External from -> External.reach t ~from
   | External t, _ -> External.to_string t
   | In_source_tree t, In_source_tree from -> Source0.reach t ~from
   | In_build_dir t, In_build_dir from -> Build.reach t ~from
@@ -564,7 +565,11 @@ let reach t ~from =
 ;;
 
 let reach_for_running ?(from = root) t =
-  let fn = reach t ~from in
+  let fn =
+    match t with
+    | External t -> External.to_string t
+    | _ -> reach t ~from
+  in
   match Filename.analyze_program_name fn with
   | In_path when not (String.equal fn ".") -> "./" ^ fn
   | _ -> fn

--- a/otherlibs/stdune/src/path_external.ml
+++ b/otherlibs/stdune/src/path_external.ml
@@ -88,6 +88,27 @@ let cwd () = Sys.getcwd ()
 let initial_cwd = Fpath.initial_cwd
 let as_local t = "." ^ t
 
+(* Only relativize POSIX-style absolute paths on non-Windows systems. Other
+   absolute syntaxes, such as Windows drive-letter and UNC paths, keep their
+   absolute spelling. *)
+let local_part t =
+  match String.drop_prefix t ~prefix:"/" with
+  | None -> None
+  | Some t when String.starts_with ~prefix:"/" t -> None
+  | Some "" -> Some Local.root
+  | Some t -> Some (Local.of_string t)
+;;
+
+let reach t ~from =
+  (* CR-someday rgrinberg: I couldn't get this to work on Windows. *)
+  if Sys.win32
+  then to_string t
+  else (
+    match local_part t, local_part from with
+    | Some t, Some from -> Local.reach t ~from
+    | _ -> to_string t)
+;;
+
 let of_filename_relative_to_initial_cwd fn =
   if Filename.is_relative fn then relative initial_cwd fn else of_string fn
 ;;

--- a/otherlibs/stdune/src/path_external.mli
+++ b/otherlibs/stdune/src/path_external.mli
@@ -11,6 +11,7 @@ val relative_fname : t -> Filename.t -> t
 val initial_cwd : t
 val cwd : unit -> t
 val as_local : t -> string
+val reach : t -> from:t -> string
 val append_local : t -> Local.t -> t
 val of_filename_relative_to_initial_cwd : string -> t
 val to_dyn : t -> Dyn.t

--- a/otherlibs/stdune/test/path_tests.ml
+++ b/otherlibs/stdune/test/path_tests.ml
@@ -271,7 +271,15 @@ None
 
 let%expect_test _ =
   reach "/foo/baz" ~from:"/foo/bar";
-  [%expect {| "/foo/baz" |}]
+  [%expect {| "../baz" |}]
+;;
+
+let%expect_test _ =
+  if Sys.win32
+  then (
+    let result = Path.reach (e "C:/foo") ~from:(e "D:/bar") in
+    if not (String.equal result "C:/foo") then print_endline result);
+  [%expect {| |}]
 ;;
 
 let%expect_test _ =
@@ -561,6 +569,14 @@ let%expect_test _ =
 
 let%expect_test _ =
   reach_for_running (e "/fake/path") ~from:(Path.relative build_dir "foo/bar/baz");
+  [%expect
+    {|
+"/fake/path"
+|}]
+;;
+
+let%expect_test _ =
+  reach_for_running (e "/fake/path") ~from:(e "/external/build/foo/bar/baz");
   [%expect
     {|
 "/fake/path"

--- a/test/blackbox-tests/test-cases/dune-package.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-package.t/run.t
@@ -201,23 +201,12 @@ Install with an absolute build directory outside the workspace
   > DUNE_INSTALL_PREFIX="$PWD/../external-prefix" \
   > dune install ext
 
+  $ grep -e external-build-dir ../external-prefix/lib/ext/dune-package
+  [1]
   $ dune_cmd cat ../external-prefix/lib/ext/dune-package \
-  > | awk '
-  >     /^[[:space:]]*\((archives|plugins|native_archives|source)/ { active = 1 }
-  >     active {
-  >       line = $0
-  >       print line
-  >       opens = gsub(/\(/, "(", line)
-  >       closes = gsub(/\)/, ")", line)
-  >       depth += opens - closes
-  >       if (depth <= 0) { active = 0; depth = 0 }
-  >     }' \
-  > | tr ' ()' '\n' \
-  > | grep -Eo '(^|/)ext[.](a|cma|cmxa|cmxs|ml)$' \
-  > | sed 's#^/##'
-  ext.cma
-  ext.cmxa
-  ext.cma
-  ext.cmxs
-  ext.a
-  ext.ml
+  > | grep -e 'archives' -e 'plugins' -e 'native_archives' -e 'impl (path' \
+  > | sed 's/^ *//'
+  (archives (byte ext.cma) (native ext.cmxa))
+  (plugins (byte ext.cma) (native ext.cmxs))
+  (native_archives ext.a)
+  (source (path Ext) (impl (path ext.ml))))))


### PR DESCRIPTION
Make `Path.reach` compute relative paths when both paths are external. This lets installed `dune-package` files use relative artifact paths even when `DUNE_BUILD_DIR` is an absolute external build directory.

Regression coverage has been split out into #15087.

Closes #11774.