### PR TITLE
feat(configurator): expose pkg-config variable queries

### DIFF
--- a/doc/changes/added/15078.md
+++ b/doc/changes/added/15078.md
@@ -1,0 +1,2 @@
+- Add `Configurator.V1.Pkg_config.query_variable` to query package variables
+  through `pkg-config --variable` (#15078, fixes #3332, @rgrinberg).

--- a/otherlibs/configurator/src/v1.ml
+++ b/otherlibs/configurator/src/v1.ml
@@ -801,6 +801,19 @@ module Pkg_config = struct
   ;;
 
   let query_expr_err t ~package ~expr = gen_query t ~package ~expr:(Some expr)
+
+  let query_variable t ~package ~variable =
+    let env = pkg_config_env t ~package in
+    let { Process.exit_code; stdout; _ } =
+      Process.run_process
+        t.configurator
+        ~dir:t.configurator.dest_dir
+        ?env
+        t.pkg_config
+        (t.pkg_config_args @ [ "--variable=" ^ variable; package ])
+    in
+    if exit_code = 0 then Some (String.trim stdout) else None
+  ;;
 end
 
 let main ?(args = []) ~name f =

--- a/otherlibs/configurator/src/v1.mli
+++ b/otherlibs/configurator/src/v1.mli
@@ -119,6 +119,10 @@ module Pkg_config : sig
       -> package:string
       -> expr:string
       -> (package_conf, string) result
+
+    (** [query_variable t ~package ~variable] query pkg-config for [variable]
+        from [package]. Returns [None] if [package] is not available. *)
+    val query_variable : t -> package:string -> variable:string -> string option
   end
   with type configurator := t
 

--- a/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/config_test.ml
+++ b/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/config_test.ml
@@ -10,4 +10,8 @@ let () =
     in
     let query package = ignore (C.Pkg_config.query pkg_config ~package) in
     query "dummy-pkg";
+    (match C.Pkg_config.query_variable pkg_config ~package:"dummy-pkg" ~variable:"prefix" with
+     | Some "value-for-prefix" -> ()
+     | Some value -> failwith ("unexpected pkg-config variable value: " ^ value)
+     | None -> failwith "pkg-config variable query failed")
   )

--- a/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/pkgconf.ml
+++ b/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/pkgconf.ml
@@ -8,6 +8,16 @@ let () =
   match List.tl (Array.to_list Sys.argv) with
   | [ "--version" ] -> print_endline (version ())
   | args ->
-    let args = List.filter not_flag args in
-    Format.printf "@[<v>%a@]@."
-      (Format.pp_print_list Format.pp_print_string) args
+    (match
+       List.find_map
+         (fun arg ->
+           match String.split_on_char '=' arg with
+           | [ "--variable"; variable ] -> Some variable
+           | _ -> None)
+         args
+     with
+     | Some variable -> Printf.printf "value-for-%s\n" variable
+     | None ->
+       let args = List.filter not_flag args in
+       Format.printf "@[<v>%a@]@."
+         (Format.pp_print_list Format.pp_print_string) args)

--- a/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/run.t
+++ b/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/run.t
@@ -28,6 +28,10 @@ These tests show that setting `PKG_CONFIG_ARGN` passes extra args to `pkg-config
    | $TARGET
    | --libs
    | dummy-pkg
+  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --personality $TARGET --variable=prefix dummy-pkg
+  -> process exited with code 0
+  -> stdout:
+   | value-for-prefix
 
   $ dune clean
   $ PKG_CONFIG_ARGN="--static" dune build 2>&1 | awk '/run:.*bin\/pkgconf/{a=1}/stderr/{a=0}a'
@@ -48,6 +52,10 @@ These tests show that setting `PKG_CONFIG_ARGN` passes extra args to `pkg-config
    | --static
    | --libs
    | dummy-pkg
+  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --static --variable=prefix dummy-pkg
+  -> process exited with code 0
+  -> stdout:
+   | value-for-prefix
 
 `--personality` was only added in pkgconf 1.5.0 (and is only safe to use
 from 1.7.0), so it is omitted when pkgconf is older:
@@ -72,3 +80,7 @@ from 1.7.0), so it is omitted when pkgconf is older:
   -> stdout:
    | --libs
    | dummy-pkg
+  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --variable=prefix dummy-pkg
+  -> process exited with code 0
+  -> stdout:
+   | value-for-prefix


### PR DESCRIPTION
Add `Configurator.V1.Pkg_config.query_variable`, a small wrapper for `pkg-config --variable=<name> <package>`, so configurator users can query package-specific variables such as `prefix`.

The implementation reuses configurator’s existing pkg-config argument and macOS Homebrew environment handling.

Closes #3332.