### PR TITLE
perf(memo): use a single-lookup find_or_add in custom memo stores

### DIFF
--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -965,6 +965,14 @@ module Table = struct
     | External p -> External.Table.find external_ p
   ;;
 
+  let[@inline] find_or_add { source; build; external_ } k ~f =
+    match k with
+    | In_source_tree p ->
+      Source0.Table.find_or_add source p ~f:(fun p -> f (In_source_tree p))
+    | In_build_dir p -> Build.Table.find_or_add build p ~f:(fun p -> f (In_build_dir p))
+    | External p -> External.Table.find_or_add external_ p ~f:(fun p -> f (External p))
+  ;;
+
   let filteri_inplace { source; build; external_ } ~f =
     Source0.Table.filteri_inplace source ~f:(fun[@inline] ~key ~data ->
       f ~key:(In_source_tree key) ~data);

--- a/otherlibs/stdune/src/path.mli
+++ b/otherlibs/stdune/src/path.mli
@@ -211,6 +211,7 @@ module Table : sig
   val iter : 'a t -> f:('a -> unit) -> unit
   val iteri : 'a t -> f:(key:path -> data:'a -> unit) -> unit
   val find : 'a t -> path -> 'a option
+  val find_or_add : 'a t -> path -> f:(path -> 'a) -> 'a
   val filteri_inplace : 'a t -> f:(key:path -> data:'a -> bool) -> unit
   val filter_inplace : 'a t -> f:('a -> bool) -> unit
   val to_dyn : ('a -> Dyn.t) -> 'a t -> Dyn.t

--- a/src/memo/store.ml
+++ b/src/memo/store.ml
@@ -11,19 +11,7 @@ let make (type k v) (module S : Store_intf.S with type key = k) : (k, v) t =
     let store = S.create ()
     let set = S.set
     let find = S.find
-
-    (* [S] only provides [find] and [set], so custom stores fall back to two lookups. The
-       default store ([of_table]) below overrides this with a single-lookup
-       implementation. *)
-    let find_or_add t key ~f =
-      match S.find t key with
-      | Some v -> v
-      | None ->
-        let v = f key in
-        S.set t key v;
-        v
-    ;;
-
+    let find_or_add = S.find_or_add
     let clear = S.clear
     let iter = S.iter
   end)

--- a/src/memo/store_intf.ml
+++ b/src/memo/store_intf.ml
@@ -12,6 +12,11 @@ module type S = sig
   val clear : 'a t -> unit
   val set : 'a t -> key -> 'a -> unit
   val find : 'a t -> key -> 'a option
+
+  (** [find_or_add t key ~f] returns the value associated with [key], or, if [key] is not
+      present, adds [f key] and returns it, in a single hash-table lookup. *)
+  val find_or_add : 'a t -> key -> f:(key -> 'a) -> 'a
+
   val iter : 'a t -> f:('a -> unit) -> unit
 end
 


### PR DESCRIPTION
`Memo.create_with_store` adapts a user-supplied store module to the internal
store instance. That adapter previously synthesised `find_or_add` as a `find`
followed by a `set` — two hash-table lookups — because the store backend module
type `Store_intf.S` only required `find`/`set`.

This requires `find_or_add` directly from `Store_intf.S` (a single lookup) and
has the adapter delegate to it. The store modules actually passed (`Hashtbl`-based,
e.g. `Path.Table`) already provide it, so there are no call-site changes.

Behaviour-preserving.
