### PR TITLE
refactor(memo): fold a node's cutoff and event tracker into one field

### DIFF
--- a/src/memo/exec.ml
+++ b/src/memo/exec.ml
@@ -83,12 +83,12 @@ let rec restore_from_cache
              | Cancelled { dependency_cycle } ->
                Fiber.return (Changed_or_not.Cancelled { dependency_cycle })
              | Out_of_date _old_value ->
-               (match dep.spec.allow_cutoff with
-                | No when not ok_to_recompute_eagerly ->
+               (match Spec.has_cutoff dep.spec with
+                | false when not ok_to_recompute_eagerly ->
                   (* If [dep] has no cutoff, it is sufficient to check whether it is up to
                      date. If not, we must recompute the [cached_value]. *)
                   Fiber.return Changed_or_not.Changed
-                | No ->
+                | false ->
                   (* [dep] is a direct child of a parallel section, so recompute it eagerly
                      (in parallel with its siblings) rather than deferring. It has no
                      cutoff, so the outcome is [Changed] regardless of the new value. *)
@@ -97,7 +97,7 @@ let rec restore_from_cache
                    | Ok (_ : _ Cached_value.t) -> Changed_or_not.Changed
                    | Error dependency_cycle ->
                      Changed_or_not.Cancelled { dependency_cycle })
-                | Yes _equal ->
+                | true ->
                   (* If [dep] has a cutoff predicate, it is not sufficient to check
                      whether it is up to date: even if it isn't, after we recompute it,
                      the resulting value may remain unchanged, allowing us to skip

--- a/src/memo/node.ml
+++ b/src/memo/node.ml
@@ -425,9 +425,7 @@ module Cached_value = struct
     | Error _, Ok _
     | Ok _, Error _ -> true
     | Ok prev_value, Ok cur_value ->
-      (match node.spec.allow_cutoff with
-       | Yes equal -> not (equal prev_value cur_value)
-       | No -> true)
+      Spec.output_changed node.spec ~old_value:prev_value ~new_value:cur_value
     | ( Error { exns = prev_exns; reproducible = true }
       , Error { exns = cur_exns; reproducible = true } ) ->
       not (Exn_set.equal prev_exns cur_exns)

--- a/src/memo/spec.ml
+++ b/src/memo/spec.ml
@@ -1,27 +1,80 @@
 open Import
 
-module Allow_cutoff = struct
-  type 'o t =
-    | No
-    | Yes of ('o -> 'o -> bool)
-end
-
 module Event = struct
   type t =
     | Live
     | Validated
 end
 
+(** Memo nodes can have some special features, for example, [cutoff]
+    predicates. *)
+module Node_kind : sig
+  type ('i, 'o) t
+
+  val create
+    :  cutoff:('o -> 'o -> bool) option
+    -> on_event:('i -> Event.t -> unit) option
+    -> ('i, 'o) t
+
+  (** Does the [new_value] differ from the [old_value]? *)
+  val output_changed : ('i, 'o) t -> old_value:'o -> new_value:'o -> bool
+
+  (** If this function returns [false], [output_changed] is guaranteed to return
+      [true] for any pair of values. *)
+  val has_cutoff : _ t -> bool
+
+  (** Notify the node about an event. *)
+  val notify : ('i, _) t -> 'i -> Event.t -> unit
+end = struct
+  (* This is a product of two options, flattened to avoid unnecessary
+     indirections. Note that only a small number of [t]s have event tracking. *)
+  type ('i, 'o) t =
+    | Vanilla
+    | With_event_tracker of { on_event : 'i -> Event.t -> unit }
+    | With_cutoff of { equal : 'o -> 'o -> bool }
+    | With_cutoff_and_event_tracker of
+        { equal : 'o -> 'o -> bool
+        ; on_event : 'i -> Event.t -> unit
+        }
+
+  let create ~cutoff ~on_event =
+    match cutoff, on_event with
+    | None, None -> Vanilla
+    | None, Some on_event -> With_event_tracker { on_event }
+    | Some equal, None -> With_cutoff { equal }
+    | Some equal, Some on_event -> With_cutoff_and_event_tracker { equal; on_event }
+  ;;
+
+  let output_changed t ~old_value ~new_value =
+    match t with
+    | Vanilla | With_event_tracker _ -> true
+    | With_cutoff { equal } | With_cutoff_and_event_tracker { equal; on_event = _ } ->
+      not (equal old_value new_value)
+  ;;
+
+  let has_cutoff = function
+    | Vanilla | With_event_tracker _ -> false
+    | With_cutoff _ | With_cutoff_and_event_tracker _ -> true
+  ;;
+
+  let notify t input event =
+    match t with
+    | Vanilla | With_cutoff _ -> ()
+    | With_event_tracker { on_event }
+    | With_cutoff_and_event_tracker { on_event; equal = _ } -> on_event input event
+  ;;
+end
+
 type ('i, 'o) t =
   { name : string option
-  ; (* If the field [witness] precedes any of the functional values ([input]
-         and [f]), then polymorphic comparison actually works for [Spec.t]s. *)
+  ; (* If the field [witness] precedes any of the functional values ([input],
+         [f], and the closures inside [node_kind]), then polymorphic comparison
+         actually works for [Spec.t]s. *)
     witness : 'i Type_eq.Id.t
   ; input : (module Store_intf.Input with type t = 'i)
-  ; allow_cutoff : 'o Allow_cutoff.t
+  ; node_kind : ('i, 'o) Node_kind.t
   ; f : 'i -> 'o Fiber.t
   ; human_readable_description : ('i -> User_message.Style.t Pp.t) option
-  ; on_event : ('i -> Event.t -> unit) option
   }
 
 let create ~name ~input ~human_readable_description ~cutoff ?on_event f =
@@ -32,23 +85,18 @@ let create ~name ~input ~human_readable_description ~cutoff ?on_event f =
         sprintf "lazy value created at %s" (Loc.to_file_colon_line loc))
     | _ -> name
   in
-  let allow_cutoff =
-    match cutoff with
-    | None -> Allow_cutoff.No
-    | Some equal -> Yes equal
-  in
   { name
   ; input
-  ; allow_cutoff
+  ; node_kind = Node_kind.create ~cutoff ~on_event
   ; witness = Type_eq.Id.create ()
   ; f
   ; human_readable_description
-  ; on_event
   }
 ;;
 
-let notify t input event =
-  match t.on_event with
-  | None -> ()
-  | Some f -> f input event
+let output_changed t ~old_value ~new_value =
+  Node_kind.output_changed t.node_kind ~old_value ~new_value
 ;;
+
+let has_cutoff t = Node_kind.has_cutoff t.node_kind
+let notify t input event = Node_kind.notify t.node_kind input event

--- a/src/memo/spec.mli
+++ b/src/memo/spec.mli
@@ -2,12 +2,6 @@
 
 open! Import
 
-module Allow_cutoff : sig
-  type 'o t =
-    | No
-    | Yes of ('o -> 'o -> bool)
-end
-
 (** Events in the life-cycle of a memoized node, used for instrumentation. *)
 module Event : sig
   type t =
@@ -16,16 +10,22 @@ module Event : sig
     (** The node's output was validated (confirmed up to date) in the current run. *)
 end
 
+(** Memo nodes can have some special features, for example, [cutoff]
+    predicates. *)
+module Node_kind : sig
+  type ('i, 'o) t
+end
+
 type ('i, 'o) t =
   { name : string option
-  ; (* If the field [witness] precedes any of the functional values ([input]
-         and [f]), then polymorphic comparison actually works for [Spec.t]s. *)
+  ; (* If the field [witness] precedes any of the functional values ([input],
+         [f], and the closures inside [node_kind]), then polymorphic comparison
+         actually works for [Spec.t]s. *)
     witness : 'i Type_eq.Id.t
   ; input : (module Store_intf.Input with type t = 'i)
-  ; allow_cutoff : 'o Allow_cutoff.t
+  ; node_kind : ('i, 'o) Node_kind.t
   ; f : 'i -> 'o Fiber.t
   ; human_readable_description : ('i -> User_message.Style.t Pp.t) option
-  ; on_event : ('i -> Event.t -> unit) option
   }
 
 val create
@@ -36,6 +36,14 @@ val create
   -> ?on_event:('a -> Event.t -> unit)
   -> ('a -> 'b Fiber.t)
   -> ('a, 'b) t
+
+(** Does the [new_value] differ from the [old_value]? Always [true] for nodes
+    without a cutoff predicate. *)
+val output_changed : (_, 'o) t -> old_value:'o -> new_value:'o -> bool
+
+(** Whether the node has a cutoff predicate. If [false], [output_changed] is
+    guaranteed to return [true] for any pair of values. *)
+val has_cutoff : _ t -> bool
 
 (** [notify spec input event] runs [spec]'s [on_event] callback, if it has one. *)
 val notify : ('i, _) t -> 'i -> Event.t -> unit


### PR DESCRIPTION
`Spec.t` carried a memoized node's cutoff predicate and its event-tracking
callback as two separate optional fields (`allow_cutoff` and `on_event`).
Replace them with a single `Node_kind.t` — a flattened product of the two
options (`Vanilla` / `With_event_tracker` / `With_cutoff` /
`With_cutoff_and_event_tracker`) — exposing `output_changed`, `has_cutoff`, and
`notify`. Only a small fraction of nodes track events, so the flattened form
avoids an extra indirection on the common path.

Behaviour-preserving.
