### PR TITLE
test: demonstrate unsimplified (when false _) in slang

### DIFF
--- a/test/expect-tests/dune_lang/slang_tests.ml
+++ b/test/expect-tests/dune_lang/slang_tests.ml
@@ -331,6 +331,27 @@ let%expect_test "when unknown nil" =
   [%expect {| Nil |}]
 ;;
 
+(* These [(when false _)] expressions aren't simplified yet: the [Nil] from
+   the [When] child survives because [Nil] is filtered before children. *)
+
+let%expect_test "concat with when-false (should simplify to \"ab\")" =
+  print_slang
+    (Slang.concat
+       [ Slang.text "a"; Slang.when_ (const false) (Slang.text ""); Slang.text "b" ]);
+  [%expect
+    {|
+    Concat (Literal "a", Nil, Literal "b")
+    |}]
+;;
+
+let%expect_test "when-unknown of when-false (should simplify to Nil)" =
+  print_slang (Slang.when_ (expr (pform "x")) (Slang.when_ (const false) (Slang.text "")));
+  [%expect
+    {|
+    When (Expr (Literal (template "%{pkg-self:x}")), Nil)
+    |}]
+;;
+
 (* Slang: If *)
 
 let%expect_test "if true" =


### PR DESCRIPTION
Adds repro unit tests to `slang_tests.ml` for the `(when false _)` simplification gap noted in #14457.

`(when false "")` is how `Slang.encode` serializes `Nil` (there is no surface syntax for `Nil`), so these expressions should fold away wherever a `Nil` does. Two cases in `Slang.simplify` currently miss them because the surrounding form filters `Nil` *before* its children are simplified, not after:

- `concat ["a"; (when false ""); "b"]` -> `Concat (Literal "a", Nil, Literal "b")` (should be `"ab"`)
- `when <unknown> (when false "")` -> `When (Expr …, Nil)` (should be `Nil`)

The tests capture the current (suboptimal) output so a follow-up fix PR can flip them to the simplified result.