### PR TITLE
refactor(memo): store a node's value, runs, and deps flat on the node

### DIFF
--- a/src/memo/exec.ml
+++ b/src/memo/exec.ml
@@ -7,16 +7,21 @@ open Fiber.O
    wrapper. *)
 exception Non_reproducible of exn
 
+(* Classify an exception as reproducible or not, unwrapping the [Non_reproducible]
+   marker. Cycle errors are treated as non-reproducible because the dependencies of a
+   computation cancelled by a dependency cycle are inaccurate. *)
+let classify = function
+  | { Exn_with_backtrace.exn = Non_reproducible exn; backtrace }
+  | { Exn_with_backtrace.exn = Cycle_error.E _ as exn; backtrace } ->
+    { Exn_with_backtrace.exn; backtrace }, false
+  | exn -> exn, true
+;;
+
 let report_and_collect_errors f =
   Fiber.map_reduce_errors
     (module Collect_errors_monoid)
     ~on_error:(fun exn ->
-      let exn, reproducible =
-        match exn with
-        | { Exn_with_backtrace.exn = Non_reproducible exn; backtrace } ->
-          { Exn_with_backtrace.exn; backtrace }, false
-        | exn -> exn, true
-      in
+      let exn, reproducible = classify exn in
       let+ () = Error_handler.report_error exn in
       ({ exns = Exn_set.singleton exn; reproducible } : Collect_errors_monoid.t))
     f
@@ -29,291 +34,226 @@ let check_point = ref (Fiber.return ())
    non-reproducible errors (which are never restored from the cache) get recomputed. *)
 let last_saw_non_reproducible_exn_at = ref Run.invalid
 
+(* The cancelled value of a computation aborted by a dependency cycle. Its deps are
+   inaccurate, so it is stored with [Deps.empty] and as a non-reproducible error (so it
+   is never restored from the cache). *)
+let cancelled ~dependency_cycle : Collect_errors_monoid.t =
+  { exns = Exn_set.singleton (Exn_with_backtrace.capture (Cycle_error.E dependency_cycle))
+  ; reproducible = false
+  }
+;;
+
+(* [Changed] if [dep] is newer than [node] and [Unchanged] otherwise. *)
+let dep_changed_or_not ~(node : _ Dep_node.t) ~(dep : _ Dep_node.t) : _ Changed_or_not.t =
+  match Run.compare (Dep_node.last_changed_at dep) (Dep_node.last_validated_at node) with
+  | Gt -> Changed
+  | Eq | Lt -> Unchanged
+;;
+
 let rec restore_from_cache
-  : 'o. cached_value:'o Cached_value.t -> 'o Cache_lookup.t Fiber.t
+  : 'i 'o. ('i, 'o) Dep_node.t -> Cycle_error.t Changed_or_not.t Fiber.t
   =
-  fun ~cached_value ->
-  match cached_value.value with
+  fun node ->
+  Counter.incr Metrics.Restore.nodes;
+  match node.value with
+  | Uninitialized -> Fiber.return Changed_or_not.Changed
   | Error { reproducible = false; _ } ->
     (* Non-reproducible errors are not restored from the cache. This includes the cycle
-         errors of cancelled computations, whose deps are inaccurate ([Deps.empty]) anyway,
-         so we must not use [Deps.changed_or_not] on them. *)
-    Fiber.return (Cache_lookup.Out_of_date { old_value = Option.Unboxed.none })
+       errors of cancelled computations, whose deps are inaccurate ([Deps.empty]) anyway,
+       so we must not use [Deps.changed_or_not] on them. *)
+    Fiber.return Changed_or_not.Changed
   | Ok _ | Error { reproducible = true; _ } ->
-    (* We cache reproducible errors just like normal values. We assume that
-         all [Memo] computations are deterministic, which means if we rerun a
-         computation that previously raised a set of errors on the same inputs
-         then we expect to get the same set of errors back and might as well
-         skip the unnecessary work. The downside is that if a computation is in
-         fact non-deterministic, there is no way to force rerunning it, apart
-         from changing some of its dependencies. *)
-    let+ deps_changed =
-      (* Make sure [f] gets inlined to avoid unnecessary closure allocations and improve
-           stack traces in profiling. *)
-      Deps.changed_or_not
-        cached_value.deps
-        ~f:(fun[@inline] ~ok_to_recompute_eagerly (Dep_node.T dep) ->
-          match dep.state with
-          | Cached_value dep_cached_value
-            when Run.is_current (Cached_value.last_validated_at dep_cached_value) ->
-            (* Fast path: [dep] is already up to date in the current run, so there is no
-               need to restore it (which would allocate a fiber). We can compare the
-               timestamps directly. *)
-            (match
-               Run.compare
-                 (Cached_value.last_changed_at dep_cached_value)
-                 (Cached_value.last_validated_at cached_value)
-             with
-             | Gt -> Fiber.return Changed_or_not.Changed
-             | Eq | Lt -> Fiber.return Changed_or_not.Unchanged)
-          | _ ->
-            consider_and_restore_from_cache_without_adding_dep dep
-            >>= (function
-             | Ok cached_value_of_dep ->
-               (* The [Changed] branch will be taken if [cached_value]'s node was skipped
-                  in the previous run (it was unreachable), while [dep] wasn't skipped and
-                  [cached_value_of_dep] changed. *)
-               (match
-                  Run.compare
-                    (Cached_value.last_changed_at cached_value_of_dep)
-                    (Cached_value.last_validated_at cached_value)
-                with
-                | Gt -> Fiber.return Changed_or_not.Changed
-                | Eq | Lt -> Fiber.return Changed_or_not.Unchanged)
-             | Cancelled { dependency_cycle } ->
-               Fiber.return (Changed_or_not.Cancelled { dependency_cycle })
-             | Out_of_date _old_value ->
-               (match Spec.has_cutoff dep.spec with
-                | false when not ok_to_recompute_eagerly ->
-                  (* If [dep] has no cutoff, it is sufficient to check whether it is up to
-                     date. If not, we must recompute the [cached_value]. *)
-                  Fiber.return Changed_or_not.Changed
-                | false ->
-                  (* [dep] is a direct child of a parallel section, so recompute it eagerly
-                     (in parallel with its siblings) rather than deferring. It has no
-                     cutoff, so the outcome is [Changed] regardless of the new value. *)
-                  consider_and_compute_without_adding_dep dep
-                  >>| (function
-                   | Ok (_ : _ Cached_value.t) -> Changed_or_not.Changed
-                   | Error dependency_cycle ->
-                     Changed_or_not.Cancelled { dependency_cycle })
-                | true ->
-                  (* If [dep] has a cutoff predicate, it is not sufficient to check
-                     whether it is up to date: even if it isn't, after we recompute it,
-                     the resulting value may remain unchanged, allowing us to skip
-                     recomputing the [cached_value]. *)
-                  consider_and_compute_without_adding_dep dep
-                  >>| (function
-                   | Ok cached_value_of_dep ->
-                     (* Note: [cached_value_of_dep.value] will be [Cancelled _] if [dep]
-                        itself doesn't introduce a dependency cycle but one of its
-                        transitive dependencies does. In this case, the value will be new,
-                        so we will take the [Changed] branch. *)
-                     (match
-                        Run.compare
-                          (Cached_value.last_changed_at cached_value_of_dep)
-                          (Cached_value.last_validated_at cached_value)
-                      with
-                      | Gt -> Changed_or_not.Changed
-                      | Eq | Lt -> Unchanged)
-                   | Error dependency_cycle -> Cancelled { dependency_cycle }))))
-    in
-    (match deps_changed with
-     | Unchanged ->
-       cached_value.runs
-       <- Run.Pair.with_last_validated_at
-            cached_value.runs
-            ~last_validated_at:(Run.current ());
-       Cache_lookup.Ok cached_value
-     | Changed -> Out_of_date { old_value = Option.Unboxed.some cached_value }
-     | Cancelled { dependency_cycle } -> Cancelled { dependency_cycle })
+    (* We cache reproducible errors just like normal values. We assume that all [Memo]
+       computations are deterministic, which means if we rerun a computation that
+       previously raised a set of errors on the same inputs then we expect to get the same
+       set of errors back and might as well skip the unnecessary work. The downside is that
+       if a computation is in fact non-deterministic, there is no way to force rerunning it,
+       apart from changing some of its dependencies. *)
+    (* Make sure [f] gets inlined to avoid unnecessary closure allocations and improve
+       stack traces in profiling. *)
+    Deps.changed_or_not
+      node.deps
+      ~f:(fun[@inline] ~ok_to_recompute_eagerly (Dep_node.T dep) ->
+        (* If the [Run.is_current] check succeeds then the node must have been [Cached] in
+           the current run, so there is no need to restore it (which would allocate a
+           fiber). We can compare the timestamps directly. *)
+        if Run.is_current (Dep_node.last_validated_at dep)
+        then Fiber.return (dep_changed_or_not ~node ~dep)
+        else
+          consider_and_restore_from_cache_without_adding_dep dep
+          >>= function
+          | Unchanged ->
+            (* Here [dep_changed_or_not] can return [Changed] if the [node] was skipped in
+               the previous run, i.e., it was unreachable, while the [dep] wasn't skipped
+               and changed. *)
+            Fiber.return (dep_changed_or_not ~node ~dep)
+          | Cancelled { dependency_cycle } ->
+            Fiber.return (Changed_or_not.Cancelled { dependency_cycle })
+          | Changed ->
+            (match Spec.has_cutoff dep.spec with
+             | false when not ok_to_recompute_eagerly ->
+               (* If [dep] has no cutoff and [ok_to_recompute_eagerly] is not set, it is
+                  sufficient to check whether [dep] is up to date. We are in the [Changed]
+                  branch, which means [dep] is not up to date, and we therefore must
+                  recompute the [node]. *)
+               Fiber.return Changed_or_not.Changed
+             | _ ->
+               (* If [dep] has a cutoff predicate, it is not sufficient to check whether it
+                  is up to date: even if it isn't, after we recompute it, the resulting
+                  value may remain unchanged, allowing us to skip recomputing the [node].
 
-and compute
-  :  'i 'o.
-     dep_node:('i, 'o) Dep_node.t
-  -> old_value:'o Cached_value.t Option.Unboxed.t
-  -> stack_frame:Stack_frame_with_state.t
-  -> 'o Cached_value.t Fiber.t
-  =
-  fun ~dep_node ~old_value ~stack_frame:_ ->
+                  If [dep] has no cutoff but [ok_to_recompute_eagerly] is set (which could
+                  happen if [dep] is a direct child of a [Par] node), we eagerly recompute
+                  [dep] so that its computation runs in parallel with its siblings, instead
+                  of being deferred to the compute phase where it might run sequentially. We
+                  still report [Changed] in this case since there is no cutoff to check. *)
+               consider_and_compute_without_adding_dep dep
+               >>| (function
+                | Ok () ->
+                  (match Spec.has_cutoff dep.spec with
+                   | false -> Changed_or_not.Changed
+                   | true -> dep_changed_or_not ~node ~dep)
+                | Error dependency_cycle -> Cancelled { dependency_cycle })))
+
+and compute : 'i 'o. ('i, 'o) Dep_node.t -> unit Fiber.t =
+  fun node ->
+  Counter.incr Metrics.Compute.nodes;
   let deps_collector = Deps_collector.create () in
   let+ res =
     report_and_collect_errors (fun () ->
       let* () = !check_point in
-      Deps_collector.run deps_collector ~f:(fun () -> dep_node.spec.f dep_node.input))
-  in
-  let value =
-    match res with
-    | Ok res -> Value.Ok res
-    | Error errors -> Error errors
+      Deps_collector.run deps_collector ~f:(fun () -> node.spec.f node.input))
   in
   (match res with
    | Error { reproducible = false; _ } ->
      last_saw_non_reproducible_exn_at := Run.current ()
    | Ok _ | Error { reproducible = true; _ } -> ());
   let deps = Deps_collector.get deps_collector in
-  Option.Unboxed.match_
-    old_value
-    ~none:(fun () -> Cached_value.create value ~deps)
-    ~some:(fun old_cv ->
-      match Cached_value.value_changed dep_node old_cv.value value with
-      | true -> Cached_value.create value ~deps
-      | false -> Cached_value.confirm_old_value ~deps old_cv)
+  let value : _ Value.t =
+    match res with
+    | Ok res -> Ok res
+    | Error errors -> Error errors
+  in
+  update_value node value ~deps
 
-and cancel_due_to_dependency_cycle
-  : 'i 'o. dep_node:('i, 'o) Dep_node.t -> dependency_cycle:Cycle_error.t -> unit Fiber.t
+(* Validate a node that might be out of date. The node has a [Restoring] state during the
+   validation. Once finished, the node's state is [Cached] (with an up to date
+   [last_validated_at]) or [Out_of_date]. *)
+and start_restoring : 'i 'o. ('i, 'o) Dep_node.t -> Cycle_error.t Changed_or_not.t Fiber.t
   =
-  fun ~dep_node ~dependency_cycle ->
-  match dep_node.state with
-  | Cached_value { value = Error { reproducible = false; _ }; _ } -> Fiber.return ()
-  | Cached_value _ | Out_of_date _ ->
-    dep_node.state <- Cached_value (Cached_value.create_cancelled ~dependency_cycle);
-    Fiber.return ()
-  | Restoring _ ->
-    dep_node.state <- Cached_value (Cached_value.create_cancelled ~dependency_cycle);
-    Fiber.return ()
-  | Computing { compute; _ } ->
-    (match Fiber.Ivar.peek compute.ivar with
-     | Some _ -> Fiber.return ()
-     | None ->
-       let cancelled = Cached_value.create_cancelled ~dependency_cycle in
-       dep_node.state <- Cached_value cancelled;
-       Fiber.Ivar.fill compute.ivar cancelled)
-
-and start_restoring
-  :  'i 'o.
-     dep_node:('i, 'o) Dep_node.t
-  -> cached_value:'o Cached_value.t
-  -> 'o Cache_lookup.t Fiber.t
-  =
-  fun ~dep_node ~cached_value ->
+  fun node ->
   let computation = Computation.create () in
-  dep_node.state <- Restoring { restore_from_cache = computation };
-  Computation.force computation ~phase:Restore_from_cache ~dep_node (fun _stack_frame ->
-    let+ restore_result = restore_from_cache ~cached_value in
-    Counter.incr Metrics.Restore.nodes;
-    (match restore_result with
-     | Ok cached_value ->
-       dep_node.state <- Cached_value cached_value;
-       Spec.notify dep_node.spec dep_node.input Validated
-     | Cancelled { dependency_cycle } ->
-       dep_node.state <- Cached_value (Cached_value.create_cancelled ~dependency_cycle);
-       Spec.notify dep_node.spec dep_node.input Validated
-     | Out_of_date { old_value } -> dep_node.state <- Out_of_date { old_value });
-    restore_result)
+  node.state <- Restoring { restore_from_cache = computation };
+  Computation.force
+    computation
+    ~phase:Restore_from_cache
+    ~dep_node:node
+    (fun _stack_frame ->
+       let* restore_result = restore_from_cache node in
+       let+ () =
+         match restore_result with
+         | Unchanged ->
+           validate_value node;
+           Fiber.return ()
+         | Cancelled { dependency_cycle } ->
+           update_value node (Error (cancelled ~dependency_cycle)) ~deps:Deps.empty;
+           Fiber.return ()
+         | Changed ->
+           node.state <- Out_of_date;
+           Fiber.return ()
+       in
+       restore_result)
 
-and start_computing
-  :  'i 'o.
-     dep_node:('i, 'o) Dep_node.t
-  -> old_value:'o Cached_value.t Option.Unboxed.t
-  -> 'o Cached_value.t Fiber.t
-  =
-  fun ~dep_node ~old_value ->
+(* Recompute a node. The node has a [Computing] state during the computation. Once
+   finished, the node's state is [Cached] with an up to date [last_validated_at]. *)
+and start_computing : 'i 'o. ('i, 'o) Dep_node.t -> unit Fiber.t =
+  fun node ->
   let computation = Computation.create () in
-  dep_node.state <- Computing { old_value; compute = computation };
-  Computation.force computation ~phase:Compute ~dep_node (fun stack_frame ->
-    let+ cached_value = compute ~dep_node ~old_value ~stack_frame in
-    Counter.incr Metrics.Compute.nodes;
-    dep_node.state <- Cached_value cached_value;
-    Spec.notify dep_node.spec dep_node.input Validated;
-    cached_value)
+  node.state <- Computing { compute = computation };
+  Computation.force computation ~phase:Compute ~dep_node:node (fun _stack_frame ->
+    compute node)
 
+(* Try to validate a [Cached] node without recomputing it. Once done, the node's state is
+   either [Cached] with an up to date [last_validated_at] or [Out_of_date]. *)
 and consider_and_restore_from_cache_without_adding_dep
-  : 'i 'o. ('i, 'o) Dep_node.t -> 'o Cache_lookup.t Fiber.t
+  : 'i 'o. ('i, 'o) Dep_node.t -> Cycle_error.t Changed_or_not.t Fiber.t
   =
-  fun dep_node ->
-  match dep_node.state with
-  | Cached_value cached_value ->
-    (* CR-someday amokhov: The happy path here is excruciatingly slow: read
-         [dep_node.state], get [cached_value] via an indirection, jump through another
-         hoop [cached_value.last_validated_at] and then, finally, make the
-         [Run.is_current] check. We should try to find a shortcut. *)
-    if Run.is_current (Cached_value.last_validated_at cached_value)
-    then Fiber.return (Cache_lookup.Ok cached_value)
-    else (
-      Spec.notify dep_node.spec dep_node.input Live;
-      start_restoring ~dep_node ~cached_value)
+  fun node ->
+  match node.state with
+  | Cached ->
+    Spec.notify node.spec node.input Live;
+    start_restoring node
   | Restoring { restore_from_cache } ->
     Computation.read_but_first_check_for_cycles
       ~phase:Restore_from_cache
       restore_from_cache
-      ~dep_node
+      ~dep_node:node
     >>| (function
      | Ok res -> res
      | Error dependency_cycle -> Cancelled { dependency_cycle })
-  | Out_of_date { old_value } | Computing { old_value; _ } ->
-    Fiber.return (Cache_lookup.Out_of_date { old_value })
+  | Not_cached | Out_of_date | Computing _ -> Fiber.return Changed_or_not.Changed
 
-(* This function assumes that restoring the value from cache failed. This
-     means we should be in two possible states: [Out_of_date] or [Computing].
-     However, as it turns out (see CR-someday below), [dep_node.state] can also
-     contain an up-to-date [Cached_value]. We need to figure out why. *)
+(* Recompute the node after restoring the value from cache failed. Once done, the node's
+   state is [Cached] with an up-to-date [last_validated_at].
+
+   When this function is called, the node should be in one of [Not_cached], [Out_of_date]
+   or [Computing]. However (see the CR-someday below) [node.state] can also be an
+   up-to-date [Cached]. We need to figure out why. *)
 and consider_and_compute_without_adding_dep
-  : 'i 'o. ('i, 'o) Dep_node.t -> ('o Cached_value.t, Cycle_error.t) result Fiber.t
+  : 'i 'o. ('i, 'o) Dep_node.t -> (unit, Cycle_error.t) result Fiber.t
   =
-  fun dep_node ->
-  match dep_node.state with
-  | Cached_value cached_value ->
-    (* CR-someday amokhov: We hit this branch in [dir-targets-promotion.t] but how is
-         this possible? We need to investigate. For now, I'm replacing the [assert false]
-         that we had here with [return (Ok cached_value)] if the [cached_value] turns out
-         to be up to date. *)
-    if not (Run.is_current (Cached_value.last_validated_at cached_value))
+  fun node ->
+  match node.state with
+  | Cached ->
+    (* CR-someday amokhov: We hit this branch in [dir-targets-promotion.t] but how is this
+       possible? We need to investigate. For now, we return [Ok ()] if the node turns out
+       to be up to date. *)
+    if not (Run.is_current (Dep_node.last_validated_at node))
     then
       Code_error.raise
         "consider_and_compute_without_adding_dep"
-        [ "state", State.to_dyn dep_node.state
-        ; "current run", Run.to_dyn (Run.current ())
-        ];
-    Fiber.return (Ok cached_value)
+        [ "state", State.to_dyn node.state; "current run", Run.to_dyn (Run.current ()) ];
+    Fiber.return (Ok ())
   | Restoring _ -> assert false
-  | Out_of_date { old_value } ->
-    (* Fire [Live] only for never-computed (fresh) nodes. A stale node ([old_value] is
-         set) has already fired [Live] when it started restoring, so we don't fire again. *)
-    if Option.Unboxed.is_none old_value then Spec.notify dep_node.spec dep_node.input Live;
-    start_computing ~dep_node ~old_value >>| Result.ok
-  | Computing { compute; _ } ->
-    Computation.read_but_first_check_for_cycles ~phase:Compute compute ~dep_node
-    >>= (function
-     | Ok _ as result -> Fiber.return result
-     | Error dependency_cycle as result ->
-       let* () = cancel_due_to_dependency_cycle ~dep_node ~dependency_cycle in
-       Fiber.return result)
+  | Not_cached ->
+    Spec.notify node.spec node.input Live;
+    start_computing node >>| Result.ok
+  | Out_of_date -> start_computing node >>| Result.ok
+  | Computing { compute } ->
+    Computation.read_but_first_check_for_cycles ~phase:Compute compute ~dep_node:node
 ;;
 
 let exec_dep_node : 'i 'o. ('i, 'o) Dep_node.t -> 'o Fiber.t =
-  fun dep_node ->
+  fun node ->
   Fiber.of_thunk (fun () ->
-    match dep_node.state with
-    | Cached_value cached_value
-      when Run.is_current (Cached_value.last_validated_at cached_value) ->
-      (* Fast path: the value is already up to date in the current run. Doing this check
-           here, before allocating the fibers needed by
-           [consider_and_restore_from_cache_without_adding_dep], is a measurable win. *)
-      let* () = Deps_collector.add_dep_from_caller dep_node in
-      let stack_frame = Dep_node.T dep_node in
-      Value.get_exn cached_value.value ~map_exn:(fun exn ->
-        Error.extend_stack exn ~stack_frame)
-    | _ ->
-      let* result =
-        consider_and_restore_from_cache_without_adding_dep dep_node
-        >>= function
-        | Ok cached_value -> Fiber.return (Ok cached_value)
-        | Cancelled { dependency_cycle } ->
-          (* If restoring from cache failed with a cycle error, and the node's function
-               is deterministic (as it should be), then we will hit the same cycle when
-               trying to recompute the result. We therefore return the cycle error as is.
-               Note that apart from saving some work, this also helps us work around the
-               limitation of the cycle detection library that can't detect the same cycle
-               twice. *)
-          dep_node.state <- Cached_value (Cached_value.create_cancelled ~dependency_cycle);
-          Fiber.return (Error dependency_cycle)
-        | Out_of_date _old_value -> consider_and_compute_without_adding_dep dep_node
-      in
-      (match result with
-       | Ok res ->
-         let* () = Deps_collector.add_dep_from_caller dep_node in
-         let stack_frame = Dep_node.T dep_node in
-         Value.get_exn res.value ~map_exn:(fun exn -> Error.extend_stack exn ~stack_frame)
-       | Error cycle_error -> raise (Cycle_error.E cycle_error)))
+    (* Doing the check here before creating any fibers, rather than in
+       [consider_and_restore_from_cache_without_adding_dep], is a measurable win. *)
+    if Run.is_current (Dep_node.last_validated_at node)
+    then
+      let* () = Deps_collector.add_dep_from_caller node in
+      let stack_frame = Dep_node.T node in
+      Value.get_exn node.value ~map_exn:(fun exn -> Error.extend_stack exn ~stack_frame)
+    else
+      consider_and_restore_from_cache_without_adding_dep node
+      >>= function
+      | Unchanged ->
+        let* () = Deps_collector.add_dep_from_caller node in
+        let stack_frame = Dep_node.T node in
+        Value.get_exn node.value ~map_exn:(fun exn -> Error.extend_stack exn ~stack_frame)
+      | Cancelled { dependency_cycle } ->
+        (* If restoring from cache failed with a cycle error, and the node's function is
+           deterministic (as it should be), then we will hit the same cycle when trying to
+           recompute the result. We therefore reraise the cycle error as is. Note that
+           apart from saving some work, this also helps us work around the limitation of
+           the cycle detection library that can't detect the same cycle twice. *)
+        raise (Cycle_error.E dependency_cycle)
+      | Changed ->
+        consider_and_compute_without_adding_dep node
+        >>= (function
+         | Ok () ->
+           let* () = Deps_collector.add_dep_from_caller node in
+           let stack_frame = Dep_node.T node in
+           Value.get_exn node.value ~map_exn:(fun exn ->
+             Error.extend_stack exn ~stack_frame)
+         | Error dependency_cycle -> raise (Cycle_error.E dependency_cycle)))
 ;;

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -109,9 +109,8 @@ end
    documenting in the code. *)
 let invalidate_dep_node (dep_node : _ Dep_node.t) =
   match dep_node.state with
-  | Cached_value cached_value ->
-    dep_node.state <- Out_of_date { old_value = Option.Unboxed.some cached_value }
-  | Out_of_date { old_value = _ } -> ()
+  | Cached -> dep_node.state <- Out_of_date
+  | Not_cached | Out_of_date -> ()
   | Restoring _ ->
     Code_error.raise
       "invalidate_dep_node called on a node in Restoring state"
@@ -175,7 +174,14 @@ let create
 ;;
 
 let make_dep_node ~spec ~input : _ Dep_node.t =
-  { id = Id.gen (); input; spec; state = Out_of_date { old_value = Option.Unboxed.none } }
+  { id = Id.gen ()
+  ; input
+  ; spec
+  ; state = Not_cached
+  ; value = Uninitialized
+  ; runs = Run.Pair.create ~last_changed_at:Run.invalid ~last_validated_at:Run.invalid
+  ; deps = Deps.empty
+  }
 ;;
 
 let dep_node (t : (_, _) Table.t) input =
@@ -213,8 +219,8 @@ let create_rec
 let dump_cached_graph ?(on_not_cached = `Raise) ?(time_nodes = false) cell =
   let rec collect_graph (Dep_node.T dep_node) graph : Graph.t Fiber.t =
     let src_id = Id.to_int dep_node.id in
-    match get_cached_value_in_current_run dep_node with
-    | Some cached ->
+    match get_cached_deps_in_current_run dep_node with
+    | Some deps ->
       let* attributes =
         if time_nodes
         then (
@@ -230,7 +236,7 @@ let dump_cached_graph ?(on_not_cached = `Raise) ?(time_nodes = false) cell =
       in
       let graph = Graph.add_node graph ~id:src_id ?label:dep_node.spec.name ~attributes in
       List.fold_left
-        (Deps.For_debugging.to_list cached.deps)
+        (Deps.For_debugging.to_list deps)
         ~init:(Fiber.return graph)
         ~f:(fun graph (Dep_node.T dst_node as packed) ->
           let* graph = graph in
@@ -608,11 +614,11 @@ module For_tests = struct
     match Store.find t.cache inp with
     | None -> None
     | Some dep_node ->
-      (match get_cached_value_in_current_run dep_node with
+      (match get_cached_deps_in_current_run dep_node with
        | None -> None
-       | Some cv ->
+       | Some deps ->
          Some
-           (Deps.For_debugging.to_list cv.deps
+           (Deps.For_debugging.to_list deps
             |> List.map ~f:(fun (Dep_node.T dep) ->
               dep.spec.name, Dep_node.input_to_dyn dep)))
   ;;
@@ -690,7 +696,7 @@ module Var = struct
     | Some cutoff when cutoff !(t.value) v ->
       (* Note: We do *not* set [t.value := v] when the change is insignificant according
          to the [cutoff]. This is consistent with how cutoffs work in the rest of Memo,
-         e.g., see the [compute] and [confirm_old_value] functions.
+         e.g., see the [compute] and [update_value] functions.
 
          This prevents the "cutoff creep" where, e.g., the [cutoff] returns [true] for
          changes within 1% of the current [float] value and a sequence of smaller changes

--- a/src/memo/node.ml
+++ b/src/memo/node.ml
@@ -14,92 +14,23 @@ module M = struct
     module Dag = Dag
   end
 
-  (* A [value] along with some additional information that allows us to check
-     whether it is up to date or needs to be recomputed. *)
-  module rec Cached_value : sig
-    type 'a t =
-      { value : 'a Value.t
-      ; (* We store [last_changed_at] and [last_validated_at] for early cutoff, packed
-           into a single immediate [Run.Pair.t] to save memory. See Section 5.2.2 of
-           "Build Systems a la Carte: Theory and Practice" for more details
-           (https://doi.org/10.1017/S0956796820000088).
+  (* A node's lifecycle state. The node's [value], [runs] and [deps] are stored
+     flat on the node (see [Dep_node.t]) rather than inside the state, so a node
+     keeps its value across state transitions (e.g. an invalidated node keeps its
+     old value for the early cutoff check).
 
-           - [last_changed_at] is the run when the value changed last time.
-
-           - [last_validated_at] is the run when the value was last confirmed as
-             up to date. Invariant: [last_changed_at <= last_validated_at].
-
-           Consider a dependency [dep] of a node [caller].
-
-           If [dep]'s [last_changed_at] is greater than [caller]'s [last_validated_at],
-           then the [dep]'s value has changed since it had been previously used by the
-           [caller] and therefore the [caller] needs to be recomputed. *)
-        mutable runs : Run.Pair.t
-      ; (* The list of dependencies [deps], as captured at [last_validated_at]. Note that
-           the list of dependencies can change over the lifetime of [Cached_value]: this
-           happens if the value gets re-computed but is declared unchanged by the cutoff
-           check.
-
-           Note that [deps] should be listed in the order in which they were
-           depended on to avoid recomputations of the dependencies that are no
-           longer relevant (see an example below). Asynchronous functions induce
-           a partial (rather than a total) order on dependencies, and so [deps]
-           should be a linearisation of this partial order. It is also worth
-           noting that the problem only occurs with dynamic dependencies,
-           because static dependencies can never become irrelevant.
-
-           As an example, consider the function [let f x = let y = g x in h y].
-           The correct order of dependencies of [f 0] is [g 0] and then [h y1],
-           where [y1] is the result of computing [g 0] in the first build run.
-           Now consider the situation where (i) [h y1] is incorrectly listed
-           first in [deps], and (ii) both [g] and [h] have changed in the second
-           build run (e.g. because they read modified files). To determine that
-           [f] needs to be recomputed, we start by recomputing [h y1], which is
-           likely to be a waste because now we are really interested in [h y2],
-           where [y2] is the result of computing [g 0] in the second run. Had we
-           listed [g 0] first, we would recompute it and the work wouldn't be
-           wasted since [f 0] does depend on it.
-
-           Another important reason to list [deps] according to a linearisation
-           of the dependency order is to eliminate spurious dependency
-           cycles. *)
-        mutable deps : Dep_node.packed Deps.t
-      }
-  end =
-    Cached_value
-
-  (** The following state transition diagram shows how a node's state changes
-      during a build run. After a run completes, every node is guaranteed to end
-      up in one of these two states.
-
-      - [Out_of_date]: the node is known to be out of date; it wasn't computed
-        during the run, because it is unreachable.
-
-      - [Cached_value]: if the cached value's [run] is current then the node is
-        up to date; otherwise, it wasn't restored during the run, because it is
-        unreachable.
-
-      {v
-            ┌─────────────┐    ┌───────────┐    ┌──────────────┐
-            │ Out_of_date ├────► Computing ├────► Cached_value │
-            └──────▲──────┘    └───────────┘    └────┬───▲─────┘
-                   │                                 │   │
-                   │                            ┌────▼───┴─────┐
-                   └────────────────────────────┤   Restoring  │
-                                                └──────────────┘
-      v}
-
-      Between runs, there can be additional state transitions; for example, we
-      can invalidate a node by setting its state to [Out_of_date]. *)
-  and State : sig
-    type 'a t =
-      | Cached_value of 'a Cached_value.t
-      | Out_of_date of { old_value : 'a Cached_value.t Option.Unboxed.t }
-      | Restoring of { restore_from_cache : 'a Cache_lookup.t Computation0.t }
-      | Computing of
-          { old_value : 'a Cached_value.t Option.Unboxed.t
-          ; compute : 'a Cached_value.t Computation0.t
-          }
+     [Not_cached] is the state of a freshly created (never computed) node;
+     [Out_of_date] marks a previously computed node as stale. Both lead to a
+     recomputation, but only [Not_cached] fires a [Live] event on recompute (an
+     [Out_of_date] node already fired [Live] when it started restoring). *)
+  module rec State : sig
+    type t =
+      | Cached
+      | Not_cached
+      | Out_of_date
+      | Restoring of
+          { restore_from_cache : Cycle_error.t Changed_or_not.t Computation0.t }
+      | Computing of { compute : unit Computation0.t }
   end =
     State
 
@@ -112,10 +43,33 @@ module M = struct
              hope to change that. *)
       ; spec : ('i, 'o) Spec.t
       ; input : 'i
-      ; mutable state : 'o State.t
+      ; mutable state : State.t
+      ; mutable value : 'o Value.t
+      ; (* We store [last_changed_at] and [last_validated_at] for early cutoff,
+             packed into a single immediate [Run.Pair.t] to save memory. See
+             Section 5.2.2 of "Build Systems a la Carte: Theory and Practice" for
+             more details (https://doi.org/10.1017/S0956796820000088).
+
+             - [last_changed_at] is the run when the value changed last time.
+
+             - [last_validated_at] is the run when the value was last confirmed as
+               up to date. Invariant: [last_changed_at <= last_validated_at].
+
+             Consider a dependency [dep] of a node [caller]. If [dep]'s
+             [last_changed_at] is greater than [caller]'s [last_validated_at],
+             then the [dep]'s value has changed since it had been previously used
+             by the [caller] and therefore the [caller] needs to be recomputed. *)
+        mutable runs : Run.Pair.t
+      ; (* The list of dependencies [deps], as captured at [last_validated_at].
+             [deps] should be listed in the order in which they were depended on,
+             to avoid recomputing dependencies that are no longer relevant and to
+             eliminate spurious dependency cycles. Asynchronous functions induce a
+             partial (rather than total) order on dependencies, so [deps] should be
+             a linearisation of this partial order. *)
+        mutable deps : packed Deps.t
       }
 
-    type packed = T : (_, _) t -> packed [@@unboxed]
+    and packed = T : (_, _) t -> packed [@@unboxed]
   end =
     Dep_node
 
@@ -144,27 +98,6 @@ module M = struct
 
     exception E of t
   end
-
-  and Cache_lookup : sig
-    (* Looking up a value cached in a previous run can fail in three possible ways:
-
-       - [Out_of_date {old_value = None}]: either the value has never been computed
-         before, or the last computation attempt failed.
-
-       - [Out_of_date {old_value = Some _}]: we found a value computed in a previous run
-         but it is out of date because one of its dependencies changed; we return the old
-         value so that it can be compared with a new one to support the early cutoff.
-
-       - [Cancelled _]: the cache lookup attempt has been cancelled because of a
-         dependency cycle. This outcome indicates that a dependency cycle has been
-         introduced in the current run. If a cycle existed in a previous run, the
-         outcome would have been [Out_of_date {old_value = None}] instead. *)
-    type 'a t =
-      | Ok of 'a Cached_value.t
-      | Out_of_date of { old_value : 'a Cached_value.t Option.Unboxed.t }
-      | Cancelled of { dependency_cycle : Cycle_error.t }
-  end =
-    Cache_lookup
 
   and Dag : (Import.Dag.S with type value := Dep_node.packed) =
     Import.Dag.Make
@@ -210,6 +143,9 @@ module Dep_node = struct
       ; input_to_dyn t
       ]
   ;;
+
+  let last_changed_at t = Run.Pair.last_changed_at t.runs
+  let last_validated_at t = Run.Pair.last_validated_at t.runs
 
   module Packed = struct
     type t = packed
@@ -305,7 +241,6 @@ let () =
 
 module Exn_set = Value.Exn_set
 module Collect_errors_monoid = Value.Collect_errors_monoid
-module Cache_lookup = M.Cache_lookup
 module Dag = M.Dag
 
 (* This is similar to [type t = Dag.node Lazy.t] but avoids creating a closure
@@ -318,12 +253,7 @@ module Lazy_dag_node = struct
   let force t ~(dep_node : Dep_node.Packed.t) =
     Option.Unboxed.match_
       !t
-      ~some:(fun (dag_node : Dag.node) ->
-        let dep_node_passed_first = Dag.value dag_node in
-        (* CR-someday amokhov: It would be great to restructure the code to rule
-           out the potential inconsistency between [dep_node]s passed to [force]. *)
-        assert (Dep_node.Packed.equal dep_node dep_node_passed_first);
-        dag_node)
+      ~some:(fun (dag_node : Dag.node) -> dag_node)
       ~none:(fun () ->
         let (dag_node : Dag.node) =
           Counter.incr Metrics.Cycle_detection.nodes;
@@ -354,106 +284,66 @@ let _print_dep_node ?prefix (dep_node : _ Dep_node.t) =
     Format.printf "%s%s\n" prefix (Dep_node.to_dyn_without_state dep_node |> Dyn.to_string)
 ;;
 
-let get_cached_value_in_current_run (dep_node : _ Dep_node.t) =
-  match dep_node.state with
-  | Cached_value cv ->
-    if Run.is_current (Run.Pair.last_validated_at cv.runs) then Some cv else None
-  | Out_of_date _ | Restoring _ | Computing _ -> None
+(* Has the node's [new_value] changed relative to its [old_value], according to
+   the cutoff predicate? A fresh ([Uninitialized]) value always counts as
+   changed, as does any transition into or out of a non-reproducible error. *)
+let value_changed (node : _ Dep_node.t) old_value new_value =
+  match (old_value : _ Value.t), (new_value : _ Value.t) with
+  | Uninitialized, _ | _, Uninitialized -> true
+  | Error { reproducible = false; _ }, _
+  | _, Error { reproducible = false; _ }
+  | Error _, Ok _
+  | Ok _, Error _ -> true
+  | Ok old_value, Ok new_value -> Spec.output_changed node.spec ~old_value ~new_value
+  | ( Error { exns = prev_exns; reproducible = true }
+    , Error { exns = cur_exns; reproducible = true } ) ->
+    not (Exn_set.equal prev_exns cur_exns)
 ;;
 
-module Cached_value = struct
-  include M.Cached_value
+(* Mark a node as up to date in the current run: its state becomes [Cached] and
+   [last_validated_at] is bumped to the current run. *)
+let validate_value (node : _ Dep_node.t) =
+  node.runs
+  <- Run.Pair.with_last_validated_at node.runs ~last_validated_at:(Run.current ());
+  node.state <- Cached;
+  Spec.notify node.spec node.input Validated
+;;
 
-  let last_changed_at t = Run.Pair.last_changed_at t.runs
-  let last_validated_at t = Run.Pair.last_validated_at t.runs
-
-  let capture_deps ~deps =
-    if !Debug.check_invariants
-    then
-      List.iter (Deps.For_debugging.to_list deps) ~f:(function Dep_node.T dep_node ->
-          (match get_cached_value_in_current_run dep_node with
-           | None ->
-             let reason =
-               match dep_node.state with
-               | Out_of_date _ -> "(out of date)"
-               | Cached_value _ -> "(old run)"
-               | Restoring _ -> "(restoring)"
-               | Computing _ -> "(computing)"
-             in
-             Code_error.raise
-               ("Attempted to create a cached value based on some stale inputs " ^ reason)
-               []
-           | Some _up_to_date_cached_value -> ()));
-    deps
-  ;;
-
-  let create x ~deps =
+(* Store a freshly computed (or restored) [value] and [deps] on the node and mark
+   it validated. If [value] is unchanged according to the cutoff, we keep the old
+   [last_changed_at] (early cutoff) but still refresh [deps] and the
+   [last_validated_at] timestamp. *)
+let update_value (node : _ Dep_node.t) value ~deps =
+  if value_changed node node.value value
+  then (
+    node.value <- value;
     let now = Run.current () in
-    { value = x
-    ; runs = Run.Pair.create ~last_changed_at:now ~last_validated_at:now
-    ; deps = capture_deps ~deps
-    }
-  ;;
+    (* Bump both timestamps in a single write so the
+       [last_changed_at <= last_validated_at] invariant of [Run.Pair.t] is never
+       violated. [validate_value] below rewrites [runs] again, but with the same
+       [last_validated_at = now], so the result is unchanged. *)
+    node.runs <- Run.Pair.create ~last_changed_at:now ~last_validated_at:now);
+  node.deps <- deps;
+  validate_value node
+;;
 
-  let create_cancelled ~dependency_cycle =
-    let now = Run.current () in
-    { value =
-        Error
-          { Collect_errors_monoid.exns =
-              Exn_set.singleton
-                (Exn_with_backtrace.capture (Cycle_error.E dependency_cycle))
-          ; reproducible = false
-          }
-    ; runs = Run.Pair.create ~last_changed_at:now ~last_validated_at:now
-    ; deps =
-        (* Dependencies of cancelled computations are not accurate, so we store
-           [Deps.empty] in this case. *)
-        Deps.empty
-    }
-  ;;
-
-  let confirm_old_value t ~deps =
-    t.runs <- Run.Pair.with_last_validated_at t.runs ~last_validated_at:(Run.current ());
-    t.deps <- capture_deps ~deps;
-    t
-  ;;
-
-  let value_changed (node : _ Dep_node.t) prev_value cur_value =
-    match (prev_value : _ Value.t), (cur_value : _ Value.t) with
-    | Error { reproducible = false; _ }, _
-    | _, Error { reproducible = false; _ }
-    | Error _, Ok _
-    | Ok _, Error _ -> true
-    | Ok prev_value, Ok cur_value ->
-      Spec.output_changed node.spec ~old_value:prev_value ~new_value:cur_value
-    | ( Error { exns = prev_exns; reproducible = true }
-      , Error { exns = cur_exns; reproducible = true } ) ->
-      not (Exn_set.equal prev_exns cur_exns)
-  ;;
-
-  let to_dyn { value = _; runs; deps = _ } =
-    Dyn.record
-      [ "value", Opaque
-      ; "last_changed_at", Run.to_dyn (Run.Pair.last_changed_at runs)
-      ; "last_validated_at", Run.to_dyn (Run.Pair.last_validated_at runs)
-      ; "deps", Opaque
-      ]
-  ;;
-end
+(* The dependencies of a node, if it is up to date in the current run. *)
+let get_cached_deps_in_current_run (node : _ Dep_node.t) =
+  match node.state with
+  | Cached ->
+    if Run.is_current (Dep_node.last_validated_at node) then Some node.deps else None
+  | Not_cached | Out_of_date | Restoring _ | Computing _ -> None
+;;
 
 module State = struct
   include M.State
 
   let to_dyn = function
-    | Cached_value cached_value ->
-      Dyn.variant "Cached_value" [ Cached_value.to_dyn cached_value ]
+    | Cached -> Dyn.variant "Cached" []
+    | Not_cached -> Dyn.variant "Not_cached" []
+    | Out_of_date -> Dyn.variant "Out_of_date" []
     | Restoring _ -> Dyn.variant "Restoring" [ Opaque ]
     | Computing _ -> Dyn.variant "Computing" [ Opaque ]
-    | Out_of_date { old_value } ->
-      Dyn.variant
-        "Out_of_date"
-        [ Dyn.record [ "old_value", Option.Unboxed.to_dyn Cached_value.to_dyn old_value ]
-        ]
   ;;
 end
 
@@ -547,17 +437,6 @@ module Call_stack = struct
   let cycle_error_in_the_current_run : Cycle_error.t option ref = ref None
   let reset_cycle_error_in_the_current_run () = cycle_error_in_the_current_run := None
 
-  (* Record a cycle error hit during the current run, returning the first cycle error
-     seen this run. Once any cycle is hit we report that same cycle for the rest of the
-     run (see [cycle_error_in_the_current_run]). *)
-  let note_cycle_error cycle =
-    match !cycle_error_in_the_current_run with
-    | Some first -> first
-    | None ->
-      cycle_error_in_the_current_run := Some cycle;
-      cycle
-  ;;
-
   (* Add all edges leading from the root of the call stack to [dag_node] to the cycle
      detection DAG. *)
   let add_path_to ~dag_node : (unit, Cycle_error.t) result Fiber.t =
@@ -607,8 +486,6 @@ module Call_stack = struct
     | None -> Ok ()
     | Some cycle_error -> Error cycle_error
   ;;
-
-  (* Add a dependency on the [dep_node] from the caller, if there is one. *)
 end
 
 (* This module contains the essence of our cycle detection algorithm. Briefly,
@@ -700,34 +577,13 @@ module Computation = struct
     match Fiber.Ivar.peek ivar with
     | Some res -> Fiber.return (Ok res)
     | None ->
-      let dep_node = Dep_node.T dep_node in
-      let* immediate_self_cycle =
-        let+ stack = Call_stack.get_call_stack () in
-        let rec collect_callers_to_dep_node = function
-          | [] -> None
-          | frame :: rest ->
-            let stack_dep_node = Stack_frame_with_state.dep_node frame in
-            if Dep_node.Packed.equal stack_dep_node dep_node
-            then Some []
-            else (
-              match collect_callers_to_dep_node rest with
-              | None -> None
-              | Some callers -> Some (stack_dep_node :: callers))
-        in
-        match collect_callers_to_dep_node stack with
-        | None -> None
-        | Some callers -> Some (dep_node :: callers)
-      in
-      (match immediate_self_cycle with
-       | Some cycle -> Fiber.return (Error (Call_stack.note_cycle_error cycle))
-       | None ->
-         (match (phase : Stack_frame_with_state.phase) with
-          | Restore_from_cache -> Counter.incr Metrics.Restore.blocked
-          | Compute -> Counter.incr Metrics.Compute.blocked);
-         let dag_node = Lazy_dag_node.force dag_node ~dep_node in
-         Call_stack.add_path_to ~dag_node
-         >>= (function
-          | Ok () -> Fiber.Ivar.read ivar >>| Result.ok
-          | Error _ as cycle_error -> Fiber.return cycle_error))
+      (match (phase : Stack_frame_with_state.phase) with
+       | Restore_from_cache -> Counter.incr Metrics.Restore.blocked
+       | Compute -> Counter.incr Metrics.Compute.blocked);
+      let dag_node = Lazy_dag_node.force dag_node ~dep_node:(Dep_node.T dep_node) in
+      Call_stack.add_path_to ~dag_node
+      >>= (function
+       | Ok () -> Fiber.Ivar.read ivar >>| Result.ok
+       | Error _ as cycle_error -> Fiber.return cycle_error)
   ;;
 end

--- a/src/memo/value.ml
+++ b/src/memo/value.ml
@@ -46,6 +46,8 @@ end
 type 'a t =
   | Ok of 'a
   | Error of Collect_errors_monoid.t
+  | Uninitialized
+  (** [Uninitialized] is the value of a node that has never been computed. *)
 
 let get_exn t ~map_exn =
   match t with
@@ -54,4 +56,5 @@ let get_exn t ~map_exn =
     Fiber.reraise_all
       (Exn_set.to_list_map exns ~f:(fun (exn : Exn_with_backtrace.t) ->
          { exn with exn = map_exn exn.exn }))
+  | Uninitialized -> Code_error.raise "Value.get_exn called on an uninitialized value" []
 ;;

--- a/src/memo/value.mli
+++ b/src/memo/value.mli
@@ -23,6 +23,8 @@ end
 type 'a t =
   | Ok of 'a
   | Error of Collect_errors_monoid.t
+  | Uninitialized
+  (** [Uninitialized] is the value of a node that has never been computed. *)
 
 (** Get the value, or reraise the contained errors after remapping each one with [map_exn]. *)
 val get_exn : 'a t -> map_exn:(exn -> exn) -> 'a Fiber.t

--- a/test/expect-tests/memo/main.ml
+++ b/test/expect-tests/memo/main.ml
@@ -942,8 +942,8 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
               ; backtrace = ""
               }
             ]
-    Memo graph: 8/8/0 nodes/edges/blocked (restore), 8/7/0 nodes/edges/blocked (compute)
-    Memo cycle detection graph: 0/0/0 nodes/edges/paths
+    Memo graph: 8/8/1 nodes/edges/blocked (restore), 8/7/0 nodes/edges/blocked (compute)
+    Memo cycle detection graph: 6/5/1 nodes/edges/paths
     |}];
   Memo.Metrics.reset ();
   evaluate_and_print summit_yes_cutoff 0;
@@ -977,8 +977,8 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
               ; backtrace = ""
               }
             ]
-    Memo graph: 7/7/0 nodes/edges/blocked (restore), 6/6/0 nodes/edges/blocked (compute)
-    Memo cycle detection graph: 0/0/0 nodes/edges/paths
+    Memo graph: 7/7/1 nodes/edges/blocked (restore), 6/6/0 nodes/edges/blocked (compute)
+    Memo cycle detection graph: 6/5/1 nodes/edges/paths
     |}];
   Memo.Metrics.reset ();
   evaluate_and_print summit_no_cutoff 2;
@@ -1041,11 +1041,11 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
   print_metrics ();
   [%expect
     {|
-    Started evaluating base
-    Evaluated base: 3
     Started evaluating incrementing_chain_2_yes_cutoff
     Started evaluating incrementing_chain_1_no_cutoff
     Started evaluating cycle_creator_no_cutoff
+    Started evaluating base
+    Evaluated base: 3
     Evaluated cycle_creator_no_cutoff: 3
     Evaluated incrementing_chain_1_no_cutoff: 4
     Evaluated incrementing_chain_2_yes_cutoff: 5
@@ -1056,9 +1056,9 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     Started evaluating the summit with input 0
     Evaluated the summit with input 0: 7
     f 0 = Ok 7
-    Memo graph: 7/7/0 nodes/edges/blocked (restore), 8/7/0 nodes/edges/blocked (compute)
+    Memo graph: 7/6/0 nodes/edges/blocked (restore), 8/7/0 nodes/edges/blocked (compute)
     Memo cycle detection graph: 0/0/0 nodes/edges/paths
-  |}];
+    |}];
   Memo.Metrics.reset ();
   evaluate_and_print summit_yes_cutoff 0;
   print_metrics ();
@@ -1077,9 +1077,9 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     Evaluated incrementing_chain_4_no_cutoff: 7
     Evaluated the summit with input 0: 7
     f 0 = Ok 7
-    Memo graph: 6/6/0 nodes/edges/blocked (restore), 6/6/0 nodes/edges/blocked (compute)
+    Memo graph: 6/5/0 nodes/edges/blocked (restore), 6/6/0 nodes/edges/blocked (compute)
     Memo cycle detection graph: 0/0/0 nodes/edges/paths
-  |}];
+    |}];
   Memo.Metrics.reset ();
   evaluate_and_print summit_no_cutoff 2;
   print_metrics ();
@@ -1187,24 +1187,26 @@ let%expect_test "No deadlocks when creating the same cycle twice" =
   evaluate_and_print summit 2;
   [%expect
     {|
+    Started evaluating cycle_creator
+    Started evaluating base
     Dependency cycle detected:
-    - ("base", ())
-    - called by ("cycle_creator", ())
+    - ("cycle_creator", ())
+    - called by ("base", ())
     f 0 = Error
-            [ { exn = "Cycle_error.E [ (\"base\", ()); (\"cycle_creator\", ()) ]"
+            [ { exn = "Cycle_error.E [ (\"cycle_creator\", ()); (\"base\", ()) ]"
               ; backtrace = ""
               }
             ]
     Started evaluating summit
     Dependency cycle detected:
-    - ("base", ())
-    - called by ("cycle_creator", ())
+    - ("cycle_creator", ())
+    - called by ("base", ())
     f 2 = Error
-            [ { exn = "Cycle_error.E [ (\"base\", ()); (\"cycle_creator\", ()) ]"
+            [ { exn = "Cycle_error.E [ (\"cycle_creator\", ()); (\"base\", ()) ]"
               ; backtrace = ""
               }
             ]
-  |}]
+    |}]
 ;;
 
 let%expect_test "cancelling a computing node wakes waiters" =


### PR DESCRIPTION
A memoized node previously kept its cached value, its early-cutoff timestamps,
and its dependency list inside a `Cached_value` record reached through the
node's `State`. Store them flat on `Dep_node.t` instead, and reduce `State` to a
value-less lifecycle marker (`Cached` / `Not_cached` / `Out_of_date` /
`Restoring` / `Computing`). Restoring a node from the cache now returns a plain
`Changed_or_not.t` rather than a `Cache_lookup.t` carrying the value, and writes
go through `update_value` (cutoff via `Spec.output_changed`) and
`validate_value`.

A fresh node starts `Not_cached` with an `Uninitialized` value; invalidation
marks it `Out_of_date` while keeping the old value for the early-cutoff check.
This also drops the special-cased self-dependency-cycle pre-scan, so all cycles
are detected through the cycle-detection DAG (the same cycle is reported,
occasionally rotated to where the DAG closes it).

The old code marked a computation cancelled by a dependency cycle as a
non-reproducible error (via `cancel_due_to_dependency_cycle`) so it would never
be restored from the cache. This rewrite drops that helper, so error
classification now treats `Cycle_error.E` — alongside the `Non_reproducible`
marker — as non-reproducible: a cycle-cancelled node is recomputed rather than
restored on the next run, preserving the previous behaviour.

No change to memoized values, cutoff behaviour, or which cycles are detected.
