### PR TITLE
test: expose external build dir install paths

### DIFF
--- a/otherlibs/stdune/test/path_tests.ml
+++ b/otherlibs/stdune/test/path_tests.ml
@@ -271,10 +271,7 @@ None
 
 let%expect_test _ =
   reach "/foo/baz" ~from:"/foo/bar";
-  [%expect
-    {|
-"/foo/baz"
-|}]
+  [%expect {| "/foo/baz" |}]
 ;;
 
 let%expect_test _ =

--- a/test/blackbox-tests/test-cases/dune-package.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-package.t/run.t
@@ -179,3 +179,34 @@ Install as opam does
 
   $ dune_cmd cat "a/_build/install/default/lib/a/dune-package" | grep -e 'lib [.]' -e 'share [.]'
   (sections (lib .) (libexec .) (share ../../share/a))
+
+Install with an absolute build directory outside the workspace
+
+  $ mkdir external-build-dir external-prefix external-project
+  $ cd external-project
+  $ cat > dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name ext))
+  > EOF
+  $ cat > ext.opam <<EOF
+  > opam-version: "2.0"
+  > EOF
+  $ cat > dune <<EOF
+  > (library (public_name ext))
+  > EOF
+  $ echo 'let x = 1' > ext.ml
+
+  $ DUNE_BUILD_DIR="$PWD/../external-build-dir" dune build -p ext @install
+  $ DUNE_BUILD_DIR="$PWD/../external-build-dir" \
+  > DUNE_INSTALL_PREFIX="$PWD/../external-prefix" \
+  > dune install ext
+
+  $ grep -e external-project ../external-prefix/lib/ext/dune-package | sed 's/^ *//; s/)*$//'
+  $TESTCASE_ROOT/external-project/../external-prefix/lib/ext
+  $TESTCASE_ROOT/external-project/../external-prefix/lib/ext
+  $TESTCASE_ROOT/external-project/../external-build-dir/install/default/lib/ext/ext.cma
+  $TESTCASE_ROOT/external-project/../external-build-dir/install/default/lib/ext/ext.cmxa
+  $TESTCASE_ROOT/external-project/../external-build-dir/install/default/lib/ext/ext.cma
+  $TESTCASE_ROOT/external-project/../external-build-dir/install/default/lib/ext/ext.cmxs
+  $TESTCASE_ROOT/external-project/../external-build-dir/install/default/lib/ext/ext.a
+  $TESTCASE_ROOT/external-project/../external-build-dir/install/default/lib/ext/ext.ml


### PR DESCRIPTION
This extracts the regression coverage from #15077 into a standalone test-only PR.

The new tests demonstrate #11774 by expecting installed dune-package artifact paths to be relative even when DUNE_BUILD_DIR is an absolute directory outside the workspace. This PR is expected to fail until the fix from #15077 (or equivalent) is applied.