### PR TITLE
[3.24.0] backport #14715

### DIFF
--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -580,7 +580,11 @@ let library_rules
   let* () = gen_wrapped_compat_modules lib cctx
   and* () =
     Memo.when_ (Compilation_mode.equal for_ Melange) (fun () ->
-      Melange_rules.setup_melange_sources_copy_rules ~sctx ~dir source_modules)
+      Melange_rules.setup_melange_sources_copy_rules
+        ~sctx
+        ~dir
+        ~preprocess:lib.buildable.preprocess.config
+        source_modules)
   and* () = Module_compilation.build_all cctx
   and* () = Check_rules.add_obj_dir sctx ~obj_dir for_
   and* () =

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -26,7 +26,7 @@ module Output_kind = struct
   ;;
 end
 
-let setup_melange_sources_copy_rules ~sctx ~dir modules =
+let setup_melange_sources_copy_rules ~sctx ~dir ~preprocess modules =
   let mods = Modules.fold_user_written modules ~init:[] ~f:List.cons in
   let context = Super_context.context sctx in
   Memo.parallel_iter mods ~f:(fun m ->
@@ -40,7 +40,16 @@ let setup_melange_sources_copy_rules ~sctx ~dir modules =
       match Path.equal src (Path.build dst) with
       | true -> Memo.return ()
       | false ->
-        Super_context.add_rule sctx ~dir (Copy_line_directive.builder context ~src ~dst)))
+        let builder =
+          match Preprocess.Per_module.find (Module.name m) preprocess with
+          | Pps { staged = false; _ } ->
+            (* Non-staged PPX preprocessing receives [-loc-filename] separately,
+               so adding a line directive here would shift diagnostics twice. *)
+            Action_builder.copy ~src ~dst
+          | No_preprocessing | Future_syntax _ | Action _ | Pps { staged = true; _ } ->
+            Copy_line_directive.builder context ~src ~dst
+        in
+        Super_context.add_rule sctx ~dir builder))
 ;;
 
 let output_of_lib =
@@ -552,7 +561,13 @@ let setup_emit_cmj_rules
         ~melange_package_name:None
         ~package:mel.package
     in
-    let* () = setup_melange_sources_copy_rules ~sctx ~dir source_modules in
+    let* () =
+      setup_melange_sources_copy_rules
+        ~sctx
+        ~dir
+        ~preprocess:mel.preprocess.config
+        source_modules
+    in
     let* () = Module_compilation.build_all cctx in
     let* () =
       Memo.when_ (Compilation_context.bin_annot cctx) (fun () ->

--- a/src/dune_rules/melange/melange_rules.mli
+++ b/src/dune_rules/melange/melange_rules.mli
@@ -3,6 +3,7 @@ open Import
 val setup_melange_sources_copy_rules
   :  sctx:Super_context.t
   -> dir:Path.Build.t
+  -> preprocess:Preprocess.With_instrumentation.t Preprocess.Per_module.t
   -> Modules.t
   -> unit Memo.t
 

--- a/src/dune_rules/pp_spec_rules.ml
+++ b/src/dune_rules/pp_spec_rules.ml
@@ -26,6 +26,16 @@ let pp_input_path m ~ml_kind =
   Module.source m ~ml_kind |> Option.value_exn |> pp_input_file ~ml_kind
 ;;
 
+let loc_filename_arg_for_pp ~input_path ~loc_filename =
+  if Path.equal input_path loc_filename
+  then Command.Args.empty
+  else
+    S
+      [ A "-loc-filename"
+      ; A (Path.drop_optional_build_context_maybe_sandboxed loc_filename |> Path.to_string)
+      ]
+;;
+
 let pp_corrected_path m ~ml_kind ~suffix =
   pp_input_path m ~ml_kind
   |> Path.as_in_build_dir_exn
@@ -338,6 +348,11 @@ let pp_one_module
         let* ast = setup_dialect_rules sctx ~sandbox ~dir ~expander m in
         let* () = Memo.when_ lint (fun () -> lint_module ~ast ~source:m) in
         pped_module ast ~f:(fun ml_kind src dst ->
+          let loc_filename_arg =
+            loc_filename_arg_for_pp
+              ~input_path:(Path.build src)
+              ~loc_filename:(pp_input_path m ~ml_kind)
+          in
           Super_context.add_rule
             sctx
             ~loc
@@ -360,6 +375,7 @@ let pp_one_module
                      [ As args
                      ; A "-o"
                      ; Path (Path.build dst)
+                     ; loc_filename_arg
                      ; Command.Ml_kind.ppx_driver_flag ml_kind
                      ; Dep (Path.build src)
                      ; Hidden_deps

--- a/test/blackbox-tests/test-cases/melange/dune
+++ b/test/blackbox-tests/test-cases/melange/dune
@@ -17,7 +17,10 @@
 
 (cram
  (deps %{bin:refmt})
- (applies_to preprocess reason-lint-promotion))
+ (applies_to
+  preprocess
+  reason-lint-promotion
+  sandbox-preprocessed-reason-source))
 
 (cram
  (deps

--- a/test/blackbox-tests/test-cases/melange/ppx-preview.t
+++ b/test/blackbox-tests/test-cases/melange/ppx-preview.t
@@ -18,6 +18,8 @@ Show PPX snippet preview is shown in Dune
   $ export DUNE_SANDBOX=symlink
   $ dune build @all
   File "lib/the_lib.ml", line 1, characters 7-11:
+  1 | let x: nope = "hello"
+             ^^^^
   Error: Unbound type constructor nope
   [1]
 
@@ -26,6 +28,8 @@ Works if the sandbox is disabled
   $ export DUNE_SANDBOX=none
   $ dune build @all
   File "lib/the_lib.ml", line 1, characters 7-11:
+  1 | let x: nope = "hello"
+             ^^^^
   Error: Unbound type constructor nope
   [1]
 
@@ -36,12 +40,16 @@ Works if the sandbox is disabled
   $ export DUNE_SANDBOX=symlink
   $ dune build @all
   File "lib/the_lib.mli", line 1, characters 7-11:
+  1 | val x: nope
+             ^^^^
   Error: Unbound type constructor nope
   [1]
 
   $ export DUNE_SANDBOX=none
   $ dune build @all
   File "lib/the_lib.mli", line 1, characters 7-11:
+  1 | val x: nope
+             ^^^^
   Error: Unbound type constructor nope
   [1]
 

--- a/test/blackbox-tests/test-cases/melange/preprocess.t
+++ b/test/blackbox-tests/test-cases/melange/preprocess.t
@@ -39,13 +39,17 @@ Reason dialect preprocessor to the PPX driver.
 
   $ cat > ppx/reason_ppx.ml <<'EOF'
   > let () =
-  >   Array.iter
-  >     (fun arg ->
+  >   let rec loop = function
+  >     | [] -> ()
+  >     | "-loc-filename" :: _ :: rest -> loop rest
+  >     | arg :: rest ->
   >       if Filename.check_suffix arg ".re" || Filename.check_suffix arg ".rei"
   >       then (
   >         Printf.eprintf "ppx saw Reason source: %s\n" arg;
-  >         exit 1))
-  >     Sys.argv
+  >         exit 1)
+  >       else loop rest
+  >   in
+  >   loop (Array.to_list Sys.argv)
   > ;;
   > let () = Ppxlib.Driver.register_transformation "reason_ppx"
   > EOF

--- a/test/blackbox-tests/test-cases/melange/sandbox-preprocessed-reason-source.t
+++ b/test/blackbox-tests/test-cases/melange/sandbox-preprocessed-reason-source.t
@@ -1,0 +1,68 @@
+Melange Reason sources are converted by refmt before PPX preprocessing. PPX
+locations should still resolve to the original Reason source so compiler
+diagnostics can print the correct snippet.
+
+  $ mkdir -p cases/ppx cases/src
+
+  $ cat > cases/dune-project <<'EOF'
+  > (lang dune 3.18)
+  > (using melange 0.1)
+  > EOF
+
+  $ cat > cases/ppx/dune <<'EOF'
+  > (library
+  >  (name ppx_locations)
+  >  (kind ppx_rewriter)
+  >  (libraries ppxlib))
+  > EOF
+
+  $ cat > cases/ppx/ppx_locations.ml <<'EOF'
+  > open Ppxlib
+  > 
+  > let impl _ =
+  >   let loc_start =
+  >     { Lexing.pos_fname = !Ocaml_common.Location.input_name
+  >     ; pos_lnum = 1
+  >     ; pos_bol = 0
+  >     ; pos_cnum = 8
+  >     }
+  >   in
+  >   let loc = { Location.loc_start; loc_end = { loc_start with pos_cnum = 12 }; loc_ghost = false } in
+  >   let open Ast_builder.Default in
+  >   [ pstr_value
+  >       ~loc
+  >       Nonrecursive
+  >       [ value_binding
+  >           ~loc
+  >           ~pat:(ppat_var ~loc { txt = "x"; loc })
+  >           ~expr:
+  >             (pexp_constraint
+  >                ~loc
+  >                (eunit ~loc)
+  >                (ptyp_constr ~loc { txt = Longident.Lident "nope"; loc } []))
+  >       ]
+  >   ]
+  > ;;
+  > 
+  > let () = Driver.register_transformation "ppx_locations" ~impl
+  > EOF
+
+  $ cat > cases/src/dune <<'EOF'
+  > (library
+  >  (name logical_reason_impl)
+  >  (modes melange)
+  >  (modules x)
+  >  (preprocess
+  >   (pps ppx_locations)))
+  > EOF
+
+  $ cat > cases/src/x.re <<'EOF'
+  > let x = "reason"
+  > EOF
+
+  $ dune build --root cases --sandbox=symlink @src/all
+  Entering directory 'cases'
+  File "src/.melange_src/x.re", line 1, characters 8-12:
+  Error: Unbound type constructor nope
+  Leaving directory 'cases'
+  [1]

--- a/test/blackbox-tests/test-cases/melange/sandbox-preprocessed-reason-source.t
+++ b/test/blackbox-tests/test-cases/melange/sandbox-preprocessed-reason-source.t
@@ -38,8 +38,8 @@ compiler diagnostic should still print the original Reason source line.
   $ dune build --root cases --sandbox=symlink @src/all
   Entering directory 'cases'
   File "src/x.re", line 2, characters 40-48:
-   |  1 + 1 + 1 + 1 + 1 + 1 + "reason"
-                                      ^^^^^^^^
+  2 | let x = 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + "reason"
+                                              ^^^^^^^^
   Error: This constant has type string but an expression was expected of type
            int
   Leaving directory 'cases'

--- a/test/blackbox-tests/test-cases/melange/sandbox-preprocessed-reason-source.t
+++ b/test/blackbox-tests/test-cases/melange/sandbox-preprocessed-reason-source.t
@@ -1,6 +1,6 @@
-Melange Reason sources are converted by refmt before PPX preprocessing. PPX
-locations should still resolve to the original Reason source so compiler
-diagnostics can print the correct snippet.
+Melange copies Reason sources into the build directory with a line directive
+before refmt converts them to OCaml. If the module then goes through a PPX, the
+compiler diagnostic should still print the original Reason source line.
 
   $ mkdir -p cases/ppx cases/src
 
@@ -11,60 +11,36 @@ diagnostics can print the correct snippet.
 
   $ cat > cases/ppx/dune <<'EOF'
   > (library
-  >  (name ppx_locations)
+  >  (name ppx_noop)
   >  (kind ppx_rewriter)
+  >  (modules ppx_noop)
   >  (libraries ppxlib))
   > EOF
 
-  $ cat > cases/ppx/ppx_locations.ml <<'EOF'
-  > open Ppxlib
-  > 
-  > let impl _ =
-  >   let loc_start =
-  >     { Lexing.pos_fname = !Ocaml_common.Location.input_name
-  >     ; pos_lnum = 1
-  >     ; pos_bol = 0
-  >     ; pos_cnum = 8
-  >     }
-  >   in
-  >   let loc = { Location.loc_start; loc_end = { loc_start with pos_cnum = 12 }; loc_ghost = false } in
-  >   let open Ast_builder.Default in
-  >   [ pstr_value
-  >       ~loc
-  >       Nonrecursive
-  >       [ value_binding
-  >           ~loc
-  >           ~pat:(ppat_var ~loc { txt = "x"; loc })
-  >           ~expr:
-  >             (pexp_constraint
-  >                ~loc
-  >                (eunit ~loc)
-  >                (ptyp_constr ~loc { txt = Longident.Lident "nope"; loc } []))
-  >       ]
-  >   ]
-  > ;;
-  > 
-  > let () = Driver.register_transformation "ppx_locations" ~impl
+  $ cat > cases/ppx/ppx_noop.ml <<'EOF'
+  > let () = Ppxlib.Driver.register_transformation "ppx_noop"
   > EOF
 
   $ cat > cases/src/dune <<'EOF'
   > (library
-  >  (name logical_reason_impl)
+  >  (name reason_impl)
   >  (modes melange)
   >  (modules x)
   >  (preprocess
-  >   (pps ppx_locations)))
+  >   (pps ppx_noop)))
   > EOF
 
   $ cat > cases/src/x.re <<'EOF'
-  > let x = "reason"
+  > let ignored = 0
+  > let x = 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + "reason"
   > EOF
 
   $ dune build --root cases --sandbox=symlink @src/all
   Entering directory 'cases'
-  File "src/x.re", line 1, characters 8-12:
-  1 | let x = "reason"
-              ^^^^
-  Error: Unbound type constructor nope
+  File "src/x.re", line 2, characters 40-48:
+   |  1 + 1 + 1 + 1 + 1 + 1 + "reason"
+                                      ^^^^^^^^
+  Error: This constant has type string but an expression was expected of type
+           int
   Leaving directory 'cases'
   [1]

--- a/test/blackbox-tests/test-cases/melange/sandbox-preprocessed-reason-source.t
+++ b/test/blackbox-tests/test-cases/melange/sandbox-preprocessed-reason-source.t
@@ -62,7 +62,9 @@ diagnostics can print the correct snippet.
 
   $ dune build --root cases --sandbox=symlink @src/all
   Entering directory 'cases'
-  File "src/.melange_src/x.re", line 1, characters 8-12:
+  File "src/x.re", line 1, characters 8-12:
+  1 | let x = "reason"
+              ^^^^
   Error: Unbound type constructor nope
   Leaving directory 'cases'
   [1]

--- a/test/blackbox-tests/test-cases/melange/sandbox-preprocessed-source.t
+++ b/test/blackbox-tests/test-cases/melange/sandbox-preprocessed-source.t
@@ -131,7 +131,9 @@ filename even though the PPX reads the copied Melange source.
 
   $ dune build --root cases --sandbox=symlink @logical-ocaml-impl/src/all
   Entering directory 'cases'
-  File "logical-ocaml-impl/src/.melange_src/x.ml", line 1, characters 8-12:
+  File "logical-ocaml-impl/src/x.ml", line 1, characters 8-12:
+  1 | let x = "ocaml"
+              ^^^^
   Error: Unbound type constructor nope
   Leaving directory 'cases'
   [1]
@@ -160,7 +162,9 @@ Melange source filename even though the PPX reads the copied Melange source.
 
   $ dune build --root cases --sandbox=symlink @logical-melange-impl/src/all
   Entering directory 'cases'
-  File "logical-melange-impl/src/.melange_src/x.ml", line 1, characters 8-12:
+  File "logical-melange-impl/src/x.melange.ml", line 1, characters 8-12:
+  1 | let x = "melange"
+              ^^^^
   Error: Unbound type constructor nope
   Leaving directory 'cases'
   [1]
@@ -189,7 +193,9 @@ filename even though the PPX reads the copied Melange source.
 
   $ dune build --root cases --sandbox=symlink @logical-ocaml-intf/src/all
   Entering directory 'cases'
-  File "logical-ocaml-intf/src/.melange_src/x.mli", line 1, characters 8-12:
+  File "logical-ocaml-intf/src/x.mli", line 1, characters 8-12:
+  1 | val x : int
+              ^^^^
   Error: Unbound type constructor nope
   Leaving directory 'cases'
   [1]
@@ -222,7 +228,9 @@ Melange source filename even though the PPX reads the copied Melange source.
 
   $ dune build --root cases --sandbox=symlink @logical-melange-intf/src/all
   Entering directory 'cases'
-  File "logical-melange-intf/src/.melange_src/x.mli", line 1, characters 8-12:
+  File "logical-melange-intf/src/x.melange.mli", line 1, characters 8-12:
+  1 | val x : string
+              ^^^^
   Error: Unbound type constructor nope
   Leaving directory 'cases'
   [1]

--- a/test/blackbox-tests/test-cases/melange/sandbox-preprocessed-source.t
+++ b/test/blackbox-tests/test-cases/melange/sandbox-preprocessed-source.t
@@ -1,0 +1,228 @@
+Melange copies OCaml source files into `.melange_src` before preprocessing.
+For preprocessed `.ml` and `.mli` files, compiler diagnostics may need either
+the copied pre-PPX source, for locations that still point at `.melange_src`, or
+the original source, for ppxlib-generated locations that use the logical input
+filename.
+
+  $ mkdir -p cases/ppx
+
+  $ cat > cases/dune-project <<'EOF'
+  > (lang dune 3.18)
+  > (using melange 0.1)
+  > EOF
+
+  $ cat > cases/ppx/dune <<'EOF'
+  > (library
+  >  (name ppx_locations)
+  >  (kind ppx_rewriter)
+  >  (libraries ppxlib))
+  > EOF
+
+  $ cat > cases/ppx/ppx_locations.ml <<'EOF'
+  > open Ppxlib
+  > 
+  > let has_substring s substr =
+  >   let len = String.length s in
+  >   let substr_len = String.length substr in
+  >   let rec loop i =
+  >     i + substr_len <= len
+  >     && (String.sub s i substr_len = substr || loop (i + 1))
+  >   in
+  >   loop 0
+  > ;;
+  > 
+  > let input_path suffix =
+  >   Array.find_opt
+  >     (fun arg -> has_substring arg (".melange_src/x" ^ suffix))
+  >     Sys.argv
+  >   |> Option.get
+  > ;;
+  > 
+  > let loc ~suffix =
+  >   ignore (input_path suffix);
+  >   let loc_start =
+  >     { Lexing.pos_fname = !Ocaml_common.Location.input_name
+  >     ; pos_lnum = 1
+  >     ; pos_bol = 0
+  >     ; pos_cnum = 8
+  >     }
+  >   in
+  >   let loc_end = { loc_start with pos_cnum = 12 } in
+  >   { Location.loc_start; loc_end; loc_ghost = false }
+  > ;;
+  > 
+  > let impl _ =
+  >   let loc = loc ~suffix:".ml" in
+  >   let open Ast_builder.Default in
+  >   [ pstr_value
+  >       ~loc
+  >       Nonrecursive
+  >       [ value_binding
+  >           ~loc
+  >           ~pat:(ppat_var ~loc { txt = "x"; loc })
+  >           ~expr:
+  >             (pexp_constraint
+  >                ~loc
+  >                (eunit ~loc)
+  >                (ptyp_constr ~loc { txt = Longident.Lident "nope"; loc } []))
+  >       ]
+  >   ]
+  > ;;
+  > 
+  > let intf _ =
+  >   let loc = loc ~suffix:".mli" in
+  >   let open Ast_builder.Default in
+  >   [ psig_value
+  >       ~loc
+  >       (value_description
+  >          ~loc
+  >          ~name:{ txt = "x"; loc }
+  >          ~type_:(ptyp_constr ~loc { txt = Longident.Lident "nope"; loc } [])
+  >          ~prim:[])
+  >   ]
+  > ;;
+  > 
+  > let () = Driver.register_transformation "ppx_locations" ~impl ~intf
+  > EOF
+
+Action preprocessors may emit locations that still point at a copied Melange
+implementation. The copied source must be available in the compile sandbox.
+
+  $ mkdir -p cases/copied-impl/src
+
+  $ cat > cases/copied-impl/src/dune <<'EOF'
+  > (library
+  >  (name copied_impl)
+  >  (modes melange)
+  >  (modules x)
+  >  (preprocess
+  >   (action
+  >    (run sh -c "printf '# 1 \"%s\"\\nlet x : nope = ()\\n' \"$1\"" -- %{input-file}))))
+  > EOF
+
+  $ cat > cases/copied-impl/src/x.ml <<'EOF'
+  > let x = 1
+  > EOF
+
+  $ dune build --root cases --sandbox=symlink @copied-impl/src/all
+  Entering directory 'cases'
+  File "copied-impl/src/.melange_src/x.ml", line 1, characters 8-12:
+  Error: Unbound type constructor nope
+  Leaving directory 'cases'
+  [1]
+
+ppxlib-generated implementation locations should use the original source
+filename even though the PPX reads the copied Melange source.
+
+  $ mkdir -p cases/logical-ocaml-impl/src
+
+  $ cat > cases/logical-ocaml-impl/src/dune <<'EOF'
+  > (library
+  >  (name logical_ocaml_impl)
+  >  (modes melange)
+  >  (modules x)
+  >  (preprocess
+  >   (pps ppx_locations)))
+  > EOF
+
+  $ cat > cases/logical-ocaml-impl/src/x.ml <<'EOF'
+  > let x = "ocaml"
+  > EOF
+
+  $ dune build --root cases --sandbox=symlink @logical-ocaml-impl/src/all
+  Entering directory 'cases'
+  File "logical-ocaml-impl/src/.melange_src/x.ml", line 1, characters 8-12:
+  Error: Unbound type constructor nope
+  Leaving directory 'cases'
+  [1]
+
+ppxlib-generated implementation locations should use the original conditional
+Melange source filename even though the PPX reads the copied Melange source.
+
+  $ mkdir -p cases/logical-melange-impl/src
+
+  $ cat > cases/logical-melange-impl/src/dune <<'EOF'
+  > (library
+  >  (name logical_melange_impl)
+  >  (modes melange)
+  >  (modules x)
+  >  (preprocess
+  >   (pps ppx_locations)))
+  > EOF
+
+  $ cat > cases/logical-melange-impl/src/x.ml <<'EOF'
+  > let x = "ocaml"
+  > EOF
+
+  $ cat > cases/logical-melange-impl/src/x.melange.ml <<'EOF'
+  > let x = "melange"
+  > EOF
+
+  $ dune build --root cases --sandbox=symlink @logical-melange-impl/src/all
+  Entering directory 'cases'
+  File "logical-melange-impl/src/.melange_src/x.ml", line 1, characters 8-12:
+  Error: Unbound type constructor nope
+  Leaving directory 'cases'
+  [1]
+
+ppxlib-generated interface locations should also use the original source
+filename even though the PPX reads the copied Melange source.
+
+  $ mkdir -p cases/logical-ocaml-intf/src
+
+  $ cat > cases/logical-ocaml-intf/src/dune <<'EOF'
+  > (library
+  >  (name logical_ocaml_intf)
+  >  (modes melange)
+  >  (modules x)
+  >  (preprocess
+  >   (pps ppx_locations)))
+  > EOF
+
+  $ cat > cases/logical-ocaml-intf/src/x.mli <<'EOF'
+  > val x : int
+  > EOF
+
+  $ cat > cases/logical-ocaml-intf/src/x.ml <<'EOF'
+  > let x = Obj.magic ()
+  > EOF
+
+  $ dune build --root cases --sandbox=symlink @logical-ocaml-intf/src/all
+  Entering directory 'cases'
+  File "logical-ocaml-intf/src/.melange_src/x.mli", line 1, characters 8-12:
+  Error: Unbound type constructor nope
+  Leaving directory 'cases'
+  [1]
+
+ppxlib-generated interface locations should use the original conditional
+Melange source filename even though the PPX reads the copied Melange source.
+
+  $ mkdir -p cases/logical-melange-intf/src
+
+  $ cat > cases/logical-melange-intf/src/dune <<'EOF'
+  > (library
+  >  (name logical_melange_intf)
+  >  (modes melange)
+  >  (modules x)
+  >  (preprocess
+  >   (pps ppx_locations)))
+  > EOF
+
+  $ cat > cases/logical-melange-intf/src/x.mli <<'EOF'
+  > val x : int
+  > EOF
+
+  $ cat > cases/logical-melange-intf/src/x.melange.mli <<'EOF'
+  > val x : string
+  > EOF
+
+  $ cat > cases/logical-melange-intf/src/x.ml <<'EOF'
+  > let x = Obj.magic ()
+  > EOF
+
+  $ dune build --root cases --sandbox=symlink @logical-melange-intf/src/all
+  Entering directory 'cases'
+  File "logical-melange-intf/src/.melange_src/x.mli", line 1, characters 8-12:
+  Error: Unbound type constructor nope
+  Leaving directory 'cases'
+  [1]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/melange-pps-runtime-libs.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/melange-pps-runtime-libs.t
@@ -41,6 +41,7 @@ stub-driver pattern in `ppx-runtime-libraries.t`).
   >     ; ("--impl", Arg.Set_string (ref ""), "")
   >     ; ("--as-ppx", Arg.Set (ref false), "")
   >     ; ("--cookie", Arg.Set (ref false), "")
+  >     ; ("-loc-filename", Arg.String ignore, "")
   >     ]
   >   in
   >   let anon _ = () in
@@ -52,7 +53,10 @@ The melange.emit preprocesses with `hello_ppx`:
 
   $ mkdir me
   $ cat > me/dune <<EOF
-  > (melange.emit (target output) (preprocess (pps hello_ppx)))
+  > (melange.emit
+  >  (target output)
+  >  (emit_stdlib false)
+  >  (preprocess (pps hello_ppx)))
   > EOF
   $ cat > me/foo.ml <<EOF
   > let _ = ()

--- a/test/blackbox-tests/utils/refmt.ml
+++ b/test/blackbox-tests/utils/refmt.ml
@@ -19,17 +19,22 @@ let read_all file =
 let write_stdout file = output_string stdout (read_all file)
 
 let write_binary_ast source kind =
+  let source =
+    if Filename.is_relative source then Filename.concat (Sys.getcwd ()) source else source
+  in
   let tmp = Filename.temp_file "refmt" ".ast" in
+  let ic = open_in source in
   Fun.protect
-    ~finally:(fun () -> Sys.remove tmp)
+    ~finally:(fun () ->
+      close_in_noerr ic;
+      Sys.remove tmp)
     (fun () ->
+       Location.input_name := source;
+       let lb = Lexing.from_channel ic in
+       Location.init lb source;
        (match kind with
-        | Impl ->
-          Pparse.parse_implementation ~tool_name:"refmt" source
-          |> Pparse.write_ast Structure tmp
-        | Intf ->
-          Pparse.parse_interface ~tool_name:"refmt" source
-          |> Pparse.write_ast Signature tmp);
+        | Impl -> Pparse.write_ast Structure tmp (Parse.implementation lb)
+        | Intf -> Pparse.write_ast Signature tmp (Parse.interface lb));
        write_stdout tmp)
 ;;
 


### PR DESCRIPTION
Backport #14715 onto 3.24.0-rc.

Fixes the melange build failure on OCaml 4.14 where dune emits an `I/O error: jscomp/runtime/.melange_src/X.mli: No such file or directory` against every `melange-re/melange.*-414` reverse dep (see ocaml/opam-repository#29996 — the 3.24.0~alpha2 release PR). The fix is to skip the line directive in `setup_melange_sources_copy_rules` when a module uses non-staged PPX, since the PPX pipeline now passes `-loc-filename` separately and adding the directive would double-shift diagnostics.

The fix has a small precursor chain on `main`; bringing the headline `#14715` alone doesn't apply cleanly because subsequent PRs introduced the test files and machinery the fix's diff targets. Included PRs (chronological):

- #14697 — test: show single context melange loses ppx snippet previews
- #14698 — test: show single context reason+melange loses ppx snippet previews
- #14708 — test: accept ppx loc-filename in fixtures
- #14706 — **fix**: preserve original ppx source locations (introduces `-loc-filename`)
- #14714 — test: reproduce reason source location regression
- #14715 — **fix**: avoid line directive when passing `-loc-filename`