### PR TITLE
fix(pkg): fold (when false _) away in slang simplify

### DIFF
--- a/doc/changes/fixed/15092.md
+++ b/doc/changes/fixed/15092.md
@@ -1,3 +1,3 @@
 - Simplify away `(when false _)` expressions (encoded `Nil`s) that previously
   survived inside `concat` and `when` forms, producing cleaner generated lock
-  directories. (#15095, #15090, @chizy7)
+  directories. (#15092, fixes #15090, @chizy7)

--- a/doc/changes/fixed/15092.md
+++ b/doc/changes/fixed/15092.md
@@ -1,0 +1,3 @@
+- Simplify away `(when false _)` expressions (encoded `Nil`s) that previously
+  survived inside `concat` and `when` forms, producing cleaner generated lock
+  directories. (#15095, #15090, @chizy7)

--- a/src/dune_lang/slang.ml
+++ b/src/dune_lang/slang.ml
@@ -284,48 +284,53 @@ let rec simplify = function
   | Literal sw -> Literal sw
   | Form (loc, form) ->
     (match form with
-     (* CR-someday Alizter: This does multiple passes: exists, filter, then
-        simplify recursively. Simplify and filter out Nil in a single pass
-        instead. *)
-     | Concat with_nil when List.exists with_nil ~f:is_nil ->
-       simplify (Form (loc, Concat (List.filter with_nil ~f:(Fun.negate is_nil))))
-     | Concat [] -> Literal (String_with_vars.make_text ~quoted:true loc "")
-     | Concat [ x ] -> simplify x
      | Concat xs ->
-       let simple_terms =
-         List.map xs ~f:(function
-           | Literal sw ->
-             (match String_with_vars.text_only sw with
-              | Some text -> Some (`Text text)
-              | None ->
-                (match String_with_vars.pform_only sw with
-                 | Some pform -> Some (`Pform pform)
-                 | None -> None))
-           | _ -> None)
+       (* Simplify each element and drop any that simplify to [Nil] in a single
+          pass, then combine the remaining terms. *)
+       let xs =
+         List.filter_map xs ~f:(fun x ->
+           let x = simplify x in
+           if is_nil x then None else Some x)
        in
-       if List.for_all simple_terms ~f:Option.is_some
-       then (
-         (* Each element of the concatenated list is either a string or pform
-            so it's trivial to combine them into a single [String_with_vars.t].
-         *)
-         let parts = List.filter_opt simple_terms in
-         let quoted =
-           (* only quote strings when not quoting them would be an error *)
-           not
-             (List.for_all parts ~f:(function
-                | `Pform _ -> true
-                | `Text s -> Atom.is_valid s))
-         in
-         let combined_sw = String_with_vars.make ~quoted loc parts in
-         Literal combined_sw)
-       else Form (loc, Concat (List.map xs ~f:simplify))
-     | When (_, Nil) -> Nil
+       (match xs with
+        | [] -> Literal (String_with_vars.make_text ~quoted:true loc "")
+        | [ x ] -> x
+        | xs ->
+          let simple_terms =
+            List.map xs ~f:(function
+              | Literal sw ->
+                (match String_with_vars.text_only sw with
+                 | Some text -> Some (`Text text)
+                 | None ->
+                   (match String_with_vars.pform_only sw with
+                    | Some pform -> Some (`Pform pform)
+                    | None -> None))
+              | _ -> None)
+          in
+          if List.for_all simple_terms ~f:Option.is_some
+          then (
+            (* Each element of the concatenated list is either a string or pform
+               so it's trivial to combine them into a single [String_with_vars.t].
+            *)
+            let parts = List.filter_opt simple_terms in
+            let quoted =
+              (* only quote strings when not quoting them would be an error *)
+              not
+                (List.for_all parts ~f:(function
+                   | `Pform _ -> true
+                   | `Text s -> Atom.is_valid s))
+            in
+            let combined_sw = String_with_vars.make ~quoted loc parts in
+            Literal combined_sw)
+          else Form (loc, Concat xs))
      | When (condition, t) ->
-       let simplified_condition = simplify_blang condition in
-       (match (simplified_condition : blang) with
-        | Const true -> t
+       (match (simplify_blang condition : blang) with
+        | Const true -> simplify t
         | Const false -> Nil
-        | _ -> Form (loc, When (simplified_condition, simplify t)))
+        | simplified_condition ->
+          (match simplify t with
+           | Nil -> Nil
+           | t -> Form (loc, When (simplified_condition, t))))
      | If { condition; then_; else_ } ->
        (match simplify_blang condition with
         | Const true -> simplify then_

--- a/test/expect-tests/dune_lang/slang_tests.ml
+++ b/test/expect-tests/dune_lang/slang_tests.ml
@@ -331,8 +331,9 @@ let%expect_test "when unknown nil" =
   [%expect {| Nil |}]
 ;;
 
-(* These [(when false _)] expressions aren't simplified yet: the [Nil] from
-   the [When] child survives because [Nil] is filtered before children. *)
+(* A [(when false _)] expression encodes [Nil], so it folds away inside [concat]
+   and [when] just like a [Nil] does, even when the [Nil] only appears after
+   simplifying a child. *)
 
 let%expect_test "concat with when-false (should simplify to \"ab\")" =
   print_slang
@@ -340,7 +341,7 @@ let%expect_test "concat with when-false (should simplify to \"ab\")" =
        [ Slang.text "a"; Slang.when_ (const false) (Slang.text ""); Slang.text "b" ]);
   [%expect
     {|
-    Concat (Literal "a", Nil, Literal "b")
+    Literal (template "ab")
     |}]
 ;;
 
@@ -348,7 +349,7 @@ let%expect_test "when-unknown of when-false (should simplify to Nil)" =
   print_slang (Slang.when_ (expr (pform "x")) (Slang.when_ (const false) (Slang.text "")));
   [%expect
     {|
-    When (Expr (Literal (template "%{pkg-self:x}")), Nil)
+    Nil
     |}]
 ;;
 


### PR DESCRIPTION
Makes `Slang.simplify` fold away `(when false _)` (encoded `Nil`) even when the `Nil` only appears after simplifying a child, in `concat` and `when` forms:

* `concat ["a"; (when false ""); "b"]` -> `"ab"` (previously `Concat (Literal "a", Nil, Literal "b")`)
* `when <unknown> (when false "")` -> `Nil` (previously `When (Expr …, Nil)`)

Flips the repro tests aded in #15084 green

Addresses **A** of #15090. The `Run`-args drop (**B**) remains separate.

Fixes #15090
Refs #14457