### PR TITLE
test(memo): add a shared test harness and an event-tracking test

### DIFF
--- a/test/expect-tests/memo/event_tracking.ml
+++ b/test/expect-tests/memo/event_tracking.ml
@@ -1,0 +1,125 @@
+(* Tests for tracking Memo node events. *)
+
+open! Stdune
+open! Memo.O
+open Test_helpers.Make ()
+
+let%expect_test _ =
+  let divisor = Memo.Var.create ~name:"divisor" 2 in
+  let table =
+    Memo.create_rec
+      "division via subtraction"
+      ~input:(module Int)
+      ~cutoff:Int.equal
+      ~on_event:(fun input event ->
+        let event =
+          match (event : Memo.Event.t) with
+          | Live -> "Live"
+          | Validated -> "Validated"
+        in
+        printf "[on_event %d %s] called\n" input event)
+      (fun f input ->
+         let* divisor = Memo.Var.read divisor in
+         if divisor < 0 then failwith "Negative divisors are not allowed!";
+         if input < divisor
+         then Memo.return 0
+         else if input = divisor
+         then Memo.return 1
+         else
+           let+ result = f (input - divisor) in
+           result + 1)
+  in
+  List.iter [ 4; 5; 6; 4; 5; 6 ] ~f:(evaluate_and_print table);
+  (* Nodes {1..6} become live; [Live] then [Validated] fire once for each live node. *)
+  [%expect
+    {|
+    [on_event 4 Live] called
+    [on_event 2 Live] called
+    [on_event 2 Validated] called
+    [on_event 4 Validated] called
+    f 4 = Ok 2
+    [on_event 5 Live] called
+    [on_event 3 Live] called
+    [on_event 1 Live] called
+    [on_event 1 Validated] called
+    [on_event 3 Validated] called
+    [on_event 5 Validated] called
+    f 5 = Ok 2
+    [on_event 6 Live] called
+    [on_event 6 Validated] called
+    f 6 = Ok 3
+    f 4 = Ok 2
+    f 5 = Ok 2
+    f 6 = Ok 3
+    |}];
+  Memo.reset (Memo.Var.set divisor 3);
+  List.iter [ 3; 6; 9 ] ~f:(evaluate_and_print table);
+  [%expect
+    {|
+    [on_event 3 Live] called
+    [on_event 3 Validated] called
+    f 3 = Ok 1
+    [on_event 6 Live] called
+    [on_event 6 Validated] called
+    f 6 = Ok 2
+    [on_event 9 Live] called
+    [on_event 9 Validated] called
+    f 9 = Ok 3
+    |}];
+  Memo.reset (Memo.Var.set divisor (-5));
+  List.iter [ 8; 9; 9 ] ~f:(evaluate_and_print table);
+  (* Liveness tracking works for nodes whose outputs are errors. *)
+  [%expect
+    {|
+    [on_event 8 Live] called
+    [on_event 8 Validated] called
+    f 8 = Error
+            [ { exn = "Failure(\"Negative divisors are not allowed!\")"
+              ; backtrace = ""
+              }
+            ]
+    [on_event 9 Live] called
+    [on_event 9 Validated] called
+    f 9 = Error
+            [ { exn = "Failure(\"Negative divisors are not allowed!\")"
+              ; backtrace = ""
+              }
+            ]
+    f 9 = Error
+            [ { exn = "Failure(\"Negative divisors are not allowed!\")"
+              ; backtrace = ""
+              }
+            ]
+    |}];
+  Memo.reset (Memo.Var.set divisor 0);
+  List.iter [ 9; 10; 9 ] ~f:(evaluate_and_print table);
+  (* Liveness tracking works with dependency cycles too. *)
+  [%expect
+    {|
+    [on_event 9 Live] called
+    [on_event 9 Validated] called
+    Dependency cycle detected:
+    - ("division via subtraction", 9)
+    f 9 = Error
+            [ { exn = "Cycle_error.E [ (\"division via subtraction\", 9) ]"
+              ; backtrace = ""
+              }
+            ]
+    [on_event 10 Live] called
+    [on_event 10 Validated] called
+    Dependency cycle detected:
+    - ("division via subtraction", 10)
+    f 10 = Error
+             [ { exn = "Cycle_error.E [ (\"division via subtraction\", 10) ]"
+               ; backtrace = ""
+               }
+             ]
+    Dependency cycle detected:
+    - ("division via subtraction", 9)
+    f 9 = Error
+            [ { exn = "Cycle_error.E [ (\"division via subtraction\", 9) ]"
+              ; backtrace = ""
+              }
+            ]
+    |}]
+;;

--- a/test/expect-tests/memo/test_helpers.ml
+++ b/test/expect-tests/memo/test_helpers.ml
@@ -1,0 +1,89 @@
+open Stdune
+open Dune_tests_common
+
+(* Shared harness for the Memo unit tests, factored out so the focused test files
+   below can each [open Test_helpers.Make ()] for a fresh scheduler. *)
+module Make () = struct
+  module Scheduler = struct
+    let t = Test_scheduler.create ()
+    let yield () = Test_scheduler.yield t
+    let run f = Test_scheduler.run t f
+  end
+
+  let () = init ()
+  let printf = Printf.printf
+  let () = Memo.Debug.check_invariants := true
+
+  let print_metrics () =
+    Memo.Metrics.assert_invariants ();
+    printf "%s\n" (Memo.Metrics.report ~reset_after_reporting:true)
+  ;;
+
+  let string_fn_create name = Memo.create name ~input:(module String) ~cutoff:String.equal
+  let int_fn_create name ~cutoff = Memo.create name ~input:(module Int) ~cutoff
+  let run m = Scheduler.run (Memo.run m)
+
+  let run_memo f v =
+    try run (Memo.exec f v) with
+    | Memo.Error.E err -> raise (Memo.Error.get err)
+  ;;
+
+  let print_cycle_error cycle_error =
+    let frames = Memo.Cycle_error.get cycle_error in
+    printf "Dependency cycle detected:\n";
+    List.iteri frames ~f:(fun i frame ->
+      let called_by =
+        match i with
+        | 0 -> ""
+        | _ -> "called by "
+      in
+      printf "- %s%s\n" called_by (Dyn.to_string (Memo.Stack_frame.to_dyn frame)))
+  ;;
+
+  let print_result arg res =
+    let res =
+      Result.map_error
+        res
+        ~f:
+          (List.map
+             ~f:
+               (Exn_with_backtrace.map ~f:(fun exn ->
+                  match exn with
+                  | Memo.Cycle_error.E error ->
+                    print_cycle_error error;
+                    exn
+                  | _ -> exn)))
+    in
+    let open Dyn in
+    Format.printf
+      "f %d = %a@."
+      arg
+      Pp.to_fmt
+      (Dyn.pp (Result.to_dyn int (list Exn_with_backtrace.to_dyn) res))
+  ;;
+
+  let run_collect_errors f =
+    let open Fiber.O in
+    Fiber.collect_errors (fun () -> Memo.run (f ()))
+    >>| function
+    | Ok _ as res -> res
+    | Error errs ->
+      Error
+        (List.map errs ~f:(fun (e : Exn_with_backtrace.t) ->
+           match e.exn with
+           | Memo.Error.E err -> { e with exn = Memo.Error.get err }
+           | _ -> e))
+  ;;
+
+  let evaluate_and_print f x =
+    let res =
+      try
+        Fiber.run
+          ~iter:(fun () -> raise Exit)
+          (run_collect_errors (fun () -> Memo.exec f x))
+      with
+      | exn -> Error [ Exn_with_backtrace.capture exn ]
+    in
+    print_result x res
+  ;;
+end


### PR DESCRIPTION
Factor the Memo unit-test helpers (scheduler, `evaluate_and_print`,
`print_cycle_error`, ...) into a `Test_helpers.Make ()` functor so focused test
files can share a fresh harness, and add `event_tracking.ml` covering `on_event`
notifications (`Live`/`Validated`) across cutoffs, invalidation, errors, and
dependency cycles.
