### PR TITLE
test(memo): cover self-dependency cycles and cross-run recovery

### DIFF
--- a/test/expect-tests/memo/cycle_detection.ml
+++ b/test/expect-tests/memo/cycle_detection.ml
@@ -1,0 +1,34 @@
+(* Tests for dependency-cycle detection and recovery across runs. *)
+
+open! Stdune
+open! Memo.O
+open Test_helpers.Make ()
+
+(* While [cyclic] is set, [node i] depends on itself, forming a direct dependency
+   cycle during its own computation. Once the cycle is removed the node must be
+   recomputed - not served the cached cycle error - which exercises the rule that
+   dependency-cycle errors are non-reproducible. *)
+let%expect_test "a self-dependency cycle is detected, then recomputed after removal" =
+  let cyclic = Memo.Var.create ~name:"cyclic" true in
+  let node = ref None in
+  let table =
+    Memo.create
+      "node"
+      ~input:(module Int)
+      (fun i ->
+         let* cyclic = Memo.Var.read cyclic in
+         if cyclic then Memo.exec (Option.value_exn !node) i else Memo.return (i + 100))
+  in
+  node := Some table;
+  evaluate_and_print table 0;
+  [%expect
+    {|
+    Dependency cycle detected:
+    - ("node", 0)
+    f 0 = Error [ { exn = "Cycle_error.E [ (\"node\", 0) ]"; backtrace = "" } ]
+    |}];
+  Memo.reset (Memo.Var.set cyclic false);
+  evaluate_and_print table 0;
+  [%expect {| f 0 = Ok 100 |}];
+  Memo.reset Memo.Invalidation.empty
+;;


### PR DESCRIPTION
Add a test driving a node into a direct self-dependency cycle, then removing the
cycle and rebuilding: run 1 detects the single-node cycle (now exercising the
cycle-detection DAG, since the self-cycle pre-scan was removed in #15085); run 2
returns a value, confirming the node is recomputed rather than served the cached
(non-reproducible) cycle error.
