### PR TITLE
refactor(memo): extract the memo table into its own module

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1,6 +1,8 @@
 module Metrics0 = Metrics
+module Table0 = Table
 open Stdune
 module Metrics = Metrics0
+module Table = Table0
 open Fiber.O
 module Graph = Dune_graph.Graph
 module Console = Console
@@ -19,7 +21,7 @@ let of_reproducible_fiber = Fun.id
 module type Input = sig
   type t
 
-  include Table.Key with type t := t
+  include Stdune.Table.Key with type t := t
 end
 
 (* We can get rid of this once we use the memoization system more pervasively
@@ -35,7 +37,6 @@ exception Non_reproducible = Exec.Non_reproducible
 open Node
 module Error = Node.Error
 module Cycle_error = Node.Cycle_error
-module Table = Node.Table
 
 let () =
   Printexc.register_printer (fun exn ->

--- a/src/memo/node.ml
+++ b/src/memo/node.ml
@@ -347,13 +347,6 @@ module State = struct
   ;;
 end
 
-module Table = struct
-  type ('input, 'output) t =
-    { spec : ('input, 'output) Spec.t
-    ; cache : ('input, ('input, 'output) Dep_node.t) Store.t
-    }
-end
-
 module Stack_frame_with_state : sig
   type phase =
     | Restore_from_cache

--- a/src/memo/store.ml
+++ b/src/memo/store.ml
@@ -1,5 +1,3 @@
-open Stdune
-
 type ('k, 'v) t = (module Store_intf.Instance with type key = 'k and type value = 'v)
 
 let make (type k v) (module S : Store_intf.S with type key = k) : (k, v) t =
@@ -27,19 +25,19 @@ let find_or_add (type k v) ((module S) : (k, v) t) (k : k) ~(f : k -> v) : v =
 
 let iter (type k v) ((module S) : (k, v) t) ~(f : v -> unit) : unit = S.iter S.store ~f
 
-let of_table (type k v) (table : (k, v) Table.t) : (k, v) t =
+let of_table (type k v) (table : (k, v) Stdune.Table.t) : (k, v) t =
   (module struct
     type key = k
     type value = v
 
     let store = table
 
-    type t = (key, v) Table.t
+    type t = (key, v) Stdune.Table.t
 
-    let clear = Table.clear
-    let find = Table.find
-    let find_or_add = Table.find_or_add
-    let set = Table.set
-    let iter = Table.iter
+    let clear = Stdune.Table.clear
+    let find = Stdune.Table.find
+    let find_or_add = Stdune.Table.find_or_add
+    let set = Stdune.Table.set
+    let iter = Stdune.Table.iter
   end)
 ;;

--- a/src/memo/store.mli
+++ b/src/memo/store.mli
@@ -1,5 +1,3 @@
-open Stdune
-
 type ('a, 'b) t
 
 val make : (module Store_intf.S with type key = 'a) -> ('a, 'b) t
@@ -12,4 +10,4 @@ val find : ('a, 'b) t -> 'a -> 'b option
 val find_or_add : ('a, 'b) t -> 'a -> f:('a -> 'b) -> 'b
 
 val iter : ('a, 'b) t -> f:('b -> unit) -> unit
-val of_table : ('a, 'b) Table.t -> ('a, 'b) t
+val of_table : ('a, 'b) Stdune.Table.t -> ('a, 'b) t

--- a/src/memo/table.ml
+++ b/src/memo/table.ml
@@ -1,0 +1,8 @@
+open! Import
+
+(** A table memoizing the results of a function: the function's [spec] plus a
+    store mapping inputs to their dependency nodes. *)
+type ('input, 'output) t =
+  { spec : ('input, 'output) Spec.t
+  ; cache : ('input, ('input, 'output) Node.Dep_node.t) Store.t
+  }


### PR DESCRIPTION
Move the memo "table" type (a memoized function's `spec` plus its store of
dependency nodes) out of `memo.ml` into a dedicated `src/memo/table.ml`, matching
the one-module-per-concept layout used by the rest of the memo internals.

This is pure code motion, with one wrinkle from dune's conservative
module-dependency scanner: with `open Stdune` in scope, a bare `Table` token is
read as a dependency on the new sibling `Table` module, which would introduce a
`Store <-> Table` build cycle. To avoid that, `store.ml`/`store.mli` now refer to
the stdlib table as `Stdune.Table` (and drop their now-unused `open Stdune`), and
`memo.ml` captures the sibling before the open with `module Table0 = Table` -- the
same idiom already used for `Metrics0`.

No behavior change.
