### PR TITLE
refactor(memo): extract invalidation into its own module

### DIFF
--- a/src/memo/caches.ml
+++ b/src/memo/caches.ml
@@ -1,0 +1,7 @@
+open! Import
+
+(* We can get rid of this once we use the memoization system more pervasively
+   and all the dependencies are properly specified *)
+let cleaners = ref []
+let register ~clear = cleaners := clear :: !cleaners
+let clear () = List.iter !cleaners ~f:(fun f -> f ())

--- a/src/memo/invalidation.ml
+++ b/src/memo/invalidation.ml
@@ -1,0 +1,176 @@
+module Table0 = Table
+open! Import
+
+(* This is currently used only for informing the user about the reason for
+   restarting a build. *)
+module Reason = struct
+  type t =
+    | Unknown
+    | Path_changed of Path.t
+    | Event_queue_overflow
+    | Upgrade
+    | Test
+    | Variable_changed of string
+
+  let to_string_hum = function
+    | Unknown -> None
+    | Path_changed path -> Some (Path.to_string path ^ " changed")
+    | Event_queue_overflow -> Some "Event queue overflow; full rebuild required"
+    | Upgrade -> Some "Dune upgrader initiated a full rebuild"
+    | Test -> Some "Rebuild initiated by an internal testsuite"
+    | Variable_changed v -> Some (sprintf "Variable %s changed" v)
+  ;;
+
+  let equal a b =
+    match a, b with
+    | Unknown, Unknown
+    | Event_queue_overflow, Event_queue_overflow
+    | Upgrade, Upgrade
+    | Test, Test -> true
+    | Path_changed a, Path_changed b -> Path.equal a b
+    | Variable_changed a, Variable_changed b -> String.equal a b
+    | ( ( Unknown
+        | Path_changed _
+        | Event_queue_overflow
+        | Upgrade
+        | Test
+        | Variable_changed _ )
+      , _ ) -> false
+  ;;
+end
+
+module Leaf = struct
+  type kind =
+    | Invalidate_node : _ Node.Dep_node.t -> kind
+    | Clear_cache : ('input, ('input, 'output) Node.Dep_node.t) Store.t -> kind
+    | Clear_caches
+    | Custom of (unit -> unit)
+
+  type t =
+    { kind : kind
+    ; reason : Reason.t
+    }
+
+  let to_string_hum { reason; _ } = Reason.to_string_hum reason
+end
+
+module T = struct
+  (* Represented as a tree mainly to get a tail-recursive execution. *)
+  type t =
+    | Empty
+    | Leaf of Leaf.t
+    | Combine of t * t
+
+  let empty : t = Empty
+
+  let combine a b =
+    match a, b with
+    | Empty, x | x, Empty -> x
+    | x, y -> Combine (x, y)
+  ;;
+end
+
+include T
+include (Monoid.Make (T) : Monoid.S with type t := t)
+
+let invalidate_store = Store.iter ~f:Node.invalidate
+
+let execute_leaf { Leaf.kind; _ } =
+  match kind with
+  | Invalidate_node dep_node -> Node.invalidate dep_node
+  | Clear_cache store -> invalidate_store store
+  | Clear_caches -> Caches.clear ()
+  | Custom f -> f ()
+;;
+
+let rec execute x xs =
+  match x with
+  | Empty -> execute_list xs
+  | Leaf f ->
+    execute_leaf f;
+    execute_list xs
+  | Combine (x, y) -> execute x (y :: xs)
+
+and execute_list = function
+  | [] -> ()
+  | x :: xs -> execute x xs
+;;
+
+let rec to_list_x_xs x xs acc =
+  match x with
+  | Empty -> to_list_xs xs acc
+  | Leaf f -> to_list_xs xs (f :: acc)
+  | Combine (x, y) -> to_list_x_xs x (y :: xs) acc
+
+and to_list_xs xs acc =
+  match xs with
+  | [] -> acc
+  | x :: xs -> to_list_x_xs x xs acc
+;;
+
+let to_list t = to_list_x_xs t [] []
+
+let details_hum ?(max_elements = 1) t =
+  assert (max_elements > 0);
+  let details =
+    List.filter_map ~f:Leaf.to_string_hum (to_list t)
+    |> String.Set.of_list
+    |> String.Set.to_list
+  in
+  (* CR-someday amokhov: Right now we just take first [max_elements] elements
+     from the sorted list, but we could prioritise some reasons over others,
+     e.g. if there is a global reset because of [Event_queue_overflow], it may
+     be better to ensure that this reason is included. *)
+  match List.truncate ~max_length:max_elements details with
+  | `Not_truncated [] -> [ "Restarting for an unknown reason, please report it as a bug" ]
+  | `Not_truncated details -> details
+  | `Truncated truncated_details ->
+    let extra_message =
+      let remaining_details = List.length details - max_elements in
+      let plural =
+        match remaining_details > 1 with
+        | true -> "s"
+        | false -> ""
+      in
+      sprintf ", and %d more change%s" remaining_details plural
+    in
+    (match List.destruct_last truncated_details with
+     | None -> assert false
+     | Some (all_but_last, last) -> all_but_last @ [ last ^ extra_message ])
+;;
+
+let changed_paths t =
+  List.filter_map (to_list t) ~f:(fun ({ Leaf.reason; _ } : Leaf.t) ->
+    match reason with
+    | Path_changed path -> Some path
+    | Unknown | Event_queue_overflow | Upgrade | Test | Variable_changed _ -> None)
+  |> Path.Set.of_list
+  |> Path.Set.to_list
+;;
+
+let execute x = execute x []
+
+let is_empty = function
+  | Empty -> true
+  | _ -> false
+;;
+
+let clear_caches ~reason = Leaf { kind = Clear_caches; reason }
+
+let invalidate_cache ~reason ({ cache; _ } : _ Table0.t) =
+  Leaf { kind = Clear_cache cache; reason }
+;;
+
+let invalidate_node ~reason (dep_node : _ Node.Dep_node.t) =
+  Leaf { kind = Invalidate_node dep_node; reason }
+;;
+
+(* For out-of-band caching mechanisms that need to run an arbitrary action when the build
+   is invalidated. *)
+let custom ~reason ~f = Leaf { kind = Custom f; reason }
+
+let to_reason_list t =
+  List.fold_left (to_list t) ~init:[] ~f:(fun acc ({ Leaf.reason; _ } : Leaf.t) ->
+    if List.mem acc reason ~equal:Reason.equal then acc else reason :: acc)
+  |> List.rev
+;;

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -26,11 +26,6 @@ end
 
 (* We can get rid of this once we use the memoization system more pervasively
    and all the dependencies are properly specified *)
-module Caches = struct
-  let cleaners = ref []
-  let register ~clear = cleaners := clear :: !cleaners
-  let clear () = List.iter !cleaners ~f:(fun f -> f ())
-end
 
 exception Non_reproducible = Exec.Non_reproducible
 
@@ -85,45 +80,6 @@ module Stack_frame = struct
   ;;
 end
 
-(* There are two approaches to invalidating memoization nodes. Currently, when a
-   node is invalidated by calling [invalidate_dep_node], only the node itself is
-   marked as "changed" (by setting its [state] to [Out_of_date]). Then the whole
-   graph is marked as "possibly changed" by calling [Run.restart ()] that makes
-   all remaining [last_validated_at : Run.t] values out of date in O(1) time. In
-   the next run, the whole graph is traversed from top to bottom to discover
-   "actual changes" and recompute all the nodes affected by these changes. One
-   disadvantage of this approach is that the whole graph needs to be traversed
-   even if only a small part of it depends on the set of invalidated nodes.
-
-   An alternative approach is as follows. When [invalidate_dep_node] is called,
-   recursively mark all of its reverse dependencies as "possibly changed". Then,
-   in the next run, traverse only the marked part of graph (instead of the whole
-   graph as we do currently). One disadvantage of this approach is that every
-   node needs to store a list of its reverse dependencies, which introduces
-   cyclic memory references and complicates garbage collection. Another issue is
-   that recursively marking all reverse dependencies as "possibly changed" can
-   still result in marking too much, because there is no way to take the cutoff
-   predicate into account when propagating "possible changes".
-
-   Is it worth switching from the current approach to the alternative? It's best
-   to answer this question by benchmarking. This is not urgent but is worth
-   documenting in the code. *)
-let invalidate_dep_node (dep_node : _ Dep_node.t) =
-  match dep_node.state with
-  | Cached -> dep_node.state <- Out_of_date
-  | Not_cached | Out_of_date -> ()
-  | Restoring _ ->
-    Code_error.raise
-      "invalidate_dep_node called on a node in Restoring state"
-      [ "dep_node", Dep_node.to_dyn_without_state dep_node ]
-  | Computing _ ->
-    Code_error.raise
-      "invalidate_dep_node called on a node in Computing state"
-      [ "dep_node", Dep_node.to_dyn_without_state dep_node ]
-;;
-
-let invalidate_store = Store.iter ~f:invalidate_dep_node
-
 let create_with_cache
       (type i o)
       name
@@ -140,7 +96,7 @@ let create_with_cache
   in
   Caches.register ~clear:(fun () ->
     Store.clear cache;
-    invalidate_store cache);
+    Invalidation.invalidate_store cache);
   { cache; spec }
 ;;
 
@@ -258,180 +214,7 @@ let dump_cached_graph ?(on_not_cached = `Raise) ?(time_nodes = false) cell =
 
 let get_call_stack = Call_stack.get_call_stack_without_state
 
-module Invalidation = struct
-  (* This is currently used only for informing the user about the reason for
-     restarting a build. *)
-  module Reason = struct
-    type t =
-      | Unknown
-      | Path_changed of Path.t
-      | Event_queue_overflow
-      | Upgrade
-      | Test
-      | Variable_changed of string
-
-    let to_string_hum = function
-      | Unknown -> None
-      | Path_changed path -> Some (Path.to_string path ^ " changed")
-      | Event_queue_overflow -> Some "Event queue overflow; full rebuild required"
-      | Upgrade -> Some "Dune upgrader initiated a full rebuild"
-      | Test -> Some "Rebuild initiated by an internal testsuite"
-      | Variable_changed v -> Some (sprintf "Variable %s changed" v)
-    ;;
-
-    let equal a b =
-      match a, b with
-      | Unknown, Unknown
-      | Event_queue_overflow, Event_queue_overflow
-      | Upgrade, Upgrade
-      | Test, Test -> true
-      | Path_changed a, Path_changed b -> Path.equal a b
-      | Variable_changed a, Variable_changed b -> String.equal a b
-      | ( ( Unknown
-          | Path_changed _
-          | Event_queue_overflow
-          | Upgrade
-          | Test
-          | Variable_changed _ )
-        , _ ) -> false
-    ;;
-  end
-
-  module Leaf = struct
-    type kind =
-      | Invalidate_node : _ Dep_node.t -> kind
-      | Clear_cache : ('input, ('input, 'output) Dep_node.t) Store.t -> kind
-      | Clear_caches
-      | Custom of (unit -> unit)
-
-    type t =
-      { kind : kind
-      ; reason : Reason.t
-      }
-
-    let to_string_hum { reason; _ } = Reason.to_string_hum reason
-  end
-
-  module T = struct
-    (* Represented as a tree mainly to get a tail-recursive execution. *)
-    type t =
-      | Empty
-      | Leaf of Leaf.t
-      | Combine of t * t
-
-    let empty : t = Empty
-
-    let combine a b =
-      match a, b with
-      | Empty, x | x, Empty -> x
-      | x, y -> Combine (x, y)
-    ;;
-  end
-
-  include T
-  include (Monoid.Make (T) : Monoid.S with type t := t)
-
-  let execute_leaf { Leaf.kind; _ } =
-    match kind with
-    | Invalidate_node dep_node -> invalidate_dep_node dep_node
-    | Clear_cache store -> invalidate_store store
-    | Clear_caches -> Caches.clear ()
-    | Custom f -> f ()
-  ;;
-
-  let rec execute x xs =
-    match x with
-    | Empty -> execute_list xs
-    | Leaf f ->
-      execute_leaf f;
-      execute_list xs
-    | Combine (x, y) -> execute x (y :: xs)
-
-  and execute_list = function
-    | [] -> ()
-    | x :: xs -> execute x xs
-  ;;
-
-  let rec to_list_x_xs x xs acc =
-    match x with
-    | Empty -> to_list_xs xs acc
-    | Leaf f -> to_list_xs xs (f :: acc)
-    | Combine (x, y) -> to_list_x_xs x (y :: xs) acc
-
-  and to_list_xs xs acc =
-    match xs with
-    | [] -> acc
-    | x :: xs -> to_list_x_xs x xs acc
-  ;;
-
-  let to_list t = to_list_x_xs t [] []
-
-  let details_hum ?(max_elements = 1) t =
-    assert (max_elements > 0);
-    let details =
-      List.filter_map ~f:Leaf.to_string_hum (to_list t)
-      |> String.Set.of_list
-      |> String.Set.to_list
-    in
-    (* CR-someday amokhov: Right now we just take first [max_elements] elements
-       from the sorted list, but we could prioritise some reasons over others,
-       e.g. if there is a global reset because of [Event_queue_overflow], it may
-       be better to ensure that this reason is included. *)
-    match List.truncate ~max_length:max_elements details with
-    | `Not_truncated [] ->
-      [ "Restarting for an unknown reason, please report it as a bug" ]
-    | `Not_truncated details -> details
-    | `Truncated truncated_details ->
-      let extra_message =
-        let remaining_details = List.length details - max_elements in
-        let plural =
-          match remaining_details > 1 with
-          | true -> "s"
-          | false -> ""
-        in
-        sprintf ", and %d more change%s" remaining_details plural
-      in
-      (match List.destruct_last truncated_details with
-       | None -> assert false
-       | Some (all_but_last, last) -> all_but_last @ [ last ^ extra_message ])
-  ;;
-
-  let changed_paths t =
-    List.filter_map (to_list t) ~f:(fun ({ Leaf.reason; _ } : Leaf.t) ->
-      match reason with
-      | Path_changed path -> Some path
-      | Unknown | Event_queue_overflow | Upgrade | Test | Variable_changed _ -> None)
-    |> Path.Set.of_list
-    |> Path.Set.to_list
-  ;;
-
-  let execute x = execute x []
-
-  let is_empty = function
-    | Empty -> true
-    | _ -> false
-  ;;
-
-  let clear_caches ~reason = Leaf { kind = Clear_caches; reason }
-
-  let invalidate_cache ~reason ({ cache; _ } : _ Table.t) =
-    Leaf { kind = Clear_cache cache; reason }
-  ;;
-
-  let invalidate_node ~reason (dep_node : _ Dep_node.t) =
-    Leaf { kind = Invalidate_node dep_node; reason }
-  ;;
-
-  (* For out-of-band caching mechanisms that need to run an arbitrary action when the build
-     is invalidated. *)
-  let custom ~reason ~f = Leaf { kind = Custom f; reason }
-
-  let to_reason_list t =
-    List.fold_left (to_list t) ~init:[] ~f:(fun acc ({ Leaf.reason; _ } : Leaf.t) ->
-      if List.mem acc reason ~equal:Reason.equal then acc else reason :: acc)
-    |> List.rev
-  ;;
-end
+module Invalidation = Invalidation
 
 module Current_run = struct
   let f () = Run.current () |> return

--- a/src/memo/node.ml
+++ b/src/memo/node.ml
@@ -347,6 +347,43 @@ module State = struct
   ;;
 end
 
+(* There are two approaches to invalidating memoization nodes. Currently, when a
+   node is invalidated by calling [invalidate], only the node itself is
+   marked as "changed" (by setting its [state] to [Out_of_date]). Then the whole
+   graph is marked as "possibly changed" by calling [Run.restart ()] that makes
+   all remaining [last_validated_at : Run.t] values out of date in O(1) time. In
+   the next run, the whole graph is traversed from top to bottom to discover
+   "actual changes" and recompute all the nodes affected by these changes. One
+   disadvantage of this approach is that the whole graph needs to be traversed
+   even if only a small part of it depends on the set of invalidated nodes.
+
+   An alternative approach is as follows. When [invalidate] is called,
+   recursively mark all of its reverse dependencies as "possibly changed". Then,
+   in the next run, traverse only the marked part of graph (instead of the whole
+   graph as we do currently). One disadvantage of this approach is that every
+   node needs to store a list of its reverse dependencies, which introduces
+   cyclic memory references and complicates garbage collection. Another issue is
+   that recursively marking all reverse dependencies as "possibly changed" can
+   still result in marking too much, because there is no way to take the cutoff
+   predicate into account when propagating "possible changes".
+
+   Is it worth switching from the current approach to the alternative? It's best
+   to answer this question by benchmarking. This is not urgent but is worth
+   documenting in the code. *)
+let invalidate (dep_node : _ Dep_node.t) =
+  match dep_node.state with
+  | Cached -> dep_node.state <- Out_of_date
+  | Not_cached | Out_of_date -> ()
+  | Restoring _ ->
+    Code_error.raise
+      "Node.invalidate called on a node in Restoring state"
+      [ "dep_node", Dep_node.to_dyn_without_state dep_node ]
+  | Computing _ ->
+    Code_error.raise
+      "Node.invalidate called on a node in Computing state"
+      [ "dep_node", Dep_node.to_dyn_without_state dep_node ]
+;;
+
 module Stack_frame_with_state : sig
   type phase =
     | Restore_from_cache


### PR DESCRIPTION
Move the `Invalidation` tree (restart reasons, leaves, and execution) out of
`memo.ml` into a dedicated `src/memo/invalidation.ml`, alongside the other memo
internals. The small `Caches` cleaner registry moves into `src/memo/caches.ml`,
and the per-node `invalidate` operation moves into `node.ml` as `Node.invalidate`.
`invalidate_store` (which invalidates a whole store via
`Store.iter ~f:Node.invalidate`) lives in `invalidation.ml` next to its only
caller, so `invalidation.ml` depends only on its sibling modules with no cycle
back through `memo.ml`.

As in `table.ml`, the sibling `Table` module is captured before `open Import`
(the `Metrics0` idiom) so `Stdune.Table` can be used without ambiguity.

Pure code motion; no behavior change.
