### PR TITLE
feat(memo): expose Run.For_testing and Run.Pair.invalid

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -136,7 +136,7 @@ let make_dep_node ~spec ~input : _ Dep_node.t =
   ; spec
   ; state = Not_cached
   ; value = Uninitialized
-  ; runs = Run.Pair.create ~last_changed_at:Run.invalid ~last_validated_at:Run.invalid
+  ; runs = Run.Pair.invalid
   ; deps = Deps.empty
   }
 ;;
@@ -418,6 +418,10 @@ module Run = struct
   module For_tests = struct
     let compare = Run.compare
     let current = Run.current
+    let of_int = Run.For_testing.of_int
+    let to_int = Run.For_testing.to_int
+
+    module Pair = Run.Pair
   end
 end
 

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -364,6 +364,19 @@ module Run : sig
   module For_tests : sig
     val compare : t -> t -> Ordering.t
     val current : unit -> t
+    val of_int : int -> t
+    val to_int : t -> int
+
+    module Pair : sig
+      type run := t
+      type t
+
+      val create : last_changed_at:run -> last_validated_at:run -> t
+      val last_changed_at : t -> run
+      val last_validated_at : t -> run
+      val with_last_validated_at : t -> last_validated_at:run -> t
+      val invalid : t
+    end
   end
 end
 

--- a/src/memo/run.ml
+++ b/src/memo/run.ml
@@ -34,4 +34,12 @@ module Pair = struct
   let[@inline always] with_last_validated_at t ~last_validated_at =
     create ~last_changed_at:(last_changed_at t) ~last_validated_at
   ;;
+
+  (* The pair of two invalid runs; packs to [0]. *)
+  let invalid = create ~last_changed_at:invalid ~last_validated_at:invalid
+end
+
+module For_testing = struct
+  let of_int t = t
+  let to_int t = t
 end

--- a/src/memo/run.mli
+++ b/src/memo/run.mli
@@ -49,4 +49,15 @@ module Pair : sig
   (** [with_last_validated_at t ~last_validated_at] preserves [last_changed_at t].
       The caller must ensure [last_changed_at t <= last_validated_at] still holds. *)
   val with_last_validated_at : t -> last_validated_at:run -> t
+
+  (** The pair of two invalid runs. *)
+  val invalid : t
+end
+
+module For_testing : sig
+  (** [of_int] / [to_int] are the identity; they expose the [int] representation
+      of [t] for tests. *)
+  val of_int : int -> t
+
+  val to_int : t -> int
 end


### PR DESCRIPTION
Add `Run.For_testing.{of_int,to_int}` (the identity on `Run`'s `int`
representation) and `Run.Pair.invalid` (the packing of two invalid runs), and
re-export `of_int`, `to_int`, and `module Pair` through `Memo.Run.For_tests`.
This is a test-only surface that lets unit tests construct and inspect
`Run.Pair` bit-packings directly. The freshly-created node now uses
`Run.Pair.invalid` in place of the open-coded `create`.

First of a short series adding regression coverage for recently-landed memo
internals; this exposes the handles a `Run.Pair` packing test needs.
