### PR TITLE
feat(memo): add Deps.For_debugging.to_dyn

### DIFF
--- a/src/memo/deps.ml
+++ b/src/memo/deps.ml
@@ -124,4 +124,15 @@ module For_debugging = struct
     in
     loop [] t
   ;;
+
+  let to_dyn node_to_dyn t =
+    let rec loop (t : _ Static.t) =
+      match t with
+      | Empty -> Dyn.variant "Empty" []
+      | Singleton node -> Dyn.variant "Singleton" [ node_to_dyn node ]
+      | Seq arr -> Dyn.variant "Seq" [ Dyn.list loop (Array.Immutable.to_list arr) ]
+      | Par arr -> Dyn.variant "Par" [ Dyn.list loop (Array.Immutable.to_list arr) ]
+    in
+    loop t
+  ;;
 end

--- a/src/memo/deps.mli
+++ b/src/memo/deps.mli
@@ -43,4 +43,8 @@ val changed_or_not
 
 module For_debugging : sig
   val to_list : 'node t -> 'node list
+
+  (** A structural rendering that preserves the [Seq]/[Par]/[Singleton]/[Empty]
+      nesting (and intra-[Seq] order), unlike [to_list] which flattens. *)
+  val to_dyn : ('node -> Dyn.t) -> 'node t -> Dyn.t
 end


### PR DESCRIPTION
Add a structural printer for the series-parallel dependency graph
(`Deps.For_debugging.to_dyn`) that preserves the `Seq`/`Par`/`Singleton`/`Empty`
nesting and intra-`Seq` order, unlike the existing `to_list` which flattens it.
This makes the dependency representation observable in tests.

Second of a short series adding regression coverage for recently-landed memo
internals; it unblocks the dependency-representation test.
