### PR TITLE
test(memo): cover the series-parallel dependency representation

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -407,6 +407,17 @@ module For_tests = struct
               dep.spec.name, Dep_node.input_to_dyn dep)))
   ;;
 
+  let get_deps_structured (cell : (_, _) Cell.t) =
+    match get_cached_deps_in_current_run cell with
+    | None -> None
+    | Some deps ->
+      Some
+        (Deps.For_debugging.to_dyn
+           (fun (Dep_node.T dep) ->
+              Dyn.Tuple [ Dyn.option Dyn.string dep.spec.name; Dep_node.input_to_dyn dep ])
+           deps)
+  ;;
+
   let clear_memoization_caches () = Caches.clear ()
 end
 

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -557,6 +557,12 @@ module For_tests : sig
       Returns [None] if the dependencies were not computed yet. *)
   val get_deps : ('i, _) Table.t -> 'i -> (string option * Dyn.t) list option
 
+  (** Like [get_deps] but preserves the series-parallel structure
+      ([Seq]/[Par]/[Singleton]/[Empty]) instead of flattening it. Each leaf is
+      rendered as [(name, input)]. Returns [None] if the cell's dependencies were
+      not computed in the current run. *)
+  val get_deps_structured : (_, _) Cell.t -> Dyn.t option
+
   (** Forget all memoized values, forcing them to be recomputed on the next
       build run. *)
   val clear_memoization_caches : unit -> unit

--- a/test/expect-tests/memo/deps_representation.ml
+++ b/test/expect-tests/memo/deps_representation.ml
@@ -1,0 +1,81 @@
+open! Stdune
+open! Memo.O
+open Test_helpers.Make ()
+
+(* These tests assert the *shape* of a memoized computation's recorded dependencies - the
+   series-parallel Seq/Par/Singleton/Empty structure - by driving each shape through the
+   public Memo combinators and reading it back with [Memo.For_tests.get_deps_structured]. *)
+
+let leaf name = Memo.lazy_cell ~name (fun () -> Memo.return ())
+let read = Memo.Cell.read
+
+let print_deps label m =
+  let cell = Memo.lazy_cell ~name:"top" (fun () -> m) in
+  let () = run (read cell) in
+  match Memo.For_tests.get_deps_structured cell with
+  | None -> printfn "%s: <none>" label
+  | Some dyn -> printfn "%s: %s" label (Dyn.to_string dyn)
+;;
+
+let%expect_test "dependency structure of Memo combinators" =
+  let a = leaf "a"
+  and b = leaf "b"
+  and c = leaf "c" in
+  (* No dependencies. *)
+  print_deps "empty" (Memo.return ());
+  [%expect {| empty: Empty |}];
+  (* A single dependency is a [Singleton], whether discovered by map or bind. *)
+  print_deps "map" (Memo.map (read a) ~f:(fun () -> ()));
+  [%expect {| map: Singleton (Some "a", ()) |}];
+  print_deps "bind" (Memo.bind (read a) ~f:(fun () -> Memo.return ()));
+  [%expect {| bind: Singleton (Some "a", ()) |}];
+  (* Sequential dependencies form a [Seq] in chronological order. *)
+  print_deps
+    "seq"
+    (let* () = read a in
+     let* () = read b in
+     read c);
+  [%expect
+    {|
+    seq: Seq
+      [ Singleton (Some "a", ())
+      ; Singleton (Some "b", ())
+      ; Singleton (Some "c", ())
+      ]
+    |}];
+  (* A parallel combinator forms a [Par]. *)
+  print_deps "par" (Memo.parallel_map [ a; b; c ] ~f:read |> Memo.map ~f:ignore);
+  [%expect
+    {|
+    par: Par
+      [ Singleton (Some "a", ())
+      ; Singleton (Some "b", ())
+      ; Singleton (Some "c", ())
+      ]
+    |}];
+  (* A single-thread parallel section is not wrapped in [Par], and nested [Seq]s are
+     flattened, so the result is one flat [Seq] in chronological order. *)
+  print_deps
+    "flatten_seqs"
+    (let* () = read a in
+     let* (_ : unit list) =
+       Memo.parallel_map [ () ] ~f:(fun () ->
+         let* () = read b in
+         read c)
+     in
+     Memo.return ());
+  [%expect
+    {|
+    flatten_seqs: Seq
+      [ Singleton (Some "a", ())
+      ; Singleton (Some "b", ())
+      ; Singleton (Some "c", ())
+      ]
+    |}];
+  (* Empty parallel and sequential sections collapse away, even when nested. *)
+  let e = Memo.return () in
+  let par m = Memo.map (Memo.all_concurrently [ m; e ]) ~f:ignore in
+  let seq m = Memo.map m ~f:(fun () -> ()) in
+  print_deps "nested_empty" (seq (par (seq (par e))));
+  [%expect {| nested_empty: Empty |}]
+;;


### PR DESCRIPTION
Drive memoized computations through the public combinators (map/bind, sequential
binds, `parallel_map`, `all_concurrently`) and assert the recorded dependency
structure - `Empty` / `Singleton` / `Seq` / `Par` - via a new
`Memo.For_tests.get_deps_structured` accessor (built on the structural
`Deps.For_debugging.to_dyn`). Covers the `flatten_seqs` behaviour (a single-thread
parallel section is not wrapped in `Par`, and nested `Seq`s flatten into one
chronological `Seq`) and the collapse of empty sections, even when nested.

Third of a short series adding regression coverage for recently-landed memo
internals.
