### PR TITLE
doc: link OCaml flag defaults from flag reference

### DIFF
--- a/doc/concepts/ocaml-flags.rst
+++ b/doc/concepts/ocaml-flags.rst
@@ -13,6 +13,10 @@ For all these fields, ``<flags>`` is specified in the
 :doc:`../reference/ordered-set-language`.
 These fields all support ``(:include ...)`` forms.
 
+The value of ``:standard`` depends on the selected build profile. See
+:ref:`default-ocaml-flags` for the default OCaml flags Dune adds, including the
+default ``-g`` in ``ocamlc_flags`` and ``ocamlopt_flags``.
+
 The default value for ``(flags ...)`` is taken from the environment,
 as a result it's recommended to write ``(flags ...)`` fields as
 follows:

--- a/doc/reference/dune-workspace/profile.rst
+++ b/doc/reference/dune-workspace/profile.rst
@@ -60,6 +60,8 @@ User-defined profiles are not aliases for ``dev`` or ``release``. They select
 matching :doc:`/reference/dune/env` stanzas by name and otherwise use Dune's
 defaults for profiles that are neither ``dev`` nor ``release``.
 
+.. _default-ocaml-flags:
+
 Default OCaml Flags
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The default OCaml flags, including the default `-g` in `ocamlc_flags` and `ocamlopt_flags`, are documented on the profile page. This adds an explicit link from the OCaml flags reference to improve discoverability.

Fixes #4075.