### PR TITLE
fix(pkg): drop nil arguments from run actions in lock directories

### DIFF
--- a/doc/changes/fixed/15128.md
+++ b/doc/changes/fixed/15128.md
@@ -1,0 +1,3 @@
+- Drop `(when false _)` arguments from `run` actions in generated lock
+  directories instead of keeping them as no-op entries that were re-encoded as
+  `(when false "")`. (#15128, fixes #15099, @chizy7)

--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -323,29 +323,37 @@ let opam_commands_to_actions
               in
               Slang.simplify slang
             in
-            Some
-              (let slang =
-                 match filter with
-                 | None -> slang
-                 | Some filter ->
-                   let filter_blang =
-                     filter_to_blang ~packages_in_solution ~package ~loc filter
-                     |> Slang.simplify_blang
-                   in
-                   let filter_blang_handling_undefined =
-                     (* Wrap the blang filter so that if any undefined
-                         variables are expanded while evaluating the filter,
-                         the filter will return false. *)
-                     let slang =
-                       Slang.catch_undefined_var
-                         (Slang.blang filter_blang)
-                         ~fallback:(Slang.bool false)
-                     in
-                     Blang.Expr slang
-                   in
-                   Slang.when_ filter_blang_handling_undefined slang
-               in
-               Slang.simplify slang))
+            let slang =
+              let slang =
+                match filter with
+                | None -> slang
+                | Some filter ->
+                  let filter_blang =
+                    filter_to_blang ~packages_in_solution ~package ~loc filter
+                    |> Slang.simplify_blang
+                  in
+                  let filter_blang_handling_undefined =
+                    (* Wrap the blang filter so that if any undefined
+                        variables are expanded while evaluating the filter,
+                        the filter will return false. *)
+                    let slang =
+                      Slang.catch_undefined_var
+                        (Slang.blang filter_blang)
+                        ~fallback:(Slang.bool false)
+                    in
+                    Blang.Expr slang
+                  in
+                  Slang.when_ filter_blang_handling_undefined slang
+              in
+              Slang.simplify slang
+            in
+            (* Drop arguments that simplify to [Nil] (e.g. an argument whose
+               filter is always false) rather than keeping them, which would
+               otherwise be re-encoded as [(when false "")] in the lock
+               directory. *)
+            (match slang with
+             | Slang.Nil -> None
+             | slang -> Some slang))
       in
       if List.is_empty terms
       then None

--- a/test/blackbox-tests/test-cases/pkg/drop-nil-run-args.t
+++ b/test/blackbox-tests/test-cases/pkg/drop-nil-run-args.t
@@ -1,11 +1,10 @@
-An argument whose filter is always false simplifies to the empty list (Nil).
-Currently it is kept in the generated "run" action and re-encoded as
-"(when false \"\")" in the lock directory, instead of being dropped. Repro for
-#15099 (fixed in the follow-up PR).
+An argument whose filter is always false simplifies to the empty list (Nil) and
+is dropped from the generated "run" action, rather than being kept and
+re-encoded as "(when false \"\")" in the lock directory. Regression test for
+#15099.
 
 Here "dropme" is filtered by "absent-pkg:installed". Since "absent-pkg" is not
-in the solution, its "installed" variable is false, so the argument simplifies
-to Nil.
+in the solution, its "installed" variable is false, so the argument is dropped.
 
   $ mkrepo
 
@@ -19,12 +18,8 @@ to Nil.
   Solution for dune.lock:
   - with-always-false-arg.0.0.1
 
-The "(when false \"\")" in the run action below is the bug being tracked: the
-always-false argument should be dropped entirely.
-
   $ cat dune.lock/with-always-false-arg.0.0.1.pkg
   (version 0.0.1)
   
   (build
-   (all_platforms ((action (run echo always (when false ""))))))
-
+   (all_platforms ((action (run echo always)))))


### PR DESCRIPTION
Arguments whose filter is always false simplifi to the empty list (`Nil`) but were kept in generated `run` actions and re-encoded as `(when false "")` in the lock directory. This change drops those arguments.

`(when false "")` is how `Slang.encode` serializes `Nil`, which has no surface syntax. Each opam command argument is already run through `Slang.simplify`, but in `opam_commands_to_actions` the result was wrapped in `Some` without checking for `Nil`. As a result, `Nil` arguments survived into the `Action.Run` term list and were re-encoded. This drops arguments that simplify to `Nil`.

It's safe: a `Nil` argument is the empty list and contributes nothing at build time, the first `run` term is the executable (and cannot be a false-filtered `Nil`), nd the existing `if List.is_empty terms then None` already handles a fully emptied `run`. this is also consistent with the same file, where `depexts_to_conditional_external_dependencies` already drops always-false entries.

Example (covered by the new regression test): an argument filtered by `{absent-pkg:installed}` a variable from a package not present in the solution, now produces:

```text
(run echo always)
````

instead of:

```text
(run echo always (when false ""))
```

### Verification

Verified against the relocatable compiler the exact case from #14457 (`relocatable-compiler.5.4.1.20251109.1`).

Before, its build action was littered with filler (~17 `(when false "")` entries per platform). After this change, the lock directory is clean, every real argument is preserved (for example `CC=cc` on macOS), and it still builds nd runs:

```text
$ dune pkg lock         # pulls relocatable-compiler.5.4.1.20251109.1
$ grep -rn "(when false" dune.lock/ || echo "CLEAN: no (when false) entries"
CLEAN: no (when false) entries

$ dune build && dune exec ./bin/main.exe
re works
```

<details>
<summary>Relocatable compiler lock entry after the fix</summary>

```text
(version 5.4.1.20251109.1)

(install
 (all_platforms
  (withenv
   ((= MSYS2_ARG_CONV_EXCL *)
    (= LSAN_OPTIONS detect_leaks=0,exitcode=0)
    (= ASAN_OPTIONS detect_leaks=0,exitcode=0))
   (run
    sh
    process.sh
    %{make}
    install
    %{pkg-self:build-id}
    %{pkg-self:name}
    %{prefix}))))

(build
 (choice
  ((((arch x86_64)
     (os linux))
    ((arch arm64)
     (os linux)))
   ((action
     (withenv
      ((= MSYS2_ARG_CONV_EXCL *)
       (= LSAN_OPTIONS detect_leaks=0,exitcode=0)
       (= ASAN_OPTIONS detect_leaks=0,exitcode=0))
      (run
       sh
       process.sh
       %{make}
       -j%{jobs}
       %{pkg-self:build-id}
       %{pkg-self:name}
       %{pkg:compiler-cloning:version}
       --prefix=%{prefix}
       --docdir=%{doc}/ocaml
       --with-relative-libdir=../lib/ocaml
       --with-stublibs=../stublibs
       --enable-runtime-search=always
       --enable-runtime-search-target
       --disable-warn-error)))))
  ((((arch x86_64)
     (os macos))
    ((arch arm64)
     (os macos)))
   ((action
     (withenv
      ((= MSYS2_ARG_CONV_EXCL *)
       (= LSAN_OPTIONS detect_leaks=0,exitcode=0)
       (= ASAN_OPTIONS detect_leaks=0,exitcode=0))
      (run
       sh
       process.sh
       %{make}
       -j%{jobs}
       %{pkg-self:build-id}
       %{pkg-self:name}
       %{pkg:compiler-cloning:version}
       --prefix=%{prefix}
       --docdir=%{doc}/ocaml
       --with-relative-libdir=../lib/ocaml
       --with-stublibs=../stublibs
       --enable-runtime-search=always
       --enable-runtime-search-target
       CC=cc
       --disable-warn-error)))))))

(depends
 (all_platforms (compiler-cloning)))

(source
 (fetch
  (url
   https://github.com/dra27/ocaml/archive/b74c645ef30c6060dcc293a73811a9ae9ceefd57.tar.gz)
  (checksum
   sha256=b461d60f5b542bbd3315d3d984efaef9113d1672b5f6bfdd46efd5e96060d17a)))

(extra_sources
 (process.sh
  (fetch
   (url
    https://raw.githubusercontent.com/dra27/ocaml/55ce12b0f197b9a7a0165310b131052951f98a02/tools/opam/process.sh)
   (checksum
    sha256=b2febe05d19e07db4881ef11cf8769c31226f32305ad10ea13b0a2262835d914))))
```

</details>

Follows up #15092 (Track A in `Slang.simplify`); this addresses Track B, the `Run`-argument cleanup in `lock_pkg.ml`.

Fixes #15099
