### PR TITLE
doc: clarify what @doc generates

### DIFF
--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -30,13 +30,25 @@ files following the syntax described in the section ``Text formatting`` of
 the `OCaml manual <http://caml.inria.fr/pub/docs/manual-ocaml/ocamldoc.html>`_.
 
 Additional documentation pages may be attached to a package using the
-:doc:`/reference/dune/documentation` stanza.
+:doc:`/reference/dune/documentation` stanza. This stanza attaches ``.mld``
+pages to packages rather than to executables.
 
 Building Documentation
 ======================
 
-To generate documentation using the :doc:`/reference/aliases/doc` alias, all
-that's required to is to build this alias:
+Dune's generated documentation is package-oriented. The
+:doc:`/reference/aliases/doc` alias builds HTML documentation for public
+libraries, that is, libraries with a ``(public_name ...)``, and for ``.mld``
+pages attached to packages. Packages are declared with
+:doc:`/reference/dune-project/package` stanzas or inferred from ``.opam`` files.
+
+Executable stanzas are not documented as API pages by ``@doc``. A project that
+contains only executables may therefore build ``@doc`` successfully without
+producing package API pages. To produce API documentation, put the documented
+code in a library with a ``(public_name ...)`` or attach ``.mld`` pages to a
+package.
+
+To generate documentation using ``@doc``, build this alias:
 
 .. code:: console
 

--- a/doc/reference/aliases/doc.rst
+++ b/doc/reference/aliases/doc.rst
@@ -1,6 +1,8 @@
 @doc
 ====
 
-This alias builds documentation for public libraries as HTML pages.
+This alias builds HTML documentation for public libraries and package ``.mld``
+pages. It does not document executable stanzas as API pages. Use
+:doc:`doc-private` to build documentation for private libraries.
 
 .. seealso:: :doc:`/documentation`


### PR DESCRIPTION
Clarify that `@doc` is package-oriented: it builds public library API documentation and package `.mld` pages, but not executable stanzas. This should make the behavior of executable-only projects less surprising.

Fixes #3334.