### PR TITLE
doc: clarify dune exec argument separators

### DIFF
--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -20,11 +20,22 @@ let man =
           path is interpreted as relative to the build context + current
           working directory (or the value of $(b,--root) when ran outside of
           the project root)|}
+  ; `S "PASSING ARGUMENTS"
+  ; `P
+      {|Options accepted by $(b,dune exec) and options accepted by the
+          executed program share the same command line. If an argument to the
+          program starts with $(b,-), separate it from Dune's options with
+          $(b,--):|}
+  ; `Pre "  \\$ dune exec PROG -- --program-option"
+  ; `P {|Equivalently, put the separator before the whole command:|}
+  ; `Pre "  \\$ dune exec -- PROG --program-option"
   ; `Blocks Common.help_secs
   ; Common.examples
       [ "Run the executable named `my_exec'", "dune exec my_exec"
       ; ( "Run the executable defined in `foo.ml' with the argument `arg'"
         , "dune exec -- ./foo.exe arg" )
+      ; ( "Pass an option to the executed program"
+        , "dune exec ./foo.exe -- --program-option" )
       ]
   ]
 ;;

--- a/doc/reference/cli.rst
+++ b/doc/reference/cli.rst
@@ -89,6 +89,20 @@ documentation for each command is available through ``dune COMMAND --help``.
 
    Execute a command in a similar environment as if installation was performed.
 
+   Dune's options and the executed program's options share the same command
+   line. If an argument to the program starts with ``-``, separate it from
+   Dune's options with ``--``:
+
+   .. code:: console
+
+      $ dune exec ./tool.exe -- --program-option
+
+   Equivalently, put the separator before the whole command:
+
+   .. code:: console
+
+      $ dune exec -- ./tool.exe --program-option
+
 .. describe:: dune fmt
 
    Format source code.


### PR DESCRIPTION
Clarify how to pass arguments that begin with `-` to programs run by `dune exec`. This updates both `dune exec --help` and the CLI reference with the `dune exec PROG -- --program-option` and `dune exec -- PROG --program-option` forms.

Fixes #9513.