### PR TITLE
test(pkg): add repro for nil run arguments in lock directories

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/drop-nil-run-args.t
+++ b/test/blackbox-tests/test-cases/pkg/drop-nil-run-args.t
@@ -1,0 +1,30 @@
+An argument whose filter is always false simplifies to the empty list (Nil).
+Currently it is kept in the generated "run" action and re-encoded as
+"(when false \"\")" in the lock directory, instead of being dropped. Repro for
+#15099 (fixed in the follow-up PR).
+
+Here "dropme" is filtered by "absent-pkg:installed". Since "absent-pkg" is not
+in the solution, its "installed" variable is false, so the argument simplifies
+to Nil.
+
+  $ mkrepo
+
+  $ mkpkg with-always-false-arg <<EOF
+  > build: [
+  >   [ "echo" "always" "dropme" { absent-pkg:installed } ]
+  > ]
+  > EOF
+
+  $ solve with-always-false-arg
+  Solution for dune.lock:
+  - with-always-false-arg.0.0.1
+
+The "(when false \"\")" in the run action below is the bug being tracked: the
+always-false argument should be dropped entirely.
+
+  $ cat dune.lock/with-always-false-arg.0.0.1.pkg
+  (version 0.0.1)
+  
+  (build
+   (all_platforms ((action (run echo always (when false ""))))))
+


### PR DESCRIPTION
Adds a regression test capturing curent behavior for #15099: an opam build-command argument whose filter is always false simplifies to `Nil`, which is kept in the generated `run` action and re-encoded as `(when false "")` in the lock directory instead of being dropped. 

This is the prequel test (split out at @Alizter's request); the fix follows in #15128, where this test's expectation flips to show the argument dropped.