### PR TITLE
refactor(memo): rename Invalidation.invalidate_cache to invalidate_table

### DIFF
--- a/src/memo/invalidation.ml
+++ b/src/memo/invalidation.ml
@@ -157,7 +157,7 @@ let is_empty = function
 
 let clear_caches ~reason = Leaf { kind = Clear_caches; reason }
 
-let invalidate_cache ~reason ({ cache; _ } : _ Table0.t) =
+let invalidate_table ~reason ({ cache; _ } : _ Table0.t) =
   Leaf { kind = Clear_cache cache; reason }
 ;;
 

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -229,7 +229,7 @@ module Invalidation : sig
   val clear_caches : reason:Reason.t -> t
 
   (** Invalidate all computations stored in a given [memo] table. *)
-  val invalidate_cache : reason:Reason.t -> _ Table.t -> t
+  val invalidate_table : reason:Reason.t -> _ Table.t -> t
 
   (** A custom invalidation, for use by out-of-band caching mechanisms: [f] is run when the
       invalidation is applied. *)

--- a/test/expect-tests/memo/main.ml
+++ b/test/expect-tests/memo/main.ml
@@ -1986,7 +1986,7 @@ let%expect_test "Test Memo.clear_cache" =
     Memo graph: 0/0/0 nodes/edges/blocked (restore), 4/2/0 nodes/edges/blocked (compute)
     Memo cycle detection graph: 0/0/0 nodes/edges/paths
   |}];
-  let invalidation = Memo.Invalidation.invalidate_cache ~reason:Test add_one in
+  let invalidation = Memo.Invalidation.invalidate_table ~reason:Test add_one in
   Memo.reset invalidation;
   evaluate_and_print add_one 1;
   evaluate_and_print add_one 2;


### PR DESCRIPTION
Rename `Memo.Invalidation.invalidate_cache` to `invalidate_table`. It invalidates
all computations stored in a single memoization *table*, so `invalidate_table`
names what it does more precisely than the more generic "cache". Three sites: the
definition, the `memo.mli` declaration, and one test call.
