### PR TITLE
test(memo): cover create_with_store, dump_cached_graph, and multi-node cycles

### DIFF
--- a/test/expect-tests/memo/create_with_store.ml
+++ b/test/expect-tests/memo/create_with_store.ml
@@ -1,0 +1,76 @@
+open! Stdune
+open! Memo.O
+open Test_helpers.Make ()
+module Reason = Memo.Invalidation.Reason
+
+(* A hand-rolled Memo store over [int] keys, backed by a mutable assoc list, to exercise
+   [create_with_store]'s custom-store path (the default [create] goes through
+   [Stdune.Table]). We use [Stdlib.List] explicitly for the assoc operations since
+   [open Stdune] shadows [List]. *)
+module Int_store = struct
+  type key = int
+  type 'a t = (int * 'a) list ref
+
+  let create () = ref []
+  let clear t = t := []
+  let find t key = Stdlib.List.assoc_opt key !t
+  let set t key v = t := (key, v) :: Stdlib.List.remove_assoc key !t
+
+  let find_or_add t key ~f =
+    match find t key with
+    | Some v -> v
+    | None ->
+      let v = f key in
+      set t key v;
+      v
+  ;;
+
+  let iter t ~f = Stdlib.List.iter (fun (_, v) -> f v) !t
+end
+
+module Int_input = struct
+  type t = int
+
+  let to_dyn = Dyn.int
+end
+
+let%expect_test "create_with_store routes memoization through a custom store" =
+  let calls = ref 0 in
+  let f =
+    Memo.create_with_store
+      "custom-store"
+      ~store:(module Int_store)
+      ~input:(module Int_input)
+      ~cutoff:Int.equal
+      (fun x ->
+         incr calls;
+         printfn "computing %d" x;
+         Memo.return (x * 10))
+  in
+  (* Bind the result before reading [calls] so the counter reflects the compute. *)
+  let show i =
+    let r = run_memo f i in
+    printfn "f %d = %d (calls = %d)" i r !calls
+  in
+  (* First evaluation computes (store: set); a second in the same run hits the store
+     (find); a distinct key computes once more. *)
+  show 1;
+  show 1;
+  show 2;
+  [%expect
+    {|
+    computing 1
+    f 1 = 10 (calls = 1)
+    f 1 = 10 (calls = 1)
+    computing 2
+    f 2 = 20 (calls = 2)
+    |}];
+  (* clear_caches empties the custom store (Store.clear), forcing a recompute. *)
+  Memo.reset (Memo.Invalidation.clear_caches ~reason:Reason.Test);
+  show 1;
+  [%expect
+    {|
+    computing 1
+    f 1 = 10 (calls = 3)
+    |}]
+;;

--- a/test/expect-tests/memo/cycle_detection.ml
+++ b/test/expect-tests/memo/cycle_detection.ml
@@ -32,3 +32,47 @@ let%expect_test "a self-dependency cycle is detected, then recomputed after remo
   [%expect {| f 0 = Ok 100 |}];
   Memo.reset Memo.Invalidation.empty
 ;;
+
+(* A cycle spanning several nodes: while the graph has 0 -> 1 -> 2 -> 0, node 0
+   depends on itself transitively. Once the edge is broken, the formerly-cyclic
+   node must recompute to a value rather than stay the cached cycle error. *)
+let%expect_test "a multi-node dependency cycle is detected, then recovered after removal" =
+  let graph : [ `Goto of int | `Stop of int ] array =
+    Array.init 4 ~f:(function
+      | 0 -> `Goto 1
+      | 1 -> `Goto 2
+      | 2 -> `Goto 0
+      | _ -> `Stop 42)
+  in
+  let gate = Memo.Var.create ~name:"gate" () in
+  let table =
+    Memo.create_rec
+      "node"
+      ~input:(module Int)
+      (fun f i ->
+         let* () = Memo.Var.read gate in
+         match graph.(i) with
+         | `Goto j -> f j
+         | `Stop result -> Memo.return result)
+  in
+  evaluate_and_print table 0;
+  [%expect
+    {|
+    Dependency cycle detected:
+    - ("node", 2)
+    - called by ("node", 1)
+    - called by ("node", 0)
+    f 0 = Error
+            [ { exn =
+                  "Cycle_error.E [ (\"node\", 2); (\"node\", 1); (\"node\", 0) ]"
+              ; backtrace = ""
+              }
+            ]
+    |}];
+  (* Break the cycle and advance the run so the cached cycle error is discarded. *)
+  graph.(0) <- `Stop 42;
+  Memo.reset (Memo.Var.set gate ());
+  evaluate_and_print table 0;
+  [%expect {| f 0 = Ok 42 |}];
+  Memo.reset Memo.Invalidation.empty
+;;

--- a/test/expect-tests/memo/graph_dump/dump_graph_tests.ml
+++ b/test/expect-tests/memo/graph_dump/dump_graph_tests.ml
@@ -191,3 +191,36 @@ let%expect_test _ =
     </graph>
     </gexf> |}]
 ;;
+
+let%expect_test "dump_cached_graph: on_not_cached" =
+  let leaf = Memo.create "Leaf" ~input:(module Unit) (fun () -> Memo.return ()) in
+  let root =
+    Memo.create
+      "Root"
+      ~input:(module Unit)
+      (fun () ->
+         let+ () = Memo.exec leaf () in
+         ())
+  in
+  run_memo root ();
+  (* Advance the run without recomputing, so [root] is no longer validated in the
+     current run (its deps are not cached now). *)
+  Memo.reset Memo.Invalidation.empty;
+  (* [`Ignore] stops at the uncached node and returns the graph built so far. *)
+  let graph =
+    Scheduler.run (Memo.dump_cached_graph ~on_not_cached:`Ignore (Memo.cell root ()))
+  in
+  Graph.print graph ~format:Graph.File_format.Dot;
+  [%expect
+    {|
+    strict digraph {
+    }
+    |}];
+  (* [`Raise] (the default) raises when a reachable node is not cached. *)
+  (match
+     Scheduler.run (Memo.dump_cached_graph ~on_not_cached:`Raise (Memo.cell root ()))
+   with
+   | (_ : Graph.t) -> print_endline "no error"
+   | exception Failure msg -> Printf.printf "raised: %s\n" msg);
+  [%expect {| raised: Memo graph contains uncached nodes |}]
+;;


### PR DESCRIPTION
Add three memo unit tests for previously-uncovered paths:

- **`create_with_store`** — memoization routed through a custom hand-rolled
  `Store` (the default path uses `Stdune.Table`): compute, cache hit, and a
  recompute after `clear_caches` empties the store.
- **`dump_cached_graph ?on_not_cached`** — ``\`Ignore`` returns the graph built
  so far; ``\`Raise`` raises on a reachable uncached node. (The existing
  `graph_dump` tests cover the rendering but not this option.)
- **multi-node cycle recovery** — a `0 -> 1 -> 2 -> 0` dependency cycle is
  detected, then recovers to a value once the cycle is broken. (The existing
  cycle test covered only a single-node self-cycle.)
