### PR TITLE
perf(memo): allocate the spec witness only for named tables

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -76,7 +76,9 @@ module Stack_frame = struct
   let to_dyn = Dep_node.Packed.to_dyn_without_state
 
   let as_instance_of stack_frame ~(of_ : _ Table.t) =
-    Dep_node.Packed.as_instance_of stack_frame of_.spec.witness
+    match of_.spec.witness with
+    | None -> None
+    | Some witness -> Dep_node.Packed.as_instance_of stack_frame witness
   ;;
 end
 
@@ -92,7 +94,14 @@ let create_with_cache
   : (i, o) Table.t
   =
   let spec =
-    Spec.create ~name:(Some name) ~input ~cutoff ~human_readable_description ?on_event f
+    Spec.create
+      ~name:(Some name)
+      ~witness:true
+      ~input
+      ~cutoff
+      ~human_readable_description
+      ?on_event
+      f
   in
   Caches.register ~clear:(fun () ->
     Store.clear cache;

--- a/src/memo/node.ml
+++ b/src/memo/node.ml
@@ -155,9 +155,12 @@ module Dep_node = struct
     let to_dyn_without_state (T t) = to_dyn_without_state t
 
     let as_instance_of (type i) (T t) (witness : i Type_eq.Id.t) : i option =
-      match Type_eq.Id.same witness t.spec.witness with
-      | Some Type_eq.T -> Some t.input
+      match t.spec.witness with
       | None -> None
+      | Some w ->
+        (match Type_eq.Id.same witness w with
+         | Some Type_eq.T -> Some t.input
+         | None -> None)
     ;;
 
     let human_readable_description (T t) =

--- a/src/memo/spec.ml
+++ b/src/memo/spec.ml
@@ -67,17 +67,20 @@ end
 
 type ('i, 'o) t =
   { name : string option
-  ; (* If the field [witness] precedes any of the functional values ([input],
-         [f], and the closures inside [node_kind]), then polymorphic comparison
-         actually works for [Spec.t]s. *)
-    witness : 'i Type_eq.Id.t
+  ; (* [witness] is [Some] only for named tables, which may be downcast to their
+         input type via [as_instance_of]; it is [None] for lazy values, stack
+         frames, and variables, avoiding a [Type_eq.Id.t] allocation per such cell.
+         If [witness] precedes the functional values ([input], [f], and the
+         closures inside [node_kind]), polymorphic comparison works for [Spec.t]s. *)
+    witness : 'i Type_eq.Id.t option
   ; input : (module Store_intf.Input with type t = 'i)
   ; node_kind : ('i, 'o) Node_kind.t
   ; f : 'i -> 'o Fiber.t
   ; human_readable_description : ('i -> User_message.Style.t Pp.t) option
   }
 
-let create ~name ~input ~human_readable_description ~cutoff ?on_event f =
+let create ~name ~input ~human_readable_description ~cutoff ?(witness = false) ?on_event f
+  =
   let name =
     match name with
     | None when !Memo_debug.track_locations_of_lazy_values ->
@@ -88,7 +91,7 @@ let create ~name ~input ~human_readable_description ~cutoff ?on_event f =
   { name
   ; input
   ; node_kind = Node_kind.create ~cutoff ~on_event
-  ; witness = Type_eq.Id.create ()
+  ; witness = (if witness then Some (Type_eq.Id.create ()) else None)
   ; f
   ; human_readable_description
   }

--- a/src/memo/spec.mli
+++ b/src/memo/spec.mli
@@ -18,10 +18,12 @@ end
 
 type ('i, 'o) t =
   { name : string option
-  ; (* If the field [witness] precedes any of the functional values ([input],
-         [f], and the closures inside [node_kind]), then polymorphic comparison
-         actually works for [Spec.t]s. *)
-    witness : 'i Type_eq.Id.t
+  ; (* [witness] is [Some] only for named tables, which may be downcast to their
+         input type via [as_instance_of]; it is [None] for lazy values, stack
+         frames, and variables, avoiding a [Type_eq.Id.t] allocation per such cell.
+         If [witness] precedes the functional values ([input], [f], and the
+         closures inside [node_kind]), polymorphic comparison works for [Spec.t]s. *)
+    witness : 'i Type_eq.Id.t option
   ; input : (module Store_intf.Input with type t = 'i)
   ; node_kind : ('i, 'o) Node_kind.t
   ; f : 'i -> 'o Fiber.t
@@ -33,6 +35,7 @@ val create
   -> input:(module Store_intf.Input with type t = 'a)
   -> human_readable_description:('a -> User_message.Style.t Pp.t) option
   -> cutoff:('b -> 'b -> bool) option
+  -> ?witness:bool
   -> ?on_event:('a -> Event.t -> unit)
   -> ('a -> 'b Fiber.t)
   -> ('a, 'b) t


### PR DESCRIPTION
## What

The memo `Spec.witness` (a `Type_eq.Id.t`) is read only by
`Stack_frame.as_instance_of`, which downcasts a stack frame back to a
named table's input type. Lazy values, stack frames and variables are
never downcast that way — but `Spec.create` allocated a fresh witness
for *every* spec, including each of those, and then never read it.

This makes the witness opt-in: `Spec.create` gains `?witness:bool`
(default `false`) and the field becomes `'i Type_eq.Id.t option`. Only
the named-table path (`create_with_cache`) requests one; `lazy_cell`,
`push_stack_frame` and the `Var` constructors leave it `None`, saving a
`Type_eq.Id.t` allocation per such cell on the hot lazy-creation path.

## Why it's safe

- The two `as_instance_of` sites return `None` for a `None` witness,
  which is correct: a lazy/var/frame node was never an instance of a
  named table.
- `Dep_node`'s `id` field is first, so the `Exn_set` polymorphic
  comparison short-circuits on `id` and never reaches the witness field
  (the ordering invariant documented on `Spec.t` is preserved — the
  field stays ahead of the functional values).