### PR TITLE
feat(memo): expose Node.Packed and pack

### DIFF
--- a/bench/micro/memo_bench/benchmarks.ml
+++ b/bench/micro/memo_bench/benchmarks.ml
@@ -37,13 +37,13 @@ let run tenacious = Memo.exec tenacious
 module Var = struct
   type 'a t =
     { value : 'a ref
-    ; cell : (unit, 'a) Memo.Cell.t
+    ; cell : (unit, 'a) Memo.Node.t
     }
 
   let create value =
     let value = ref value in
     { value
-    ; cell = Memo.lazy_cell ~cutoff:(fun _ _ -> false) (fun () -> Memo.return !value)
+    ; cell = Memo.lazy_node ~cutoff:(fun _ _ -> false) (fun () -> Memo.return !value)
     }
   ;;
 
@@ -52,10 +52,10 @@ module Var = struct
     invalidation_acc
     := Memo.Invalidation.combine
          !invalidation_acc
-         (Memo.Cell.invalidate ~reason:Memo.Invalidation.Reason.Test t.cell)
+         (Memo.Node.invalidate ~reason:Memo.Invalidation.Reason.Test t.cell)
   ;;
 
-  let read t = Memo.of_thunk (fun () -> Memo.Cell.read t.cell)
+  let read t = Memo.of_thunk (fun () -> Memo.Node.read t.cell)
   let peek t = !(t.value)
 end
 

--- a/bench/micro/memo_bench/memo_tests_env.ml
+++ b/bench/micro/memo_bench/memo_tests_env.ml
@@ -54,20 +54,20 @@ module Memo = struct
   let all l = Memo.all_concurrently l
 
   module Glass = struct
-    type t = (unit, unit) Memo.Cell.t
+    type t = (unit, unit) Memo.Node.t
 
-    let create () = Memo.lazy_cell ~cutoff:(fun _ _ -> false) (fun () -> Memo.return ())
+    let create () = Memo.lazy_node ~cutoff:(fun _ _ -> false) (fun () -> Memo.return ())
 
     let break (t : t) =
       invalidation_acc
       := Memo.Invalidation.combine
-           (Memo.Cell.invalidate ~reason:Memo.Invalidation.Reason.Test t)
+           (Memo.Node.invalidate ~reason:Memo.Invalidation.Reason.Test t)
            !invalidation_acc
     ;;
   end
 
   let of_glass (g : Glass.t) v =
-    Memo.of_thunk (fun () -> Memo.map (Memo.Cell.read g) ~f:(fun () -> v))
+    Memo.of_thunk (fun () -> Memo.map (Memo.Node.read g) ~f:(fun () -> v))
   ;;
 
   let of_thunk f = Memo.of_reproducible_fiber (Fiber.of_thunk (fun () -> Memo.run (f ())))
@@ -88,7 +88,7 @@ let make_counter () =
   let glass = Glass.create () in
   let break () = Glass.break glass in
   ( Memo.map
-      (Memo.of_thunk (fun () -> Memo.Cell.read glass))
+      (Memo.of_thunk (fun () -> Memo.Node.read glass))
       ~f:(fun () ->
         incr r;
         !r)
@@ -98,13 +98,13 @@ let make_counter () =
 module Var = struct
   type 'a t =
     { value : 'a ref
-    ; cell : (unit, 'a) Memo.Cell.t
+    ; cell : (unit, 'a) Memo.Node.t
     }
 
   let create value =
     let value = ref value in
     { value
-    ; cell = Memo.lazy_cell ~cutoff:(fun _ _ -> false) (fun () -> Memo.return !value)
+    ; cell = Memo.lazy_node ~cutoff:(fun _ _ -> false) (fun () -> Memo.return !value)
     }
   ;;
 
@@ -113,9 +113,9 @@ module Var = struct
     invalidation_acc
     := Memo.Invalidation.combine
          !invalidation_acc
-         (Memo.Cell.invalidate ~reason:Memo.Invalidation.Reason.Test t.cell)
+         (Memo.Node.invalidate ~reason:Memo.Invalidation.Reason.Test t.cell)
   ;;
 
-  let read t = Memo.of_thunk (fun () -> Memo.Cell.read t.cell)
+  let read t = Memo.of_thunk (fun () -> Memo.Node.read t.cell)
   let peek t = !(t.value)
 end

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -91,7 +91,7 @@ include T
 module Map = struct
   module M = Map.Make (T)
   include M
-  include Memo.Make_parallel_map (M)
+  include Memo.Map (M)
 
   let has_universe t = mem t Universe
 end

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -806,8 +806,8 @@ end = struct
         Path_changed (Path.outside_build_dir path)
       in
       Memo.Invalidation.combine
-        (Memo.Cell.invalidate (Memo.cell memo_for_watching_directly path) ~reason)
-        (Memo.Cell.invalidate (Memo.cell memo_for_watching_via_parent path) ~reason)
+        (Memo.Node.invalidate (Memo.node memo_for_watching_directly path) ~reason)
+        (Memo.Node.invalidate (Memo.node memo_for_watching_via_parent path) ~reason)
   ;;
 
   let init ~dune_file_watcher =

--- a/src/dune_lang/dune_project.ml
+++ b/src/dune_lang/dune_project.ml
@@ -1147,7 +1147,7 @@ let gen_load ~read ~dir ~files ~infer_from_opam_files ~load_opam_file_with_conte
   else if infer_from_opam_files && not (Package.Name.Map.is_empty opam_packages)
   then
     let+ opam_packages =
-      let module Memo_package_name = Memo.Make_parallel_map (Package.Name.Map) in
+      let module Memo_package_name = Memo.Map (Package.Name.Map) in
       Memo_package_name.parallel_map opam_packages ~f:(fun _ (_loc, pkg) -> pkg)
     in
     Some (infer Package_info.empty ~dir opam_packages)

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -1,6 +1,6 @@
 open Import
 open Memo.O
-module Parallel_map = Memo.Make_parallel_map (Module_name.Unique.Map)
+module Parallel_map = Memo.Map (Module_name.Unique.Map)
 
 module Merge_dep_output = struct
   module Spec = struct

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -629,7 +629,7 @@ end = struct
       Some (name, entries)
   ;;
 
-  module Package_map_traversals = Memo.Make_parallel_map (Package.Name.Map)
+  module Package_map_traversals = Memo.Map (Package.Name.Map)
 
   let stanzas_to_entries sctx =
     let context = Super_context.context sctx in

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -851,7 +851,7 @@ module Sub_system = struct
     (* TODO this should continue using [Resolve]. Not doing so
        will prevent generating the [dune-package] rule if the sub system is
        missing *)
-    let module M = Memo.Make_parallel_map (Sub_system_name.Map) in
+    let module M = Memo.Map (Sub_system_name.Map) in
     fun lib ->
       M.parallel_map lib.sub_systems ~f:(fun _name inst ->
         let* (Sub_system0.Instance.T ((module M), t)) = Memo.Lazy.force inst in

--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -1,6 +1,6 @@
 open Import
 open Memo.O
-module Parallel_map = Memo.Make_parallel_map (Module_name.Map)
+module Parallel_map = Memo.Map (Module_name.Map)
 
 module Common = struct
   module Encode = struct

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -292,7 +292,7 @@ module DB = struct
         ()
   ;;
 
-  module Path_source_map_traversals = Memo.Make_parallel_map (Path.Source.Map)
+  module Path_source_map_traversals = Memo.Map (Path.Source.Map)
 
   let scopes_by_dir
         ~build_dir

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -53,6 +53,7 @@ end
 
 open To_open
 include Parallel
+module Map = Make_parallel_map
 
 let pp_stack () =
   let open Pp.O in
@@ -182,7 +183,7 @@ let create_rec
   Stdlib.Lazy.force table
 ;;
 
-let dump_cached_graph ?(on_not_cached = `Raise) ?(time_nodes = false) cell =
+let dump_cached_graph ?(on_not_cached = `Raise) ?(time_nodes = false) node =
   let rec collect_graph (Dep_node.T dep_node) graph : Graph.t Fiber.t =
     let src_id = Id.to_int dep_node.id in
     match get_cached_deps_in_current_run dep_node with
@@ -218,7 +219,7 @@ let dump_cached_graph ?(on_not_cached = `Raise) ?(time_nodes = false) cell =
   in
   Error_handler.with_error_handler
     (fun (_ : Exn_with_backtrace.t) -> Fiber.return ())
-    (fun () -> collect_graph (Dep_node.T cell) Graph.empty)
+    (fun () -> collect_graph (Dep_node.T node) Graph.empty)
 ;;
 
 let get_call_stack = Call_stack.get_call_stack_without_state
@@ -289,7 +290,7 @@ module With_implicit_output = struct
   let exec t = t
 end
 
-module Cell = struct
+module Node = struct
   type ('i, 'o) t = ('i, 'o) Dep_node.t
 
   let input (t : (_, _) t) = t.input
@@ -297,11 +298,11 @@ module Cell = struct
   let invalidate = Invalidation.invalidate_node
 end
 
-let cell = dep_node
+let node = dep_node
 
 module Implicit_output = Implicit_output
 
-let lazy_cell ?cutoff ?name ?human_readable_description ?on_event f =
+let lazy_node ?cutoff ?name ?human_readable_description ?on_event f =
   let on_event = Option.map on_event ~f:(fun on_event () event -> on_event event) in
   let spec =
     Spec.create ~name ~input:(module Unit) ~cutoff ~human_readable_description ?on_event f
@@ -310,7 +311,7 @@ let lazy_cell ?cutoff ?name ?human_readable_description ?on_event f =
 ;;
 
 let push_stack_frame ~human_readable_description f =
-  Cell.read (lazy_cell ~human_readable_description f)
+  Node.read (lazy_node ~human_readable_description f)
 ;;
 
 module Lazy = struct
@@ -320,14 +321,14 @@ module Lazy = struct
 
   module Expert = struct
     let create ?cutoff ?name ?human_readable_description ?on_event f =
-      let cell = lazy_cell ?cutoff ?name ?human_readable_description ?on_event f in
-      cell, fun () -> Cell.read cell
+      let node = lazy_node ?cutoff ?name ?human_readable_description ?on_event f in
+      node, fun () -> Node.read node
     ;;
   end
 
   let create ?cutoff ?name ?human_readable_description ?on_event f =
-    let cell = lazy_cell ?cutoff ?name ?human_readable_description ?on_event f in
-    fun () -> Cell.read cell
+    let node = lazy_node ?cutoff ?name ?human_readable_description ?on_event f in
+    fun () -> Node.read node
   ;;
 
   let force f = f ()
@@ -416,8 +417,8 @@ module For_tests = struct
               dep.spec.name, Dep_node.input_to_dyn dep)))
   ;;
 
-  let get_deps_structured (cell : (_, _) Cell.t) =
-    match get_cached_deps_in_current_run cell with
+  let get_deps_structured (node : (_, _) Node.t) =
+    match get_cached_deps_in_current_run node with
     | None -> None
     | Some deps ->
       Some
@@ -468,19 +469,19 @@ module Option = Monad.Option (Fiber)
 module Result = Monad.Result (Fiber)
 
 module Var = struct
-  (* CR-soon amokhov: Simplify this to [type 'a t = (unit, 'a) Cell.t].
+  (* CR-soon amokhov: Simplify this to [type 'a t = (unit, 'a) Node.t].
 
-     [Cell.t]s already store all the information we need, and the only change that needs
-     to happen is making [Cell.invalidate] smart enough to return [Invalidation.empty]
+     [Node.t]s already store all the information we need, and the only change that needs
+     to happen is making [Node.invalidate] smart enough to return [Invalidation.empty]
      when the [cutoff] fires.
 
      Once we have that, we should also be able to implement [Fs_memo] on top of [Var.t]s
      instead of hand-written "variable tables".
   *)
   type 'a t =
-    { cell : (unit, 'a) Cell.t
+    { node : (unit, 'a) Node.t
     ; value : 'a ref
-      (* We manually cutoff instead of depending on [Cell.t] cutoff mechanism, so that
+      (* We manually cutoff instead of depending on [Node.t] cutoff mechanism, so that
            we don't pay for invalidation when the value doesn't change. *)
     ; cutoff : ('a -> 'a -> bool) option
     }
@@ -495,8 +496,8 @@ module Var = struct
         ~cutoff:None
         (fun () -> return !value)
     in
-    let cell = make_dep_node ~spec ~input:() in
-    { cell; value; cutoff }
+    let node = make_dep_node ~spec ~input:() in
+    { node; value; cutoff }
   ;;
 
   let set t v =
@@ -512,15 +513,15 @@ module Var = struct
       Invalidation.empty
     | Some _ | None ->
       t.value := v;
-      Cell.invalidate
-        t.cell
-        ~reason:(Variable_changed (Stdune.Option.value_exn t.cell.spec.name))
+      Node.invalidate
+        t.node
+        ~reason:(Variable_changed (Stdune.Option.value_exn t.node.spec.name))
   ;;
 
-  let read t = Cell.read t.cell
+  let read t = Node.read t.node
 
   module Unit = struct
-    type t = (unit, unit) Cell.t
+    type t = (unit, unit) Node.t
 
     (* All [unit]-valued variables share a single spec; they only differ by node identity,
        which is what invalidation acts on. *)
@@ -534,7 +535,7 @@ module Var = struct
     ;;
 
     let create () : t = make_dep_node ~spec ~input:()
-    let invalidate t ~reason = Cell.invalidate t ~reason
-    let read t = Cell.read t
+    let invalidate t ~reason = Node.invalidate t ~reason
+    let read t = Node.read t
   end
 end

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -296,6 +296,14 @@ module Node = struct
   let input (t : (_, _) t) = t.input
   let read = Exec.exec_dep_node
   let invalidate = Invalidation.invalidate_node
+
+  module Packed = struct
+    type 'o t = T : (_, 'o) Dep_node.t -> 'o t [@@unboxed]
+
+    let read (T node) = read node
+  end
+
+  let pack node = Packed.T node
 end
 
 let node = dep_node

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -130,7 +130,7 @@ val map_reduce_array
 (** Like [map_reduce_seq], for lists. *)
 val map_reduce : 'a list -> f:('a -> 'b t) -> empty:'b -> combine:('b -> 'b -> 'b) -> 'b t
 
-module Make_parallel_map (Map : Map.S) : sig
+module Map (Map : Map.S) : sig
   val parallel_map : 'a Map.t -> f:(Map.key -> 'a -> 'b t) -> 'b Map.t t
 end
 
@@ -383,34 +383,34 @@ end
 (** Introduces a dependency on the current build run. *)
 val current_run : unit -> Run.t t
 
-module Cell : sig
+module Node : sig
   type ('i, 'o) t
 
   val input : ('i, _) t -> 'i
   val read : (_, 'o) t -> 'o memo
 
-  (** Mark this cell as invalid, forcing recomputation of this value. The
+  (** Mark this node as invalid, forcing recomputation of this value. The
       consumers may be recomputed or not, depending on early cutoff. *)
   val invalidate : reason:Invalidation.Reason.t -> _ t -> Invalidation.t
 end
 
-(** Create a "memoization cell" that focuses on a single input/output pair of a
+(** Create a "memoization node" that focuses on a single input/output pair of a
     memoized function. *)
-val cell : ('i, 'o) Table.t -> 'i -> ('i, 'o) Cell.t
+val node : ('i, 'o) Table.t -> 'i -> ('i, 'o) Node.t
 
-val lazy_cell
+val lazy_node
   :  ?cutoff:('a -> 'a -> bool)
   -> ?name:string
   -> ?human_readable_description:(unit -> User_message.Style.t Pp.t)
   -> ?on_event:(Event.t -> unit)
   -> (unit -> 'a t)
-  -> (unit, 'a) Cell.t
+  -> (unit, 'a) Node.t
 
 (** Returns the cached dependency graph discoverable from the specified node *)
 val dump_cached_graph
   :  ?on_not_cached:[ `Ignore | `Raise ]
   -> ?time_nodes:bool
-  -> ('i, 'o) Cell.t
+  -> ('i, 'o) Node.t
   -> Dune_graph.Graph.t Fiber.t
 
 module Lazy : sig
@@ -430,7 +430,7 @@ module Lazy : sig
   val map : 'a t -> f:('a -> 'b) -> 'b t
 
   module Expert : sig
-    (** Like [Lazy.create] but returns the underlying Memo [Cell], which can be
+    (** Like [Lazy.create] but returns the underlying Memo [Node], which can be
         useful for testing and debugging. *)
     val create
       :  ?cutoff:('a -> 'a -> bool)
@@ -438,7 +438,7 @@ module Lazy : sig
       -> ?human_readable_description:(unit -> User_message.Style.t Pp.t)
       -> ?on_event:(Event.t -> unit)
       -> (unit -> 'a memo)
-      -> (unit, 'a) Cell.t * 'a t
+      -> (unit, 'a) Node.t * 'a t
   end
 end
 
@@ -559,9 +559,9 @@ module For_tests : sig
 
   (** Like [get_deps] but preserves the series-parallel structure
       ([Seq]/[Par]/[Singleton]/[Empty]) instead of flattening it. Each leaf is
-      rendered as [(name, input)]. Returns [None] if the cell's dependencies were
+      rendered as [(name, input)]. Returns [None] if the node's dependencies were
       not computed in the current run. *)
-  val get_deps_structured : (_, _) Cell.t -> Dyn.t option
+  val get_deps_structured : (_, _) Node.t -> Dyn.t option
 
   (** Forget all memoized values, forcing them to be recomputed on the next
       build run. *)

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -392,6 +392,15 @@ module Node : sig
   (** Mark this node as invalid, forcing recomputation of this value. The
       consumers may be recomputed or not, depending on early cutoff. *)
   val invalidate : reason:Invalidation.Reason.t -> _ t -> Invalidation.t
+
+  (** Like [Node.t] but with the input type hidden. *)
+  module Packed : sig
+    type 'o t
+
+    val read : 'o t -> 'o memo
+  end
+
+  val pack : ('i, 'o) t -> 'o Packed.t
 end
 
 (** Create a "memoization node" that focuses on a single input/output pair of a

--- a/src/source/source_tree.ml
+++ b/src/source/source_tree.ml
@@ -131,7 +131,7 @@ let rec physical
       Some
         { Dir0.sub_dir_status = dir_status
         ; sub_dir_as_t =
-            Memo.lazy_cell (fun () ->
+            Memo.lazy_node (fun () ->
               find_dir_raw
                 ~default_vcs
                 ~path
@@ -141,7 +141,7 @@ let rec physical
                 ~dune_file
                 ~status:dir_status
                 ~project)
-            |> Memo.Cell.read
+            |> Memo.Node.read
         })
 
 and virtual_ ~project ~sub_dirs ~parent_status ~dune_file ~init ~path =
@@ -164,7 +164,7 @@ and virtual_ ~project ~sub_dirs ~parent_status ~dune_file ~init ~path =
               ( fn
               , { Dir0.sub_dir_status = status
                 ; sub_dir_as_t =
-                    Memo.lazy_cell (fun () ->
+                    Memo.lazy_node (fun () ->
                       find_dir_raw
                         ~default_vcs:Dir0.Vcs.Ancestor_vcs
                         ~path:(Path.Source.relative_fname path fn)
@@ -174,7 +174,7 @@ and virtual_ ~project ~sub_dirs ~parent_status ~dune_file ~init ~path =
                         ~status
                         ~dirs_visited:Dirs_visited.empty
                         ~project)
-                    |> Memo.Cell.read
+                    |> Memo.Node.read
                 } ))
       |> List.filter_opt
       |> Filename.Array.Map.of_sorted_list_exn
@@ -264,7 +264,7 @@ and find_dir_raw
 ;;
 
 let root =
-  Memo.lazy_cell
+  Memo.lazy_node
   @@ fun () ->
   let path = Path.Source.root in
   let dir_status : Source_dir_status.t = Normal in
@@ -312,7 +312,7 @@ let gen_find_dir =
        | Some dir -> dir.sub_dir_as_t >>= loop on_success on_last_found xs)
   in
   fun ~on_success ~on_last_found p ->
-    Memo.Cell.read root >>= loop on_success on_last_found (Path.Source.explode p)
+    Memo.Node.read root >>= loop on_success on_last_found (Path.Source.explode p)
 ;;
 
 let find_dir =
@@ -341,11 +341,11 @@ let find_excluded_ancestor path =
             |> Option.map ~f:(fun loc -> Path.Source.relative_fname dir.path sub_dir, loc)
           | _ -> None))
   in
-  let* root = Memo.Cell.read root in
+  let* root = Memo.Node.read root in
   loop root (Path.Source.explode path)
 ;;
 
-let root () = Memo.Cell.read root
+let root () = Memo.Node.read root
 
 let files_of path =
   find_dir path

--- a/test/expect-tests/memo/deps_representation.ml
+++ b/test/expect-tests/memo/deps_representation.ml
@@ -6,11 +6,11 @@ open Test_helpers.Make ()
    series-parallel Seq/Par/Singleton/Empty structure - by driving each shape through the
    public Memo combinators and reading it back with [Memo.For_tests.get_deps_structured]. *)
 
-let leaf name = Memo.lazy_cell ~name (fun () -> Memo.return ())
-let read = Memo.Cell.read
+let leaf name = Memo.lazy_node ~name (fun () -> Memo.return ())
+let read = Memo.Node.read
 
 let print_deps label m =
-  let cell = Memo.lazy_cell ~name:"top" (fun () -> m) in
+  let cell = Memo.lazy_node ~name:"top" (fun () -> m) in
   let () = run (read cell) in
   match Memo.For_tests.get_deps_structured cell with
   | None -> printfn "%s: <none>" label

--- a/test/expect-tests/memo/graph_dump/dump_graph_tests.ml
+++ b/test/expect-tests/memo/graph_dump/dump_graph_tests.ml
@@ -58,7 +58,7 @@ let e =
 let () = run_memo e ()
 
 let%expect_test _ =
-  let graph = Scheduler.run (Memo.dump_cached_graph (Memo.cell d ())) in
+  let graph = Scheduler.run (Memo.dump_cached_graph (Memo.node d ())) in
   Graph.print graph ~format:Graph.File_format.Gexf;
   [%expect
     {|
@@ -82,7 +82,7 @@ let%expect_test _ =
 ;;
 
 let%expect_test _ =
-  let graph = Scheduler.run (Memo.dump_cached_graph (Memo.cell d ())) in
+  let graph = Scheduler.run (Memo.dump_cached_graph (Memo.node d ())) in
   Graph.print graph ~format:Graph.File_format.Dot;
   [%expect
     {|
@@ -95,7 +95,7 @@ let%expect_test _ =
 ;;
 
 let%expect_test _ =
-  let graph = Scheduler.run (Memo.dump_cached_graph ~time_nodes:true (Memo.cell d ())) in
+  let graph = Scheduler.run (Memo.dump_cached_graph ~time_nodes:true (Memo.node d ())) in
   Graph.For_tests.print
     graph
     ~format:Graph.File_format.Gexf
@@ -141,7 +141,7 @@ let%expect_test _ =
 ;;
 
 let%expect_test _ =
-  let graph = Scheduler.run (Memo.dump_cached_graph ~time_nodes:true (Memo.cell e ())) in
+  let graph = Scheduler.run (Memo.dump_cached_graph ~time_nodes:true (Memo.node e ())) in
   Graph.For_tests.print
     graph
     ~format:Graph.File_format.Gexf
@@ -208,7 +208,7 @@ let%expect_test "dump_cached_graph: on_not_cached" =
   Memo.reset Memo.Invalidation.empty;
   (* [`Ignore] stops at the uncached node and returns the graph built so far. *)
   let graph =
-    Scheduler.run (Memo.dump_cached_graph ~on_not_cached:`Ignore (Memo.cell root ()))
+    Scheduler.run (Memo.dump_cached_graph ~on_not_cached:`Ignore (Memo.node root ()))
   in
   Graph.print graph ~format:Graph.File_format.Dot;
   [%expect
@@ -218,7 +218,7 @@ let%expect_test "dump_cached_graph: on_not_cached" =
     |}];
   (* [`Raise] (the default) raises when a reachable node is not cached. *)
   (match
-     Scheduler.run (Memo.dump_cached_graph ~on_not_cached:`Raise (Memo.cell root ()))
+     Scheduler.run (Memo.dump_cached_graph ~on_not_cached:`Raise (Memo.node root ()))
    with
    | (_ : Graph.t) -> print_endline "no error"
    | exception Failure msg -> Printf.printf "raised: %s\n" msg);

--- a/test/expect-tests/memo/lazy_expert.ml
+++ b/test/expect-tests/memo/lazy_expert.ml
@@ -14,7 +14,7 @@ let%expect_test "Lazy.Expert.create exposes the cell and the thunk" =
       Memo.return 42)
   in
   printfn "thunk = %d" (run (Memo.Lazy.force thunk));
-  printfn "cell = %d" (run (Memo.Cell.read cell));
+  printfn "cell = %d" (run (Memo.Node.read cell));
   printfn "calls = %d" !calls;
   [%expect
     {|
@@ -24,7 +24,7 @@ let%expect_test "Lazy.Expert.create exposes the cell and the thunk" =
     calls = 1
     |}];
   (* Invalidating the cell forces recomputation. *)
-  Memo.reset (Memo.Cell.invalidate ~reason:Reason.Test cell);
+  Memo.reset (Memo.Node.invalidate ~reason:Reason.Test cell);
   printfn "thunk = %d" (run (Memo.Lazy.force thunk));
   printfn "calls = %d" !calls;
   [%expect

--- a/test/expect-tests/memo/main.ml
+++ b/test/expect-tests/memo/main.ml
@@ -367,14 +367,14 @@ let%expect_test _ =
     running foobar |}]
 ;;
 
-(* Tests for Memo.Cell *)
+(* Tests for Memo.Node *)
 
 let%expect_test _ =
   let f x = Memo.return ("*" ^ x) in
   let memo = Memo.create "for-cell" ~input:(module String) ~cutoff:String.equal f in
-  let cell = Memo.cell memo "foobar" in
-  print_endline (run (Memo.Cell.read cell));
-  print_endline (run (Memo.Cell.read cell));
+  let cell = Memo.node memo "foobar" in
+  print_endline (run (Memo.Node.read cell));
+  print_endline (run (Memo.Node.read cell));
   [%expect
     {|
     *foobar
@@ -385,18 +385,18 @@ let%expect_test "fib linked list" =
   Memo.Metrics.reset ();
   let module Element = struct
     type t =
-      { prev_cell : (int, t) Memo.Cell.t
+      { prev_cell : (int, t) Memo.Node.t
       ; value : int
-      ; next_cell : (int, t) Memo.Cell.t
+      ; next_cell : (int, t) Memo.Node.t
       }
   end
   in
-  let force cell : Element.t Memo.t = Memo.Cell.read cell in
+  let force cell : Element.t Memo.t = Memo.Node.read cell in
   let memo_fdecl = Fdecl.create Dyn.opaque in
   let compute_element x =
     let memo = Fdecl.get memo_fdecl in
     printf "computing %d\n" x;
-    let prev_cell = Memo.cell memo (x - 1) in
+    let prev_cell = Memo.node memo (x - 1) in
     let+ value =
       if x < 1
       then Memo.return 0
@@ -408,7 +408,7 @@ let%expect_test "fib linked list" =
         let+ z = force y.prev_cell in
         x.value + z.value
     in
-    { Element.next_cell = Memo.cell memo (x + 1); prev_cell; value }
+    { Element.next_cell = Memo.node memo (x + 1); prev_cell; value }
   in
   let memo = Memo.create "fib" ~input:(module Int) compute_element in
   Fdecl.set memo_fdecl memo;
@@ -1446,7 +1446,7 @@ let%expect_test "Test that there are no phantom dependencies" =
       printf "base = %d\n" result;
       Memo.return result)
   in
-  let cell = Memo.cell const_8 () in
+  let cell = Memo.node const_8 () in
   let summit =
     Memo.create
       "summit"
@@ -1459,7 +1459,7 @@ let%expect_test "Test that there are no phantom dependencies" =
              match !counter with
              | 1 ->
                printf "*** middle depends on base ***\n";
-               Memo.Cell.read cell
+               Memo.Node.read cell
              | _ ->
                printf "*** middle does not depend on base ***\n";
                Memo.return 0)
@@ -1491,7 +1491,7 @@ let%expect_test "Test that there are no phantom dependencies" =
     Memo graph: 3/2/0 nodes/edges/blocked (restore), 0/0/0 nodes/edges/blocked (compute)
     Memo cycle detection graph: 0/0/0 nodes/edges/paths
   |}];
-  Memo.reset (Memo.Cell.invalidate ~reason:Test cell);
+  Memo.reset (Memo.Node.invalidate ~reason:Test cell);
   evaluate_and_print summit 0;
   (* Note that we no longer depend on the [cell]. *)
   [%expect
@@ -1501,7 +1501,7 @@ let%expect_test "Test that there are no phantom dependencies" =
     Evaluated summit: 0
     f 0 = Ok 0
   |}];
-  Memo.reset (Memo.Cell.invalidate ~reason:Test cell);
+  Memo.reset (Memo.Node.invalidate ~reason:Test cell);
   evaluate_and_print summit 0;
   print_metrics ();
   (* [middle] is not recomputed, since it no longer depends on the [cell]. In the past,
@@ -1915,7 +1915,7 @@ let%expect_test "Test that there are no spurious cycles" =
     Memo graph: 0/0/0 nodes/edges/blocked (restore), 2/1/0 nodes/edges/blocked (compute)
     Memo cycle detection graph: 0/0/0 nodes/edges/paths
   |}];
-  Memo.reset (Memo.Cell.invalidate ~reason:Test (Memo.cell task_b 0));
+  Memo.reset (Memo.Node.invalidate ~reason:Test (Memo.node task_b 0));
   evaluate_and_print task_a 0;
   (* Note that here task B blows up with a cycle error when trying to restore
      its result from the cache. A doesn't need it and terminates correctly. *)
@@ -2171,8 +2171,8 @@ let%expect_test "Simple computation chain with a cutoff" =
     Memo graph: 0/0/0 nodes/edges/blocked (restore), 4/3/0 nodes/edges/blocked (compute)
     Memo cycle detection graph: 0/0/0 nodes/edges/paths
   |}];
-  let cell = Memo.cell f 1 in
-  Memo.reset (Memo.Cell.invalidate ~reason:Test cell);
+  let cell = Memo.node f 1 in
+  Memo.reset (Memo.Node.invalidate ~reason:Test cell);
   evaluate_and_print f 3;
   print_metrics ();
   (* CR-someday amokhov: f(1) is recomputed because we've just invalidated it.
@@ -2189,7 +2189,7 @@ let%expect_test "Simple computation chain with a cutoff" =
 
 let%expect_test "loss of concurrency" =
   let cell name =
-    Memo.lazy_cell ~cutoff:Unit.equal (fun () ->
+    Memo.lazy_node ~cutoff:Unit.equal (fun () ->
       (* this hackery needed to observe concurrency *)
       Memo.of_reproducible_fiber
       @@ Fiber.of_thunk (fun () ->
@@ -2201,10 +2201,10 @@ let%expect_test "loss of concurrency" =
   let a = cell "a" in
   let b = cell "b" in
   let c =
-    Memo.lazy_cell (fun () ->
-      Memo.fork_and_join (fun () -> Memo.Cell.read a) (fun () -> Memo.Cell.read b))
+    Memo.lazy_node (fun () ->
+      Memo.fork_and_join (fun () -> Memo.Node.read a) (fun () -> Memo.Node.read b))
   in
-  let read x = run @@ Memo.map ~f:ignore @@ Memo.Cell.read x in
+  let read x = run @@ Memo.map ~f:ignore @@ Memo.Node.read x in
   (* First we evaluate everything. Note that [a] and [b] are evalauted concurrently *)
   read c;
   [%expect
@@ -2216,8 +2216,8 @@ let%expect_test "loss of concurrency" =
   (* Now we invalidate [a] and [b]. As a consequence [c] should be recomputed. *)
   Memo.reset
     (Memo.Invalidation.combine
-       (Memo.Cell.invalidate a ~reason:Test)
-       (Memo.Cell.invalidate b ~reason:Test));
+       (Memo.Node.invalidate a ~reason:Test)
+       (Memo.Node.invalidate b ~reason:Test));
   (* Now we recompute [c]. Because [c] recorded [a] and [b] as a parallel section (via
      [fork_and_join]), restoring [c] from the cache checks them concurrently, so the
      cutoff-driven recomputations of [a] and [b] also run concurrently. *)
@@ -2263,11 +2263,11 @@ let%expect_test "fork_and_join: parallel cutoff restore" =
   let a, a_var = yielding_node ~name:"a" () in
   let b, b_var = yielding_node ~name:"b" () in
   let top =
-    Memo.lazy_cell (fun () ->
+    Memo.lazy_node (fun () ->
       printf "top* ";
       Memo.fork_and_join (fun () -> Memo.exec a ()) (fun () -> Memo.exec b ()))
   in
-  let evaluate () = run (Memo.map ~f:ignore (Memo.Cell.read top)) in
+  let evaluate () = run (Memo.map ~f:ignore (Memo.Node.read top)) in
   printf "1st run: ";
   evaluate ();
   Memo.reset
@@ -2292,11 +2292,11 @@ let%expect_test "parallel_map: parallel cutoff restore" =
   let a, a_var = yielding_node ~name:"a" () in
   let b, b_var = yielding_node ~name:"b" () in
   let top =
-    Memo.lazy_cell (fun () ->
+    Memo.lazy_node (fun () ->
       printf "top* ";
       Memo.parallel_map [ a; b ] ~f:(fun node -> Memo.exec node ()))
   in
-  let evaluate () = run (Memo.map ~f:ignore (Memo.Cell.read top)) in
+  let evaluate () = run (Memo.map ~f:ignore (Memo.Node.read top)) in
   printf "1st run: ";
   evaluate ();
   Memo.reset
@@ -2319,10 +2319,10 @@ let%expect_test "fork_and_join: a failing thread still lets its sibling run" =
   let a, _ = yielding_node ~name:"a" ~fail:true () in
   let b, _ = yielding_node ~name:"b" () in
   let top =
-    Memo.lazy_cell (fun () ->
+    Memo.lazy_node (fun () ->
       Memo.fork_and_join (fun () -> Memo.exec a ()) (fun () -> Memo.exec b ()))
   in
-  run_and_log_errors (Memo.map ~f:ignore (Memo.Cell.read top));
+  run_and_log_errors (Memo.map ~f:ignore (Memo.Node.read top));
   (* [a] raises, but [b] still runs to completion ([a+ b+ a! b-]) and the error from [a]
      propagates. *)
   [%expect
@@ -2467,11 +2467,11 @@ let%expect_test "Invalidation.to_reason_list deduplicates reasons" =
 let%expect_test "reset_if_necessary" =
   let calls = ref 0 in
   let cell =
-    Memo.lazy_cell (fun () ->
+    Memo.lazy_node (fun () ->
       incr calls;
       Memo.return ())
   in
-  let eval () = run (Memo.Cell.read cell) in
+  let eval () = run (Memo.Node.read cell) in
   eval ();
   printf "calls = %d\n" !calls;
   [%expect {| calls = 1 |}];
@@ -2482,7 +2482,7 @@ let%expect_test "reset_if_necessary" =
   printf "calls = %d\n" !calls;
   [%expect {| calls = 1 |}];
   (* A non-empty invalidation forces a reset, so the cell is recomputed. *)
-  Memo.reset_if_necessary (Memo.Cell.invalidate ~reason:Test cell);
+  Memo.reset_if_necessary (Memo.Node.invalidate ~reason:Test cell);
   eval ();
   printf "calls = %d\n" !calls;
   [%expect {| calls = 2 |}]
@@ -2491,11 +2491,11 @@ let%expect_test "reset_if_necessary" =
 let%expect_test "reset_if_necessary retries non-reproducible errors" =
   let calls = ref 0 in
   let cell =
-    Memo.lazy_cell (fun () ->
+    Memo.lazy_node (fun () ->
       incr calls;
       raise (Memo.Non_reproducible (Failure "boom")))
   in
-  run_and_log_errors (Memo.Cell.read cell);
+  run_and_log_errors (Memo.Node.read cell);
   printf "calls = %d\n" !calls;
   [%expect
     {|
@@ -2509,7 +2509,7 @@ let%expect_test "reset_if_necessary retries non-reproducible errors" =
      run, so [reset_if_necessary] still advances the run and the computation is retried
      instead of being served stale from the cache. *)
   Memo.reset_if_necessary Memo.Invalidation.empty;
-  run_and_log_errors (Memo.Cell.read cell);
+  run_and_log_errors (Memo.Node.read cell);
   printf "calls = %d\n" !calls;
   [%expect
     {|

--- a/test/expect-tests/memo/parallelism_cutoffs.ml
+++ b/test/expect-tests/memo/parallelism_cutoffs.ml
@@ -9,7 +9,7 @@
    recomputation.
 
    Notes on scope:
-   - [Memo.Map.parallel_iter] does not exist (only the [Make_parallel_map] functor exposes
+   - [Memo.Map.parallel_iter] does not exist (only the [Map] functor exposes
      [parallel_map]), so the map-based cases are not covered here.
    - Memo errors carry no dependency subtrees, so the error case asserts only the marker
      interleaving and the raised exception, not dep structure.
@@ -23,11 +23,11 @@ open Test_helpers.Make ()
    the variable forces the node to recompute. *)
 module Node = struct
   type t =
-    { cell : (unit, unit) Memo.Cell.t
+    { cell : (unit, unit) Memo.Node.t
     ; var : Memo.Var.Unit.t
     }
 
-  let read t = Memo.Cell.read t.cell
+  let read t = Memo.Node.read t.cell
 end
 
 (* A computation with a [Scheduler.yield] between its start and end markers, making it
@@ -67,19 +67,19 @@ let node ?dep ~cutoff ?(fail = false) name : Node.t =
              raise_notrace (Failure name));
            printf "%s- " name)))
   in
-  { cell = Memo.cell table (); var }
+  { cell = Memo.node table (); var }
 ;;
 
-let evaluate (top : (unit, _) Memo.Cell.t) : unit =
-  run (Memo.map ~f:ignore (Memo.Cell.read top))
+let evaluate (top : (unit, _) Memo.Node.t) : unit =
+  run (Memo.map ~f:ignore (Memo.Node.read top))
 ;;
 
 (* Like [evaluate], but reports (rather than raises) errors so the error case can observe
    both the marker interleaving and the raised exception. *)
-let evaluate_and_log_errors (top : (unit, _) Memo.Cell.t) : unit =
+let evaluate_and_log_errors (top : (unit, _) Memo.Node.t) : unit =
   match
     Scheduler.run
-      (Fiber.collect_errors (fun () -> Memo.run (Memo.map ~f:ignore (Memo.Cell.read top))))
+      (Fiber.collect_errors (fun () -> Memo.run (Memo.map ~f:ignore (Memo.Node.read top))))
   with
   | Ok () -> ()
   | Error exns ->
@@ -113,7 +113,7 @@ let test ~nodes ~top =
 let%expect_test "fork_and_join" =
   let a, b = node ~cutoff:true "a", node ~cutoff:true "b" in
   let top =
-    Memo.lazy_cell ~name:"top" (fun () ->
+    Memo.lazy_node ~name:"top" (fun () ->
       Memo.fork_and_join (fun () -> Node.read a) (fun () -> Node.read b))
   in
   test ~nodes:[ a; b ] ~top;
@@ -132,7 +132,7 @@ let%expect_test "fork_and_join" =
 let%expect_test "fork_and_join_unit" =
   let a, b = node ~cutoff:true "a", node ~cutoff:true "b" in
   let top =
-    Memo.lazy_cell ~name:"top" (fun () ->
+    Memo.lazy_node ~name:"top" (fun () ->
       Memo.fork_and_join_unit (fun () -> Node.read a) (fun () -> Node.read b))
   in
   test ~nodes:[ a; b ] ~top;
@@ -150,7 +150,7 @@ let%expect_test "fork_and_join_unit" =
 
 let%expect_test "parallel_map" =
   let nodes = List.map [ "a"; "b"; "c"; "d"; "e" ] ~f:(node ~cutoff:true) in
-  let top = Memo.lazy_cell ~name:"top" (fun () -> Memo.parallel_map nodes ~f:Node.read) in
+  let top = Memo.lazy_node ~name:"top" (fun () -> Memo.parallel_map nodes ~f:Node.read) in
   test ~nodes ~top;
   [%expect
     {|
@@ -176,7 +176,7 @@ let%expect_test "seq inside par: no-cutoff nodes are not eagerly recomputed" =
   let b = node ~dep:shared ~cutoff:false "b" in
   let c = node ~dep:shared ~cutoff:true "c" in
   let top =
-    Memo.lazy_cell ~name:"top" (fun () ->
+    Memo.lazy_node ~name:"top" (fun () ->
       Memo.fork_and_join_unit
         (fun () ->
            let* () = Node.read a in
@@ -203,7 +203,7 @@ let%expect_test "par with all no-cutoff nodes preserves parallelism" =
   let a = node ~dep:shared ~cutoff:false "a" in
   let b = node ~dep:shared ~cutoff:false "b" in
   let top =
-    Memo.lazy_cell ~name:"top" (fun () ->
+    Memo.lazy_node ~name:"top" (fun () ->
       Memo.fork_and_join_unit (fun () -> Node.read a) (fun () -> Node.read b))
   in
   test ~nodes:[ shared ] ~top;
@@ -226,7 +226,7 @@ let%expect_test "error in no-cutoff node inside par" =
   let a = node ~dep:shared ~cutoff:false ~fail:true "a" in
   let b = node ~dep:shared ~cutoff:true "b" in
   let top =
-    Memo.lazy_cell ~name:"top" (fun () ->
+    Memo.lazy_node ~name:"top" (fun () ->
       Memo.fork_and_join_unit (fun () -> Node.read a) (fun () -> Node.read b))
   in
   printf "1st run: ";
@@ -264,7 +264,7 @@ let%expect_test "nested par-seq-par: eagerness re-enables under a Par" =
   let c = node ~dep:shared ~cutoff:false "c" in
   let d = node ~dep:shared ~cutoff:true "d" in
   let top =
-    Memo.lazy_cell ~name:"top" (fun () ->
+    Memo.lazy_node ~name:"top" (fun () ->
       Memo.fork_and_join_unit
         (fun () ->
            let* () = Node.read a in


### PR DESCRIPTION
## What

Expose `Node.Packed` — an existential that hides a node's input type while
preserving its output type — along with `Node.pack` to construct one:

```ocaml
module Packed : sig
  type 'o t
  val read : 'o t -> 'o memo
end

val pack : ('i, 'o) t -> 'o Packed.t
```

This lets a caller hold nodes of differing input types in a single
collection and read their (uniformly typed) outputs. Purely additive.

Stacked on #15139 (the `Cell`→`Node` rename); the diff above is just the
`Packed` addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
