### PR TITLE
fix(configurator): only pass --personality to pkgconf >= 1.7.0

### DIFF
--- a/doc/changes/fixed/15142.md
+++ b/doc/changes/fixed/15142.md
@@ -1,0 +1,2 @@
+- Make dune-configurator pass `--personality` to `pkgconf` only for
+  version 1.7.0 and later. (#15142, fixes #11536, @dra27)

--- a/otherlibs/configurator/src/v1.ml
+++ b/otherlibs/configurator/src/v1.ml
@@ -657,12 +657,31 @@ module Pkg_config = struct
     ; configurator : t
     }
 
+  (* The [--personality] flag was added in pkgconf 1.5.0. However, up to
+     and including 1.6.x, pkgconf crashes when no personality file exists
+     for the given triplet; from 1.7.0 it falls back to the default
+     personality instead. We therefore only pass [--personality] to
+     pkgconf 1.7.0 and newer. *)
+  let supports_personality c pkg_config =
+    let { Process.exit_code; stdout; _ } =
+      Process.run_process c ~dir:c.dest_dir pkg_config [ "--version" ]
+    in
+    exit_code = 0
+    &&
+    match String.split (String.trim stdout) ~on:'.' with
+    | major :: minor :: _ ->
+      (match Int.of_string major, Int.of_string minor with
+       | Some major, Some minor -> major > 1 || (major = 1 && minor >= 7)
+       | _ -> false)
+    | _ -> false
+  ;;
+
   let get ?static c =
     let get_pkg_config_args default =
       let args =
         match Sys.getenv "PKG_CONFIG_ARGN" with
         | s -> String.split ~on:' ' s
-        | exception Not_found -> default
+        | exception Not_found -> default ()
       in
       match static with
       | None -> args
@@ -673,20 +692,21 @@ module Pkg_config = struct
     match Sys.getenv "PKG_CONFIG" with
     | s ->
       Option.map (which c s) ~f:(fun pkg_config ->
-        let pkg_config_args = get_pkg_config_args [] in
+        let pkg_config_args = get_pkg_config_args (fun () -> []) in
         { pkg_config; pkg_config_args; configurator = c })
     | exception Not_found ->
       (match which c "pkgconf" with
        | None ->
          Option.map (which c "pkg-config") ~f:(fun pkg_config ->
-           let pkg_config_args = get_pkg_config_args [] in
+           let pkg_config_args = get_pkg_config_args (fun () -> []) in
            { pkg_config; pkg_config_args; configurator = c })
        | Some pkg_config ->
          let pkg_config_args =
-           get_pkg_config_args
-             (match ocaml_config_var c "target" with
-              | None -> []
-              | Some target -> [ "--personality"; target ])
+           get_pkg_config_args (fun () ->
+             match ocaml_config_var c "target" with
+             | Some target when supports_personality c pkg_config ->
+               [ "--personality"; target ]
+             | None | Some _ -> [])
          in
          Some { pkg_config; pkg_config_args; configurator = c })
   ;;

--- a/otherlibs/configurator/src/v1.mli
+++ b/otherlibs/configurator/src/v1.mli
@@ -99,8 +99,8 @@ module Pkg_config : sig
     (** [query t ~package] query pkg-config for the [package]. The package must
         not contain a version constraint. Multiple, unversioned packages are
         separated with spaces, for example "gtk+-3.0 gtksourceview-3.0". By
-        default, the OCaml compiler [target] is passed to pkgconf as
-        [--personality] argument.
+        default, if pkgconf is at least version 1.7.0, the OCaml compiler
+        [target] is passed to pkgconf as [--personality] argument.
         Returns [None] if [package] is not available *)
     val query : t -> package:string -> package_conf option
 
@@ -110,8 +110,9 @@ module Pkg_config : sig
     (** [query_expr_err t ~package ~expr] query pkg-config for the [package].
         [expr] may contain a version constraint, for example "gtk+-3.0 >= 3.18".
         [package] must be just the name of the package. If [expr] is specified,
-        [package] must be specified as well. By default, the OCaml compiler
-        "target" is passed to pkgconf as [--personality] argument.
+        [package] must be specified as well. By default, if pkgconf is at
+        least version 1.7.0, the OCaml compiler "target" is passed to pkgconf
+        as [--personality] argument.
         Returns [Error error_msg] if [package] is not available *)
     val query_expr_err
       :  t

--- a/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/pkgconf.ml
+++ b/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/pkgconf.ml
@@ -1,8 +1,13 @@
 (* We'd like to use String.equal but that's OCaml >= 4.03 *)
 let not_flag x = not ("--print-errors" = x)
 
+let version () =
+  try Sys.getenv "FAKE_PKGCONF_VERSION" with Not_found -> "2.4.3"
+
 let () =
-  let args = List.tl (Array.to_list Sys.argv) in
-  let args = List.filter not_flag args in
-  Format.printf "@[<v>%a@]@."
-    (Format.pp_print_list Format.pp_print_string) args
+  match List.tl (Array.to_list Sys.argv) with
+  | [ "--version" ] -> print_endline (version ())
+  | args ->
+    let args = List.filter not_flag args in
+    Format.printf "@[<v>%a@]@."
+      (Format.pp_print_list Format.pp_print_string) args

--- a/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/run.t
+++ b/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/run.t
@@ -4,6 +4,10 @@
 These tests show that setting `PKG_CONFIG_ARGN` passes extra args to `pkg-config`
 
   $ dune build 2>&1 | awk '/run:.*bin\/pkgconf/{a=1}/stderr/{a=0}a' | sed s/$(ocamlc -config | sed -n "/^target:/ {s/target: //; p; }")/\$TARGET/g
+  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --version
+  -> process exited with code 0
+  -> stdout:
+   | 2.4.3
   run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --personality $TARGET --print-errors dummy-pkg
   -> process exited with code 0
   -> stdout:
@@ -42,5 +46,29 @@ These tests show that setting `PKG_CONFIG_ARGN` passes extra args to `pkg-config
   -> process exited with code 0
   -> stdout:
    | --static
+   | --libs
+   | dummy-pkg
+
+`--personality` was only added in pkgconf 1.5.0 (and is only safe to use
+from 1.7.0), so it is omitted when pkgconf is older:
+
+  $ dune clean
+  $ FAKE_PKGCONF_VERSION=1.4.2 dune build 2>&1 | awk '/run:.*bin\/pkgconf/{a=1}/stderr/{a=0}a'
+  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --version
+  -> process exited with code 0
+  -> stdout:
+   | 1.4.2
+  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --print-errors dummy-pkg
+  -> process exited with code 0
+  -> stdout:
+   | dummy-pkg
+  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --cflags dummy-pkg
+  -> process exited with code 0
+  -> stdout:
+   | --cflags
+   | dummy-pkg
+  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --libs dummy-pkg
+  -> process exited with code 0
+  -> stdout:
    | --libs
    | dummy-pkg

--- a/otherlibs/configurator/test/blackbox-tests/pkg-config-static.t/pkgconf.ml
+++ b/otherlibs/configurator/test/blackbox-tests/pkg-config-static.t/pkgconf.ml
@@ -1,8 +1,13 @@
 (* We'd like to use String.equal but that's OCaml >= 4.03 *)
 let not_flag x = not ("--print-errors" = x)
 
+let version () =
+  try Sys.getenv "FAKE_PKGCONF_VERSION" with Not_found -> "2.4.3"
+
 let () =
-  let args = List.tl (Array.to_list Sys.argv) in
-  let args = List.filter not_flag args in
-  Format.printf "@[<v>%a@]@."
-    (Format.pp_print_list Format.pp_print_string) args
+  match List.tl (Array.to_list Sys.argv) with
+  | [ "--version" ] -> print_endline (version ())
+  | args ->
+    let args = List.filter not_flag args in
+    Format.printf "@[<v>%a@]@."
+      (Format.pp_print_list Format.pp_print_string) args

--- a/otherlibs/configurator/test/blackbox-tests/pkg-config-static.t/run.t
+++ b/otherlibs/configurator/test/blackbox-tests/pkg-config-static.t/run.t
@@ -4,6 +4,10 @@
 These tests show that setting `PKG_CONFIG_ARGN` passes extra args to `pkg-config`
 
   $ STATIC_TEST__=true dune build 2>&1 | awk '/run:.*bin\/pkgconf/{a=1}/stderr/{a=0}a' | sed s/$(ocamlc -config | sed -n "/^target:/ {s/target: //; p; }")/\$TARGET/g
+  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --version
+  -> process exited with code 0
+  -> stdout:
+   | 2.4.3
   run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --static --personality $TARGET --print-errors dummy-pkg
   -> process exited with code 0
   -> stdout:
@@ -53,6 +57,10 @@ These tests show that setting `PKG_CONFIG_ARGN` passes extra args to `pkg-config
 
   $ dune clean
   $ STATIC_TEST__=false dune build 2>&1 | awk '/run:.*bin\/pkgconf/{a=1}/stderr/{a=0}a' | sed s/$(ocamlc -config | sed -n "/^target:/ {s/target: //; p; }")/\$TARGET/g
+  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --version
+  -> process exited with code 0
+  -> stdout:
+   | 2.4.3
   run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --personality $TARGET --print-errors dummy-pkg
   -> process exited with code 0
   -> stdout:
@@ -96,6 +104,10 @@ These tests show that setting `PKG_CONFIG_ARGN` passes extra args to `pkg-config
 
   $ dune clean
   $ dune build 2>&1 | awk '/run:.*bin\/pkgconf/{a=1}/stderr/{a=0}a' | sed s/$(ocamlc -config | sed -n "/^target:/ {s/target: //; p; }")/\$TARGET/g
+  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --version
+  -> process exited with code 0
+  -> stdout:
+   | 2.4.3
   run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --personality $TARGET --print-errors dummy-pkg
   -> process exited with code 0
   -> stdout:


### PR DESCRIPTION
Since #10937, dune-configurator unconditionally passes `--personality <target>` when the pkg-config implementation is pkgconf. This is a nuisance on RHEL 8 systems (which are still supported until May 2029):

```
#=== ERROR while compiling curl.0.10.0 ========================================#
# context     2.5.1 | linux/x86_64 |  | git+https://github.com/ocaml/opam-repository.git
# path        $HOME/.opam/oxcaml-dev/.opam-switch/build/curl.0.10.0
# command     $HOME/.opam/opam-init/hooks/sandbox.sh build dune build -p curl -j 63 @install
# exit-code   1
# env-file    $HOME/.opam/log/curl-1717245-f5c6dc.env
# output-file $HOME/.opam/log/curl-1717245-f5c6dc.out
### output ###
# [...]
# 26 |  (targets config.h cflags.sexp clibs.sexp)
# 27 |  (action (run config/discover.exe)))
# (cd _build/default && config/discover.exe)
# which: pkgconf
# -> found: /usr/bin/pkgconf
# run: /usr/bin/pkgconf --personality x86_64-pc-linux-gnu --print-errors 'libcurl >= 7.28.0'
# -> process exited with code 1
# -> stdout:
# -> stderr:
#  | pkgconf: unknown option -- personality
# Error: pkgconf: unknown option -- personality
# 
```

RHEL 9 actually has 1.7.0+, so I wasn't easily able to find a system with pkgconf 1.6, but doing this based on a version number probe, rather than detecting the error response to the flag, doesn't seem too hideous to me.