### PR TITLE
feat(memo): expose Spec and Table.spec; downcast frames via Spec.t

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -998,14 +998,16 @@ module Internal = struct
       let+ stack = Memo.get_call_stack () in
       List.find_map stack ~f:(fun frame ->
         match
-          Memo.Stack_frame.as_instance_of frame ~of_:(Lazy.force execute_rule_memo)
+          Memo.Stack_frame.as_instance_of
+            frame
+            ~of_:(Memo.Table.spec (Lazy.force execute_rule_memo))
         with
         | Some r -> Some (Rule.loc r)
         | None ->
           Option.bind
             (Memo.Stack_frame.as_instance_of
                frame
-               ~of_:(Lazy.force execute_action_generic_stage2_memo))
+               ~of_:(Memo.Table.spec (Lazy.force execute_action_generic_stage2_memo)))
             ~f:(fun (x : Anonymous_action.t) ->
               Option.some_if (not @@ Loc.is_none x.action.loc) x.action.loc)))
   ;;

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -2,7 +2,14 @@ module Metrics0 = Metrics
 module Table0 = Table
 open Stdune
 module Metrics = Metrics0
-module Table = Table0
+
+module Table = struct
+  include Table0
+
+  let spec (t : (_, _) t) = t.spec
+end
+
+module Spec = Spec
 open Fiber.O
 module Graph = Dune_graph.Graph
 module Console = Console
@@ -76,8 +83,8 @@ module Stack_frame = struct
   let input (Dep_node.T t) = Dep_node.input_to_dyn t
   let to_dyn = Dep_node.Packed.to_dyn_without_state
 
-  let as_instance_of stack_frame ~(of_ : _ Table.t) =
-    match of_.spec.witness with
+  let as_instance_of stack_frame ~(of_ : _ Spec.t) =
+    match of_.witness with
     | None -> None
     | Some witness -> Dep_node.Packed.as_instance_of stack_frame witness
   ;;

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -134,9 +134,17 @@ module Map (Map : Map.S) : sig
   val parallel_map : 'a Map.t -> f:(Map.key -> 'a -> 'b t) -> 'b Map.t t
 end
 
+(** The specification of a memoized function. *)
+module Spec : sig
+  type ('input, 'output) t
+end
+
 (** A table memoizing results of executing a function. *)
 module Table : sig
   type ('input, 'output) t
+
+  (** The specification of the memoized function backing this table. *)
+  val spec : ('input, 'output) t -> ('input, 'output) Spec.t
 end
 
 (** A stack frame within a computation. *)
@@ -149,7 +157,7 @@ module Stack_frame : sig
 
   (** Checks if the stack frame is a frame of the given memoized function and if
       so, returns [Some i] where [i] is the argument of the function. *)
-  val as_instance_of : t -> of_:('input, _) Table.t -> 'input option
+  val as_instance_of : t -> of_:('input, _) Spec.t -> 'input option
 
   val human_readable_description : t -> User_message.Style.t Pp.t option
 end

--- a/test/expect-tests/memo/main.ml
+++ b/test/expect-tests/memo/main.ml
@@ -159,7 +159,8 @@ let%expect_test _ =
   | Memo.Cycle_error.E err ->
     let cycle =
       Memo.Cycle_error.get err
-      |> List.filter_map ~f:(Memo.Stack_frame.as_instance_of ~of_:mcompcycle)
+      |> List.filter_map
+           ~f:(Memo.Stack_frame.as_instance_of ~of_:(Memo.Table.spec mcompcycle))
     in
     print (Pp.enumerate cycle ~f:(Pp.textf "%d"));
     print (Pp.textf "%d" !counter);


### PR DESCRIPTION
## What

Expose `Memo.Spec` (the specification of a memoized function) and
`Memo.Table.spec` (retrieve the spec backing a table), and change
`Stack_frame.as_instance_of` to take its `of_` argument as a `Spec.t`
rather than a `Table.t`:

```ocaml
module Spec : sig type ('input, 'output) t end

module Table : sig
  ...
  val spec : ('input, 'output) t -> ('input, 'output) Spec.t
end

(* Stack_frame: *)
val as_instance_of : t -> of_:('input, _) Spec.t -> 'input option
```

A frame can now be downcast against any spec, not only a table's. The two
existing callers pass `Table.spec table` where they previously passed the
table directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
