### PR TITLE
feat(memo): let human_readable_description opt out per input

### DIFF
--- a/src/dune_engine/action_builder.ml
+++ b/src/dune_engine/action_builder.ml
@@ -208,6 +208,9 @@ let evaluate_and_collect_deps t = eval t Lazy
 let evaluate_and_collect_facts t = eval t Eager
 
 let create_memo name ~input ?cutoff ?human_readable_description f =
+  let human_readable_description =
+    Option.map human_readable_description ~f:(fun f x -> Some (f x))
+  in
   let lazy_ =
     lazy
       (let cutoff =

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -963,7 +963,8 @@ module Internal = struct
     lazy
       (Memo.create
          "eval-pred"
-         ~human_readable_description:file_selector_stack_frame_description
+         ~human_readable_description:(fun fs ->
+           Some (file_selector_stack_frame_description fs))
          ~input:(module File_selector)
          ~cutoff:Filename_set.equal
          eval_pred_impl)

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -511,7 +511,8 @@ end = struct
       ~human_readable_description:(fun (_, dir) ->
         Pp.textf
           "Computing directory contents of %s"
-          (Path.to_string_maybe_quoted (Path.build dir)))
+          (Path.to_string_maybe_quoted (Path.build dir))
+        |> Option.some)
   ;;
 
   let get sctx ~dir =

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -1259,7 +1259,8 @@ let symlinked_entries =
       ~human_readable_description:(fun (_, pkg) ->
         Pp.textf
           "Computing installable artifacts for package %s"
-          (Package.Name.to_string pkg))
+          (Package.Name.to_string pkg)
+        |> Option.some)
       "symlinked_entries"
       (fun (sctx, pkg) -> symlinked_entries sctx pkg)
   in
@@ -1513,7 +1514,8 @@ let memo =
     ~human_readable_description:(fun (_, pkg) ->
       Pp.textf
         "Computing installable artifacts for package %s"
-        (Package.Name.to_string pkg))
+        (Package.Name.to_string pkg)
+      |> Option.some)
     "install-rules-and-pkg-entries"
     (fun (sctx, pkg) ->
        Memo.return

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1705,7 +1705,7 @@ end = struct
         ~input:(module Input)
         (instantiate_impl db)
         ~human_readable_description:(fun (name, info, _hidden) ->
-          Dep_path.Entry.Lib.pp { name; path = Lib_info.src_dir info })
+          Dep_path.Entry.Lib.pp { name; path = Lib_info.src_dir info } |> Option.some)
     in
     Staged.stage (fun name info ~hidden -> Memo.exec memo (name, info, hidden))
 

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -217,7 +217,8 @@ let get_with_path =
     Memo.exec
       (Memo.create
          ~human_readable_description:(fun p ->
-           Pp.textf "read lock directory %s" (Path.to_string_maybe_quoted p))
+           Pp.textf "read lock directory %s" (Path.to_string_maybe_quoted p)
+           |> Option.some)
          "read-lock-dir"
          ~input:(module Path)
          (fun path ->

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1671,7 +1671,8 @@ end = struct
         "pkg-resolve"
         ~input:(module Input)
         ~human_readable_description:(fun t ->
-          Pp.textf "- package %s" (Package.Name.to_string t.pkg_digest.name))
+          Pp.textf "- package %s" (Package.Name.to_string t.pkg_digest.name)
+          |> Option.some)
         resolve_impl
     in
     fun (db : DB.t) loc pkg_digest package_universe ->

--- a/src/dune_rules/rocq/rocq_lib.ml
+++ b/src/dune_rules/rocq/rocq_lib.ml
@@ -474,7 +474,7 @@ module DB = struct
       Memo.create
         "create-from-stanza"
         ~human_readable_description:(fun (_, _, path, theory) ->
-          Id.pp (Id.create ~path:(Path.build path) ~name:theory.name))
+          Id.pp (Id.create ~path:(Path.build path) ~name:theory.name) |> Option.some)
         ~input:(module Input)
         create_from_stanza_impl
     ;;

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -324,6 +324,9 @@ module Implicit_output = Implicit_output
 
 let lazy_node ?cutoff ?name ?human_readable_description ?on_event f =
   let on_event = Option.map on_event ~f:(fun on_event () event -> on_event event) in
+  let human_readable_description =
+    Option.map human_readable_description ~f:(fun f () -> Some (f ()))
+  in
   let spec =
     Spec.create ~name ~input:(module Unit) ~cutoff ~human_readable_description ?on_event f
   in

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -304,7 +304,7 @@ val create
   -> input:(module Input with type t = 'i)
   -> ?initial_store_size:int
   -> ?cutoff:('o -> 'o -> bool)
-  -> ?human_readable_description:('i -> User_message.Style.t Pp.t)
+  -> ?human_readable_description:('i -> User_message.Style.t Pp.t option)
   -> ?on_event:('i -> Event.t -> unit)
   -> ('i -> 'o t)
   -> ('i, 'o) Table.t
@@ -327,7 +327,7 @@ val create_with_store
   -> store:(module Store.S with type key = 'i)
   -> input:(module Store.Input with type t = 'i)
   -> ?cutoff:('o -> 'o -> bool)
-  -> ?human_readable_description:('i -> User_message.Style.t Pp.t)
+  -> ?human_readable_description:('i -> User_message.Style.t Pp.t option)
   -> ?on_event:('i -> Event.t -> unit)
   -> ('i -> 'o t)
   -> ('i, 'o) Table.t
@@ -350,7 +350,7 @@ val create_rec
   -> input:(module Input with type t = 'i)
   -> ?initial_store_size:int
   -> ?cutoff:('o -> 'o -> bool)
-  -> ?human_readable_description:('i -> User_message.Style.t Pp.t)
+  -> ?human_readable_description:('i -> User_message.Style.t Pp.t option)
   -> ?on_event:('i -> Event.t -> unit)
   -> (('i -> 'o t) -> 'i -> 'o t)
   -> ('i, 'o) Table.t

--- a/src/memo/node.ml
+++ b/src/memo/node.ml
@@ -165,7 +165,7 @@ module Dep_node = struct
     ;;
 
     let human_readable_description (T t) =
-      Option.map t.spec.human_readable_description ~f:(fun f -> f t.input)
+      Option.bind t.spec.human_readable_description ~f:(fun f -> f t.input)
     ;;
   end
 end

--- a/src/memo/spec.ml
+++ b/src/memo/spec.ml
@@ -76,7 +76,7 @@ type ('i, 'o) t =
   ; input : (module Store_intf.Input with type t = 'i)
   ; node_kind : ('i, 'o) Node_kind.t
   ; f : 'i -> 'o Fiber.t
-  ; human_readable_description : ('i -> User_message.Style.t Pp.t) option
+  ; human_readable_description : ('i -> User_message.Style.t Pp.t option) option
   }
 
 let create ~name ~input ~human_readable_description ~cutoff ?(witness = false) ?on_event f

--- a/src/memo/spec.mli
+++ b/src/memo/spec.mli
@@ -27,13 +27,13 @@ type ('i, 'o) t =
   ; input : (module Store_intf.Input with type t = 'i)
   ; node_kind : ('i, 'o) Node_kind.t
   ; f : 'i -> 'o Fiber.t
-  ; human_readable_description : ('i -> User_message.Style.t Pp.t) option
+  ; human_readable_description : ('i -> User_message.Style.t Pp.t option) option
   }
 
 val create
   :  name:string option
   -> input:(module Store_intf.Input with type t = 'a)
-  -> human_readable_description:('a -> User_message.Style.t Pp.t) option
+  -> human_readable_description:('a -> User_message.Style.t Pp.t option) option
   -> cutoff:('b -> 'b -> bool) option
   -> ?witness:bool
   -> ?on_event:('a -> Event.t -> unit)


### PR DESCRIPTION
## What

`create`, `create_with_store` and `create_rec` now take
`?human_readable_description:('i -> _ Pp.t option)` instead of
`('i -> _ Pp.t)`, so a memoized function can describe some inputs and omit
others (return `None`).

The `Spec` field and `Stack_frame.human_readable_description` accessor thread
the `option` through (the accessor already returned an `option`). The lazy and
stack-frame paths keep their non-optional `(unit -> _ Pp.t)` thunks and are
adapted internally.

The two call sites that forward a description to `create` —
`Action_builder.create_memo` and the build system's file-selector node — wrap
it to keep their own `'i -> Pp.t` interfaces unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
