### PR TITLE
feat(memo): add all_concurrently_unit, parallel_iter_set, Map.parallel_iter

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -60,7 +60,12 @@ end
 
 open To_open
 include Parallel
-module Map = Make_parallel_map
+
+module Map (M : Map.S) = struct
+  include Make_parallel_map (M)
+
+  let parallel_iter t ~f = parallel_iter (M.to_list t) ~f:(fun (key, data) -> f key data)
+end
 
 let pp_stack () =
   let open Pp.O in

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -96,11 +96,19 @@ val fork_and_join_unit : (unit -> unit t) -> (unit -> 'a t) -> 'a t
 val all : 'a t list -> 'a list t
 
 val all_concurrently : 'a t list -> 'a list t
+val all_concurrently_unit : unit t list -> unit t
 val when_ : bool -> (unit -> unit t) -> unit t
 val sequential_map : 'a list -> f:('a -> 'b t) -> 'b list t
 val sequential_iter : 'a list -> f:('a -> unit t) -> unit t
 val parallel_map : 'a list -> f:('a -> 'b t) -> 'b list t
 val parallel_iter : 'a list -> f:('a -> unit t) -> unit t
+
+val parallel_iter_set
+  :  (module Set.S with type elt = 'a and type t = 's)
+  -> 's
+  -> f:('a -> unit t)
+  -> unit t
+
 val parallel_iter_seq : 'a Seq.t -> f:('a -> unit t) -> unit t
 
 (** [map_reduce_seq xs ~f ~empty ~combine] runs [f] on every element of
@@ -132,6 +140,7 @@ val map_reduce : 'a list -> f:('a -> 'b t) -> empty:'b -> combine:('b -> 'b -> '
 
 module Map (Map : Map.S) : sig
   val parallel_map : 'a Map.t -> f:(Map.key -> 'a -> 'b t) -> 'b Map.t t
+  val parallel_iter : 'a Map.t -> f:(Map.key -> 'a -> unit t) -> unit t
 end
 
 (** The specification of a memoized function. *)

--- a/src/memo/parallel.ml
+++ b/src/memo/parallel.ml
@@ -31,6 +31,13 @@ let all_concurrently l =
       Fiber.parallel_map l ~f:(fun x -> run ~f:(fun () -> x)))
 ;;
 
+let all_concurrently_unit l =
+  Deps_collector.run_parallel ~num_threads:(List.length l) (function
+    | None -> Fiber.all_concurrently_unit l
+    | Some { Deps_collector.run } ->
+      Fiber.all_concurrently_unit (List.map l ~f:(fun x -> run ~f:(fun () -> x))))
+;;
+
 let parallel_map l ~f =
   Deps_collector.run_parallel ~num_threads:(List.length l) (function
     | None -> Fiber.parallel_map l ~f
@@ -43,6 +50,15 @@ let parallel_iter l ~f =
     | None -> Fiber.parallel_iter l ~f
     | Some { Deps_collector.run } ->
       Fiber.parallel_iter l ~f:(fun value -> run ~f:(fun () -> f value)))
+;;
+
+let parallel_iter_set
+      (type a s)
+      (module S : Set.S with type elt = a and type t = s)
+      (set : s)
+      ~f
+  =
+  parallel_iter (S.to_list set) ~f
 ;;
 
 let map_reduce l ~f ~empty ~combine =

--- a/src/memo/parallel.mli
+++ b/src/memo/parallel.mli
@@ -8,8 +8,15 @@ open! Import
 val fork_and_join : (unit -> 'a Fiber.t) -> (unit -> 'b Fiber.t) -> ('a * 'b) Fiber.t
 val fork_and_join_unit : (unit -> unit Fiber.t) -> (unit -> 'a Fiber.t) -> 'a Fiber.t
 val all_concurrently : 'a Fiber.t list -> 'a list Fiber.t
+val all_concurrently_unit : unit Fiber.t list -> unit Fiber.t
 val parallel_map : 'a list -> f:('a -> 'b Fiber.t) -> 'b list Fiber.t
 val parallel_iter : 'a list -> f:('a -> unit Fiber.t) -> unit Fiber.t
+
+val parallel_iter_set
+  :  (module Set.S with type elt = 'a and type t = 's)
+  -> 's
+  -> f:('a -> unit Fiber.t)
+  -> unit Fiber.t
 
 val map_reduce
   :  'a list


### PR DESCRIPTION
## What

Round out the parallel-combinator surface — which already exposes
`all_concurrently`, `parallel_map`, `parallel_iter`, `Map.parallel_map` —
with three more:

- `all_concurrently_unit : unit t list -> unit t` — like `all_concurrently`
  but for `unit` computations (doesn't allocate a result list).
- `parallel_iter_set : (module Set.S with ...) -> _ -> f:_ -> unit t` —
  iterate a set's elements concurrently.
- `Map.parallel_iter` — iterate a map's bindings concurrently.

Each records its branches as a parallel section (like the existing
combinators) so cache restoration can check them concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
