### PR TITLE
test(melange): target module system fixture outputs

### DIFF
--- a/test/blackbox-tests/test-cases/melange/multiple-module-systems-node-modules.t
+++ b/test/blackbox-tests/test-cases/melange/multiple-module-systems-node-modules.t
@@ -34,7 +34,9 @@ directories, so there's no overlap
 
   $ write_module_systems_dune yes
 
-  $ dune build
+  $ dune build \
+  >   target_esm/node_modules/melange.js/caml_string.js \
+  >   target_commonjs/node_modules/melange.js/caml_string.js
 
   $ cat target_esm/node_modules/melange.js/caml_string.js | head -n3
   


### PR DESCRIPTION
Build only the ESM and CommonJS runtime files inspected by the test instead of building the whole fixture.