### PR TITLE
test(odoc): build inspected syntax output directly

### DIFF
--- a/test/blackbox-tests/test-cases/odoc/odoc-syntax-env-github1117/new.t
+++ b/test/blackbox-tests/test-cases/odoc/odoc-syntax-env-github1117/new.t
@@ -13,10 +13,11 @@ variable, and can rebuild as needed.
   > EOF
 
 
-  $ dune build @doc-new
-  $ odoc_detect_syntax _build/default/_doc_new/html/docs/local/l/L/index.html
+  $ html=_build/default/_doc_new/html/docs/local/l/L/index.html
+  $ dune build "$html"
+  $ odoc_detect_syntax "$html"
   it is ocaml
 
-  $ ODOC_SYNTAX=re dune build @doc-new
-  $ odoc_detect_syntax _build/default/_doc_new/html/docs/local/l/L/index.html
+  $ ODOC_SYNTAX=re dune build "$html"
+  $ odoc_detect_syntax "$html"
   it is reason


### PR DESCRIPTION
Build the generated HTML page read by the ODOC_SYNTAX assertions for both OCaml and Reason syntax instead of the full doc-new alias.