### PR TITLE
test(odoc): target external libs output

### DIFF
--- a/test/blackbox-tests/test-cases/odoc/new/external-libs.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/new/external-libs.t/run.t
@@ -1,5 +1,6 @@
 Check that a type path referring to Stdlib.Format is resolved:
 
-  $ dune build @doc-new
-  $ grep unresolved _build/default/_doc_new/html/docs/local/odoctest/Odoctest/index.html
+  $ html=_build/default/_doc_new/html/docs/local/odoctest/Odoctest/index.html
+  $ dune build "$html"
+  $ grep unresolved "$html"
   [1]


### PR DESCRIPTION
Build the generated module HTML page checked for unresolved references instead of the full doc-new alias.