### PR TITLE
test(odoc): target compile-deps outputs

### DIFF
--- a/test/blackbox-tests/test-cases/odoc/new/multi-lib.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/new/multi-lib.t/run.t
@@ -1,9 +1,10 @@
 This test checks that compilation dependencies are correct
 
-  $ dune build @doc-new
+  $ dir=_build/default/_doc_new/html/docs/local/odoctest2/Odoctest2/B
+  $ dune build "$dir/index.html"
 
 There should be an expansion of `B.Foo` - ie, a directory called `Foo`:
 
-  $ ls _build/default/_doc_new/html/docs/local/odoctest2/Odoctest2/B
+  $ ls "$dir"
   Foo
   index.html

--- a/test/blackbox-tests/test-cases/odoc/new/transitive-compile-deps.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/new/transitive-compile-deps.t/run.t
@@ -1,9 +1,10 @@
 This test checks that compilation dependencies are correct
 
-  $ dune build @doc-new
+  $ dir=_build/default/_doc_new/html/docs/local/odoctest3/Odoctest3/C
+  $ dune build "$dir/index.html"
 
 There should be an expansion of S:
 
-  $ ls _build/default/_doc_new/html/docs/local/odoctest3/Odoctest3/C/
+  $ ls "$dir"
   index.html
   module-type-S


### PR DESCRIPTION
Build the specific module HTML pages checked by the multi-lib and transitive compile-deps tests instead of the full doc-new alias.