### PR TITLE
test(odoc): target wrapped library docs

### DIFF
--- a/test/blackbox-tests/test-cases/odoc/new/odoc-wrapped-lib.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/new/odoc-wrapped-lib.t/run.t
@@ -1,18 +1,22 @@
 This test generates documentation for non-hidden modules only for a library:
 
-  $ dune build @doc-new
+  $ html_dir=_build/default/_doc_new/html/docs/local/foo
+  $ odoc_dir=_build/default/_doc_new/odoc/local/foo
+  $ dune build \
+  >   "$html_dir/Foo/index.html" \
+  >   "$html_dir/index.html"
 
  Hidden modules should be compiled
-  $ find _build/default/_doc_new/odoc/local/foo -name '*.odoc' | sort -n
+  $ find "$odoc_dir" -name '*.odoc' | sort -n
   _build/default/_doc_new/odoc/local/foo/foo.odoc
   _build/default/_doc_new/odoc/local/foo/foo__.odoc
   _build/default/_doc_new/odoc/local/foo/foo__Bar.odoc
 
  Hidden modules should not be linked
-  $ find _build/default/_doc_new/odoc/local/foo -name '*.odocl' | sort -n
+  $ find "$odoc_dir" -name '*.odocl' | sort -n
   _build/default/_doc_new/odoc/local/foo/foo.odocl
 
  We don't expect html for hidden modules
-  $ find _build/default/_doc_new/html/docs/local/foo -name '*.html' | sort -n
+  $ find "$html_dir" -name '*.html' | sort -n
   _build/default/_doc_new/html/docs/local/foo/Foo/index.html
   _build/default/_doc_new/html/docs/local/foo/index.html


### PR DESCRIPTION
Build only the wrapped library HTML pages inspected by the test while keeping the hidden-module file assertions unchanged.