### PR TITLE
test(odoc): target simple docs outputs

### DIFF
--- a/test/blackbox-tests/test-cases/odoc/new/odoc-simple.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/new/odoc-simple.t/run.t
@@ -1,15 +1,24 @@
 This test generates documentation using odoc for a library:
 
-  $ dune build @doc-new
+  $ odoc_dir=_build/default/_doc_new/odoc/local
+  $ html_dir=_build/default/_doc_new/html/docs/local
+  $ dune build \
+  >   "$odoc_dir/bar/bar.odocl" \
+  >   "$odoc_dir/foo/byte/foo_byte.odocl" \
+  >   "$odoc_dir/foo/foo.odocl" \
+  >   "$odoc_dir/foo/foo2.odocl" \
+  >   "$html_dir/index.html" \
+  >   "$html_dir/bar/index.html" \
+  >   "$html_dir/foo/index.html"
 
 This test if `.odocl` files are generated
-  $ find _build/default/_doc_new/odoc/local -name '*.odocl' | sort -n
+  $ find "$odoc_dir" -name '*.odocl' | sort -n
   _build/default/_doc_new/odoc/local/bar/bar.odocl
   _build/default/_doc_new/odoc/local/foo/byte/foo_byte.odocl
   _build/default/_doc_new/odoc/local/foo/foo.odocl
   _build/default/_doc_new/odoc/local/foo/foo2.odocl
 
-  $ ls _build/default/_doc_new/html/docs/local/
+  $ ls "$html_dir"
   bar
   foo
   index.html


### PR DESCRIPTION
Build the odocl files and package HTML pages enumerated by odoc-simple instead of the full doc-new alias.