### PR TITLE
test(odoc): target package index outputs

### DIFF
--- a/test/blackbox-tests/test-cases/odoc/new/github717-odoc-index.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/new/github717-odoc-index.t/run.t
@@ -1,5 +1,6 @@
 Tests odoc index generation in the new pipeline.
 
-  $ dune build @doc-new
+  $ html=_build/default/_doc_new/html/docs/local/hello_world/index.html
+  $ dune build "$html"
 
-  $ grep Test _build/default/_doc_new/html/docs/local/hello_world/index.html > /dev/null || echo Missing
+  $ grep Test "$html" > /dev/null || echo Missing

--- a/test/blackbox-tests/test-cases/odoc/new/odoc-package-mld-link.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/new/odoc-package-mld-link.t/run.t
@@ -3,7 +3,8 @@ no library associated with the project
 
 This test case is based on code provided by @vphantom, ocaml/dune#2007
 
-  $ dune build @doc-new
+  $ html=_build/default/_doc_new/html/docs/local/odoc_page_link_bug/index.html
+  $ dune build "$html"
 
-  $ grep -r xref-unresolved _build/default/_doc_new/html/docs/local/odoc_page_link_bug/index.html
+  $ grep -r xref-unresolved "$html"
   [1]


### PR DESCRIPTION
Build the package index HTML pages checked by the package MLD link and GitHub #717 odoc tests instead of the full doc-new alias.