### PR TITLE
test(instrumentation): target instrumented executable

### DIFF
--- a/test/blackbox-tests/test-cases/instrumentation/arguments.t
+++ b/test/blackbox-tests/test-cases/instrumentation/arguments.t
@@ -1,9 +1,11 @@
   $ make_instrumentation_backends
   $ make_argument_instrumentation_project
+  $ exe=./main.exe
+  $ built_exe=_build/default/main.exe
 
 We check that we can pass arguments to the ppx.
 
-  $ dune build --instrument-with hello
+  $ dune build --instrument-with hello "$exe"
   File "dune", line 6, characters 33-39:
   6 |  (instrumentation (backend hello -place Spain)))
                                        ^^^^^^
@@ -13,8 +15,8 @@ We check that we can pass arguments to the ppx.
   [1]
 
   $ make_dune_project 2.8
-  $ dune build --instrument-with hello
-  $ _build/default/main.exe
+  $ dune build --instrument-with hello "$exe"
+  $ "$built_exe"
   Hello from Spain (<none>)!
 
 Check that we do not pass the instrumentation flags when the instrumentation is
@@ -22,12 +24,12 @@ disabled. If the flags were passed with the instrumentation disabled, the
 following command would fail (as the flags would be passed to the "trivial"
 ppx).
 
-  $ dune build
+  $ dune build "$exe"
 
 We also check that we can declare dependencies to the ppx.
 
   $ make_dependency_instrumentation_project 2.8
-  $ dune build --instrument-with hello
+  $ dune build --instrument-with hello "$exe"
   File "dune", line 7, characters 65-83:
   7 |  (instrumentation (backend hello -place Spain -file input/input) (deps input/input)))
                                                                        ^^^^^^^^^^^^^^^^^^
@@ -36,13 +38,13 @@ We also check that we can declare dependencies to the ppx.
   [1]
 
   $ make_dune_project 3.0
-  $ dune build --instrument-with hello
-  $ _build/default/main.exe
+  $ dune build --instrument-with hello "$exe"
+  $ "$built_exe"
   Hello from Spain (really)!
 
 Can also enable with an environment variable.
 
-  $ DUNE_INSTRUMENT_WITH=hello dune build
+  $ DUNE_INSTRUMENT_WITH=hello dune build "$exe"
 
-  $ _build/default/main.exe
+  $ "$built_exe"
   Hello from Spain (really)!


### PR DESCRIPTION
Build ./main.exe in the instrumentation argument scenarios instead of the default alias, keeping the same ppx and runtime assertions.