### PR TITLE
test(instrumentation): target basic executable

### DIFF
--- a/test/blackbox-tests/test-cases/instrumentation/basic.t
+++ b/test/blackbox-tests/test-cases/instrumentation/basic.t
@@ -3,18 +3,20 @@ Dune!" at the beginning of the module.
 
   $ make_instrumentation_backends
   $ make_basic_instrumentation_project
+  $ exe=./main.exe
+  $ built_exe=_build/default/main.exe
 
 As instrumentation is disabled, this should not print the instrumentation
 message.
 
-  $ dune build
-  $ _build/default/main.exe
+  $ dune build "$exe"
+  $ "$built_exe"
 
 This should print the instrumentation message twice, once for "main" and once
 for "mylib":
 
-  $ dune build --instrument-with hello
-  $ _build/default/main.exe
+  $ dune build --instrument-with hello "$exe"
+  $ "$built_exe"
   Hello from Mylib!
   Hello from Main!
 
@@ -25,17 +27,17 @@ An empty file:
 
 We build the empty file.
 
-  $ dune build
+  $ dune build "$exe"
 
 Nothing happens:
 
-  $ _build/default/main.exe
+  $ "$built_exe"
 
 We rebuild with instrumentation via the CLI.
 
-  $ dune build --instrument-with hello
+  $ dune build --instrument-with hello "$exe"
 
 We get the message.
 
-  $ _build/default/main.exe
+  $ "$built_exe"
   Hello from Main!


### PR DESCRIPTION
Build ./main.exe in the basic instrumentation fixture for each assertion instead of invoking untargeted builds.