### PR TITLE
test(toplevel-plugin): build install targets only

### DIFF
--- a/test/blackbox-tests/test-cases/toplevel-plugin/toplevel-plugin.t
+++ b/test/blackbox-tests/test-cases/toplevel-plugin/toplevel-plugin.t
@@ -6,7 +6,7 @@ Testsuite for (toplevel that loads plugins).
   $ make_toplevel_plugin 1
   $ make_toplevel_plugin 2
 
-  $ dune build @all 2>&1 | dune_cmd sanitize
+  $ dune build @install
   $ dune install --prefix _install --display short
   Installing _install/lib/top-plugin1/META
   Installing _install/lib/top-plugin1/dune-package


### PR DESCRIPTION
Build @install before installing in the successful toplevel-plugin test instead of building @all.