### PR TITLE
test(toplevel-plugin): build failing install targets only

### DIFF
--- a/test/blackbox-tests/test-cases/toplevel-plugin/toplevel-plugin-fail2.t
+++ b/test/blackbox-tests/test-cases/toplevel-plugin/toplevel-plugin-fail2.t
@@ -10,7 +10,7 @@ This is not allowed in toplevels, so it fails.
   $ make_toplevel_plugin 1
   $ make_toplevel_plugin 2
 
-  $ dune build @all 2>&1 | dune_cmd sanitize
+  $ dune build @install
   $ dune install --prefix _install --display short
   Installing _install/lib/top-plugin1/META
   Installing _install/lib/top-plugin1/dune-package


### PR DESCRIPTION
Build @install before installing in the dynlink failure variant instead of building @all.