### PR TITLE
test(jsoo): skip unused install targets in no-check-prim

### DIFF
--- a/test/blackbox-tests/test-cases/jsoo/no-check-prim.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/no-check-prim.t/run.t
@@ -1,6 +1,8 @@
 Compilation using jsoo
 
-  $ dune build bin/technologic.bc.js @install
+  $ js=bin/technologic.bc.js
+  $ built_js=./_build/default/$js
+  $ dune build "$js"
   $ dune trace cat | jq_dune -r '
   >   processes
   > | select(.args.prog | test("js_of_ocaml$"))
@@ -14,13 +16,13 @@ Compilation using jsoo
   bin/.technologic.eobjs/jsoo/z.cmo.js
   bin/technologic.bc.js
   lib/.x.objs/jsoo/default/x.cma.js
-  $ node ./_build/default/bin/technologic.bc.js
+  $ node "$built_js"
   buy it
   use it
   break it
   fix it
-  $ dune build bin/technologic.bc.js @install --profile release
-  $ node ./_build/default/bin/technologic.bc.js
+  $ dune build "$js" --profile release
+  $ node "$built_js"
   buy it
   use it
   break it
@@ -30,5 +32,5 @@ Compilation using jsoo
   > (context
   >   (default (disable_dynamically_linked_foreign_archives true)))
   > EOF
-  $ dune build bin/technologic.bc.js @install --profile dev
-  $ dune build bin/technologic.bc.js @install --profile release
+  $ dune build "$js" --profile dev
+  $ dune build "$js" --profile release


### PR DESCRIPTION
Drop @install from no-check-prim builds because the test only runs the generated JavaScript and traces js_of_ocaml targets.