### PR TITLE
test(jsoo): target public lib executable

### DIFF
--- a/test/blackbox-tests/test-cases/jsoo/public-libs.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/public-libs.t/run.t
@@ -1,3 +1,3 @@
 Compilation of libraries with public-names
 
-  $ dune build
+  $ dune build b/main.bc.js


### PR DESCRIPTION
Build the public-library consumer JavaScript executable directly instead of the default alias.