### PR TITLE
test(rpc): poll for server connection more often

### DIFF
--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -33,7 +33,7 @@ let init_chan ~root_dir =
     let* res = once () in
     match res with
     | Some res -> Fiber.return res
-    | None -> Scheduler.sleep (Time.Span.of_secs 0.2) >>= loop
+    | None -> Scheduler.sleep (Time.Span.of_secs 0.05) >>= loop
   in
   loop ()
 ;;


### PR DESCRIPTION
Reduce the RPC client connection polling interval so diagnostics tests spend less time waiting for the watch server to become available.