### PR TITLE
test(odoc): target conflicting module docs

### DIFF
--- a/test/blackbox-tests/test-cases/odoc/conflicting-modules-github1645/new.t
+++ b/test/blackbox-tests/test-cases/odoc/conflicting-modules-github1645/new.t
@@ -23,7 +23,10 @@ built. See #1645.
   $ touch two/module.ml
 
   $ dune build @install
-  $ dune build @doc-new
+  $ docs=_build/default/_doc_new/html/docs/local/l
+  $ dune build \
+  >   "$docs/one/Module/index.html" \
+  >   "$docs/two/Module/index.html"
   File "Module":
   Ambiguous lookup. Possible files: Module
   Module


### PR DESCRIPTION
Build the two conflicting module HTML pages needed to reproduce the ambiguous lookup warnings instead of all docs.