### PR TITLE
doc: clarify default alias interaction with tests

### DIFF
--- a/doc/reference/aliases/default.rst
+++ b/doc/reference/aliases/default.rst
@@ -25,3 +25,33 @@ used instead. For example, if the following is present in ``tests/dune``,
    (alias
     (name default)
     (deps (alias_rec runtest)))
+
+Interaction With Tests
+~~~~~~~~~~~~~~~~~~~~~~
+
+The default alias is distinct from the :doc:`runtest` alias. Plain
+``dune build`` builds ``@@default``. It doesn't run actions attached only to
+``runtest`` unless they are requested explicitly, for example with
+``dune runtest`` or ``dune build @runtest``.
+
+However, the implicit definition of ``default`` depends recursively on
+:doc:`all`, and ``all`` includes file targets produced by tests, executables,
+libraries, and rules. As a result, plain ``dune build`` can still build test
+executables or generated test artifacts in subdirectories.
+
+To keep a tests directory out of plain ``dune build``, override ``default`` in a
+parent directory so that it only depends on the subtrees that should be part of
+the ordinary build. For example, a project with ``bin/``, ``lib/``, and
+``tests/`` can put this in the top-level ``dune`` file:
+
+.. code:: dune
+
+   (alias
+    (name default)
+    (deps
+     (alias_rec bin/all)
+     (alias_rec lib/all)))
+
+Overriding ``default`` inside ``tests/dune`` would only affect commands such as
+``dune build tests`` or ``dune build @@tests/default``; it would not change the
+implicit recursive dependency used by the parent directory's ``default`` alias.

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -51,6 +51,13 @@ with other targets by passing ``@runtest`` to ``dune build``. For instance:
    $ dune build @install @runtest
    $ dune build @install @test/runtest
 
+This is distinct from plain ``dune build``, which builds the
+:doc:`default alias </reference/aliases/default>`. By default, that alias
+recursively builds :doc:`all </reference/aliases/all>` file targets, including
+test executables and generated files in test directories, but it doesn't run
+actions attached only to ``runtest``. If you want plain ``dune build`` to skip a
+tests subtree, override ``default`` in a parent directory.
+
 
 Running a Single Test
 ---------------------


### PR DESCRIPTION
Clarify the distinction between `dune build` / `@default` and `dune runtest` / `@runtest`. In particular, document that plain `dune build` does not run `runtest` actions, but the implicit `default` alias recursively depends on `all`, so it can still build test executables or generated test artifacts.

Also document that excluding a tests subtree from plain builds should be done by overriding `default` in a parent directory, not inside the tests directory itself.

Fixes #11217.