### PR TITLE
feat(env): add env_vars alias

### DIFF
--- a/doc/changes/added/15187.md
+++ b/doc/changes/added/15187.md
@@ -1,0 +1,2 @@
+- Add `env_vars` as an alias for the `env-vars` field in `env` stanzas
+  (#15187, fixes #11424, @rgrinberg).

--- a/doc/reference/dune/env.rst
+++ b/doc/reference/dune/env.rst
@@ -32,9 +32,10 @@ Fields supported in ``<settings>`` are:
 - ``(c_flags <flags>)`` and ``(cxx_flags <flags>)`` specify compilation flags
   for C and C++ stubs, respectively. See :doc:`library` for more details.
 
-- ``(env-vars (<var1> <val1>) .. (<varN> <valN>))`` will add the corresponding
+- ``(env_vars (<var1> <val1>) .. (<varN> <valN>))`` will add the corresponding
   variables to the environment where the build commands are executed and are
-  used by ``dune exec``.
+  used by ``dune exec``. This field has been available since Dune 3.24. The
+  dashed spelling ``env-vars`` is also supported for compatibility.
 
 - ``(menhir_flags <flags>))`` specifies flags for Menhir stanzas. This flag was
   replaced by the ``(menhir)`` field (see below) starting in version 3.0 of the

--- a/src/dune_lang/dune_env.ml
+++ b/src/dune_lang/dune_env.ml
@@ -196,17 +196,21 @@ let inline_tests_field =
   field_o "inline_tests" (Syntax.since Stanza.syntax (1, 11) >>> Inline_tests.decode)
 ;;
 
+let env_vars_decode =
+  located (repeat (pair string string))
+  >>| fun (loc, pairs) ->
+  match Env.Map.of_list pairs with
+  | Ok vars -> Env.extend Env.empty ~vars
+  | Error (k, _, _) ->
+    User_error.raise ~loc [ Pp.textf "Variable %s is specified several times" k ]
+;;
+
 let env_vars_field =
-  field
-    "env-vars"
+  fields_mutually_exclusive
     ~default:Env.empty
-    (Syntax.since Stanza.syntax (1, 5)
-     >>> located (repeat (pair string string))
-     >>| fun (loc, pairs) ->
-     match Env.Map.of_list pairs with
-     | Ok vars -> Env.extend Env.empty ~vars
-     | Error (k, _, _) ->
-       User_error.raise ~loc [ Pp.textf "Variable %s is specified several times" k ])
+    [ "env-vars", Syntax.since Stanza.syntax (1, 5) >>> env_vars_decode
+    ; "env_vars", Syntax.since Stanza.syntax (3, 24) >>> env_vars_decode
+    ]
 ;;
 
 let odoc_field =

--- a/test/blackbox-tests/test-cases/stanzas/env/env-dune-file/env-subdir.t/dune
+++ b/test/blackbox-tests/test-cases/stanzas/env/env-dune-file/env-subdir.t/dune
@@ -1,6 +1,6 @@
 (env
  (_
-  (env-vars
+  (env_vars
    (DUNE_FOO PASS))))
 
 (alias

--- a/test/blackbox-tests/test-cases/stanzas/env/env-dune-file/env-subdir.t/dune-project
+++ b/test/blackbox-tests/test-cases/stanzas/env/env-dune-file/env-subdir.t/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.5)
+(lang dune 3.24)

--- a/test/blackbox-tests/test-cases/stanzas/env/env-dune-file/env-subdir.t/sub/dune
+++ b/test/blackbox-tests/test-cases/stanzas/env/env-dune-file/env-subdir.t/sub/dune
@@ -1,3 +1,3 @@
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (echo %{env:DUNE_FOO=FAIL})))


### PR DESCRIPTION
Add `env_vars` as an underscore-spelled alias for the existing `env-vars` field in `env` stanzas. The dashed spelling remains supported for compatibility.

Fixes #11424.