### PR TITLE
doc: make syntax symbols searchable

### DIFF
--- a/doc/_static/js/symbol-search.js
+++ b/doc/_static/js/symbol-search.js
@@ -1,0 +1,126 @@
+(function () {
+  "use strict";
+
+  function documentationRoot() {
+    var currentScript = document.currentScript;
+
+    if (!currentScript || !currentScript.src) {
+      for (var i = 0; i < document.scripts.length; i++) {
+        var script = document.scripts[i];
+        if (script.src && script.src.indexOf("/_static/js/symbol-search.js") !== -1) {
+          currentScript = script;
+          break;
+        }
+      }
+    }
+
+    if (!currentScript || !currentScript.src) {
+      return null;
+    }
+
+    return new URL("../../", currentScript.src).href;
+  }
+
+  var root = documentationRoot();
+
+  function anchorForQuery(query) {
+    var q = query.trim();
+
+    if (q === "") {
+      return null;
+    }
+
+    if (q.indexOf("@@") === 0) {
+      return "symbol-double-at";
+    }
+
+    if (q.indexOf("@") === 0) {
+      return "symbol-at";
+    }
+
+    if (q.indexOf("%{") === 0) {
+      return "symbol-percent-brace";
+    }
+
+    if (q.indexOf("(:include") === 0) {
+      return "symbol-include";
+    }
+
+    switch (q) {
+      case ":standard":
+        return "symbol-colon-standard";
+      case "\\":
+        return "symbol-backslash";
+      case "->":
+        return "symbol-arrow";
+      case "!":
+        return "symbol-bang";
+      case "*":
+        return "symbol-star";
+      case "**":
+        return "symbol-star";
+      case "?":
+        return "symbol-question";
+      default:
+        return null;
+    }
+  }
+
+  function redirectToSymbol(query) {
+    var anchor = anchorForQuery(query);
+
+    if (anchor === null || root === null) {
+      return false;
+    }
+
+    window.location.assign(root + "reference/syntax-symbols.html#" + anchor);
+    return true;
+  }
+
+  function maybeRedirectSearchPage() {
+    if (!/\/search\.html$/.test(window.location.pathname)) {
+      return;
+    }
+
+    var params = new URLSearchParams(window.location.search);
+    var query = params.get("q") || params.get("query");
+
+    if (query !== null) {
+      redirectToSymbol(query);
+    }
+  }
+
+  function connectSearchForms() {
+    var forms = document.querySelectorAll("form[action]");
+
+    for (var i = 0; i < forms.length; i++) {
+      var form = forms[i];
+
+      if (form.action.indexOf("search") === -1) {
+        continue;
+      }
+
+      var input = form.querySelector(
+        'input[name="q"], input[name="query"], input[type="search"]'
+      );
+
+      if (input === null) {
+        continue;
+      }
+
+      form.addEventListener(
+        "submit",
+        (function (searchInput) {
+          return function (event) {
+            if (redirectToSymbol(searchInput.value)) {
+              event.preventDefault();
+            }
+          };
+        })(input)
+      );
+    }
+  }
+
+  maybeRedirectSearchPage();
+  window.addEventListener("DOMContentLoaded", connectSearchForms);
+})();

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -157,6 +157,9 @@ html_static_path = ['_static']
 html_css_files = [
     'css/custom.css'
 ]
+html_js_files = [
+    'js/symbol-search.js'
+]
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -45,6 +45,7 @@ These documents specify the various features and languages present in Dune.
        ../concepts/promotion
        ../concepts/package-spec
        aliases
+       syntax-symbols
 
   .. grid-item::
 

--- a/doc/reference/syntax-symbols.rst
+++ b/doc/reference/syntax-symbols.rst
@@ -1,0 +1,92 @@
+Syntax Symbols
+==============
+
+Dune uses punctuation in several command-line and ``dune`` file syntaxes. This
+page gives those symbols text names so they are easier to find with search.
+
+If the documentation search box does not find a symbol directly, try searching
+for its text name, such as "double at", "percent brace", or "colon standard".
+
+.. _symbol-at:
+
+Single at: ``@``
+----------------
+
+The single at sign names a recursive alias target on the command line. For
+example, ``dune build @runtest`` builds the ``runtest`` alias in the current
+directory and its subdirectories. See :doc:`aliases`.
+
+.. _symbol-double-at:
+
+Double at: ``@@``
+-----------------
+
+The double at sign names a non-recursive alias target on the command line. For
+example, ``dune build @@runtest`` builds the ``runtest`` alias in the current
+directory only. See :doc:`aliases`.
+
+.. _symbol-percent-brace:
+
+Percent brace: ``%{...}``
+-------------------------
+
+Percent-brace forms are variables. For example, ``%{target}`` expands to a rule
+target and ``%{env:VAR=default}`` reads an environment variable. See
+:doc:`../concepts/variables`.
+
+.. _symbol-colon-standard:
+
+Colon standard: ``:standard``
+-----------------------------
+
+``:standard`` denotes the default value in the :doc:`ordered set language
+<ordered-set-language>` and in some :doc:`predicates <predicate-language>`.
+
+.. _symbol-backslash:
+
+Backslash: ``\``
+----------------
+
+In the ordered set language, ``\`` subtracts one set from another. For example,
+``(:standard \ -w)`` removes ``-w`` from the standard set. See
+:doc:`ordered-set-language`.
+
+.. _symbol-include:
+
+Colon include: ``(:include ...)``
+---------------------------------
+
+Some ordered-set fields use ``(:include <filename>)`` to read an ordered set
+from a file. See :doc:`ordered-set-language`.
+
+.. _symbol-arrow:
+
+Arrow: ``->``
+-------------
+
+The arrow appears in ``select`` forms in library dependencies, where it
+separates a list of library availability conditions from the file selected when
+those conditions match. See :doc:`library-dependencies`.
+
+.. _symbol-bang:
+
+Bang: ``!``
+-----------
+
+In ``select`` forms, ``!<library-name>`` means that the library must not be
+available. In glob patterns, ``[!<set>]`` matches a character not in ``<set>``.
+See :doc:`library-dependencies` and :ref:`glob`.
+
+.. _symbol-star:
+
+Star: ``*`` and double star: ``**``
+------------------------------------
+
+Glob patterns use ``*`` and ``**`` to match file names. See :ref:`glob`.
+
+.. _symbol-question:
+
+Question mark: ``?``
+--------------------
+
+Glob patterns use ``?`` to match a single character. See :ref:`glob`.


### PR DESCRIPTION
Add a reference page that gives punctuation-heavy Dune syntax searchable text names, including `@@`, `@`, `%{...}`, `:standard`, and related symbols.

Also add a small documentation search hook that redirects exact symbol searches such as `@@` to the corresponding section.

Fixes #7307.