### PR TITLE
fix(odoc): sandbox documentation rules

### DIFF
--- a/doc/changes/changed/15190.md
+++ b/doc/changes/changed/15190.md
@@ -1,0 +1,1 @@
+- Odoc rules are now sandboxed (#15190, @rgrinberg)

--- a/src/dune_rules/odoc/odoc.ml
+++ b/src/dune_rules/odoc/odoc.ml
@@ -243,6 +243,17 @@ end
 
 let odoc_ext = ".odoc"
 
+let odoc_files_in_dirs dirs =
+  let predicate =
+    Glob.matching_extensions [ Filename.Extension.odoc ] |> Predicate_lang.Glob.of_glob
+  in
+  Command.Args.Hidden_deps
+    (List.fold_left dirs ~init:Dune_engine.Dep.Set.empty ~f:(fun deps dir ->
+       File_selector.of_predicate_lang ~dir predicate
+       |> Dune_engine.Dep.file_selector
+       |> Dune_engine.Dep.Set.add deps))
+;;
+
 module Mld : sig
   type t
 
@@ -341,7 +352,11 @@ let run_odoc sctx ~dir command ~quiet ~flags_for args =
   let deps = Action_builder.env_var "ODOC_SYNTAX" in
   let open Action_builder.With_targets.O in
   Action_builder.with_no_targets deps
-  >>> Command.run_dyn_prog ~dir program [ A command; Dyn base_flags; S args ]
+  >>> Command.run_dyn_prog
+        ~dir
+        ~sandbox:Sandbox_config.needs_sandboxing
+        program
+        [ A command; Dyn base_flags; S args ]
 ;;
 
 let module_deps (m : Module.t) ~obj_dir ~(dep_graphs : Dep_graph.Ml_kind.t) =
@@ -444,7 +459,8 @@ let odoc_include_flags ctx pkg requires =
        Path.Set.to_list paths
      in
      Command.Args.S
-       (List.concat_map paths ~f:(fun dir -> [ Command.Args.A "-I"; Path dir ])))
+       (odoc_files_in_dirs paths
+        :: List.concat_map paths ~f:(fun dir -> [ Command.Args.A "-I"; Path dir ])))
 ;;
 
 let link_odoc_rules sctx (odoc_file : Artifact.t) ~pkg ~requires =
@@ -507,6 +523,53 @@ let setup_library_odoc_rules cctx (local_lib : Lib.Local.t) =
   >>= Dep.setup_deps ctx (Lib local_lib)
 ;;
 
+let odoc_output_targets sctx odoc_file (out : Output_format.t) ~output_dir =
+  let action =
+    let command =
+      match out with
+      | Html | Json -> "html-targets"
+      | Markdown -> "markdown-targets"
+    in
+    let ctx = Super_context.context sctx in
+    let open Action_builder.O in
+    let* odoc = odoc_program sctx output_dir in
+    Command.run'
+      odoc
+      ~sandbox:Sandbox_config.needs_sandboxing
+      ~dir:(Path.build output_dir)
+      [ Command.Args.A command
+      ; A "-o"
+      ; Path (Path.build output_dir)
+      ; Dep (Path.build (Artifact.odocl_file ctx odoc_file))
+      ; Output_format.args out
+      ]
+  in
+  Super_context.execute_action_stdout sctx ~loc:Loc.none ~dir:output_dir action
+  >>| String.split_lines
+  >>| List.filter ~f:(fun s -> not (String.is_empty s))
+  >>| List.map ~f:(Path.Build.relative output_dir)
+;;
+
+let html_generate_args sctx ~search_db ~html_root ~odoc_support_path odoc_file out =
+  let ctx = Super_context.context sctx in
+  let search_args =
+    match search_db with
+    | None -> Command.Args.empty
+    | Some search_db ->
+      Sherlodoc.odoc_args sctx ~search_db ~dir_sherlodoc_dot_js:html_root
+  in
+  [ search_args
+  ; Command.Args.A "-o"
+  ; Path (Path.build html_root)
+  ; A "--support-uri"
+  ; Path (Path.build odoc_support_path)
+  ; A "--theme-uri"
+  ; Path (Path.build odoc_support_path)
+  ; Dep (Path.build (Artifact.odocl_file ctx odoc_file))
+  ; Output_format.args out
+  ]
+;;
+
 let setup_generate sctx ~search_db odoc_file out =
   let ctx = Super_context.context sctx in
   let odoc_support_path = Paths.odoc_support ctx in
@@ -516,40 +579,60 @@ let setup_generate sctx ~search_db odoc_file out =
       ( "markdown-generate"
       , Paths.markdown_root ctx
       , [ Command.Args.A "-o"
-        ; Command.Args.Path (Path.build (Paths.markdown_root ctx))
-        ; Command.Args.Dep (Path.build (Artifact.odocl_file ctx odoc_file))
-        ; Command.Args.Hidden_targets [ Artifact.output_file ctx out odoc_file ]
+        ; Path (Path.build (Paths.markdown_root ctx))
+        ; Dep (Path.build (Artifact.odocl_file ctx odoc_file))
         ] )
     | Html | Json ->
-      let search_args =
-        match search_db with
-        | None -> Command.Args.empty
-        | Some search_db ->
-          Sherlodoc.odoc_args sctx ~search_db ~dir_sherlodoc_dot_js:(Paths.html_root ctx)
-      in
+      let html_root = Paths.html_root ctx in
       ( "html-generate"
-      , Paths.html_root ctx
-      , [ search_args
-        ; Command.Args.A "-o"
-        ; Command.Args.Path (Path.build (Paths.html_root ctx))
-        ; Command.Args.A "--support-uri"
-        ; Command.Args.Path (Path.build odoc_support_path)
-        ; Command.Args.A "--theme-uri"
-        ; Command.Args.Path (Path.build odoc_support_path)
-        ; Command.Args.Dep (Path.build (Artifact.odocl_file ctx odoc_file))
-        ; Output_format.args out
-        ; Command.Args.Hidden_targets [ Artifact.output_file ctx out odoc_file ]
-        ] )
+      , html_root
+      , html_generate_args sctx ~search_db ~html_root ~odoc_support_path odoc_file out )
+  in
+  let* targets =
+    match out with
+    | Markdown -> odoc_output_targets sctx odoc_file out ~output_dir
+    | Html | Json -> Memo.return [ Artifact.output_file ctx out odoc_file ]
   in
   let run_odoc =
     run_odoc sctx ~dir:(Path.build output_dir) command ~quiet:false ~flags_for:None args
+    |> Action_builder.With_targets.add ~file_targets:targets
   in
   add_rule sctx run_odoc
 ;;
 
+let setup_generate_module_html_and_json sctx ~search_db odoc_file =
+  let ctx = Super_context.context sctx in
+  let odoc_support_path = Paths.odoc_support ctx in
+  let html_root = Paths.html_root ctx in
+  let run_odoc out =
+    run_odoc
+      sctx
+      ~dir:(Path.build html_root)
+      "html-generate"
+      ~quiet:false
+      ~flags_for:None
+      (html_generate_args
+         sctx
+         ~search_db:(Some search_db)
+         ~html_root
+         ~odoc_support_path
+         odoc_file
+         out)
+  in
+  let dir = Artifact.output_file ctx Html odoc_file |> Path.Build.parent_exn in
+  let rule =
+    Action_builder.progn [ run_odoc Html; run_odoc Json ]
+    |> Action_builder.With_targets.add_directories ~directory_targets:[ dir ]
+  in
+  add_rule sctx rule
+;;
+
 let setup_generate_html_and_json sctx ~search_db odoc_file =
-  let* () = setup_generate sctx ~search_db:(Some search_db) odoc_file Html in
-  setup_generate sctx ~search_db:(Some search_db) odoc_file Json
+  match odoc_file.Artifact.target with
+  | Lib _ -> setup_generate_module_html_and_json sctx ~search_db odoc_file
+  | Pkg _ ->
+    let* () = setup_generate sctx ~search_db:(Some search_db) odoc_file Html in
+    setup_generate sctx ~search_db:(Some search_db) odoc_file Json
 ;;
 
 let setup_generate_markdown sctx odoc_file =
@@ -1159,8 +1242,14 @@ let setup_private_library_doc_alias sctx ~scope ~dir (l : Library.t) =
 ;;
 
 let has_rules ?(directory_targets = Path.Build.Map.empty) m =
-  let rules = Rules.collect_unit (fun () -> m) in
-  Memo.return (Gen_rules.make ~directory_targets rules)
+  let+ rules = Rules.collect_unit (fun () -> m) in
+  let directory_targets =
+    Path.Build.Map.union
+      directory_targets
+      (Rules.directory_targets rules)
+      ~f:(fun _ loc _ -> Some loc)
+  in
+  Gen_rules.make ~directory_targets (Memo.return rules)
 ;;
 
 let with_package pkg ~f =

--- a/src/dune_rules/odoc/odoc.mli
+++ b/src/dune_rules/odoc/odoc.mli
@@ -8,6 +8,7 @@ end
 
 val lib_unique_name : Lib.t -> string
 val odoc_program : Super_context.t -> Path.Build.t -> Action.Prog.t Action_builder.t
+val odoc_files_in_dirs : Path.t list -> _ Command.Args.t
 val libs_of_pkg : Context_name.t -> pkg:Package.Name.t -> Lib.Local.t list Memo.t
 
 val mlds

--- a/src/dune_rules/odoc/odoc_new.ml
+++ b/src/dune_rules/odoc/odoc_new.ml
@@ -843,9 +843,10 @@ let odoc_include_flags ctx all maps pkg requires indices =
       let odoc_dir = Artifact.odoc_file index |> Path.Build.parent_exn in
       Path.Set.add p (Path.build odoc_dir))
   in
+  let paths = Path.Set.to_list paths in
   Command.Args.S
-    (Path.Set.to_list paths
-     |> List.concat_map ~f:(fun dir -> [ Command.Args.A "-I"; Path dir ]))
+    (Odoc.odoc_files_in_dirs paths
+     :: List.concat_map paths ~f:(fun dir -> [ Command.Args.A "-I"; Path dir ]))
 ;;
 
 (* Create a dependency on the odoc file of an index *)
@@ -1084,7 +1085,11 @@ let external_module_deps sctx ~all a =
       let open Action_builder.O in
       (let* odoc = Odoc.odoc_program sctx dir in
        let deps_dir = Artifact.odoc_file a |> Path.build |> Path.parent_exn in
-       Command.run' odoc ~dir:deps_dir [ A "compile-deps"; Dep (Artifact.source_file a) ])
+       Command.run'
+         odoc
+         ~sandbox:Sandbox_config.needs_sandboxing
+         ~dir:deps_dir
+         [ A "compile-deps"; Dep (Artifact.source_file a) ])
       |> Super_context.execute_action_stdout sctx ~loc:Loc.none ~dir
       |> Action_builder.of_memo
     in

--- a/src/dune_rules/odoc/sherlodoc.ml
+++ b/src/dune_rules/odoc/sherlodoc.ml
@@ -11,10 +11,11 @@ let resolve_sherlodoc sctx ~dir =
 ;;
 
 let add_index_db_rule sctx ~dir ~external_odocls odocls =
-  let program = resolve_sherlodoc sctx ~dir in
   let action =
+    let program = resolve_sherlodoc sctx ~dir in
     Command.run_dyn_prog
       ~dir:(Path.build dir)
+      ~sandbox:Sandbox_config.needs_sandboxing
       program
       Command.Args.
         [ A "index"
@@ -37,6 +38,7 @@ let sherlodoc_dot_js sctx ~dir =
     sctx
     (Command.run_dyn_prog
        ~dir:(Path.build dir)
+       ~sandbox:Sandbox_config.needs_sandboxing
        program
        [ A "js"; Target (Paths.sherlodoc_dot_js ~dir) ])
 ;;

--- a/test/blackbox-tests/test-cases/invalid-opam-file-name-github8281.t
+++ b/test/blackbox-tests/test-cases/invalid-opam-file-name-github8281.t
@@ -26,16 +26,9 @@ Whenever an invalid package name is used, dune crashes when building @doc
   providing the file _build/trace.csexp, if possible. This includes build
   commands, message logs, and file paths.
   Description:
-    ("[gen_rules] returned rules in a directory that is not a descendant of the directory it was called for",
+    ("[gen_rules] returned directory target in a directory that is not a descendant of the directory it was called for",
      { dir = In_build_dir "default/_doc/_html/x.y"
-     ; example =
-         Rule
-           { targets =
-               { root = In_build_dir "default/_doc/_html/x"
-               ; files = set { "db.js" }
-               ; dirs = set {}
-               }
-           }
+     ; example = In_build_dir "default/_doc/_html/x/X"
      })
   Raised at Stdune__Code_error.raise in file
   [1]

--- a/test/blackbox-tests/test-cases/odoc/conflicting-modules-github1645/legacy.t
+++ b/test/blackbox-tests/test-cases/odoc/conflicting-modules-github1645/legacy.t
@@ -24,17 +24,8 @@ built. See #1645.
 
   $ dune build @install
   $ dune build @doc
-  Error: Multiple rules generated for
-  _build/default/_doc/_html/l/Module/index.html:
+  Error: Multiple rules generated for _build/default/_doc/_html/l/Module:
   - <internal location>
   - <internal location>
-  -> required by alias _doc/_html/l/doc
-  -> required by alias doc
-  Error: Multiple rules generated for
-  _build/default/_doc/_odocls/l/module.odocl:
-  - <internal location>
-  - <internal location>
-  -> required by _build/default/_doc/_html/l/index.html
-  -> required by alias _doc/_html/l/doc
   -> required by alias doc
   [1]

--- a/test/blackbox-tests/test-cases/odoc/doc-json.t
+++ b/test/blackbox-tests/test-cases/odoc/doc-json.t
@@ -21,9 +21,14 @@
   > }
 
   $ dune build @doc-json
+
+Module HTML and JSON are emitted by the same directory-target rule.
+
   $ list_docs
   _build/default/_doc/_html/index.html.json
+  _build/default/_doc/_html/l/L/M/index.html
   _build/default/_doc/_html/l/L/M/index.html.json
+  _build/default/_doc/_html/l/L/index.html
   _build/default/_doc/_html/l/L/index.html.json
   _build/default/_doc/_html/l/index.html.json
 

--- a/test/blackbox-tests/test-cases/odoc/new/warnings.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/new/warnings.t/run.t
@@ -37,10 +37,10 @@ In release mode, no error:
 
   $ dune build -p foo_doc,foo_lib \
   >   "$foo_doc_odoc" \
-  >   "$foo_lib_odoc"
-  (cd _build/default/_doc_new/odoc/local/foo_doc && odoc compile -o page-foo.odoc ../../../../foo_doc/foo.mld -I ../../../index/local/foo_doc --parent 'page-"foo_doc"')
+  >   "$foo_lib_odoc" 2>&1 | censor
+  (cd _build/.sandbox/$DIGEST1/default/_doc_new/odoc/local/foo_doc && odoc compile -o page-foo.odoc ../../../../foo_doc/foo.mld -I ../../../index/local/foo_doc --parent 'page-"foo_doc"')
   File "../../../../foo_doc/foo.mld", line 4, characters 0-0:
   Warning: End of text is not allowed in '[...]' (code).
-  (cd _build/default/_doc_new/odoc/local/foo_lib && odoc compile -I . -I ../../stdlib -o foo.odoc ../../../../foo_lib/.foo.objs/byte/foo.cmti -I ../../../index/local/foo_lib --parent 'page-"foo_lib"')
+  (cd _build/.sandbox/$DIGEST2/default/_doc_new/odoc/local/foo_lib && odoc compile -I . -I ../../stdlib -o foo.odoc ../../../../foo_lib/.foo.objs/byte/foo.cmti -I ../../../index/local/foo_lib --parent 'page-"foo_lib"')
   File "foo_lib/foo.mli", line 1, characters 7-7:
   Warning: End of text is not allowed in '[...]' (code).

--- a/test/blackbox-tests/test-cases/odoc/warnings.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/warnings.t/run.t
@@ -26,10 +26,10 @@ These packages are in a nested env, the option is disabled, should success with 
 
 In release mode, no error:
 
-  $ dune build -p foo_doc,foo_lib @doc
-  (cd _build/default/_doc/_odoc/pkg/foo_doc && odoc compile --pkg foo_doc -o page-foo.odoc ../../../../foo_doc/foo.mld)
+  $ dune build -p foo_doc,foo_lib @doc 2>&1 | censor
+  (cd _build/.sandbox/$DIGEST1/default/_doc/_odoc/pkg/foo_doc && odoc compile --pkg foo_doc -o page-foo.odoc ../../../../foo_doc/foo.mld)
   File "../../../../foo_doc/foo.mld", line 4, characters 0-0:
   Warning: End of text is not allowed in '[...]' (code).
-  (cd _build/default/foo_lib/.foo.objs/byte && odoc compile -I . -I ../../../_doc/_odoc/pkg/foo_lib --pkg foo_lib -o foo.odoc foo.cmti)
+  (cd _build/.sandbox/$DIGEST2/default/foo_lib/.foo.objs/byte && odoc compile -I . -I ../../../_doc/_odoc/pkg/foo_lib --pkg foo_lib -o foo.odoc foo.cmti)
   File "foo_lib/foo.mli", line 1, characters 7-7:
   Warning: End of text is not allowed in '[...]' (code).


### PR DESCRIPTION
Run odoc and sherlodoc actions under sandboxing and declare hidden .odoc dependencies for odoc include directories so linked docs are available inside the sandbox.

Adjust legacy HTML/JSON generation to use directory targets for module output, and query odoc for markdown targets instead of assuming a single output file. Update odoc cram expectations for the resulting directory-target behavior and sandboxed command paths.