### PR TITLE
fix(watch): complete RPC builds independently

### DIFF
--- a/doc/changes/changed/15191.md
+++ b/doc/changes/changed/15191.md
@@ -1,0 +1,3 @@
+- In watch mode, `$ dune rpc build` requests now complete as soon as their
+  requested build finishes, instead of waiting for unrelated concurrent RPC build
+  requests in the same build iteration. (#15191, @rgrinberg)

--- a/src/dune_engine/build_loop.ml
+++ b/src/dune_engine/build_loop.ml
@@ -55,6 +55,7 @@ type t =
        distinguish input changes from other wakeups. *)
   ; mutable next_run_id : int
   ; mutable rpc_requests : Build_system.Request.Goal.t Rpc_request_id.Map.t
+  ; mutable current_request : Build_system.Request.t option
   ; mutable state : [ `Awaiting_init | `Init ]
   }
 
@@ -140,6 +141,7 @@ let request_restart t invalidation =
     then t.watch_restart_started_at <- Some now;
     add_pending_reset t invalidation;
     t.input_change_generation <- t.input_change_generation + 1;
+    Option.iter t.current_request ~f:Build_system.Request.cancel_completion;
     let* () =
       match t.status with
       | Restarting_build _ -> Fiber.return ()
@@ -185,6 +187,7 @@ let create () =
   ; input_change_generation = 0
   ; next_run_id = 1
   ; rpc_requests = Rpc_request_id.Map.empty
+  ; current_request = None
   ; state = `Awaiting_init
   }
 ;;
@@ -219,6 +222,11 @@ let reset_wakeup t =
   Trigger.trigger previous_wakeup
 ;;
 
+let all_rpc_requests_finished t =
+  Rpc_request_id.Map.to_list t.rpc_requests
+  |> List.for_all ~f:(fun (_, request) -> Build_system.Request.Goal.is_finished request)
+;;
+
 let run_current_build
       ({ watch_restart_started_at = restart_started_at
        ; input_change_generation = build_start_input_change_generation
@@ -227,7 +235,9 @@ let run_current_build
        } as t)
       ~action_runner
       ~run_id
-      request
+      ~finish_when_rpc_requests_finished
+      ~request
+      run_build
   =
   let* () = reset_wakeup t in
   (match t.status with
@@ -235,16 +245,29 @@ let run_current_build
    | Standing_by | Restarting_build _ -> ());
   t.status <- Building run_id;
   clear_status_overlay t;
+  t.current_request <- Some request;
   let* outcome =
-    let build_ctx =
-      Process.Build.create ~action_runner ~run_id ~cancellation:(Fiber.Cancel.create ())
-    in
-    Process.Build.with_ build_ctx (fun () ->
-      Build_system.run_build_requests ?restart_started_at ~build:build_ctx request)
+    Fiber.finalize
+      (fun () ->
+         let build_ctx =
+           Process.Build.create
+             ~action_runner
+             ~run_id
+             ~cancellation:(Fiber.Cancel.create ())
+         in
+         run_build ?restart_started_at ~build:build_ctx ())
+      ~finally:(fun () ->
+        t.current_request <- None;
+        Fiber.return ())
   in
   let+ () = Scheduler.cleanup_subreaper_child_processes () in
   let next =
     match t.status with
+    | Restarting_build _
+      when finish_when_rpc_requests_finished && all_rpc_requests_finished t ->
+      t.status <- Standing_by;
+      t.watch_restart_started_at <- None;
+      `Done
     | Restarting_build _ -> `Restart
     | Standing_by | Building _ ->
       t.status <- Standing_by;
@@ -274,11 +297,17 @@ let cancel_rpc_requests t ~f =
   | to_cancel ->
     List.iter to_cancel ~f:(fun (id, _) ->
       t.rpc_requests <- Rpc_request_id.Map.remove t.rpc_requests id);
+    let to_cancel_unfinished =
+      List.filter to_cancel ~f:(fun (_, request) ->
+        not (Build_system.Request.Goal.is_finished request))
+    in
     let* () =
-      Fiber.parallel_iter to_cancel ~f:(fun (_, request) ->
+      Fiber.parallel_iter to_cancel_unfinished ~f:(fun (_, request) ->
         Build_system.Request.Goal.complete request Failure)
     in
-    request_rebuild_due_to_rpc_request t
+    if List.is_empty to_cancel_unfinished
+    then Fiber.return ()
+    else request_rebuild_due_to_rpc_request t
 ;;
 
 let cancel_rpc_requests_by_session t ~session_id =
@@ -299,7 +328,9 @@ let submit_rpc_request t ~session_id ~request_id ~build =
        [ "id", Rpc_request_id.to_dyn id ]
    | None -> t.rpc_requests <- Rpc_request_id.Map.add_exn t.rpc_requests id request);
   let* () = request_rebuild_due_to_rpc_request t in
-  Build_system.Request.Goal.await request
+  let+ outcome = Build_system.Request.Goal.await request in
+  t.rpc_requests <- Rpc_request_id.Map.remove t.rpc_requests id;
+  outcome
 ;;
 
 type rpc_poll_iter_result =
@@ -309,6 +340,10 @@ type rpc_poll_iter_result =
 
 let rpc_poll_iter t ~action_runner ~sticky_goal ~sticky_built_at =
   let rec loop () =
+    Rpc_request_id.Map.to_list t.rpc_requests
+    |> List.iter ~f:(fun (id, request) ->
+      if Build_system.Request.Goal.is_finished request
+      then t.rpc_requests <- Rpc_request_id.Map.remove t.rpc_requests id);
     let rpc_requests = Rpc_request_id.Map.to_list t.rpc_requests in
     let sticky_goal_to_build =
       match sticky_goal with
@@ -332,15 +367,13 @@ let rpc_poll_iter t ~action_runner ~sticky_goal ~sticky_built_at =
       Fiber.return { wakeup_generation = t.wakeup_generation; sticky_built_at = None }
     | _ ->
       let* res, next, input_change_generation, wakeup_generation =
-        let rpc_requests_in_build = List.map rpc_requests ~f:snd in
         let request =
-          let goals =
-            match sticky_goal_to_build with
-            | None -> rpc_requests_in_build
-            | Some sticky_goal ->
-              Build_system.Request.Goal.create sticky_goal :: rpc_requests_in_build
-          in
-          Build_system.Request.create goals
+          Build_system.Request.create
+            (let rpc_requests_in_build = List.map rpc_requests ~f:snd in
+             match sticky_goal_to_build with
+             | None -> rpc_requests_in_build
+             | Some sticky_goal ->
+               Build_system.Request.Goal.create sticky_goal :: rpc_requests_in_build)
         in
         let run_id = next_watch_run_id t in
         let () =
@@ -354,7 +387,15 @@ let rpc_poll_iter t ~action_runner ~sticky_goal ~sticky_built_at =
               Console.maybe_clear_screen ~details_hum);
             Memo.reset invalidation
         in
-        run_current_build t ~action_runner ~run_id request
+        let finish_when_rpc_requests_finished = Option.is_none sticky_goal_to_build in
+        run_current_build
+          t
+          ~action_runner
+          ~run_id
+          ~finish_when_rpc_requests_finished
+          ~request
+          (fun ?restart_started_at ~build () ->
+             Build_system.run_build_requests ?restart_started_at ~build request)
       in
       (match next with
        | `Restart -> loop ()
@@ -365,15 +406,13 @@ let rpc_poll_iter t ~action_runner ~sticky_goal ~sticky_built_at =
              | Ok () -> Build_outcome.Success
              | Error `Already_reported -> Failure
            in
-           let+ () =
-             Fiber.sequential_iter rpc_requests ~f:(fun (id, _) ->
-               match Rpc_request_id.Map.find t.rpc_requests id with
-               | None -> Fiber.return ()
-               | Some request ->
-                 t.rpc_requests <- Rpc_request_id.Map.remove t.rpc_requests id;
-                 Build_system.Request.Goal.complete request outcome)
+           let* () =
+             Fiber.sequential_iter rpc_requests ~f:(fun (id, request) ->
+               t.rpc_requests <- Rpc_request_id.Map.remove t.rpc_requests id;
+               Build_system.Request.Goal.complete request outcome)
            in
-           build_finish t outcome
+           build_finish t outcome;
+           Fiber.return ()
          in
          { wakeup_generation
          ; sticky_built_at =

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1223,6 +1223,7 @@ module Request = struct
 
     let create build = { build; outcome = Fiber.Ivar.create () }
     let await t = Fiber.Ivar.read t.outcome
+    let is_finished t = Option.is_some (Fiber.Ivar.peek t.outcome)
 
     let complete t outcome =
       Fiber.of_thunk (fun () ->
@@ -1234,9 +1235,17 @@ module Request = struct
     let build t = t.build
   end
 
-  type t = { goals : Goal.t list }
+  type completion =
+    | Complete_goals
+    | Do_not_complete_goals
 
-  let create goals = { goals }
+  type t =
+    { goals : Goal.t list
+    ; mutable completion : completion
+    }
+
+  let create goals = { goals; completion = Complete_goals }
+  let cancel_completion t = t.completion <- Do_not_complete_goals
   let goals t = t.goals
 end
 
@@ -1252,17 +1261,50 @@ let complete_action_runner_build = function
          ~cancellation:(Process.Build.cancellation build))
 ;;
 
-let run_build_requests ?restart_started_at ?build request =
+let run_build_requests ?restart_started_at ?build (request : Request.t) =
+  let open Fiber.O in
+  let finish_request goal outcome =
+    let* pending =
+      let pending = Diff_promotion.has_pending () in
+      let+ () =
+        (* Process source invalidations before completing the request; an
+           invalidation may cancel completion so the request waits for the
+           restarted build instead of receiving a stale result. *)
+        Scheduler.flush_file_watcher ()
+      in
+      pending
+    in
+    match request.completion, !Clflags.promote with
+    | Do_not_complete_goals, _ -> Fiber.return ()
+    | Complete_goals, Some Automatically when pending -> Fiber.return ()
+    | Complete_goals, _ -> Request.Goal.complete goal outcome
+  in
+  let run_request goal =
+    Fiber.collect_errors (fun () ->
+      Memo.run_with_error_handler ~handle_error_no_raise:report_early_exn (fun () ->
+        Request.Goal.build goal |> evaluate_action_builder))
+    >>= function
+    | Ok () ->
+      let+ () = finish_request goal Success in
+      Ok ()
+    | Error exns when List.for_all exns ~f:caused_by_cancellation ->
+      Fiber.return (Error exns)
+    | Error exns ->
+      let+ () = finish_request goal Failure in
+      Error exns
+  in
   Fiber.finalize
     ~finally:(fun () -> complete_action_runner_build build)
     (fun () ->
        run_with_error_collection ?restart_started_at ~build (fun () ->
-         Fiber.collect_errors (fun () ->
-           Memo.run_with_error_handler ~handle_error_no_raise:report_early_exn (fun () ->
-             Request.goals request
-             |> List.map ~f:Request.Goal.build
-             |> Action_builder.all_unit
-             |> evaluate_action_builder))))
+         Request.goals request
+         |> Fiber.parallel_map ~f:run_request
+         >>| List.concat_map ~f:(function
+           | Ok () -> []
+           | Error exns -> exns)
+         >>| function
+         | [] -> Ok ()
+         | exns -> Error exns))
 ;;
 
 let run ?restart_started_at ?build f =

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -66,12 +66,17 @@ module Request : sig
 
     val create : unit Action_builder.t -> t
     val await : t -> Build_outcome.t Fiber.t
+    val is_finished : t -> bool
     val complete : t -> Build_outcome.t -> unit Fiber.t
   end
 
   type t
 
   val create : Goal.t list -> t
+
+  (** Prevent this request from completing goals that have not already
+      completed. *)
+  val cancel_completion : t -> unit
 end
 
 val run_build_requests

--- a/src/dune_engine/diff_promotion.ml
+++ b/src/dune_engine/diff_promotion.ml
@@ -125,6 +125,7 @@ type db = op list
 
 let db : db ref = ref []
 let clear_cache () = db := []
+let has_pending () = not (List.is_empty !db)
 
 let register_intermediate how ~source_file ~correction_file =
   let src = snd (Path.Build.split_sandbox_root correction_file) in
@@ -370,9 +371,10 @@ let finalize () =
 (* Returns the list of files that were in [files_to_promote]
    but not present in the promotion database. *)
 let promote_files_registered_in_last_run ~matching files_to_promote =
-  let db = load_db () in
-  let remaining, missing = do_promote ~matching db files_to_promote in
-  dump_db remaining;
+  let using_current_run_db = has_pending () in
+  let db_to_promote = if using_current_run_db then !db else load_db () in
+  let remaining, missing = do_promote ~matching db_to_promote files_to_promote in
+  if using_current_run_db then db := remaining else dump_db remaining;
   missing
 ;;
 

--- a/src/dune_engine/diff_promotion.mli
+++ b/src/dune_engine/diff_promotion.mli
@@ -20,6 +20,11 @@ type db
 val finalize : unit -> unit
 
 val clear_cache : unit -> unit
+
+(** Whether the current build has registered promotions that have not been
+    finalized yet. *)
+val has_pending : unit -> bool
+
 val load_db : unit -> db
 
 type all =

--- a/test/blackbox-tests/test-cases/actions/subreaper.t
+++ b/test/blackbox-tests/test-cases/actions/subreaper.t
@@ -3,6 +3,16 @@ is adopted by Dune and cleaned up after the build.
 
   $ make_dune_project 3.23
 
+  $ wait_for_child_process_cleanup_finished () {
+  >   child_pid="$1"
+  >   wait_for_trace_jq_true '
+  >     any(.[];
+  >       .name == "child-process-cleanup"
+  >       and .args.stage == "finished"
+  >       and ((.args.pids // []) | index('"$child_pid"')))
+  >   '
+  > }
+
   $ pid_file=$TMPDIR/escaped-pid
   $ cat >dune <<EOF
   > (rule
@@ -24,6 +34,7 @@ processes.
 
   $ with_timeout dune_cmd wait-for-file-to-appear "$pid_file"
   $ child_pid=$(cat "$pid_file")
+  $ wait_for_child_process_cleanup_finished "$child_pid"
   $ if kill -0 "$child_pid" 2>/dev/null; then
   >   echo "FAILURE: escaped process is still running"
   > else

--- a/test/blackbox-tests/test-cases/watching/fmt-test.t
+++ b/test/blackbox-tests/test-cases/watching/fmt-test.t
@@ -28,5 +28,5 @@ Remove the fake ocamlformat from the dune file to see the real output
   -let ()=print_int (5+4)
   +(* fake ocamlformat output *)
   \ No newline at end of file
-  Had 1 error, waiting for filesystem changes...
   Promoting _build/default/foo.ml.corrected to foo.ml.
+  Had 1 error, waiting for filesystem changes...

--- a/test/blackbox-tests/test-cases/watching/rpc-build-auto-promote-restart.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-auto-promote-restart.t
@@ -64,7 +64,7 @@ by another request in the same batch.
   > else
   >   echo "fast rpc request timed out"
   > fi
-  fast rpc request timed out
+  fast rpc request finished
   $ cat source2
   old
 

--- a/test/blackbox-tests/test-cases/watching/rpc-build-concurrent-finish.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-concurrent-finish.t
@@ -1,4 +1,4 @@
-Concurrent RPC build requests currently finish together even if one target is done.
+Concurrent RPC build requests finish independently when their targets are done.
 
   $ make_dune_project 3.23
   $ export DUNE_TRACE=rpc,process
@@ -46,6 +46,12 @@ Concurrent RPC build requests currently finish together even if one target is do
   $ SLOW=$!
   $ with_timeout dune_cmd wait-for-file-to-appear "$fast_started"
   $ with_timeout dune_cmd wait-for-file-to-appear "$slow_started"
+  $ if grep -qx Success fast.out 2>/dev/null; then
+  >   echo "fast rpc request finished before release"
+  > else
+  >   echo "fast rpc request is waiting"
+  > fi
+  fast rpc request is waiting
 
 Let the fast action finish, and wait until dune has observed its process exit.
 
@@ -55,15 +61,14 @@ Let the fast action finish, and wait until dune has observed its process exit.
   $ cat _build/default/fast-target
   fast
 
-The fast RPC build should finish now, but it remains blocked until the slow
-request is also done.
+The fast RPC build should finish now, before the slow request is done.
 
   $ if wait_for_success_with_timeout fast.out 200; then
   >   echo "fast rpc request finished"
   > else
   >   echo "fast rpc request timed out"
   > fi
-  fast rpc request timed out
+  fast rpc request finished
   $ file_status _build/default/slow-target
   _build/default/slow-target missing
 
@@ -80,19 +85,8 @@ request is also done.
   slow
   $ stop_dune_quiet
 
-Concurrent RPC build failures also currently finish together with unrelated
-requests.
+Concurrent RPC build failures also finish independently.
 
-  $ wait_for_failure_with_timeout () {
-  >   output="$1"
-  >   iterations="$2"
-  >   while ! grep -qx Failure "$output" 2>/dev/null
-  >   do
-  >     if [ "$iterations" = 0 ]; then return 124; fi
-  >     iterations=$((iterations - 1))
-  >     sleep 0.01
-  >   done
-  > }
   $ fail_started="$(mktemp -u)"
   $ fail_release="$(mktemp -u)"
   $ slow_started="$(mktemp -u)"
@@ -119,25 +113,24 @@ requests.
   $ with_timeout dune_cmd wait-for-file-to-appear "$slow_started"
 
   $ printf '.\n' > "$fail_release"
-  $ if wait_for_failure_with_timeout fail.out 200; then
+  $ if wait_for_line_with_timeout fail.out Failure 200; then
   >   echo "failing rpc request finished"
   > else
   >   echo "failing rpc request timed out"
   > fi
-  failing rpc request timed out
+  failing rpc request finished
+  $ wait_for_pid_to_exit_with_timeout "$FAIL" 200 || (cat fail.out; false)
+  $ wait "$FAIL"
+  [1]
   $ file_status _build/default/slow-after-fail
   _build/default/slow-after-fail missing
 
   $ printf '.\n' > "$slow_release"
-  $ wait_for_pid_to_exit_with_timeout "$FAIL" 200 || (cat fail.out; false)
-  $ wait "$FAIL"
-  [1]
   $ wait_for_pid_to_exit_with_timeout "$SLOW" 200 || (cat slow-after-fail.out; false)
   $ wait "$SLOW"
-  [1]
   $ cat fail.out slow-after-fail.out | sort
   Failure
-  Failure
+  Success
   $ cat _build/default/slow-after-fail
   slow
   $ stop_dune_quiet
@@ -188,4 +181,61 @@ failure.
   > fi
   slow rpc request finished
   Failure
+  $ stop_dune_quiet
+
+Promotions registered by an independently-finished request are available to RPC
+promotion requests while the rest of the batch is still running, and are not
+resurrected when that batch finishes.
+
+  $ cat > source <<EOF
+  > old
+  > EOF
+  $ slow_started="$(mktemp -u)"
+  $ slow_release="$(mktemp -u)"
+  $ cat > dune <<EOF
+  > (rule
+  >  (target source.corrected)
+  >  (action (write-file %{target} "new\n")))
+  > (rule
+  >  (alias repro)
+  >  (action (diff source source.corrected)))
+  > (rule
+  >  (target slow-with-promotion)
+  >  (action
+  >   (bash "\| touch '$slow_started'
+  >         "\| while [ ! -e '$slow_release' ]; do
+  >         "\|   sleep 0.01
+  >         "\| done
+  >         "\| echo slow > slow-with-promotion
+  > )))
+  > EOF
+
+  $ start_dune -j 2
+  $ dune rpc build --wait '(alias repro)' > promotion-build.out 2>&1 &
+  $ PROMOTION_BUILD=$!
+  $ dune rpc build --wait slow-with-promotion > slow-with-promotion.out 2>&1 &
+  $ SLOW=$!
+  $ with_timeout dune_cmd wait-for-file-to-appear "$slow_started"
+  $ if wait_for_line_with_timeout promotion-build.out Failure 200; then
+  >   echo "promotion rpc request finished"
+  > else
+  >   echo "promotion rpc request timed out"
+  > fi
+  promotion rpc request finished
+  $ dune promote source
+  Success
+  $ cat source
+  new
+
+  $ touch "$slow_release"
+  $ wait_for_pid_to_exit_with_timeout "$PROMOTION_BUILD" 200 || (cat promotion-build.out; false)
+  $ wait "$PROMOTION_BUILD"
+  [1]
+  $ wait_for_pid_to_exit_with_timeout "$SLOW" 200 || (cat slow-with-promotion.out; false)
+  $ wait "$SLOW"
+  $ cat promotion-build.out slow-with-promotion.out | sort
+  Failure
+  Success
+  $ dune promotion list source 2>&1
+  Warning: Nothing to promote for source.
   $ stop_dune_quiet


### PR DESCRIPTION
Introduce build requests with hidden completion ivars in the build system. The watch build loop can still batch RPC build requests together, but each request now reports success as soon as its own action builder completes instead of waiting for the entire batch.

Update the concurrent RPC build cram test to expect the fast request to finish before the slow target is released.