### PR TITLE
Add Fiber.Pool.with_

### DIFF
--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -540,18 +540,17 @@ module Background = struct
   ;;
 
   let with_background_rpc server f =
-    let pool = Fiber.Pool.create () in
-    let v = { state = `Awaiting_start; server; pool } in
-    let previous = !current in
-    current := Some v;
-    Fiber.finalize
-      (fun () ->
-         Fiber.fork_and_join_unit
-           (fun () -> Fiber.Pool.run pool)
-           (fun () -> Fiber.finalize f ~finally:(fun () -> stop_background v)))
-      ~finally:(fun () ->
-        current := previous;
-        Fiber.return ())
+    Fiber.of_thunk (fun () ->
+      let previous = !current in
+      Fiber.finalize
+        (fun () ->
+           Fiber.Pool.with_ (fun pool ->
+             let v = { state = `Awaiting_start; server; pool } in
+             current := Some v;
+             Fiber.finalize f ~finally:(fun () -> stop_background v)))
+        ~finally:(fun () ->
+          current := previous;
+          Fiber.return ()))
   ;;
 
   let ensure_ready () =

--- a/src/fiber/src/fiber.mli
+++ b/src/fiber/src/fiber.mli
@@ -420,6 +420,10 @@ module Pool : sig
   (** Create a new pool. *)
   val create : unit -> t
 
+  (** [with_ f] runs [f pool] with a fresh pool. Tasks submitted to [pool] run
+      in parallel, and [pool] is closed when [f pool] terminates. *)
+  val with_ : (t -> 'a fiber) -> 'a fiber
+
   (** [running pool] returns whether it's possible to submit tasks to [pool] *)
   val running : t -> bool fiber
 

--- a/src/fiber/src/pool.ml
+++ b/src/fiber/src/pool.ml
@@ -88,3 +88,11 @@ let run t k =
     in
     read t
 ;;
+
+let with_ f =
+  of_thunk (fun () ->
+    let pool = create () in
+    fork_and_join_unit
+      (fun () -> run pool)
+      (fun () -> finalize (fun () -> f pool) ~finally:(fun () -> close pool)))
+;;

--- a/src/fiber/test/fiber_tests.ml
+++ b/src/fiber/test/fiber_tests.ml
@@ -918,19 +918,12 @@ let%expect_test "start & stop pool" =
 
 let%expect_test "run 2 tasks" =
   Scheduler.run
-    (let pool = Pool.create () in
-     let task n () =
-       printf "task %d\n" n;
-       Fiber.return ()
-     in
-     let tasks () =
-       Fiber.parallel_iter [ 1; 2 ] ~f:(fun n -> Pool.task pool ~f:(task n))
-     in
-     Fiber.fork_and_join_unit
-       (fun () -> Pool.run pool)
-       (fun () ->
-          let* () = tasks () in
-          Pool.close pool));
+    (Pool.with_ (fun pool ->
+       let task n () =
+         printf "task %d\n" n;
+         Fiber.return ()
+       in
+       Fiber.parallel_iter [ 1; 2 ] ~f:(fun n -> Pool.task pool ~f:(task n))));
   [%expect
     {|
     task 1
@@ -939,18 +932,16 @@ let%expect_test "run 2 tasks" =
 
 let%expect_test "raise exception" =
   Scheduler.run
-    (let pool = Pool.create () in
-     let* () = Pool.task pool ~f:(fun () -> raise Exit) in
-     Fiber.fork_and_join_unit
-       (fun () ->
-          let+ res = Fiber.collect_errors (fun () -> Pool.run pool) in
-          match res with
-          | Ok _ -> assert false
-          | Error [ e ] ->
-            assert (e.exn = Exit);
-            print_endline "Caught Exit"
-          | _ -> assert false)
-       (fun () -> Pool.close pool));
+    (let+ res =
+       Fiber.collect_errors (fun () ->
+         Pool.with_ (fun pool -> Pool.task pool ~f:(fun () -> raise Exit)))
+     in
+     match res with
+     | Ok _ -> assert false
+     | Error [ e ] ->
+       assert (e.exn = Exit);
+       print_endline "Caught Exit"
+     | _ -> assert false);
   [%expect {| Caught Exit |}]
 ;;
 

--- a/src/rpc/server.ml
+++ b/src/rpc/server.ml
@@ -159,9 +159,8 @@ module Session = struct
         Fiber.Ivar.fill ivar Pending_response.Closed)
     ;;
 
-    let create (type s) ~name ~version (chan, s) ~finalizer =
+    let create (type s) ~id ~pool ~name ~version (chan, s) ~finalizer =
       let pending = Table.create (module Dune_rpc.Private.Id) 16 in
-      let pool = Fiber.Pool.create () in
       let module Chan = (val chan : Session with type t = s) in
       { version
       ; chan = Chan (chan, s)
@@ -175,7 +174,7 @@ module Session = struct
             and+ () = close_pending_requests pending in
             ())
       ; state = Uninitialized
-      ; id = Id.gen ()
+      ; id
       ; pool
       ; pending
       ; requests_in_flight = Dune_rpc.Private.Id.Map.empty
@@ -773,23 +772,36 @@ type t = Server : 'a H.stage1 -> t
 let make (type a) (h : a H.Builder.t) : t = Server (H.Builder.to_handler h)
 
 let new_session (Server handler) ~name chan =
-  let session = Fdecl.create Dyn.opaque in
-  Fdecl.set
-    session
-    (Session.Stage1.create ~name ~version:handler.base.version chan ~finalizer:(fun () ->
-       let session : _ Session.Stage1.t = Fdecl.get session in
-       handler.base.on_terminate session));
-  let session = Fdecl.get session in
+  let id = Session.Id.gen () in
+  let session = ref None in
   object
-    method id = session.id
-    method close = Session.Stage1.close session
+    method id = id
+
+    method close =
+      match !session with
+      | None -> Fiber.return ()
+      | Some session -> Session.Stage1.close session
 
     method start =
-      Fiber.fork_and_join_unit
-        (fun () -> Fiber.Pool.run session.pool)
-        (fun () ->
-           let* () = H.handle handler session in
-           Session.Stage1.close session)
+      Fiber.Pool.with_ (fun pool ->
+        let session_fdecl = Fdecl.create Dyn.opaque in
+        Fdecl.set
+          session_fdecl
+          (Session.Stage1.create
+             ~id
+             ~pool
+             ~name
+             ~version:handler.base.version
+             chan
+             ~finalizer:(fun () ->
+               let session : _ Session.Stage1.t = Fdecl.get session_fdecl in
+               handler.base.on_terminate session));
+        let session' = Fdecl.get session_fdecl in
+        session := Some session';
+        let* () = H.handle handler session' in
+        let* () = Session.Stage1.close session' in
+        session := None;
+        Fiber.return ())
   end
 ;;
 


### PR DESCRIPTION
Introduce a helper that creates a pool, runs the caller-provided fiber alongside the pool runner, and closes the pool afterwards.

Use it for RPC session/background pools and update pool tests to exercise the helper.