### PR TITLE
refactor(lang): derive env update op equality from repr

### DIFF
--- a/src/dune_lang/action.ml
+++ b/src/dune_lang/action.ml
@@ -85,16 +85,35 @@ module Env_update = struct
       | EqColon
       | EqPlusEq
 
-    let equal a b =
-      match a, b with
-      | Eq, Eq
-      | PlusEq, PlusEq
-      | EqPlus, EqPlus
-      | ColonEq, ColonEq
-      | EqColon, EqColon
-      | EqPlusEq, EqPlusEq -> true
-      | _ -> false
+    let repr =
+      Repr.variant
+        "env-update-op"
+        [ Repr.case0 "=" ~test:(function
+            | Eq -> true
+            | PlusEq | EqPlus | ColonEq | EqColon | EqPlusEq -> false)
+        ; Repr.case0 "+=" ~test:(function
+            | PlusEq -> true
+            | Eq | EqPlus | ColonEq | EqColon | EqPlusEq -> false)
+        ; Repr.case0 "=+" ~test:(function
+            | EqPlus -> true
+            | Eq | PlusEq | ColonEq | EqColon | EqPlusEq -> false)
+        ; Repr.case0 ":=" ~test:(function
+            | ColonEq -> true
+            | Eq | PlusEq | EqPlus | EqColon | EqPlusEq -> false)
+        ; Repr.case0 "=:" ~test:(function
+            | EqColon -> true
+            | Eq | PlusEq | EqPlus | ColonEq | EqPlusEq -> false)
+        ; Repr.case0 "=+=" ~test:(function
+            | EqPlusEq -> true
+            | Eq | PlusEq | EqPlus | ColonEq | EqColon -> false)
+        ]
     ;;
+
+    include Repr.Poly (struct
+        type nonrec t = t
+
+        let repr = repr
+      end)
 
     let all =
       [ "=", Eq
@@ -105,13 +124,6 @@ module Env_update = struct
       ; "=+=", EqPlusEq
       ]
     ;;
-
-    let to_string t =
-      List.find_map all ~f:(fun (k, t') -> if equal t t' then Some k else None)
-      |> Option.value_exn
-    ;;
-
-    let repr = Repr.view Repr.string ~to_:to_string
   end
 
   type 'a t =

--- a/test/expect-tests/dune_pkg/encode_decode_tests.ml
+++ b/test/expect-tests/dune_pkg/encode_decode_tests.ml
@@ -365,7 +365,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                                { url = "file://randomurl"; checksum = None })
                             ]
                         }
-                    ; exported_env = [ { op = "="; var = "foo"; value = "bar" } ]
+                    ; exported_env = [ { op = =; var = "foo"; value = "bar" } ]
                     ; enabled_on_platforms = []
                     }
                 }


### PR DESCRIPTION
Replace the hand-written Env_update.Op equality with a Repr.t and derive the polymorphic operations from Repr.Poly.