### PR TITLE
fix: pass CI=true in nix CI to disable bwrap sandbox tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: nixbuild/nix-quick-install-action@v34
-      - run: nix develop -i -c make test
+      - run: nix develop -i -s CI true -c make test
 
   fmt:
     name: Format

--- a/.github/workflows/workflow.yml.in
+++ b/.github/workflows/workflow.yml.in
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: nixbuild/nix-quick-install-action@v34
-      - run: nix develop -i -c make test
+      - run: nix develop -i -s CI true -c make test
 
   fmt:
     name: Format


### PR DESCRIPTION
The nix-test CI job uses 'nix develop -i' which clears the environment, including the CI=true variable that GitHub Actions sets automatically. Without CI=true, the bwrap tests' runtest_alias expression
  (<> %{env:CI=false} true)
evaluates to true, meaning the tests are incorrectly included in @runtest.

Fix by explicitly passing '-s CI true make test' so the bwrap tests are excluded from CI as intended.