### PR TITLE
perf(memo): remove hot-path closures via new Fiber.Var combinators

### DIFF
--- a/src/fiber/src/core.ml
+++ b/src/fiber/src/core.ml
@@ -312,6 +312,24 @@ module Var = struct
     fun k -> Update_var (key, f, fun () -> fiber () (fun x -> Unwind (k, x)))
   ;;
 
+  let get_apply (key : 'a Var_map.Key.t) (f : 'a -> 'b -> 'c t) (x : 'b) : 'c t =
+    fun k -> Get_var (key, fun value -> f value x k)
+  ;;
+
+  let get_apply_map (key : 'a Var_map.Key.t) (f : 'a -> 'b -> 'c) (x : 'b) : 'c t =
+    fun k -> Get_var (key, fun value -> k (f value x))
+  ;;
+
+  let set_apply (key : 'a Var_map.Key.t) (value : 'a) (f : 'b -> 'c t) (x : 'b) : 'c t =
+    fun k -> Set_var (key, value, fun () -> f x (fun y -> Unwind (k, y)))
+  ;;
+
+  let update_apply (key : 'a Var_map.Key.t) ~(f : 'a -> 'a) (g : 'b -> 'c t) (x : 'b)
+    : 'c t
+    =
+    fun k -> Update_var (key, f, fun () -> g x (fun y -> Unwind (k, y)))
+  ;;
+
   include Var_map.Key
 end
 

--- a/src/fiber/src/fiber.mli
+++ b/src/fiber/src/fiber.mli
@@ -171,6 +171,24 @@ module Var : sig
   (** [update var ~f fiber] runs [fiber] with [var] updated by applying [f] to its current
       value. Warning: do not use a lot of stack space in [f]. *)
   val update : 'a t -> f:('a -> 'a) -> (unit -> 'b fiber) -> 'b fiber
+
+  (** The [*_apply] combinators below behave like [get]/[set]/[update] but take a separate
+      argument [x] that is threaded into the continuation. This lets callers on hot paths
+      pass a hoisted (closure-free) function instead of allocating a fresh
+      [unit -> _ fiber] thunk on every call. *)
+
+  (** [get_apply var f x] reads [var] and continues with [f value x]. *)
+  val get_apply : 'a t -> ('a -> 'b -> 'c fiber) -> 'b -> 'c fiber
+
+  (** Like [get_apply] but [f] returns a plain value rather than a fiber. *)
+  val get_apply_map : 'a t -> ('a -> 'b -> 'c) -> 'b -> 'c fiber
+
+  (** [set_apply var value f x] sets [var] to [value] during the execution of [f x]. *)
+  val set_apply : 'a t -> 'a -> ('b -> 'c fiber) -> 'b -> 'c fiber
+
+  (** [update_apply var ~f g x] runs [g x] with [var] updated by applying [f] to its
+      current value. Warning: do not use a lot of stack space in [f]. *)
+  val update_apply : 'a t -> f:('a -> 'a) -> ('b -> 'c fiber) -> 'b -> 'c fiber
 end
 
 (** {1 Error handling} *)

--- a/src/fiber/test/var_tests.ml
+++ b/src/fiber/test/var_tests.ml
@@ -20,3 +20,57 @@ let%expect_test "fiber vars are preserved across yields" =
     {|
     () |}]
 ;;
+
+let%expect_test "Var.get_apply and get_apply_map read the var and thread the argument" =
+  let var = Fiber.Var.create 0 in
+  let run =
+    Fiber.Var.set var 10 (fun () ->
+      let* sum = Fiber.Var.get_apply var (fun value x -> Fiber.return (value + x)) 5 in
+      let+ product = Fiber.Var.get_apply_map var (fun value x -> value * x) 5 in
+      printf "get_apply = %d, get_apply_map = %d\n" sum product)
+  in
+  test unit run;
+  [%expect
+    {|
+    get_apply = 15, get_apply_map = 50
+    () |}]
+;;
+
+let%expect_test "Var.set_apply and update_apply scope the change and thread the argument" =
+  let var = Fiber.Var.create 0 in
+  let run =
+    Fiber.Var.set var 1 (fun () ->
+      let* set_inner, arg =
+        Fiber.Var.set_apply
+          var
+          2
+          (fun x ->
+             let+ value = Fiber.Var.get var in
+             value, x)
+          100
+      in
+      let* set_outer = Fiber.Var.get var in
+      let* update_inner =
+        Fiber.Var.update_apply
+          var
+          ~f:(fun v -> v + 10)
+          (fun x ->
+             let+ value = Fiber.Var.get var in
+             value + x)
+          5
+      in
+      let+ update_outer = Fiber.Var.get var in
+      printf
+        "set_apply: inner=%d arg=%d outer=%d; update_apply: inner=%d outer=%d\n"
+        set_inner
+        arg
+        set_outer
+        update_inner
+        update_outer)
+  in
+  test unit run;
+  [%expect
+    {|
+    set_apply: inner=2 arg=100 outer=1; update_apply: inner=16 outer=1
+    () |}]
+;;

--- a/src/memo/deps_collector.ml
+++ b/src/memo/deps_collector.ml
@@ -9,20 +9,25 @@ type t = Dep_node.packed Deps.Dynamic.t ref
 
 let var : t option Fiber.Var.t = Fiber.Var.create None
 let create () : t = ref Deps.Dynamic.empty
-let run (t : t) ~f = Fiber.Var.set var (Some t) f
+let run_apply (t : t) ~f x = Fiber.Var.set_apply var (Some t) f x
 let get (t : t) : Dep_node.packed Deps.t = Deps.Dynamic.to_static !t
 let add (t : t) dep_node = t := Deps.Dynamic.append_seq !t ~node:(Dep_node.T dep_node)
 
-(* Add a dependency on [dep_node] to the currently running computation, if there is one. *)
-let add_dep_from_caller dep_node =
-  Fiber.Var.get var
-  >>| function
+(* Add a dependency on [dep_node] to [collector], if there is an active one. Defined at
+   the top level so it is hoisted (closure-free) when passed to [get_apply_map]. *)
+let add_dep_to_collector collector dep_node =
+  match collector with
   | None -> ()
   | Some t -> add t dep_node
 ;;
 
+(* Add a dependency on [dep_node] to the currently running computation, if there is one. *)
+let add_dep_from_caller dep_node =
+  Fiber.Var.get_apply_map var add_dep_to_collector dep_node
+;;
+
 (* A way to run a parallel thread while collecting its dependencies separately. *)
-type run_thread = { run : 'a. f:(unit -> 'a Fiber.t) -> 'a Fiber.t } [@@unboxed]
+type run_thread = { run : 'a 'b. f:('b -> 'a Fiber.t) -> 'b -> 'a Fiber.t } [@@unboxed]
 
 (* A pool of large per-thread sub-collector arrays, keyed by power-of-two size, to avoid
    repeated major-heap allocations of the outer thread array in [run_parallel] when the
@@ -137,12 +142,12 @@ let run_parallel ~num_threads k =
       let thread_index = ref 0 in
       let run_thread =
         { run =
-            (fun ~f ->
+            (fun ~f x ->
               (* The scheduler is cooperative and single-threaded, so reading and bumping
                    [thread_index] is atomic and each thread gets a distinct sub-collector. *)
               let i = !thread_index in
               incr thread_index;
-              Fiber.Var.set var (Some (Pool.get threads i)) f)
+              Fiber.Var.set_apply var (Some (Pool.get threads i)) f x)
         }
       in
       let* result = Fiber.collect_errors (fun () -> k (Some run_thread)) in

--- a/src/memo/deps_collector.mli
+++ b/src/memo/deps_collector.mli
@@ -7,8 +7,8 @@ type t
 
 val create : unit -> t
 
-(** Run [f] with [t] as the active collector. *)
-val run : t -> f:(unit -> 'a Fiber.t) -> 'a Fiber.t
+(** Run [f x] with [t] as the active collector. *)
+val run_apply : t -> f:('b -> 'a Fiber.t) -> 'b -> 'a Fiber.t
 
 (** The dependencies collected so far, as a series-parallel graph. *)
 val get : t -> Dep_node.packed Deps.t
@@ -17,7 +17,7 @@ val get : t -> Dep_node.packed Deps.t
 val add_dep_from_caller : ('i, 'o) Dep_node.t -> unit Fiber.t
 
 (** A way to run one parallel thread while collecting its dependencies separately. *)
-type run_thread = { run : 'a. f:(unit -> 'a Fiber.t) -> 'a Fiber.t } [@@unboxed]
+type run_thread = { run : 'a 'b. f:('b -> 'a Fiber.t) -> 'b -> 'a Fiber.t } [@@unboxed]
 
 (** Run [num_threads] parallel threads, recording their dependencies as a single parallel
     section in the active collector. [k] is called with [None] when [num_threads < 2] or

--- a/src/memo/exec.ml
+++ b/src/memo/exec.ml
@@ -122,7 +122,10 @@ and compute : 'i 'o. ('i, 'o) Dep_node.t -> unit Fiber.t =
   let+ res =
     report_and_collect_errors (fun () ->
       let* () = !check_point in
-      Deps_collector.run deps_collector ~f:(fun () -> node.spec.f node.input))
+      Deps_collector.run_apply
+        deps_collector
+        ~f:(fun (node : (_, _) Dep_node.t) -> node.spec.f node.input)
+        node)
   in
   (match res with
    | Error { reproducible = false; _ } ->

--- a/src/memo/node.ml
+++ b/src/memo/node.ml
@@ -458,9 +458,13 @@ module Call_stack = struct
   ;;
 
   let push_frame (frame : Stack_frame_with_state.t) f =
-    let* stack = get_call_stack () in
-    let stack = frame :: stack in
-    Fiber.Var.set call_stack_var (Some stack) (fun () -> Implicit_output.forbid f)
+    (* Update the call-stack variable and run [f] (with implicit output forbidden) in a
+       single effect, without reading the stack first or allocating a thunk per push. *)
+    Fiber.Var.update_apply
+      call_stack_var
+      ~f:(fun stack -> Some (frame :: Option.value stack ~default:[]))
+      Implicit_output.forbid
+      f
   ;;
 
   (* As soon as we hit a cycle error in the current run, we stop adding new edges to the

--- a/src/memo/parallel.ml
+++ b/src/memo/parallel.ml
@@ -14,42 +14,40 @@ let fork_and_join x y =
   Deps_collector.run_parallel ~num_threads:2 (function
     | None -> Fiber.fork_and_join x y
     | Some { Deps_collector.run } ->
-      Fiber.fork_and_join (fun () -> run ~f:x) (fun () -> run ~f:y))
+      Fiber.fork_and_join (fun () -> run ~f:x ()) (fun () -> run ~f:y ()))
 ;;
 
 let fork_and_join_unit x y =
   Deps_collector.run_parallel ~num_threads:2 (function
     | None -> Fiber.fork_and_join_unit x y
     | Some { Deps_collector.run } ->
-      Fiber.fork_and_join_unit (fun () -> run ~f:x) (fun () -> run ~f:y))
+      Fiber.fork_and_join_unit (fun () -> run ~f:x ()) (fun () -> run ~f:y ()))
 ;;
 
 let all_concurrently l =
   Deps_collector.run_parallel ~num_threads:(List.length l) (function
     | None -> Fiber.all_concurrently l
     | Some { Deps_collector.run } ->
-      Fiber.parallel_map l ~f:(fun x -> run ~f:(fun () -> x)))
+      Fiber.parallel_map l ~f:(fun fiber -> run ~f:Fun.id fiber))
 ;;
 
 let all_concurrently_unit l =
   Deps_collector.run_parallel ~num_threads:(List.length l) (function
     | None -> Fiber.all_concurrently_unit l
     | Some { Deps_collector.run } ->
-      Fiber.all_concurrently_unit (List.map l ~f:(fun x -> run ~f:(fun () -> x))))
+      Fiber.all_concurrently_unit (List.map l ~f:(fun fiber -> run ~f:Fun.id fiber)))
 ;;
 
 let parallel_map l ~f =
   Deps_collector.run_parallel ~num_threads:(List.length l) (function
     | None -> Fiber.parallel_map l ~f
-    | Some { Deps_collector.run } ->
-      Fiber.parallel_map l ~f:(fun value -> run ~f:(fun () -> f value)))
+    | Some { Deps_collector.run } -> Fiber.parallel_map l ~f:(fun value -> run ~f value))
 ;;
 
 let parallel_iter l ~f =
   Deps_collector.run_parallel ~num_threads:(List.length l) (function
     | None -> Fiber.parallel_iter l ~f
-    | Some { Deps_collector.run } ->
-      Fiber.parallel_iter l ~f:(fun value -> run ~f:(fun () -> f value)))
+    | Some { Deps_collector.run } -> Fiber.parallel_iter l ~f:(fun value -> run ~f value))
 ;;
 
 let parallel_iter_set
@@ -65,12 +63,12 @@ let map_reduce l ~f ~empty ~combine =
   Deps_collector.run_parallel ~num_threads:(List.length l) (function
     | None -> Fiber.map_reduce l ~f ~empty ~combine
     | Some { Deps_collector.run } ->
-      Fiber.map_reduce l ~f:(fun x -> run ~f:(fun () -> f x)) ~empty ~combine)
+      Fiber.map_reduce l ~f:(fun x -> run ~f x) ~empty ~combine)
 ;;
 
 let map_reduce_array arr ~f ~empty ~combine =
   Deps_collector.run_parallel ~num_threads:(Array.length arr) (function
     | None -> Fiber.map_reduce_array arr ~f ~empty ~combine
     | Some { Deps_collector.run } ->
-      Fiber.map_reduce_array arr ~f:(fun x -> run ~f:(fun () -> f x)) ~empty ~combine)
+      Fiber.map_reduce_array arr ~f:(fun x -> run ~f x) ~empty ~combine)
 ;;


### PR DESCRIPTION
Remove per-call closure allocations from the parts of Memo that run on every
dependency edge and every node.

### Fiber

Adds argument-threading combinators to `Fiber.Var`: `get_apply`,
`get_apply_map`, `set_apply`, and `update_apply`. They behave like
`get`/`set`/`update` but take a separate argument that is threaded into the
continuation, so callers on hot paths can pass a hoisted, closure-free function
instead of allocating a fresh `unit -> _ fiber` thunk on every call. They mirror
the existing `of_thunk_apply` and come with tests in `src/fiber/test/var_tests.ml`.

### Memo

Uses the new combinators to drop per-call closures:

- **Dependency collection** (`deps_collector.ml`): `run` becomes `run_apply`
  (threads the computation's input via `set_apply`); `add_dep_from_caller` reads
  the active collector via `get_apply_map` with a hoisted function; and the
  parallel combinators (`parallel.ml`) thread each element instead of wrapping it
  in a `fun () -> ...` thunk.
- **Call stack** (`node.ml`): `Call_stack.push_frame` updates the call-stack
  variable and runs the body in a single `update_apply` effect, dropping both the
  separate read and the per-push thunk.

Behaviour is unchanged — this only reduces allocations on the hot path.