### PR TITLE
Fix sites plugin test

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/sites-plugin.t
+++ b/test/blackbox-tests/test-cases/pkg/sites-plugin.t
@@ -116,3 +116,27 @@ Registration of Plugin1
 Main app starts...
 Plugin1 is doing something...
 ```
+
+So, what went wrong?  The findlib library is not available:
+
+  $ dune exec ocamlfind query plugin1.plugin1_impl | censor
+  ocamlfind: Package `plugin1.plugin1_impl' not found
+  
+  [2]
+
+And the corresponding files are missing from the installation:
+
+  $ find _build -path '*/target/*' | sort | censor
+  _build/_private/default/.pkg/app.0.0.1-$DIGEST1/target/bin
+  _build/_private/default/.pkg/app.0.0.1-$DIGEST1/target/bin/app
+  _build/_private/default/.pkg/app.0.0.1-$DIGEST1/target/cookie
+  _build/_private/default/.pkg/app.0.0.1-$DIGEST1/target/lib
+  _build/_private/default/.pkg/app.0.0.1-$DIGEST1/target/lib/app
+  _build/_private/default/.pkg/app.0.0.1-$DIGEST1/target/lib/app/META
+  _build/_private/default/.pkg/app.0.0.1-$DIGEST1/target/lib/app/dune-package
+  _build/_private/default/.pkg/app.0.0.1-$DIGEST1/target/lib/app/register
+  _build/_private/default/.pkg/app.0.0.1-$DIGEST1/target/lib/app/register/registration.cma
+  _build/_private/default/.pkg/app.0.0.1-$DIGEST1/target/lib/app/register/registration.cmi
+  _build/_private/default/.pkg/app.0.0.1-$DIGEST1/target/lib/app/register/registration.cmt
+  _build/_private/default/.pkg/app.0.0.1-$DIGEST1/target/lib/app/register/registration.ml
+  _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/cookie

--- a/test/blackbox-tests/test-cases/pkg/sites-plugin.t
+++ b/test/blackbox-tests/test-cases/pkg/sites-plugin.t
@@ -33,6 +33,7 @@ Make an executable using dune-site (example mostly from the manual)
   Registration of Plugin1
   Main app starts...
   Plugin1 is doing something...
+  $ tar cf ../plugin.tar plugin
   $ cd ..
   $ tar cf app.tar app
   $ rm -rf app
@@ -40,7 +41,9 @@ Make an executable using dune-site (example mostly from the manual)
 Configure our fake curl to serve the tarball:
 
   $ echo app.tar >> fake-curls
-  $ PORT=1
+  $ APP_PORT=1
+  $ echo plugin.tar >> fake-curls
+  $ PLUGIN_PORT=2
 
 Make a package for the executable and the plugin:
   $ mkpkg app <<EOF
@@ -53,7 +56,7 @@ Make a package for the executable and the plugin:
   >   ]
   > ]
   > url {
-  >  src: "http://0.0.0.0:$PORT"
+  >  src: "http://0.0.0.0:$APP_PORT"
   >  checksum: [
   >   "md5=$(md5sum app.tar | cut -f1 -d' ')"
   >  ]
@@ -72,9 +75,9 @@ Make a package for the executable and the plugin:
   >   ]
   > ]
   > url {
-  >  src: "http://0.0.0.0:$PORT"
+  >  src: "http://0.0.0.0:$PLUGIN_PORT"
   >  checksum: [
-  >   "md5=$(md5sum app.tar | cut -f1 -d' ')"
+  >   "md5=$(md5sum plugin.tar | cut -f1 -d' ')"
   >  ]
   > }
   > EOF
@@ -117,14 +120,13 @@ Main app starts...
 Plugin1 is doing something...
 ```
 
-So, what went wrong?  The findlib library is not available:
+So, what went wrong?  The findlib library is now available:
 
   $ dune exec ocamlfind query plugin1.plugin1_impl | censor
-  ocamlfind: Package `plugin1.plugin1_impl' not found
-  
-  [2]
+  $PWD/_build/_private/default/.pkg/plugin1.0.0.1-$DIGEST/target/lib/plugin1/plugin1_impl
 
-And the corresponding files are missing from the installation:
+And the files have been installed, though maybe the app/plugins directory needs
+to be located under the same target directory?
 
   $ find _build -path '*/target/*' | sort | censor
   _build/_private/default/.pkg/app.0.0.1-$DIGEST1/target/bin
@@ -140,3 +142,21 @@ And the corresponding files are missing from the installation:
   _build/_private/default/.pkg/app.0.0.1-$DIGEST1/target/lib/app/register/registration.cmt
   _build/_private/default/.pkg/app.0.0.1-$DIGEST1/target/lib/app/register/registration.ml
   _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/cookie
+  _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/lib
+  _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/lib/app
+  _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/lib/app/plugins
+  _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/lib/app/plugins/plugin1
+  _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/lib/app/plugins/plugin1/META
+  _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/lib/plugin1
+  _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/lib/plugin1/META
+  _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/lib/plugin1/dune-package
+  _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/lib/plugin1/opam
+  _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/lib/plugin1/plugin1_impl
+  _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/lib/plugin1/plugin1_impl/plugin1_impl.a
+  _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/lib/plugin1/plugin1_impl/plugin1_impl.cma
+  _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/lib/plugin1/plugin1_impl/plugin1_impl.cmi
+  _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/lib/plugin1/plugin1_impl/plugin1_impl.cmt
+  _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/lib/plugin1/plugin1_impl/plugin1_impl.cmx
+  _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/lib/plugin1/plugin1_impl/plugin1_impl.cmxa
+  _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/lib/plugin1/plugin1_impl/plugin1_impl.cmxs
+  _build/_private/default/.pkg/plugin1.0.0.1-$DIGEST2/target/lib/plugin1/plugin1_impl/plugin1_impl.ml


### PR DESCRIPTION
As discussed in #11998 the test as it currently stands does not test loading of plugins since there seems to be a bug in the package installation for the plugin.  To illustrate this, I made two commits, one which exposes the installation issue and another which fixes the issue.  Or is the fix really a workaround for an unrelated issue with dune pkg lock?

There may be another thing blocking the loading of the plugin.  Notice that the plugins directory for app ends up under the plugin1 installation, while I presume it's meant to mix into the app installation.  Is that supported by the plugin system?  In any case, that's not the (only) real issue:

I also tried to check `Sites.Plugins.Plugins.list ()`, which always returns the empty list with the variations I've tried for this test, contrary to my observation for an opam-installed binary, as mentioned in paurkedal/ocaml-caqti#140.