### PR TITLE
[3.24.0] backport #15156

### DIFF
--- a/doc/changes/changed/15156.md
+++ b/doc/changes/changed/15156.md
@@ -1,0 +1,5 @@
+- Path-valued pforms (`%{bin:...}`, `%{dep:...}`, `%{path:...}`, and
+  friends) now expand same-directory paths with a leading `./`, so that
+  shells like `bash` in `(bash ...)` and `(system ...)` actions execute
+  them directly instead of looking them up in `PATH`.
+  (#15156, fixes #15147, @Alizter)

--- a/doc/concepts/variables.rst
+++ b/doc/concepts/variables.rst
@@ -96,18 +96,24 @@ In addition, ``(action ...)`` fields support the following special variables:
   the action).
 - ``exe:<path>`` is the same as ``<path>``, except when cross-compiling, in
   which case it will expand to ``<path>`` from the host build context.
-- ``bin:<program>`` expands to the path of ``program``. If ``program``
-  is installed by a workspace package (see :doc:`/reference/dune/install`
-  stanzas), it expands to the build artifact path of the locally built
-  binary; otherwise the program is looked up in the ``PATH`` of the
-  current build context. When ``%{bin:program}`` is listed in
-  ``(deps ...)``, the action additionally gets a per-rule directory
-  prepended to ``PATH`` containing a correctly-named symlink for
-  ``program`` (and any other ``%{bin:...}`` deps of the same rule), so
-  ``program`` can be invoked from ``(bash ...)`` or ``(system ...)``
-  by its bare name. Note that ``(run %{bin:program} ...)`` and ``(run
-  program ...)`` behave in the same way; ``%{bin:...}`` is only
-  necessary when you are using ``(bash ...)`` or ``(system ...)``.
+- ``bin:<program>`` expands to a runnable path for ``program`` and adds
+  it as a dependency of the action. If ``<program>`` is the public name
+  of an executable in the workspace, the expansion is the build-artifact
+  path of the locally built binary; otherwise, ``<program>`` is looked
+  up in the build context's ``PATH`` and the expansion is its absolute
+  path. When the resulting relative path is a bare basename (i.e. the
+  binary lives in the action's directory), Dune prepends ``./`` so that
+  shells like ``bash`` execute the file directly rather than performing
+  a ``PATH`` lookup.
+
+  When ``%{bin:<program>}`` appears in ``(deps ...)``, the action
+  additionally gets an isolated directory prepended to ``PATH``,
+  containing a symlink named ``<program>`` (without the artifact
+  extension) for each declared ``%{bin:...}`` dep. This lets the binary
+  be invoked by its bare name from ``(bash ...)`` or ``(system ...)``.
+
+  ``%{bin:...}`` is not required with ``(run ...)``: ``(run %{bin:foo}
+  ...)`` and ``(run foo ...)`` behave the same. conflict 1 of 1 ends
 - ``bin-available:<program>`` expands to ``true`` or ``false``, depending
   on whether ``<program>`` is available or not.
 - ``file-available:<path>`` expands to ``true`` or ``false``, depending on

--- a/nix/ox-package-set.nix
+++ b/nix/ox-package-set.nix
@@ -60,7 +60,16 @@ overlay // {
   # CR-soon Alizter: binaryen-bin is a conf package (skipped by opam-overlay)
   # that provides wasm-merge, needed at build time. Consider adding conf
   # package mapping to opam-overlay.
+  #
+  # runtime/wasm/args.ml derives module names from %{deps} via
+  # Filename.chop_suffix on the raw path string. When dune emits same-
+  # directory paths with a leading "./" this yields module names like
+  # "./array" instead of "array", and the wasm linker fails to resolve
+  # primitives. Patch routes through Filename.basename first. Drop once
+  # the fix lands upstream in js_of_ocaml and the OxCaml opam-repository
+  # pin updates.
   wasm_of_ocaml-compiler = overlay.wasm_of_ocaml-compiler.overrideAttrs (old: {
     nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.binaryen ];
+    patches = (old.patches or [ ]) ++ [ ./patches/wasm_of_ocaml-args-basename.patch ];
   });
 }

--- a/nix/patches/wasm_of_ocaml-args-basename.patch
+++ b/nix/patches/wasm_of_ocaml-args-basename.patch
@@ -1,0 +1,9 @@
+--- a/runtime/wasm/args.ml
++++ b/runtime/wasm/args.ml
+@@ -1,4 +1,5 @@
+ let () =
+   for i = 1 to Array.length Sys.argv - 1 do
+-    Format.printf "%s:%s@." (Filename.chop_suffix Sys.argv.(i) ".wat") Sys.argv.(i)
++    let p = Sys.argv.(i) in
++    Format.printf "%s:%s@." (Filename.chop_suffix (Filename.basename p) ".wat") p
+   done

--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -562,7 +562,7 @@ let reach t ~from =
 let reach_for_running ?(from = root) t =
   let fn = reach t ~from in
   match Filename.analyze_program_name fn with
-  | In_path -> "./" ^ fn
+  | In_path when not (String.equal fn ".") -> "./" ^ fn
   | _ -> fn
 ;;
 

--- a/otherlibs/stdune/test/path_tests.ml
+++ b/otherlibs/stdune/test/path_tests.ml
@@ -574,7 +574,7 @@ let%expect_test _ =
   reach_for_running (Path.relative root "foo") ~from:(Path.relative root "foo");
   [%expect
     {|
-"./."
+"."
 |}]
 ;;
 

--- a/src/dune_lang/value.ml
+++ b/src/dune_lang/value.ml
@@ -33,7 +33,7 @@ let to_dyn = function
   | Dir p -> Dyn.variant "dir" [ Path.to_dyn p ]
 ;;
 
-let string_of_path ~dir p = Path.reach ~from:dir p
+let string_of_path ~dir p = Path.reach_for_running ~from:dir p
 
 let to_string t ~dir =
   match t with

--- a/test/blackbox-tests/test-cases/bin-pform/public-name.t
+++ b/test/blackbox-tests/test-cases/bin-pform/public-name.t
@@ -18,7 +18,7 @@ The pform resolves to the build artifact:
 
   $ dune build bin-path
   $ cat _build/default/bin-path
-  mybin.exe
+  ./mybin.exe
 
 The rule depends on the build artifact:
 

--- a/test/blackbox-tests/test-cases/bin-pform/runnable-argument.t
+++ b/test/blackbox-tests/test-cases/bin-pform/runnable-argument.t
@@ -1,0 +1,38 @@
+When %{bin:foo} occurs in a bash action, it may be assumed to be runnable which
+was the case until after 3.23. In 3.24 %{bin:foo} would expand to the build
+path rather than the install staging path.
+
+This meant that binaries in the same directory are indistiguishable from
+commands, i.e. things to be looked up in PATH.
+
+  $ make_dune_project 3.24
+  $ cat >> dune-project <<EOF
+  > (package (name foopkg))
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable (public_name foo) (package foopkg))
+  > (rule
+  >  (alias runtest)
+  >  (action (bash %{bin:foo})))
+  > EOF
+
+  $ cat >foo.ml <<'EOF'
+  > let () = print_endline "hello from foo"
+  > EOF
+
+The following does not work because bash is looking up foo.exe in PATH rather
+than executing ./foo.exe directly.
+
+CR-soon Alizter: We should expand as ./ so that bash and other tools don't have
+to fall into this trap.
+
+The exact bash error message varies across systems, so we strip the
+bash-prefixed line and keep only the dune-side context.
+
+  $ dune build @runtest 2>&1 | grep -v '/bash:\|^bash:'
+  File "dune", lines 2-4, characters 0-51:
+  2 | (rule
+  3 |  (alias runtest)
+  4 |  (action (bash %{bin:foo})))
+  [1]

--- a/test/blackbox-tests/test-cases/bin-pform/runnable-argument.t
+++ b/test/blackbox-tests/test-cases/bin-pform/runnable-argument.t
@@ -1,9 +1,6 @@
-When %{bin:foo} occurs in a bash action, it may be assumed to be runnable which
-was the case until after 3.23. In 3.24 %{bin:foo} would expand to the build
-path rather than the install staging path.
-
-This meant that binaries in the same directory are indistiguishable from
-commands, i.e. things to be looked up in PATH.
+When %{bin:foo} occurs in a bash action, it must be runnable. This requires
+beginning the path with `./` when it occurs in the same directory, avoiding its
+lookup in PATH.
 
   $ make_dune_project 3.24
   $ cat >> dune-project <<EOF
@@ -21,18 +18,5 @@ commands, i.e. things to be looked up in PATH.
   > let () = print_endline "hello from foo"
   > EOF
 
-The following does not work because bash is looking up foo.exe in PATH rather
-than executing ./foo.exe directly.
-
-CR-soon Alizter: We should expand as ./ so that bash and other tools don't have
-to fall into this trap.
-
-The exact bash error message varies across systems, so we strip the
-bash-prefixed line and keep only the dune-side context.
-
-  $ dune build @runtest 2>&1 | grep -v '/bash:\|^bash:'
-  File "dune", lines 2-4, characters 0-51:
-  2 | (rule
-  3 |  (alias runtest)
-  4 |  (action (bash %{bin:foo})))
-  [1]
+  $ dune build @runtest
+  hello from foo

--- a/test/blackbox-tests/test-cases/dep-vars.t/run.t
+++ b/test/blackbox-tests/test-cases/dep-vars.t/run.t
@@ -1,5 +1,5 @@
 Dependencies are allowed :patterns
 
   $ dune runtest
-  foo = a b
-  baz = foo
+  foo = ./a ./b
+  baz = ./foo

--- a/test/blackbox-tests/test-cases/dialects/good.t/run.t
+++ b/test/blackbox-tests/test-cases/dialects/good.t/run.t
@@ -3,5 +3,5 @@ Test the (dialect ...) stanza inside the dune-project file.
   $ dune exec ./main.exe
 
   $ dune build @fmt
-  Formatting main.mf
-  Formatting main.mfi
+  Formatting ./main.mf
+  Formatting ./main.mfi

--- a/test/blackbox-tests/test-cases/dialects/no_impl.t/run.t
+++ b/test/blackbox-tests/test-cases/dialects/no_impl.t/run.t
@@ -3,7 +3,7 @@ Test the (dialect ...) stanza inside the `dune-project` file.
   $ dune exec ./main.exe
 
   $ dune build @fmt 2>&1 | grep -v "fake ocamlformat is running"
-  Formatting main.mfi
+  Formatting ./main.mfi
   File "fmt.ml", line 1, characters 0-0:
   --- fmt.ml
   +++ fmt.ml.corrected
@@ -27,5 +27,5 @@ Test the (dialect ...) stanza inside the `dune-project` file.
   > | .args.stderr
   > | gsub("^\\s+|\\s+$"; "")
   > ' | sort
-  fake ocamlformat is running: "--impl" "fmt.ml"
-  fake ocamlformat is running: "--impl" "main.ml"
+  fake ocamlformat is running: "--impl" "./fmt.ml"
+  fake ocamlformat is running: "--impl" "./main.ml"

--- a/test/blackbox-tests/test-cases/dialects/no_intf_good.t/run.t
+++ b/test/blackbox-tests/test-cases/dialects/no_intf_good.t/run.t
@@ -3,8 +3,8 @@ Test the (dialect ...) stanza inside the dune-project file.
   $ dune exec ./main.exe
 
   $ dune build @fmt
-  fake ocamlformat is running: "--impl" "fmt.ml"
-  Formatting main.mf
+  fake ocamlformat is running: "--impl" "./fmt.ml"
+  Formatting ./main.mf
   File "fmt.ml", line 1, characters 0-0:
   --- fmt.ml
   +++ fmt.ml.corrected

--- a/test/blackbox-tests/test-cases/dynamic-dependencies.t
+++ b/test/blackbox-tests/test-cases/dynamic-dependencies.t
@@ -37,7 +37,7 @@ Building `./output` should now produce a file with contents "depA depB"
   $ dune build ./output
 
   $ cat _build/default/output
-  depA depB
+  ./depA ./depB
 
 Doesn't work in dune pre 3.0
 
@@ -90,7 +90,7 @@ Works with aliases and other dependency specifications
   $ dune build @output
   building depA
   building depB
-  dependencies depB another_dep
+  dependencies ./depB ./another_dep
 
 Multiple `(include)` nesting
 
@@ -107,4 +107,4 @@ Multiple `(include)` nesting
   > EOF
 
   $ dune build @nested
-  metadeps: depB another_dep
+  metadeps: ./depB ./another_dep

--- a/test/blackbox-tests/test-cases/dynamic-dependencies/read-macro-produces-dyn-deps.t
+++ b/test/blackbox-tests/test-cases/dynamic-dependencies/read-macro-produces-dyn-deps.t
@@ -42,4 +42,4 @@ Building `./output` should now produce a file with contents "depA depB"
   contentsB
 
   $ cat ./_build/default/output
-  depA depB
+  ./depA ./depB

--- a/test/blackbox-tests/test-cases/formatting/no-gen.t
+++ b/test/blackbox-tests/test-cases/formatting/no-gen.t
@@ -57,8 +57,8 @@ Now we add [mli] files for the two modules whose implementation is generated:
 
 We format again. Filter menhir warnings (which vary by version) to keep output stable.
   $ dune build @fmt 2>&1 | grep -v "end-of-stream" | grep -v "never reduced" | grep -v 'File "parser_raw.mly"' | grep -v "in total"
-  fake ocamlformat is running: "--intf" "other_gen.mli"
-  fake ocamlformat is running: "--intf" "parser_raw.mli"
+  fake ocamlformat is running: "--intf" "./other_gen.mli"
+  fake ocamlformat is running: "--intf" "./parser_raw.mli"
   File "other_gen.mli", line 1, characters 0-0:
   --- other_gen.mli
   +++ other_gen.mli.corrected

--- a/test/blackbox-tests/test-cases/misc.t/dune
+++ b/test/blackbox-tests/test-cases/misc.t/dune
@@ -5,7 +5,7 @@
  (deps    dune (glob_files *.txt))
  (action  (progn
            (with-stdout-to result   (echo %{deps}))
-           (with-stdout-to expected (echo "dune a.txt b.txt c.txt")))))
+           (with-stdout-to expected (echo "./dune ./a.txt ./b.txt ./c.txt")))))
 
 (rule
  (targets result2 expected2)

--- a/test/blackbox-tests/test-cases/output-obj.t/dune
+++ b/test/blackbox-tests/test-cases/output-obj.t/dune
@@ -63,9 +63,9 @@
 (alias
  (name   runtest)
  (deps   test.bc%{ext_dll})
- (action (run ./dynamic.exe ./%{deps})))
+ (action (run ./dynamic.exe %{deps})))
 
 (alias
  (name   runtest)
  (deps   test%{ext_dll})
- (action (run ./dynamic.exe ./%{deps})))
+ (action (run ./dynamic.exe %{deps})))

--- a/test/blackbox-tests/test-cases/quoting/good.t/run.t
+++ b/test/blackbox-tests/test-cases/quoting/good.t/run.t
@@ -1,11 +1,10 @@
 The targets should only be interpreted as a single path when quoted
 
   $ dune build s
-  File "dune", lines 1-3, characters 0-72:
-  1 | (rule
-  2 |  (targets s t)
+  File "dune", line 3, characters 25-37:
   3 |  (action (with-stdout-to "%{targets}" (echo foo))))
-  Error: Rule failed to generate the following targets:
-  - s
-  - t
+                               ^^^^^^^^^^^^
+  Error: This action has targets in a different directory than the current one,
+  this is not allowed by dune at the moment:
+  - "s ./t"
   [1]

--- a/test/blackbox-tests/test-cases/shadow-bindings.t/run.t
+++ b/test/blackbox-tests/test-cases/shadow-bindings.t/run.t
@@ -1,5 +1,5 @@
 Bindings introduced by user dependencies should shadow existing bindings
 
   $ dune runtest
-  foo
-  xb
+  ./foo
+  ./xb

--- a/test/blackbox-tests/test-cases/string-with-vars.t
+++ b/test/blackbox-tests/test-cases/string-with-vars.t
@@ -26,9 +26,9 @@ Expanding a pform with multiple values:
 
   $ dune build foo.txt
   $ cat _build/default/foo.txt
-  foo.txt bar.txt
-  foo.txt bar.txt
-  beforefoo.txtbar.txtafter
-  beforefoo.txt bar.txtafter
-  foo.txtbar.txtfoo.txtbar.txt
-  foo.txt bar.txtfoo.txt bar.txt
+  ./foo.txt ./bar.txt
+  ./foo.txt ./bar.txt
+  before./foo.txt./bar.txtafter
+  before./foo.txt ./bar.txtafter
+  ./foo.txt./bar.txt./foo.txt./bar.txt
+  ./foo.txt ./bar.txt./foo.txt ./bar.txt

--- a/test/blackbox-tests/test-cases/watching/fmt-test.t
+++ b/test/blackbox-tests/test-cases/watching/fmt-test.t
@@ -20,7 +20,7 @@ Remove the fake ocamlformat from the dune file to see the real output
   (* fake ocamlformat output *)
 
   $ stop_dune
-  fake ocamlformat is running: "--impl" "foo.ml"
+  fake ocamlformat is running: "--impl" "./foo.ml"
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml
   +++ foo.ml.corrected

--- a/test/blackbox-tests/test-cases/watching/retriggering.t
+++ b/test/blackbox-tests/test-cases/watching/retriggering.t
@@ -27,8 +27,8 @@ is ignored because the contents of new-source.txt is the same,
 i.e. the empty file.
 
   $ cat ../output
-  I'm seeing: old-source.txt
-  I'm seeing: new-source.txt old-source.txt
+  I'm seeing: ./old-source.txt
+  I'm seeing: ./new-source.txt ./old-source.txt
 
   $ stop_dune
   Success, waiting for filesystem changes...


### PR DESCRIPTION
Backport #15156 onto 3.24.0-rc.

Also includes the test commit from #15148 (`test: bash bin pform`) as a prerequisite, since the test file `runnable-argument.t` modified by #15156 was introduced in #15148 and is not yet on 3.24.0-rc.