### PR TITLE
refactor(rpc): remove csexp server ready barrier

### DIFF
--- a/src/rpc/csexp_rpc.ml
+++ b/src/rpc/csexp_rpc.ml
@@ -442,7 +442,6 @@ module Server = struct
   type t =
     { id : Id.t
     ; mutable state : [ `Listening of Transport.t | `Serving of Transport.t | `Closed ]
-    ; ready : unit Fiber.Ivar.t
     }
 
   let create sockaddrs ~backlog =
@@ -475,12 +474,10 @@ module Server = struct
         let fds = List.map sockaddrs ~f:bind_socket in
         let transport = Transport.create (List.combine sockaddrs fds) ~backlog in
         bound := [];
-        Ok { id = Id.gen (); state = `Listening transport; ready = Fiber.Ivar.create () })
+        Ok { id = Id.gen (); state = `Listening transport })
     with
     | Unix.Unix_error (EADDRINUSE, _, _) -> Error `Already_in_use
   ;;
-
-  let ready t = Fiber.Ivar.read t.ready
 
   let serve (t : t) =
     let transport =
@@ -490,7 +487,6 @@ module Server = struct
       | `Listening transport -> transport
     in
     t.state <- `Serving transport;
-    let+ () = Fiber.Ivar.fill t.ready () in
     let loop () =
       Dune_trace.emit Rpc (fun () ->
         Dune_trace.Event.Rpc.accept ~id:(Id.to_int t.id) `Start None);
@@ -507,7 +503,7 @@ module Server = struct
       | Error _ | Ok None -> None
       | Ok (Some fd) -> Some (Session.create fd)
     in
-    Fiber.Stream.In.create loop
+    Fiber.return (Fiber.Stream.In.create loop)
   ;;
 
   let stop t =

--- a/src/rpc/csexp_rpc.mli
+++ b/src/rpc/csexp_rpc.mli
@@ -47,10 +47,6 @@ module Server : sig
   (** [create sockaddrs ~backlog] binds and starts listening on [sockaddrs]. *)
   val create : Unix.sockaddr list -> backlog:int -> (t, [ `Already_in_use ]) result
 
-  (** [ready t] returns a fiber that completes once [serve t] is accepting
-      clients. *)
-  val ready : t -> unit Fiber.t
-
   (** [stop t] completes only after the listening sockets are closed and no new
       clients can connect. *)
   val stop : t -> unit Fiber.t

--- a/src/rpc/server.ml
+++ b/src/rpc/server.ml
@@ -929,9 +929,7 @@ module Lifecycle = struct
   let ready t =
     Fiber.Ivar.read t.startup_ivar
     >>= function
-    | Ok server ->
-      let+ () = Csexp_rpc.Server.ready server in
-      Ok ()
+    | Ok _ -> Fiber.return (Ok ())
     | Error _ as error -> Fiber.return error
   ;;
 


### PR DESCRIPTION
Csexp_rpc.Server.create binds and listens immediately, so drop the ready ivar and public ready API. Keep Rpc.Server.Lifecycle.ready as the Dune-facing startup barrier, but make it depend only on server creation.