### PR TITLE
stdune: add Linux process-tree helpers

### DIFF
--- a/otherlibs/stdune/src/pid.ml
+++ b/otherlibs/stdune/src/pid.ml
@@ -11,3 +11,5 @@ let of_int_exn t =
 ;;
 
 let me () = Unix.getpid ()
+
+module Set = Int.Set

--- a/otherlibs/stdune/src/pid.mli
+++ b/otherlibs/stdune/src/pid.mli
@@ -10,3 +10,5 @@ val me : unit -> t
 (** Unsafe cast of integers to pids. Will be removed once we improve the API
     further *)
 val of_int_exn : int -> t
+
+module Set : Set.S with type elt = t

--- a/otherlibs/stdune/src/proc.ml
+++ b/otherlibs/stdune/src/proc.ml
@@ -68,6 +68,70 @@ module Process_info = struct
     }
 end
 
+module Linux = struct
+  module Process_tree = struct
+    type error =
+      | Cannot_read_directory of
+          { path : string
+          ; error : Unix_error.Detailed.t
+          }
+      | Cannot_read_file of
+          { path : string
+          ; error : Unix_error.Detailed.t
+          }
+      | Cannot_parse_children_file of
+          { path : string
+          ; word : string
+          }
+
+    let pp_error = function
+      | Cannot_read_directory { path; error } ->
+        Pp.textf
+          "unable to read process directory %s: %s"
+          path
+          (Unix_error.Detailed.to_string_hum error)
+      | Cannot_read_file { path; error } ->
+        Pp.textf
+          "unable to read process children file %s: %s"
+          path
+          (Unix_error.Detailed.to_string_hum error)
+      | Cannot_parse_children_file { path; word } ->
+        Pp.textf "unable to parse process id %S in %s" word path
+    ;;
+
+    let parse_children_file path lines =
+      Result.List.fold_left lines ~init:Pid.Set.empty ~f:(fun acc line ->
+        String.split line ~on:' '
+        |> Result.List.fold_left ~init:acc ~f:(fun acc word ->
+          if String.is_empty word
+          then Ok acc
+          else (
+            match Int.of_string word with
+            | Some pid when pid > 0 -> Ok (Pid.Set.add acc (Pid.of_int_exn pid))
+            | Some _ | None -> Error (Cannot_parse_children_file { path; word }))))
+    ;;
+
+    let children_of pid =
+      let pid = Pid.to_int pid in
+      match
+        let tasks_dir = Printf.sprintf "/proc/%d/task" pid in
+        match Readdir.read_directory tasks_dir with
+        | Ok entries -> Ok entries
+        | Error error -> Error (Cannot_read_directory { path = tasks_dir; error })
+      with
+      | Error _ as error -> error
+      | Ok tasks ->
+        Result.List.fold_left tasks ~init:Pid.Set.empty ~f:(fun acc tid ->
+          let path = Printf.sprintf "/proc/%d/task/%s/children" pid tid in
+          match Unix_error.Detailed.catch Io.String_path.lines_of_file path with
+          | Error (Unix.ENOENT, _, _) -> Ok acc
+          | Error error -> Error (Cannot_read_file { path; error })
+          | Ok lines ->
+            parse_children_file path lines |> Result.map ~f:(Pid.Set.union acc))
+    ;;
+  end
+end
+
 external stub_wait4
   :  int
   -> Unix.wait_flag list

--- a/otherlibs/stdune/src/proc.mli
+++ b/otherlibs/stdune/src/proc.mli
@@ -2,7 +2,7 @@
 
   - [prog] is the program being run. It should be a filename in the current working
     directory.
-  
+
   - [args] is a list of arguments to the program. Unlike in the system call [execve], the
     first argument is not the program name. The first argument is the first argument
     to the program. The program name is set to [prog] without the caller needing to.
@@ -45,6 +45,18 @@ module Process_info : sig
     ; end_time : Time.t (** Time at which the process finished. *)
     ; resource_usage : Resource_usage.t option
     }
+end
+
+module Linux : sig
+  module Process_tree : sig
+    type error
+
+    val pp_error : error -> _ Pp.t
+
+    (** [children_of pid] returns the direct children of [pid] by reading
+        /proc/<pid>/task/<tid>/children. *)
+    val children_of : Pid.t -> (Pid.Set.t, error) Result.t
+  end
 end
 
 type wait =

--- a/otherlibs/stdune/test/dune
+++ b/otherlibs/stdune/test/dune
@@ -1,6 +1,6 @@
 (library
  (name stdune_unit_tests)
- (modules :standard \ path_external_build_tests path_tests)
+ (modules :standard \ path_external_build_tests path_tests proc_linux_tests)
  (inline_tests
   (deps
    (source_tree ../unit-tests/findlib-db)
@@ -36,6 +36,22 @@
 (library
  (name stdune_external_build_tests)
  (modules path_external_build_tests)
+ (inline_tests)
+ (libraries
+  stdune
+  unix
+  ppx_expect.config
+  ppx_expect.config_types
+  base
+  ppx_inline_test.config)
+ (preprocess
+  (pps ppx_expect)))
+
+(library
+ (name stdune_proc_linux_tests)
+ (modules proc_linux_tests)
+ (enabled_if
+  (= %{system} linux))
  (inline_tests)
  (libraries
   stdune

--- a/otherlibs/stdune/test/proc_linux_tests.ml
+++ b/otherlibs/stdune/test/proc_linux_tests.ml
@@ -1,0 +1,102 @@
+open Stdune
+
+(* Avoid running inherited [at_exit] hooks in forked children. *)
+external sys_exit : int -> 'a = "caml_sys_exit"
+
+let sleep_forever () =
+  while true do
+    Unix.sleep max_int
+  done
+;;
+
+let wait_no_eintr pid =
+  let pid = Pid.to_int pid in
+  let rec loop () =
+    match Unix.waitpid [] pid with
+    | _ -> ()
+    | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop ()
+  in
+  loop ()
+;;
+
+let read_until_eof fd =
+  let buffer = Bytes.create 1 in
+  let rec loop () =
+    match Unix.read fd buffer 0 1 with
+    | 0 -> Unix.close fd
+    | _ -> loop ()
+    | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop ()
+  in
+  loop ()
+;;
+
+let fork_child_with_grandchild () =
+  let read_fd, write_fd = Unix.pipe () in
+  match Unix.fork () with
+  | 0 ->
+    (match
+       Unix.close read_fd;
+       let child_read_fd, child_write_fd = Unix.pipe () in
+       match Unix.fork () with
+       | 0 ->
+         Unix.close write_fd;
+         Unix.close child_write_fd;
+         read_until_eof child_read_fd;
+         sys_exit 0
+       | grandchild ->
+         Unix.close child_read_fd;
+         let oc = Unix.out_channel_of_descr write_fd in
+         Printf.fprintf oc "%d\n%!" grandchild;
+         close_out oc;
+         sleep_forever ()
+     with
+     | _ -> sys_exit 1)
+  | child ->
+    let child = Pid.of_int_exn child in
+    Unix.close write_fd;
+    let ic = Unix.in_channel_of_descr read_fd in
+    let grandchild = input_line ic |> Int.of_string_exn |> Pid.of_int_exn in
+    close_in ic;
+    child, grandchild
+;;
+
+let cleanup_child_tree (child, _grandchild) =
+  Unix.kill (Pid.to_int child) Sys.sigkill;
+  wait_no_eintr child
+;;
+
+let children_contain_only_child ~child ~grandchild =
+  let self = Pid.me () in
+  let rec loop attempts_left =
+    match Proc.Linux.Process_tree.children_of self with
+    | Error _ -> Error ()
+    | Ok children ->
+      if Pid.Set.mem children child && not (Pid.Set.mem children grandchild)
+      then Ok true
+      else if attempts_left = 0
+      then Ok false
+      else (
+        Unix.sleepf 0.01;
+        loop (attempts_left - 1))
+  in
+  loop 100
+;;
+
+let%expect_test "Linux process tree direct children" =
+  let child_tree = fork_child_with_grandchild () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_child_tree child_tree)
+    (fun () ->
+       let child, grandchild = child_tree in
+       match children_contain_only_child ~child ~grandchild with
+       | Error () -> print_endline "error reading process tree"
+       | Ok found -> printfn "found direct child only: %b" found);
+  [%expect {| found direct child only: true |}]
+;;
+
+let%expect_test "Linux process tree reports missing roots" =
+  (match Proc.Linux.Process_tree.children_of (Pid.of_int_exn max_int) with
+   | Ok _ -> print_endline "unexpected success"
+   | Error _ -> print_endline "error");
+  [%expect {| error |}]
+;;


### PR DESCRIPTION
Expose [Pid.Set] and add [Proc.Linux.Process_tree.children_of] for reading direct children from /proc/<pid>/task/*/children on Linux.

Add Linux-only expect tests for direct-child scanning and missing process roots.