### PR TITLE
scheduler: clean up escaped subreaper children before builds

### DIFF
--- a/doc/changes/changed/15239.md
+++ b/doc/changes/changed/15239.md
@@ -1,0 +1,2 @@
+- Cleanup all build processes spawned by dune before starting a fresh build on
+  Linux. (#15239, @rgrinberg)

--- a/src/dune_engine/build_loop.ml
+++ b/src/dune_engine/build_loop.ml
@@ -236,13 +236,14 @@ let run_current_build
    | Building _ -> assert false
    | Standing_by | Restarting_build _ -> ());
   t.status <- Building run_id;
-  let+ outcome =
+  let* outcome =
     let build_ctx =
       Process.Build.create ~action_runner ~run_id ~cancellation:(Fiber.Cancel.create ())
     in
     Process.Build.with_ build_ctx (fun () ->
       Build_system.run_action_builder ?restart_started_at ~build:build_ctx build)
   in
+  let+ () = Scheduler.cleanup_subreaper_child_processes () in
   let next =
     match t.status with
     | Restarting_build _ -> `Restart

--- a/src/dune_scheduler/dune
+++ b/src/dune_scheduler/dune
@@ -25,7 +25,7 @@
   (pps ppx_expect -- %{read-lines:ppx-extra-flags}))
  (foreign_stubs
   (language c)
-  (names fsevents_stubs fswatch_win_stubs))
+  (names fsevents_stubs fswatch_win_stubs subreaper_stubs))
  (libraries
   ocaml_inotify
   lev

--- a/src/dune_scheduler/file_watcher.ml
+++ b/src/dune_scheduler/file_watcher.ml
@@ -440,6 +440,12 @@ let dispatch_backend_events events backend_events =
 let close t = Thread_safe_channel.close t.events
 let read t = Thread_safe_channel.read t.events
 
+let child_pids t =
+  match t.kind with
+  | Fswatch { pid; _ } -> Some pid
+  | Inotify _ | Fsevents _ | Fswatch_win _ -> None
+;;
+
 let shutdown t =
   close t;
   match t.kind with

--- a/src/dune_scheduler/file_watcher.mli
+++ b/src/dune_scheduler/file_watcher.mli
@@ -17,6 +17,9 @@ val close : t -> unit
 val read : t -> Event.File_watcher_event.t list option Fiber.t
 val flush : t -> unit Fiber.t
 
+(** Child processes owned by the file watcher. *)
+val child_pids : t -> Pid.t option
+
 (** The action that needs to be taken to shutdown the watcher. *)
 val shutdown : t -> [ `Kill of Pid.t | `No_op | `Thunk of unit -> unit ]
 

--- a/src/dune_scheduler/process_watcher.ml
+++ b/src/dune_scheduler/process_watcher.ml
@@ -87,6 +87,10 @@ module Process_table = struct
 
   let iter t ~f = Table.iter t.table ~f
   let running_count t = t.running_count
+
+  let running_pids t =
+    Table.foldi t.table ~init:Pid.Set.empty ~f:(fun pid _ acc -> Pid.Set.add acc pid)
+  ;;
 end
 
 let register_job_win32 t job =
@@ -102,6 +106,12 @@ let running_count_win32 t =
 
 let running_count_unix t = Process_table.running_count t
 let running_count = if Sys.win32 then running_count_win32 else running_count_unix
+
+let running_pids_win32 t =
+  Mutex.protect (Lazy.force t.mutex) (fun () -> Process_table.running_pids t)
+;;
+
+let running_pids = if Sys.win32 then running_pids_win32 else Process_table.running_pids
 
 let killall_unix t signal =
   Process_table.iter t ~f:(fun job ->

--- a/src/dune_scheduler/process_watcher.mli
+++ b/src/dune_scheduler/process_watcher.mli
@@ -13,6 +13,7 @@ val register_job : t -> Event.job -> unit
 
 val is_running : t -> Pid.t -> bool
 val running_count : t -> int
+val running_pids : t -> Pid.Set.t
 
 (** Send the following signal to all running processes. *)
 val killall : t -> Signal.t -> unit

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -13,6 +13,15 @@ let spawn_thread ~name f = Thread0.spawn ~name f
 
 include Types.Scheduler
 
+external set_child_subreaper : unit -> bool = "dune_scheduler_set_child_subreaper"
+
+let child_subreaper_enabled =
+  lazy
+    (match Platform.OS.value with
+     | Platform.OS.Linux -> set_child_subreaper ()
+     | _ -> false)
+;;
+
 let running_jobs_count (t : t) = Process_watcher.running_count t.process_watcher
 
 exception Build_cancelled
@@ -50,7 +59,12 @@ let with_job_slot ?cancellation f =
 let wait_for_process t ~is_process_group_leader pid =
   let ivar = Fiber.Ivar.create () in
   Process_watcher.register_job t.process_watcher { pid; is_process_group_leader; ivar };
-  Fiber.Ivar.read ivar
+  let+ proc_info = Fiber.Ivar.read ivar in
+  if Pid.Set.mem t.preserved_child_processes proc_info.pid
+  then
+    t.preserved_child_processes
+    <- Pid.Set.remove t.preserved_child_processes proc_info.pid;
+  proc_info
 ;;
 
 (* Grace period before escalating from SIGTERM to SIGKILL *)
@@ -60,6 +74,135 @@ type termination_reason =
   | Normal
   | Cancel
   | Timeout
+
+let child_process_poll_interval = Time.Span.of_secs 0.01
+
+let preserve_child_process pid =
+  Option.iter (t_opt ()) ~f:(fun t ->
+    t.preserved_child_processes <- Pid.Set.add t.preserved_child_processes pid)
+;;
+
+let trace_child_process_cleanup pids stage =
+  Dune_trace.emit Process (fun () ->
+    let pids = Pid.Set.to_list pids in
+    Dune_trace.Event.child_process_cleanup ~pids stage)
+;;
+
+let warn_child_process_cleanup_failed pids paragraphs =
+  trace_child_process_cleanup pids `Failed;
+  User_warning.emit
+    ([ Pp.text "Unable to clean up subreaper child processes." ]
+     @ paragraphs
+     @ [ Pp.text "Continuing without failing the current operation." ])
+;;
+
+let child_process_cleanup_candidates t =
+  let preserved_child_processes =
+    Pid.Set.union
+      t.preserved_child_processes
+      (Process_watcher.running_pids t.process_watcher)
+  in
+  match Proc.Linux.Process_tree.children_of (Pid.me ()) with
+  | Error _ as error -> error
+  | Ok pids -> Ok (Pid.Set.diff pids preserved_child_processes)
+;;
+
+let child_process_cleanup_candidates_after_reap t =
+  match child_process_cleanup_candidates t with
+  | Error _ as error -> error
+  | Ok pids ->
+    Pid.Set.iter pids ~f:(fun pid ->
+      ignore (Proc.wait (Proc.Pid pid) [ WNOHANG ] : Proc.Process_info.t option));
+    child_process_cleanup_candidates t
+;;
+
+let signal_processes pids signal =
+  if Pid.Set.is_empty pids
+  then Ok ()
+  else (
+    trace_child_process_cleanup pids (`Sent_signal signal);
+    Pid.Set.fold pids ~init:(Ok ()) ~f:(fun pid acc ->
+      match acc with
+      | Error _ -> acc
+      | Ok () ->
+        (match Pid.kill pid `Pid signal with
+         | () -> Ok ()
+         | exception Unix.Unix_error (Unix.ESRCH, _, _) -> Ok ()
+         | exception exn ->
+           Error
+             [ Pp.textf
+                 "failed to signal child process %d with SIG%s"
+                 (Pid.to_int pid)
+                 (Signal.name signal)
+             ; Exn.pp exn
+             ])))
+;;
+
+let rec await_no_child_processes t ~deadline ~signal ~signaled =
+  match child_process_cleanup_candidates_after_reap t with
+  | Error error -> Fiber.return (`Failed [ Proc.Linux.Process_tree.pp_error error ])
+  | Ok pids when Pid.Set.is_empty pids -> Fiber.return `Exited
+  | Ok pids when Time.(now () >= deadline) -> Fiber.return (`Timed_out pids)
+  | Ok pids ->
+    let unsignaled = Pid.Set.diff pids signaled in
+    (match signal_processes unsignaled signal with
+     | Error paragraphs -> Fiber.return (`Failed paragraphs)
+     | Ok () ->
+       Async_io.Task.await (Async_io.sleep t.async_io child_process_poll_interval)
+       >>= (function
+        | Ok () ->
+          let signaled = Pid.Set.union signaled unsignaled in
+          await_no_child_processes t ~deadline ~signal ~signaled
+        | Error (`Exn _) -> assert false
+        | Error `Cancelled ->
+          (match child_process_cleanup_candidates_after_reap t with
+           | Ok pids -> Fiber.return (`Timed_out pids)
+           | Error error ->
+             Fiber.return (`Failed [ Proc.Linux.Process_tree.pp_error error ]))))
+;;
+
+let cleanup_subreaper_child_processes_impl t =
+  match child_process_cleanup_candidates_after_reap t with
+  | Error error ->
+    warn_child_process_cleanup_failed
+      Pid.Set.empty
+      [ Proc.Linux.Process_tree.pp_error error ];
+    Fiber.return ()
+  | Ok pids when Pid.Set.is_empty pids -> Fiber.return ()
+  | Ok pids ->
+    trace_child_process_cleanup pids `Started;
+    let deadline = Time.add (Time.now ()) sigterm_grace_period in
+    await_no_child_processes t ~deadline ~signal:Term ~signaled:Pid.Set.empty
+    >>= (function
+     | `Failed paragraphs ->
+       warn_child_process_cleanup_failed pids paragraphs;
+       Fiber.return ()
+     | `Exited ->
+       trace_child_process_cleanup pids `Finished;
+       Fiber.return ()
+     | `Timed_out _ ->
+       let deadline = Time.add (Time.now ()) sigterm_grace_period in
+       await_no_child_processes t ~deadline ~signal:Kill ~signaled:Pid.Set.empty
+       >>| (function
+        | `Failed paragraphs -> warn_child_process_cleanup_failed pids paragraphs
+        | `Exited -> trace_child_process_cleanup pids `Finished
+        | `Timed_out pids ->
+          warn_child_process_cleanup_failed
+            pids
+            [ Pp.text "child processes remained alive after SIGTERM and SIGKILL"
+            ; Pp.textf
+                "child processes still alive: %s"
+                (Pid.Set.to_list pids
+                 |> List.map ~f:(fun pid -> Pid.to_int pid |> Int.to_string)
+                 |> String.concat ~sep:", ")
+            ]))
+;;
+
+let cleanup_subreaper_child_processes () =
+  if Lazy.force child_subreaper_enabled
+  then cleanup_subreaper_child_processes_impl (t ())
+  else Fiber.return ()
+;;
 
 (* We use this version privately in this module whenever we can pass the
    scheduler explicitly *)
@@ -160,7 +303,7 @@ let kill_and_wait_for_all_processes t =
      reset with the correct event queue. *)
   if not Sys.win32
   then (
-    Unix.kill (Unix.getpid ()) (Signal.to_int Thread0.signal_watcher_interrupt);
+    Pid.kill (Pid.me ()) `Pid Thread0.signal_watcher_interrupt;
     Thread.join t.signal_watcher);
   !saw_signal
 ;;
@@ -180,6 +323,7 @@ let () =
 ;;
 
 let prepare (config : Config.t) ~events ~file_watcher =
+  ignore (Lazy.force child_subreaper_enabled : bool);
   (* The signal watcher must be initialized first so that signals are
      blocked in all threads. *)
   let signal_watcher =
@@ -195,6 +339,14 @@ let prepare (config : Config.t) ~events ~file_watcher =
     ; thread_pool = lazy (Thread_pool.create ~min_workers:4 ~max_workers:50)
     ; signal_watcher
     ; async_io
+    ; preserved_child_processes =
+        (match
+           match file_watcher with
+           | None -> None
+           | Some file_watcher -> File_watcher.child_pids file_watcher
+         with
+         | None -> Pid.Set.empty
+         | Some p -> Pid.Set.singleton p)
     }
   in
   current := Some t;

--- a/src/dune_scheduler/scheduler.mli
+++ b/src/dune_scheduler/scheduler.mli
@@ -90,6 +90,14 @@ val running_jobs_count : t -> int
     restart. *)
 val shutdown : [ `Ok | `Failure ] -> unit
 
+(** Terminate child processes that Dune adopted as a Linux subreaper. No-op on
+    other platforms. Failures are reported as warnings and do not fail the
+    current operation. *)
+val cleanup_subreaper_child_processes : unit -> unit Fiber.t
+
+(** Prevent subreaper cleanup from treating [pid] as an escaped action child. *)
+val preserve_child_process : Pid.t -> unit
+
 (** [sleep duration] waits for [duration] to elapse. *)
 val sleep : Time.Span.t -> unit Fiber.t
 

--- a/src/dune_scheduler/subreaper_stubs.c
+++ b/src/dune_scheduler/subreaper_stubs.c
@@ -1,0 +1,25 @@
+#include <caml/mlvalues.h>
+
+#if defined(__linux__)
+
+#include <caml/unixsupport.h>
+#include <errno.h>
+#include <sys/prctl.h>
+
+CAMLprim value dune_scheduler_set_child_subreaper(value v_unit) {
+  (void)v_unit;
+  if (prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) == -1) {
+    if (errno == EINVAL) return Val_false;
+    uerror("prctl", Nothing);
+  }
+  return Val_true;
+}
+
+#else
+
+CAMLprim value dune_scheduler_set_child_subreaper(value v_unit) {
+  (void)v_unit;
+  return Val_false;
+}
+
+#endif

--- a/src/dune_scheduler/types.ml
+++ b/src/dune_scheduler/types.ml
@@ -67,6 +67,7 @@ module Scheduler = struct
     ; thread_pool : Thread_pool.t Lazy.t
     ; signal_watcher : Thread.t
     ; async_io : Async_io.t
+    ; mutable preserved_child_processes : Pid.Set.t
     }
 
   let current : t option ref = ref None

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -118,6 +118,12 @@ module Event : sig
   val process_cleanup_start : unit -> t
   val process_cleanup_sigkill : unit -> t
   val process_cleanup_finish : unit -> t
+
+  val child_process_cleanup
+    :  pids:Pid.t list
+    -> [ `Started | `Sent_signal of Signal.t | `Finished | `Failed ]
+    -> t
+
   val watch_build_start : run_id:int -> restart:bool -> start:Time.t -> t
   val watch_build_restart : run_id:int -> reasons:string list -> at:Time.t -> t
 

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -252,6 +252,27 @@ let process_cleanup_finish () =
   Event.instant ~name:"process-cleanup-finish" (Time.now ()) Process
 ;;
 
+let child_process_cleanup ~pids stage =
+  let stage, extra_args =
+    match stage with
+    | `Started -> "started", []
+    | `Sent_signal signal -> "sent-signal", [ "signal", Arg.string (Signal.name signal) ]
+    | `Finished -> "finished", []
+    | `Failed -> "failed", []
+  in
+  let args =
+    [ "stage", Arg.string stage
+    ; "pid_count", Arg.int (List.length pids)
+    ; "pids", Arg.list (List.map pids ~f:(fun pid -> Arg.int (Pid.to_int pid)))
+    ]
+  in
+  Event.instant
+    ~args:(args @ extra_args)
+    ~name:"child-process-cleanup"
+    (Time.now ())
+    Process
+;;
+
 let watch_build_start ~run_id ~restart ~start =
   let args =
     [ "run_id", Arg.int run_id; "restart", Arg.bool restart ]

--- a/test/blackbox-tests/test-cases/actions/bin/dune
+++ b/test/blackbox-tests/test-cases/actions/bin/dune
@@ -1,0 +1,5 @@
+(executable
+ (name sub_process)
+ (enabled_if
+  (= %{system} linux))
+ (libraries unix))

--- a/test/blackbox-tests/test-cases/actions/bin/sub_process.ml
+++ b/test/blackbox-tests/test-cases/actions/bin/sub_process.ml
@@ -1,0 +1,73 @@
+let write_pid path =
+  let oc = open_out path in
+  Printf.fprintf oc "%d" (Unix.getpid ());
+  close_out oc
+;;
+
+let sleep_forever () =
+  while true do
+    Unix.sleep max_int
+  done
+;;
+
+let signal_ready write_fd =
+  let ready = Bytes.of_string "x" in
+  ignore (Unix.write write_fd ready 0 1 : int);
+  Unix.close write_fd
+;;
+
+let wait_ready read_fd =
+  let ready = Bytes.create 1 in
+  ignore (Unix.read read_fd ready 0 1 : int);
+  Unix.close read_fd
+;;
+
+let install_term_writer path =
+  Sys.set_signal
+    Sys.sigterm
+    (Sys.Signal_handle
+       (fun _ ->
+         write_pid path;
+         exit 0))
+;;
+
+let () =
+  match Sys.argv with
+  | [| _; "setsid"; pid_file |] ->
+    let read_fd, write_fd = Unix.pipe () in
+    (match Unix.fork () with
+     | 0 ->
+       Unix.close read_fd;
+       ignore (Unix.setsid () : int);
+       write_pid pid_file;
+       signal_ready write_fd;
+       sleep_forever ()
+     | _ ->
+       Unix.close write_fd;
+       wait_ready read_fd)
+  | [| _; "term-child"; parent_pid_file; child_cleanup_file |] ->
+    let parent_read_fd, parent_write_fd = Unix.pipe () in
+    (match Unix.fork () with
+     | 0 ->
+       Unix.close parent_read_fd;
+       ignore (Unix.setsid () : int);
+       let child_read_fd, child_write_fd = Unix.pipe () in
+       (match Unix.fork () with
+        | 0 ->
+          Unix.close parent_write_fd;
+          Unix.close child_read_fd;
+          install_term_writer child_cleanup_file;
+          signal_ready child_write_fd;
+          sleep_forever ()
+        | _ ->
+          Unix.close child_write_fd;
+          wait_ready child_read_fd;
+          Sys.set_signal Sys.sigterm (Sys.Signal_handle (fun _ -> exit 0));
+          write_pid parent_pid_file;
+          signal_ready parent_write_fd;
+          sleep_forever ())
+     | _ ->
+       Unix.close parent_write_fd;
+       wait_ready parent_read_fd)
+  | _ -> assert false
+;;

--- a/test/blackbox-tests/test-cases/actions/dune
+++ b/test/blackbox-tests/test-cases/actions/dune
@@ -4,5 +4,12 @@
   (<> %{system} macosx)))
 
 (cram
+ (applies_to subreaper)
+ (deps
+  (source_tree bin))
+ (enabled_if
+  (= %{system} linux)))
+
+(cram
  (applies_to concurrent)
  (enabled_if false))

--- a/test/blackbox-tests/test-cases/actions/subreaper.t
+++ b/test/blackbox-tests/test-cases/actions/subreaper.t
@@ -1,0 +1,120 @@
+Dune is a Linux subreaper, so a process that leaves the action's process group
+is adopted by Dune and cleaned up after the build.
+
+  $ make_dune_project 3.23
+
+  $ pid_file=$TMPDIR/escaped-pid
+  $ cat >dune <<EOF
+  > (rule
+  >  (target first)
+  >  (action
+  >   (progn
+  >    (run %{exe:bin/sub_process.exe} setsid "$pid_file")
+  >    (with-stdout-to first (echo done)))))
+  > EOF
+
+  $ start_dune
+
+  $ build first
+  Success
+
+The process called setsid, so it left the process group that Dune created for
+the action. Dune scans its children after the build and terminates adopted
+processes.
+
+  $ with_timeout dune_cmd wait-for-file-to-appear "$pid_file"
+  $ child_pid=$(cat "$pid_file")
+  $ if kill -0 "$child_pid" 2>/dev/null; then
+  >   echo "FAILURE: escaped process is still running"
+  > else
+  >   echo "SUCCESS: escaped process was killed"
+  > fi
+  SUCCESS: escaped process was killed
+
+  $ stop_dune_quiet
+
+  $ dune trace cat | jq -r '
+  >   select(.name == "child-process-cleanup" and .args.pid_count > 0)
+  > | .args.stage
+  > ' | sort -u
+  finished
+  sent-signal
+  started
+
+If a file change cancels a build, Dune runs subreaper cleanup before starting
+the replacement build.
+
+  $ cancel_pid_file=$TMPDIR/cancel-pid
+  $ cancel_started_file=$TMPDIR/cancel-started
+  $ cancel_release_file=$TMPDIR/cancel-release
+  $ echo initial > watched-input
+  $ cat >>dune <<EOF
+  > (rule
+  >  (target eighth)
+  >  (deps watched-input)
+  >  (action
+  >   (bash "\| if grep -q initial watched-input; then
+  >         "\|   %{exe:bin/sub_process.exe} setsid '$cancel_pid_file'
+  >         "\| fi
+  >         "\| touch '$cancel_started_file'
+  >         "\| while [ ! -e '$cancel_release_file' ]; do
+  >         "\|   sleep 0.01
+  >         "\| done
+  >         "\| echo done > eighth
+  > )))
+  > EOF
+
+  $ start_dune
+
+  $ dune rpc build --wait eighth >cancel-build.out 2>&1 &
+  $ cancel_build=$!
+  $ with_timeout dune_cmd wait-for-file-to-appear "$cancel_pid_file"
+  $ with_timeout dune_cmd wait-for-file-to-appear "$cancel_started_file"
+  $ cancel_child_pid=$(cat "$cancel_pid_file")
+  $ echo changed > watched-input
+  $ if wait_for_pid_to_exit_with_timeout "$cancel_child_pid" 200; then
+  >   echo "SUCCESS: escaped process was killed before the replacement build"
+  > else
+  >   echo "FAILURE: escaped process survived into the replacement build"
+  > fi
+  SUCCESS: escaped process was killed before the replacement build
+
+  $ touch "$cancel_release_file"
+  $ wait_for_pid_to_exit_with_timeout "$cancel_build" 200 || (cat cancel-build.out; false)
+  $ wait "$cancel_build"
+  $ cat cancel-build.out
+  Success
+
+  $ stop_dune_quiet
+
+If a child exits during the SIGTERM grace period and leaves another child
+behind, the newly adopted child gets SIGTERM before cleanup escalates to
+SIGKILL.
+
+  $ parent_pid_file=$TMPDIR/term-parent-pid
+  $ child_cleanup_file=$TMPDIR/term-child-cleanup
+  $ cat >>dune <<EOF
+  > (rule
+  >  (target fourth)
+  >  (action
+  >   (progn
+  >    (run %{exe:bin/sub_process.exe} term-child "$parent_pid_file" "$child_cleanup_file")
+  >    (with-stdout-to fourth (echo done)))))
+  > (rule
+  >  (target fifth)
+  >  (action (with-stdout-to fifth (echo done))))
+  > EOF
+
+  $ start_dune
+
+  $ build fourth
+  Success
+
+  $ with_timeout dune_cmd wait-for-file-to-appear "$parent_pid_file"
+
+  $ build fifth
+  Success
+
+  $ with_timeout dune_cmd wait-for-file-to-appear "$child_cleanup_file"
+
+  $ stop_dune_quiet


### PR DESCRIPTION
On Linux, mark Dune as a child subreaper so descendants that escape an action process group are reparented to Dune. Before batch and watch-mode builds, scan direct child processes from /proc, signal adopted action children with SIGTERM, and escalate to SIGKILL after the grace period.

Preserve Dune-owned child processes and registered jobs during cleanup. Cleanup candidates are reaped by explicit PID, and each cleanup phase rescans for newly adopted children so children reparented during SIGTERM are also handled. Cleanup failures are reported as warnings and do not fail the current operation.

Add Linux-only blackbox coverage for setsid escapes, file-change cancellation before replacement builds, and SIGTERM reparenting.