### PR TITLE
refactor(action_runner): initialize RPC server with runner

### DIFF
--- a/bin/action_runner.ml
+++ b/bin/action_runner.ml
@@ -2,6 +2,14 @@ open Import
 
 let name = Action_runner_name.of_string "action-runner"
 
+type t =
+  { runner : Dune_engine.Action_runner.t
+  ; rpc_server : Dune_engine.Action_runner.Rpc_server.t
+  }
+
+let runner t = t.runner
+let rpc_server t = t.rpc_server
+
 let find_in_path_exn prog =
   match Bin.which ~path:(Env_path.path Env.initial) prog with
   | Some path -> path
@@ -21,56 +29,62 @@ let dune_prog () =
   else Path.of_filename_relative_to_initial_cwd prog
 ;;
 
-let create rpc_server ~config ~sandbox_actions =
-  let rpc = Dune_rpc_impl.Server.action_runner rpc_server in
-  let dune_prog = dune_prog () in
-  let worker_argv =
-    [ Path.to_string dune_prog
-    ; "internal"
-    ; "action-runner"
-    ; "start"
-    ; Action_runner_name.to_string name
-    ]
-  in
-  let prog, argv =
-    if sandbox_actions
-    then (
-      let { Bwrap.prog; argv } =
-        Bwrap.wrap ~cwd:(Path.to_absolute_filename Path.root) worker_argv
+let create ~where ~config ~sandbox_actions =
+  let runner =
+    let pid =
+      let env =
+        let jobs =
+          let scheduler_config =
+            Dune_config.for_scheduler
+              config
+              ~watch_exclusions:[]
+              ~print_ctrl_c_warning:true
+          in
+          Int.to_string scheduler_config.concurrency
+        in
+        Env.add Env.initial ~var:"DUNE_JOBS" ~value:jobs
+        |> Env.add ~var:"DUNE_BUILD_DIR" ~value:(Path.Build.to_string Path.Build.root)
+        |> Env.to_unix
+        |> Spawn.Env.of_list
       in
-      prog, argv)
-    else Path.to_string dune_prog, worker_argv
+      let trace_fd = Dune_trace.duplicate_global_fd () in
+      let prog, argv =
+        let dune_prog = dune_prog () in
+        let worker_argv =
+          [ Path.to_string dune_prog
+          ; "internal"
+          ; "action-runner"
+          ; "start"
+          ; Action_runner_name.to_string name
+          ]
+        in
+        if sandbox_actions
+        then (
+          let { Bwrap.prog; argv } =
+            Bwrap.wrap ~cwd:(Path.to_absolute_filename Path.root) worker_argv
+          in
+          prog, argv)
+        else Path.to_string dune_prog, worker_argv
+      in
+      let argv =
+        let where = Dune_rpc.Where.to_string where in
+        argv
+        @ [ where ]
+        @
+        match trace_fd with
+        | Some fd -> [ "--trace-fd"; Int.to_string (Fd.unsafe_to_int fd) ]
+        | None -> []
+      in
+      Exn.protect
+        ~f:(fun () ->
+          Spawn.spawn ~env ~prog ~argv ~setpgid:Spawn.Pgid.new_process_group ())
+        ~finally:(fun () -> Option.iter trace_fd ~f:Fd.close)
+      |> Pid.of_int_exn
+    in
+    Dune_engine.Action_runner.create name pid
   in
-  let where =
-    Dune_rpc.Where.to_string (Dune_rpc_impl.Server.listening_address rpc_server)
-  in
-  let trace_fd = Dune_trace.duplicate_global_fd () in
-  let argv =
-    argv
-    @ [ where ]
-    @
-    match trace_fd with
-    | Some fd -> [ "--trace-fd"; Int.to_string (Fd.unsafe_to_int fd) ]
-    | None -> []
-  in
-  let scheduler_config =
-    Dune_config.for_scheduler config ~watch_exclusions:[] ~print_ctrl_c_warning:true
-  in
-  let env =
-    let jobs = Int.to_string scheduler_config.concurrency in
-    Env.initial
-    |> Env.add ~var:"DUNE_JOBS" ~value:jobs
-    |> Env.add ~var:"DUNE_BUILD_DIR" ~value:(Path.Build.to_string Path.Build.root)
-    |> Env.to_unix
-    |> Spawn.Env.of_list
-  in
-  let pid =
-    Exn.protect
-      ~f:(fun () -> Spawn.spawn ~env ~prog ~argv ~setpgid:Spawn.Pgid.new_process_group ())
-      ~finally:(fun () -> Option.iter trace_fd ~f:Fd.close)
-    |> Pid.of_int_exn
-  in
-  Dune_engine.Action_runner.create rpc name pid
+  let rpc_server = Dune_engine.Action_runner.Rpc_server.create (Some runner) in
+  { runner; rpc_server }
 ;;
 
 let parse_name name = Action_runner_name.parse_string_exn (Loc.none, name)

--- a/bin/action_runner.mli
+++ b/bin/action_runner.mli
@@ -1,9 +1,8 @@
 open Import
 
-val create
-  :  Dune_rpc_impl.Server.t
-  -> config:Dune_config.t
-  -> sandbox_actions:bool
-  -> Dune_engine.Action_runner.t
+type t
 
+val create : where:Dune_rpc.Where.t -> config:Dune_config.t -> sandbox_actions:bool -> t
+val runner : t -> Dune_engine.Action_runner.t
+val rpc_server : t -> Dune_engine.Action_runner.Rpc_server.t
 val start_worker : name:string -> where:string -> trace_fd:string option -> unit Fiber.t

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1208,28 +1208,9 @@ let rpc_request_action ~root (kind : Dune_rpc_impl.Server.build_request) =
 
 (* CR-someday rleshchinskiy: The split between `build` and `init` seems quite arbitrary,
    we should probably refactor that at some point. *)
-let build (root : Workspace_root.t) (builder : Builder.t) ~rpc_build =
+let build (root : Workspace_root.t) (builder : Builder.t) =
   let build_loop = Dune_engine.Build_loop.create () in
-  let rpc_build =
-    match rpc_build with
-    | `Disabled -> Dune_rpc_impl.Server.Disabled
-    | `Enabled ->
-      Dune_rpc_impl.Server.Enabled { build_loop; build_action = rpc_request_action ~root }
-  in
-  let rpc =
-    if builder.allow_builds
-    then
-      `Allow
-        (lazy
-          (let registry, build =
-             match builder.watch with
-             | Yes _ -> `Add, rpc_build
-             | No -> `Skip, Dune_rpc_impl.Server.Disabled
-           in
-           Dune_rpc_impl.Server.create ~registry ~root:root.dir ~build builder.watch))
-    else `Forbid_builds
-  in
-  { builder; root; build_loop; rpc; action_runner = lazy None }
+  { builder; root; build_loop; rpc = `Forbid_builds; action_runner = lazy None }
 ;;
 
 let maybe_init_cache (cache_config : Dune_cache.Config.t) =
@@ -1249,14 +1230,21 @@ let maybe_init_cache (cache_config : Dune_cache.Config.t) =
        Disabled)
 ;;
 
-let action_runner t = Lazy.force t.action_runner
-
 let action_runner_requested t =
   t.builder.allow_builds && (t.builder.action_runner || t.builder.sandbox_actions)
 ;;
 
+let action_runner t =
+  if action_runner_requested t
+  then (
+    match t.rpc with
+    | `Allow rpc -> ignore (Lazy.force rpc : Dune_rpc_impl.Server.t)
+    | `Forbid_builds -> Code_error.raise "action runners require the dune RPC server" []);
+  Lazy.force t.action_runner
+;;
+
 let init_with_root_and_rpc ~(root : Workspace_root.t) ~rpc_build (builder : Builder.t) =
-  let c = build root builder ~rpc_build in
+  let c = build root builder in
   No_build.set c.builder.no_build;
   if c.root.dir <> Filename.current_dir_name then Sys.chdir c.root.dir;
   Path.set_root (normalize_path (Path.External.cwd ()));
@@ -1396,24 +1384,54 @@ let init_with_root_and_rpc ~(root : Workspace_root.t) ~rpc_build (builder : Buil
       let stat = Gc.stat () in
       let path = Path.external_ file in
       Dune_util.Gc.serialize ~path stat);
+  let where = lazy (Dune_rpc_impl.Where.default ()) in
   let action_runner =
     lazy
-      (if c.builder.allow_builds && (c.builder.action_runner || c.builder.sandbox_actions)
-       then (
-         let rpc_server =
-           match rpc c with
-           | `Allow rpc_server -> rpc_server
-           | `Forbid_builds ->
-             Code_error.raise "action runners require the dune RPC server" []
-         in
+      (if action_runner_requested c
+       then
          Some
            (Action_runner.create
-              rpc_server
+              ~where:(Lazy.force where)
               ~config
-              ~sandbox_actions:c.builder.sandbox_actions))
+              ~sandbox_actions:c.builder.sandbox_actions)
        else None)
   in
-  let c = { c with action_runner } in
+  let rpc =
+    let action_runner_server =
+      lazy
+        (match Lazy.force action_runner with
+         | None -> Dune_engine.Action_runner.Rpc_server.create None
+         | Some action_runner -> Action_runner.rpc_server action_runner)
+    in
+    let rpc_build =
+      match rpc_build with
+      | `Disabled -> Dune_rpc_impl.Server.Disabled
+      | `Enabled ->
+        Dune_rpc_impl.Server.Enabled
+          { build_loop = c.build_loop; build_action = rpc_request_action ~root }
+    in
+    if c.builder.allow_builds
+    then
+      `Allow
+        (lazy
+          (let registry, build =
+             match c.builder.watch with
+             | Yes _ -> `Add, rpc_build
+             | No -> `Skip, Dune_rpc_impl.Server.Disabled
+           in
+           Dune_rpc_impl.Server.create
+             ~registry
+             ~root:root.dir
+             ~build
+             ~where:(Lazy.force where)
+             ~action_runner:(Lazy.force action_runner_server)
+             c.builder.watch))
+    else `Forbid_builds
+  in
+  let action_runner =
+    lazy (Lazy.force action_runner |> Option.map ~f:Action_runner.runner)
+  in
+  let c = { c with rpc; action_runner } in
   c, config
 ;;
 

--- a/src/dune_engine/action_runner.ml
+++ b/src/dune_engine/action_runner.ml
@@ -143,32 +143,31 @@ let exec_process t ~run_id ~cancellation process =
 
 module Rpc_server = struct
   type nonrec t =
-    { workers : (Action_runner_name.t, t) Table.t
+    { worker : t option
     ; pool : Fiber.Pool.t
     }
 
-  let create () =
-    { workers = Table.create (module Action_runner_name) 16; pool = Fiber.Pool.create () }
-  ;;
+  let create worker = { worker; pool = Fiber.Pool.create () }
 
-  let run t = Fiber.Pool.run t.pool
+  let run t =
+    match t.worker with
+    | None -> Fiber.Pool.run t.pool
+    | Some worker ->
+      Fiber.fork_and_join_unit
+        (fun () -> Fiber.Pool.run t.pool)
+        (fun () -> Fiber.Pool.run worker.monitor_pool)
+  ;;
 
   let stop t =
-    Table.iter t.workers ~f:(fun worker ->
-      let how = if Sys.win32 then `Pid else `Group in
-      Pid.kill worker.pid how Term);
-    Fiber.Pool.close t.pool
-  ;;
-
-  let register t worker =
-    match Table.add t.workers worker.name worker with
-    | Ok () -> ()
-    | Error _ ->
-      User_error.raise
-        [ Pp.textf
-            "Cannot register %s as it already exists"
-            (Action_runner_name.to_string worker.name)
-        ]
+    let stop_worker () =
+      match t.worker with
+      | None -> Fiber.return ()
+      | Some worker ->
+        let how = if Sys.win32 then `Pid else `Group in
+        Pid.kill worker.pid how Term;
+        Fiber.Pool.close worker.monitor_pool
+    in
+    Fiber.fork_and_join_unit (fun () -> Fiber.Pool.close t.pool) stop_worker
   ;;
 
   let invalid_request message =
@@ -177,8 +176,10 @@ module Rpc_server = struct
   ;;
 
   let ready t session ({ Request.Ready.name } : Request.Ready.t) =
-    match Table.find t.workers name with
+    match t.worker with
     | None -> invalid_request "unexpected action runner"
+    | Some worker when not (Action_runner_name.equal name worker.name) ->
+      invalid_request "unexpected action runner"
     | Some worker ->
       (match worker.status with
        | Closed -> invalid_request "disconnected earlier"
@@ -202,18 +203,13 @@ module Rpc_server = struct
   ;;
 end
 
-let create server name pid =
+let create name pid =
   Dune_trace.emit Action (fun () ->
     Dune_trace.Event.Action.Runner.runner_event ~name (Spawn pid));
-  let { Rpc_server.pool = monitor_pool; _ } = server in
-  let t =
-    { name
-    ; status = Starting { ready = Fiber.Ivar.create () }
-    ; pid
-    ; monitor_pool
-    ; monitoring = false
-    }
-  in
-  Rpc_server.register server t;
-  t
+  { name
+  ; status = Starting { ready = Fiber.Ivar.create () }
+  ; pid
+  ; monitor_pool = Fiber.Pool.create ()
+  ; monitoring = false
+  }
 ;;

--- a/src/dune_engine/action_runner.mli
+++ b/src/dune_engine/action_runner.mli
@@ -11,23 +11,26 @@ open Import
 type t
 
 module Rpc_server : sig
-  (** The server-side component responsible for orchestrating action runners. *)
-  type t
+    type action_runner
 
-  val create : unit -> t
+    (** The server-side component responsible for orchestrating action runners. *)
+    type t
 
-  (** [implement_handler t handler] wires the action runner requests into an
+    val create : action_runner option -> t
+
+    (** [implement_handler t handler] wires the action runner requests into an
       existing RPC handler. *)
-  val implement_handler : t -> 'a Root.Rpc.Server.Handler.t -> unit
+    val implement_handler : t -> 'a Root.Rpc.Server.Handler.t -> unit
 
-  (** [run t] is to be run by the RPC server. *)
-  val run : t -> unit Fiber.t
+    (** [run t] is to be run by the RPC server. *)
+    val run : t -> unit Fiber.t
 
-  (** [stop t] is to be run by the RPC server. *)
-  val stop : t -> unit Fiber.t
-end
+    (** [stop t] is to be run by the RPC server. *)
+    val stop : t -> unit Fiber.t
+  end
+  with type action_runner := t
 
-val create : Rpc_server.t -> Action_runner_name.t -> Pid.t -> t
+val create : Action_runner_name.t -> Pid.t -> t
 val ensure_ready : t -> unit Fiber.t
 
 (** [exec_process t ~run_id ~cancellation process] dispatches [process] to [t]

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -69,7 +69,6 @@ end
 type server =
   { lifecycle : Rpc.Server.Lifecycle.t
   ; action_runner : Action_runner.Rpc_server.t
-  ; where : Dune_rpc.Where.t
   ; registry : [ `Add | `Skip ]
   ; watch_mode : Watch_mode_config.t
   ; mutable clients : Clients.t
@@ -415,8 +414,7 @@ let handler (t : t Fdecl.t) action_runner_server : unit Handler.t =
   rpc
 ;;
 
-let create ~registry ~root ~build watch_mode =
-  let where = Where.default () in
+let create ~registry ~root ~build ~where ~action_runner watch_mode =
   Global_lock.lock_exn ();
   let t = Fdecl.create Dyn.opaque in
   let config =
@@ -440,14 +438,13 @@ let create ~registry ~root ~build watch_mode =
                  (Path.Build.to_string_maybe_quoted (Where.rpc_socket_file ()))
              ])
     in
-    let action_runner = Action_runner.Rpc_server.create () in
     let handler = Rpc.Server.make (handler t action_runner) in
     let lifecycle = Rpc.Server.Lifecycle.create ~handler ~root ~where ~registry ~server in
     action_runner, lifecycle
   in
   let action_runner, lifecycle = config in
   let server =
-    { lifecycle; action_runner; where; registry; watch_mode; clients = Clients.empty }
+    { lifecycle; action_runner; registry; watch_mode; clients = Clients.empty }
   in
   let res = { server; build } in
   current := Some server;
@@ -525,5 +522,3 @@ end
 
 let with_background_rpc = Background.with_background_rpc
 let ensure_ready = Background.ensure_ready
-let listening_address t = t.server.where
-let action_runner t = t.server.action_runner

--- a/src/dune_rpc_impl/server.mli
+++ b/src/dune_rpc_impl/server.mli
@@ -18,11 +18,11 @@ val create
   :  registry:[ `Add | `Skip ]
   -> root:string
   -> build:build
+  -> where:Dune_rpc.Where.t
+  -> action_runner:Dune_engine.Action_runner.Rpc_server.t
   -> Watch_mode_config.t
   -> t
 
 val run : t -> unit Fiber.t
 val with_background_rpc : t -> (unit -> 'a Fiber.t) -> 'a Fiber.t
 val ensure_ready : unit -> unit Fiber.t
-val listening_address : t -> Dune_rpc.Where.t
-val action_runner : t -> Dune_engine.Action_runner.Rpc_server.t


### PR DESCRIPTION
Have bin/action_runner create both the spawned runner and its Rpc_server, then pass that server into Dune_rpc_impl.Server.create. This removes the empty server plus later registration path and shares the precomputed RPC address with the worker.