### PR TITLE
refactor(stdune): add Pid.kill helper

### DIFF
--- a/otherlibs/stdune/src/pid.ml
+++ b/otherlibs/stdune/src/pid.ml
@@ -12,4 +12,15 @@ let of_int_exn t =
 
 let me () = Unix.getpid ()
 
+let kill pid where signal =
+  let where =
+    match where with
+    | `Pid -> pid
+    | `Group ->
+      assert (not Sys.win32);
+      -pid
+  in
+  Unix.kill where (Signal.to_int signal)
+;;
+
 module Set = Int.Set

--- a/otherlibs/stdune/src/pid.mli
+++ b/otherlibs/stdune/src/pid.mli
@@ -11,4 +11,6 @@ val me : unit -> t
     further *)
 val of_int_exn : int -> t
 
+val kill : t -> [ `Pid | `Group ] -> Signal.t -> unit
+
 module Set : Set.S with type elt = t

--- a/otherlibs/stdune/test/proc_linux_tests.ml
+++ b/otherlibs/stdune/test/proc_linux_tests.ml
@@ -61,7 +61,7 @@ let fork_child_with_grandchild () =
 ;;
 
 let cleanup_child_tree (child, _grandchild) =
-  Unix.kill (Pid.to_int child) Sys.sigkill;
+  Pid.kill child `Pid Kill;
   wait_no_eintr child
 ;;
 

--- a/src/dune_engine/action_runner.ml
+++ b/src/dune_engine/action_runner.ml
@@ -158,9 +158,8 @@ module Rpc_server = struct
 
   let stop t =
     Table.iter t.workers ~f:(fun worker ->
-      let pid = Pid.to_int worker.pid in
-      let pid = if Sys.win32 then pid else -pid in
-      Unix.kill pid Sys.sigterm);
+      let how = if Sys.win32 then `Pid else `Group in
+      Pid.kill worker.pid how Term);
     Fiber.Pool.close t.pool
   ;;
 

--- a/src/dune_scheduler/process_watcher.ml
+++ b/src/dune_scheduler/process_watcher.ml
@@ -18,7 +18,7 @@ let kill_process_group pid signal ~is_process_group_leader =
        The downside is that it's more complicated, but also that by sending the
        signal twice we're greatly increasing the existing race condition where
        we call [wait] in parallel with [kill]. *)
-    (try Unix.kill (-Pid.to_int pid) signal with
+    (try Pid.kill pid `Group signal with
      (* CR-someday rgrinerg: do we need to catch this error now that we're no
         longer racing? *)
      | Unix.Unix_error _ -> ())
@@ -31,7 +31,7 @@ let kill_process_group pid signal ~is_process_group_leader =
       a process group id that we know about. This happens when
       [is_process_group_leader] is [false]. In those cases, it doesn't make
       sense to pretend the pid corresponds to the correct process group. *)
-    (try Unix.kill (Pid.to_int pid) signal with
+    (try Pid.kill pid `Pid signal with
      | Unix.Unix_error _ -> ())
 ;;
 

--- a/src/dune_scheduler/process_watcher.mli
+++ b/src/dune_scheduler/process_watcher.mli
@@ -1,6 +1,6 @@
 open Stdune
 
-val kill_process_group : Pid.t -> int -> is_process_group_leader:bool -> unit
+val kill_process_group : Pid.t -> Signal.t -> is_process_group_leader:bool -> unit
 
 (** Initialize the process watcher thread. *)
 type t
@@ -15,6 +15,6 @@ val is_running : t -> Pid.t -> bool
 val running_count : t -> int
 
 (** Send the following signal to all running processes. *)
-val killall : t -> int -> unit
+val killall : t -> Signal.t -> unit
 
 val wait_unix : t -> Fiber.fill list

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -68,7 +68,7 @@ let wait_for_build_process t ?cancellation ~is_process_group_leader pid =
   let wait () =
     let* r = wait_for_process t ~is_process_group_leader pid in
     if not Sys.win32
-    then Process_watcher.kill_process_group pid Sys.sigterm ~is_process_group_leader;
+    then Process_watcher.kill_process_group pid Term ~is_process_group_leader;
     let+ () =
       match !sigkill_alarm with
       | None -> Fiber.return ()
@@ -86,14 +86,13 @@ let wait_for_build_process t ?cancellation ~is_process_group_leader pid =
         cancel
         ~on_cancel:(fun () ->
           if not Sys.win32
-          then Process_watcher.kill_process_group pid Sys.sigterm ~is_process_group_leader;
+          then Process_watcher.kill_process_group pid Term ~is_process_group_leader;
           let sleep = Async_io.sleep t.async_io sigterm_grace_period in
           sigkill_alarm := Some sleep;
           Async_io.Task.await sleep
           >>| function
           | Error `Cancelled -> ()
-          | Ok () ->
-            Process_watcher.kill_process_group pid Sys.sigkill ~is_process_group_leader
+          | Ok () -> Process_watcher.kill_process_group pid Kill ~is_process_group_leader
           | Error (`Exn _) -> assert false)
         wait
     in
@@ -125,12 +124,12 @@ let kill_and_wait_for_all_processes t =
        would raise because [Proc.wait] has no implementation there. Send
        SIGKILL directly; the main drain loop below observes exits via
        [jobs_completed] events pushed by the Win32 polling thread. *)
-    Process_watcher.killall t.process_watcher Sys.sigkill
+    Process_watcher.killall t.process_watcher Kill
   else if Process_watcher.running_count t.process_watcher > 0
   then (
     Dune_trace.emit Process Dune_trace.Event.process_cleanup_start;
     (* Send SIGTERM first to give processes a chance to clean up *)
-    Process_watcher.killall t.process_watcher Sys.sigterm;
+    Process_watcher.killall t.process_watcher Term;
     (* Poll until all processes exit or the grace period expires, then SIGKILL *)
     let deadline = Time.add (Time.now ()) sigterm_grace_period in
     let sent_sigkill = ref false in
@@ -141,7 +140,7 @@ let kill_and_wait_for_all_processes t =
         if (not !sent_sigkill) && Time.(now () >= deadline)
         then (
           Dune_trace.emit Process Dune_trace.Event.process_cleanup_sigkill;
-          Process_watcher.killall t.process_watcher Sys.sigkill;
+          Process_watcher.killall t.process_watcher Kill;
           sent_sigkill := true)
         else Unix.sleepf 0.01
     done;
@@ -265,7 +264,7 @@ module Run_once = struct
         (* CR-someday rgrinberg: Instead of this hackery, we should probably
            just rgister the watcher as a non build process. Luckily, this code
            path is incredibly rare as the external file watchers are bad. *)
-        Unix.kill (Pid.to_int pid) Sys.sigterm
+        Pid.kill pid `Pid Term
       | `Thunk f -> f ()
       | `No_op -> ());
     Console.Status_line.clear ();
@@ -376,7 +375,7 @@ let wait_for_process_with_timeout t pid waiter ~timeout ~is_process_group_leader
       Async_io.Task.await sleep
       >>| function
       | Ok () when Process_watcher.is_running t.process_watcher pid ->
-        Process_watcher.kill_process_group pid Sys.sigkill ~is_process_group_leader;
+        Process_watcher.kill_process_group pid Kill ~is_process_group_leader;
         Dune_trace.emit Process (fun () ->
           Dune_trace.Event.signal_sent
             Kill

--- a/src/dune_tui/dune_tui.ml
+++ b/src/dune_tui/dune_tui.ml
@@ -26,7 +26,7 @@ let term =
                    match Lazy.force old with
                    | Sys.Signal_handle f -> f i
                    | _ ->
-                     Unix.kill (Unix.getpid ()) (Signal.to_int Stop);
+                     Pid.kill (Pid.me ()) `Pid Stop;
                      Dune_trace.emit Process (fun () ->
                        Dune_trace.Event.signal_sent Stop `Ui)))
        in
@@ -270,7 +270,7 @@ let document =
   let keyboard_handler = function
     (* When we encounter q we make sure to quit by signaling termination. *)
     | `ASCII 'q', _ ->
-      Unix.kill (Unix.getpid ()) (Signal.to_int Term);
+      Pid.kill (Pid.me ()) `Pid Term;
       Dune_trace.emit Process (fun () -> Dune_trace.Event.signal_sent Term `Ui);
       `Handled
     (* Toggle help screen *)


### PR DESCRIPTION
Add a typed Pid.kill wrapper for signalling either a process or process group, then use it in scheduler, action-runner, TUI, and stdune tests instead of open-coding Unix.kill calls.