### PR TITLE
fix: stop signalling action runners

### DIFF
--- a/src/dune_engine/action_runner.ml
+++ b/src/dune_engine/action_runner.ml
@@ -161,15 +161,18 @@ module Rpc_server = struct
   ;;
 
   let stop t =
-    let stop_worker () =
-      match t.worker with
-      | None -> Fiber.return ()
-      | Some worker ->
-        let how = if Sys.win32 then `Pid else `Group in
-        Pid.kill worker.pid how Term;
-        Fiber.Pool.close worker.monitor_pool
-    in
-    Fiber.fork_and_join_unit (fun () -> Fiber.Pool.close t.pool) stop_worker
+    Fiber.fork_and_join_unit
+      (fun () -> Fiber.Pool.close t.pool)
+      (fun () ->
+         match t.worker with
+         | None -> Fiber.return ()
+         | Some worker ->
+           let* () =
+             match worker.status with
+             | Starting _ | Closed -> Fiber.return ()
+             | Initialized (Session session) -> Server.Session.close session
+           in
+           Fiber.Pool.close worker.monitor_pool)
   ;;
 
   let invalid_request message =

--- a/src/rpc/server.ml
+++ b/src/rpc/server.ml
@@ -354,6 +354,7 @@ module Session = struct
   let get t = Stage1.get t.base
   let set t = Stage1.set t.base
   let closed t = Fiber.Ivar.read t.base.close.ivar
+  let close t = Stage1.close t.base
   let compare x y = Stage1.compare x.base y.base
   let id t = t.base.id
 

--- a/src/rpc/server.mli
+++ b/src/rpc/server.mli
@@ -52,6 +52,7 @@ module Session : sig
   val compare : 'a t -> 'a t -> Ordering.t
   val to_dyn : ('a -> Dyn.t) -> 'a t -> Dyn.t
   val closed : _ t -> unit Fiber.t
+  val close : _ t -> unit Fiber.t
 
   (** A ['a Session.Stage1.t] represents a session prior to version negotiation.
 


### PR DESCRIPTION
An action runner should terminate itself once its connection dies.