### PR TITLE
scheduler: clean up escaped subreaper children on shutdown

### DIFF
--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -406,6 +406,8 @@ module Run_once = struct
 
   let run_and_cleanup t f =
     let res = run t f in
+    if Lazy.force child_subreaper_enabled
+    then Fiber.run (cleanup_subreaper_child_processes_impl t) ~iter:(fun () -> iter t);
     Async_io.shutdown t.async_io;
     Option.iter t.file_watcher ~f:(fun watcher ->
       (* CR-someday rgrinberg: we do not wind down the threads for the file

--- a/test/blackbox-tests/test-cases/actions/bin/sub_process.ml
+++ b/test/blackbox-tests/test-cases/actions/bin/sub_process.ml
@@ -31,6 +31,12 @@ let install_term_writer path =
          exit 0))
 ;;
 
+let wait_for_file path =
+  while not (Sys.file_exists path) do
+    Unix.sleepf 0.01
+  done
+;;
+
 let () =
   match Sys.argv with
   | [| _; "setsid"; pid_file |] ->
@@ -42,6 +48,20 @@ let () =
        write_pid pid_file;
        signal_ready write_fd;
        sleep_forever ()
+     | _ ->
+       Unix.close write_fd;
+       wait_ready read_fd)
+  | [| _; "setsid-until-file"; pid_file; release_file; survived_file; cleanup_file |] ->
+    let read_fd, write_fd = Unix.pipe () in
+    (match Unix.fork () with
+     | 0 ->
+       Unix.close read_fd;
+       ignore (Unix.setsid () : int);
+       write_pid pid_file;
+       install_term_writer cleanup_file;
+       signal_ready write_fd;
+       wait_for_file release_file;
+       write_pid survived_file
      | _ ->
        Unix.close write_fd;
        wait_ready read_fd)

--- a/test/blackbox-tests/test-cases/actions/subreaper.t
+++ b/test/blackbox-tests/test-cases/actions/subreaper.t
@@ -118,3 +118,38 @@ SIGKILL.
   $ with_timeout dune_cmd wait-for-file-to-appear "$child_cleanup_file"
 
   $ stop_dune_quiet
+
+Shutdown also runs subreaper cleanup, so an escaped child from the final build
+is terminated before Dune exits.
+
+  $ shutdown_pid_file=$TMPDIR/shutdown-pid
+  $ shutdown_release_file=$TMPDIR/shutdown-release
+  $ shutdown_survived_file=$TMPDIR/shutdown-survived
+  $ shutdown_cleanup_file=$TMPDIR/shutdown-cleanup
+  $ cat >>dune <<EOF
+  > (rule
+  >  (target sixth)
+  >  (action
+  >   (progn
+  >    (run %{exe:bin/sub_process.exe} setsid-until-file "$shutdown_pid_file" "$shutdown_release_file" "$shutdown_survived_file" "$shutdown_cleanup_file")
+  >    (with-stdout-to sixth (echo done)))))
+  > EOF
+
+  $ start_dune
+
+  $ build sixth
+  Success
+
+  $ with_timeout dune_cmd wait-for-file-to-appear "$shutdown_pid_file"
+
+  $ stop_dune_quiet
+
+  $ touch "$shutdown_release_file"
+
+  $ if test -e "$shutdown_cleanup_file"; then
+  >   echo "SUCCESS: escaped process was cleaned up during shutdown"
+  > else
+  >   with_timeout dune_cmd wait-for-file-to-appear "$shutdown_survived_file"
+  >   echo "FAILURE: escaped process survived shutdown"
+  > fi
+  SUCCESS: escaped process was cleaned up during shutdown


### PR DESCRIPTION
Run Linux subreaper child cleanup during scheduler shutdown, before scheduler resources are torn down. This terminates escaped children from the final build even when no later build starts.

Extend the Linux subreaper blackbox test with shutdown cleanup coverage.