### PR TITLE
fix(action-runner): keep worker spawn lazy

### DIFF
--- a/bin/action_runner.ml
+++ b/bin/action_runner.ml
@@ -2,13 +2,9 @@ open Import
 
 let name = Action_runner_name.of_string "action-runner"
 
-type t =
-  { runner : Dune_engine.Action_runner.t
-  ; rpc_server : Dune_engine.Action_runner.Rpc_server.t
-  }
+type t = { runner : Dune_engine.Action_runner.t }
 
 let runner t = t.runner
-let rpc_server t = t.rpc_server
 
 let find_in_path_exn prog =
   match Bin.which ~path:(Env_path.path Env.initial) prog with
@@ -29,7 +25,7 @@ let dune_prog () =
   else Path.of_filename_relative_to_initial_cwd prog
 ;;
 
-let create ~where ~config ~sandbox_actions =
+let create ~rpc_server ~where ~config ~sandbox_actions =
   let runner =
     let pid =
       let env =
@@ -80,10 +76,9 @@ let create ~where ~config ~sandbox_actions =
         ~finally:(fun () -> Option.iter trace_fd ~f:Fd.close)
       |> Pid.of_int_exn
     in
-    Dune_engine.Action_runner.create name pid
+    Dune_engine.Action_runner.create rpc_server name pid
   in
-  let rpc_server = Dune_engine.Action_runner.Rpc_server.create (Some runner) in
-  { runner; rpc_server }
+  { runner }
 ;;
 
 let parse_where where =

--- a/bin/action_runner.mli
+++ b/bin/action_runner.mli
@@ -2,7 +2,12 @@ open Import
 
 type t
 
-val create : where:Dune_rpc.Where.t -> config:Dune_config.t -> sandbox_actions:bool -> t
+val create
+  :  rpc_server:Dune_engine.Action_runner.Rpc_server.t
+  -> where:Dune_rpc.Where.t
+  -> config:Dune_config.t
+  -> sandbox_actions:bool
+  -> t
+
 val runner : t -> Dune_engine.Action_runner.t
-val rpc_server : t -> Dune_engine.Action_runner.Rpc_server.t
 val start_worker : name:string -> where:string -> trace_fd:string option -> unit Fiber.t

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1385,28 +1385,32 @@ let init_with_root_and_rpc ~(root : Workspace_root.t) ~rpc_build (builder : Buil
       let path = Path.external_ file in
       Dune_util.Gc.serialize ~path stat);
   let where = lazy (Dune_rpc_impl.Where.default ()) in
-  let action_runner =
+  (* The RPC server must start listening before the action runner is spawned:
+     the worker connects back to this server during initialization. Keep the
+     worker lazy so constructing the RPC server does not spawn it. *)
+  let rec action_runner =
     lazy
       (if action_runner_requested c
        then
          Some
            (Action_runner.create
+              ~rpc_server:(Lazy.force action_runner_server)
               ~where:(Lazy.force where)
               ~config
               ~sandbox_actions:c.builder.sandbox_actions)
        else None)
+  and engine_action_runner =
+    lazy (Lazy.force action_runner |> Option.map ~f:Action_runner.runner)
+  and action_runner_server =
+    lazy (Dune_engine.Action_runner.Rpc_server.create engine_action_runner)
   in
+  let action_runner_server = Lazy.force action_runner_server in
   let rpc =
     if c.builder.allow_builds
     then
       `Allow
         (lazy
-          (let action_runner =
-             match Lazy.force action_runner with
-             | None -> Dune_engine.Action_runner.Rpc_server.create None
-             | Some action_runner -> Action_runner.rpc_server action_runner
-           in
-           let rpc_build =
+          (let rpc_build =
              lazy
                (match rpc_build with
                 | `Disabled -> Dune_rpc_impl.Server.Disabled
@@ -1424,13 +1428,11 @@ let init_with_root_and_rpc ~(root : Workspace_root.t) ~rpc_build (builder : Buil
              ~root:root.dir
              ~build
              ~where:(Lazy.force where)
-             ~action_runner
+             ~action_runner:action_runner_server
              c.builder.watch))
     else `Forbid_builds
   in
-  let action_runner =
-    lazy (Lazy.force action_runner |> Option.map ~f:Action_runner.runner)
-  in
+  let action_runner = engine_action_runner in
   let c = { c with rpc; action_runner } in
   c, config
 ;;

--- a/src/dune_engine/action_runner.ml
+++ b/src/dune_engine/action_runner.ml
@@ -145,34 +145,37 @@ let exec_process t ~run_id ~cancellation process =
 
 module Rpc_server = struct
   type nonrec t =
-    { worker : t option
+    { worker : t option Lazy.t
     ; pool : Fiber.Pool.t
+    ; monitor_pool : Fiber.Pool.t
     }
 
-  let create worker = { worker; pool = Fiber.Pool.create () }
+  let create worker =
+    { worker; pool = Fiber.Pool.create (); monitor_pool = Fiber.Pool.create () }
+  ;;
 
   let run t =
-    match t.worker with
-    | None -> Fiber.Pool.run t.pool
-    | Some worker ->
-      Fiber.fork_and_join_unit
-        (fun () -> Fiber.Pool.run t.pool)
-        (fun () -> Fiber.Pool.run worker.monitor_pool)
+    Fiber.fork_and_join_unit
+      (fun () -> Fiber.Pool.run t.pool)
+      (fun () -> Fiber.Pool.run t.monitor_pool)
   ;;
 
   let stop t =
     Fiber.fork_and_join_unit
       (fun () -> Fiber.Pool.close t.pool)
       (fun () ->
-         match t.worker with
-         | None -> Fiber.return ()
-         | Some worker ->
-           let* () =
-             match worker.status with
-             | Starting _ | Closed -> Fiber.return ()
-             | Initialized (Session session) -> Server.Session.close session
-           in
-           Fiber.Pool.close worker.monitor_pool)
+         let* () =
+           if Lazy.is_val t.worker
+           then (
+             match Lazy.force t.worker with
+             | None -> Fiber.return ()
+             | Some worker ->
+               (match worker.status with
+                | Starting _ | Closed -> Fiber.return ()
+                | Initialized (Session session) -> Server.Session.close session))
+           else Fiber.return ()
+         in
+         Fiber.Pool.close t.monitor_pool)
   ;;
 
   let invalid_request message =
@@ -181,7 +184,7 @@ module Rpc_server = struct
   ;;
 
   let ready t session ({ Request.Ready.name } : Request.Ready.t) =
-    match t.worker with
+    match Lazy.force t.worker with
     | None -> invalid_request "unexpected action runner"
     | Some worker when not (Action_runner_name.equal name worker.name) ->
       invalid_request "unexpected action runner"
@@ -208,13 +211,14 @@ module Rpc_server = struct
   ;;
 end
 
-let create name pid =
+let create server name pid =
   Dune_trace.emit Action (fun () ->
     Dune_trace.Event.Action.Runner.runner_event ~name (Spawn pid));
+  let { Rpc_server.monitor_pool; _ } = server in
   { name
   ; status = Starting { ready = Fiber.Ivar.create () }
   ; pid
-  ; monitor_pool = Fiber.Pool.create ()
+  ; monitor_pool
   ; monitoring = false
   }
 ;;

--- a/src/dune_engine/action_runner.mli
+++ b/src/dune_engine/action_runner.mli
@@ -16,7 +16,7 @@ module Rpc_server : sig
     (** The server-side component responsible for orchestrating action runners. *)
     type t
 
-    val create : action_runner option -> t
+    val create : action_runner option Lazy.t -> t
 
     (** [implement_handler t handler] wires the action runner requests into an
       existing RPC handler. *)
@@ -30,7 +30,7 @@ module Rpc_server : sig
   end
   with type action_runner := t
 
-val create : Action_runner_name.t -> Pid.t -> t
+val create : Rpc_server.t -> Action_runner_name.t -> Pid.t -> t
 val ensure_ready : t -> unit Fiber.t
 
 (** [exec_process t ~run_id ~cancellation process] dispatches [process] to [t]


### PR DESCRIPTION
Construct the action-runner RPC server without forcing the worker lazy value, so the RPC listener can start before the worker process attempts to connect back. Pass the RPC server into the spawned runner and avoid forcing the worker during shutdown unless it already exists.