### PR TITLE
refactor(action-runner): avoid disabled runner pool

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1385,12 +1385,13 @@ let init_with_root_and_rpc ~(root : Workspace_root.t) ~rpc_build (builder : Buil
       let path = Path.external_ file in
       Dune_util.Gc.serialize ~path stat);
   let where = lazy (Dune_rpc_impl.Where.default ()) in
+  let action_runner_requested = action_runner_requested c in
   (* The RPC server must start listening before the action runner is spawned:
      the worker connects back to this server during initialization. Keep the
      worker lazy so constructing the RPC server does not spawn it. *)
   let rec action_runner =
     lazy
-      (if action_runner_requested c
+      (if action_runner_requested
        then
          Some
            (Action_runner.create
@@ -1401,8 +1402,15 @@ let init_with_root_and_rpc ~(root : Workspace_root.t) ~rpc_build (builder : Buil
        else None)
   and engine_action_runner =
     lazy (Lazy.force action_runner |> Option.map ~f:Action_runner.runner)
+  and worker =
+    lazy
+      (match Lazy.force engine_action_runner with
+       | Some action_runner -> action_runner
+       | None -> Code_error.raise "action runner unexpectedly disabled" [])
   and action_runner_server =
-    lazy (Dune_engine.Action_runner.Rpc_server.create engine_action_runner)
+    lazy
+      (Dune_engine.Action_runner.Rpc_server.create
+         (if action_runner_requested then `Enabled worker else `Disabled))
   in
   let action_runner_server = Lazy.force action_runner_server in
   let rpc =

--- a/src/dune_engine/action_runner.ml
+++ b/src/dune_engine/action_runner.ml
@@ -145,26 +145,35 @@ let exec_process t ~run_id ~cancellation process =
 
 module Rpc_server = struct
   type nonrec t =
-    { worker : t option Lazy.t
-    ; pool : Fiber.Pool.t
-    }
+    | No_worker
+    | Worker of
+        { worker : t Lazy.t
+        ; pool : Fiber.Pool.t
+        }
 
-  let create worker = { worker; pool = Fiber.Pool.create () }
-  let run t = Fiber.Pool.run t.pool
+  let create = function
+    | `Disabled -> No_worker
+    | `Enabled worker -> Worker { worker; pool = Fiber.Pool.create () }
+  ;;
 
-  let stop t =
-    let* () =
-      if Lazy.is_val t.worker
-      then (
-        match Lazy.force t.worker with
-        | None -> Fiber.return ()
-        | Some worker ->
-          (match worker.status with
-           | Starting _ | Closed -> Fiber.return ()
-           | Initialized (Session session) -> Server.Session.close session))
-      else Fiber.return ()
-    in
-    Fiber.Pool.close t.pool
+  let run = function
+    | No_worker -> Fiber.return ()
+    | Worker { pool; _ } -> Fiber.Pool.run pool
+  ;;
+
+  let stop = function
+    | No_worker -> Fiber.return ()
+    | Worker { worker; pool } ->
+      let* () =
+        if Lazy.is_val worker
+        then (
+          let worker = Lazy.force worker in
+          match worker.status with
+          | Starting _ | Closed -> Fiber.return ()
+          | Initialized (Session session) -> Server.Session.close session)
+        else Fiber.return ()
+      in
+      Fiber.Pool.close pool
   ;;
 
   let invalid_request message =
@@ -173,24 +182,26 @@ module Rpc_server = struct
   ;;
 
   let ready t session ({ Request.Ready.name } : Request.Ready.t) =
-    match Lazy.force t.worker with
-    | None -> invalid_request "unexpected action runner"
-    | Some worker when not (Action_runner_name.equal name worker.name) ->
-      invalid_request "unexpected action runner"
-    | Some worker ->
-      (match worker.status with
-       | Closed -> invalid_request "disconnected earlier"
-       | Initialized _ -> invalid_request "already signalled readiness to the server"
-       | Starting { ready } ->
-         worker.status <- Initialized (Session session);
-         Dune_trace.emit Action (fun () ->
-           Dune_trace.Event.Action.Runner.runner_event ~name:worker.name Connected);
-         let* () =
-           Fiber.Pool.task t.pool ~f:(fun () ->
-             let* () = Server.Session.closed session in
-             disconnect worker)
-         in
-         Fiber.Ivar.fill ready ())
+    match t with
+    | No_worker -> invalid_request "unexpected action runner"
+    | Worker { worker; pool } ->
+      let worker = Lazy.force worker in
+      if not (Action_runner_name.equal name worker.name)
+      then invalid_request "unexpected action runner"
+      else (
+        match worker.status with
+        | Closed -> invalid_request "disconnected earlier"
+        | Initialized _ -> invalid_request "already signalled readiness to the server"
+        | Starting { ready } ->
+          worker.status <- Initialized (Session session);
+          Dune_trace.emit Action (fun () ->
+            Dune_trace.Event.Action.Runner.runner_event ~name:worker.name Connected);
+          let* () =
+            Fiber.Pool.task pool ~f:(fun () ->
+              let* () = Server.Session.closed session in
+              disconnect worker)
+          in
+          Fiber.Ivar.fill ready ())
   ;;
 
   let implement_handler t (handler : _ Root.Rpc.Server.Handler.t) =
@@ -200,10 +211,15 @@ module Rpc_server = struct
   ;;
 end
 
-let create server name pid =
+let create (server : Rpc_server.t) name pid =
   Dune_trace.emit Action (fun () ->
     Dune_trace.Event.Action.Runner.runner_event ~name (Spawn pid));
-  let { Rpc_server.pool; _ } = server in
+  let pool =
+    match server with
+    | Worker { pool; _ } -> pool
+    | No_worker ->
+      Code_error.raise "cannot create an action runner for a disabled RPC server" []
+  in
   { name
   ; status = Starting { ready = Fiber.Ivar.create () }
   ; pid

--- a/src/dune_engine/action_runner.mli
+++ b/src/dune_engine/action_runner.mli
@@ -16,7 +16,7 @@ module Rpc_server : sig
     (** The server-side component responsible for orchestrating action runners. *)
     type t
 
-    val create : action_runner option Lazy.t -> t
+    val create : [ `Disabled | `Enabled of action_runner Lazy.t ] -> t
 
     (** [implement_handler t handler] wires the action runner requests into an
       existing RPC handler. *)


### PR DESCRIPTION
Do not allocate an action-runner RPC pool when action runners are disabled. The worker remains lazy, so thread through the already-known enabled flag instead of forcing the worker during server construction.
