### PR TITLE
action-runner: retry worker RPC connection

### DIFF
--- a/bin/action_runner.ml
+++ b/bin/action_runner.ml
@@ -2,9 +2,13 @@ open Import
 
 let name = Action_runner_name.of_string "action-runner"
 
-type t = { runner : Dune_engine.Action_runner.t }
+type t =
+  { runner : Dune_engine.Action_runner.t
+  ; rpc_server : Dune_engine.Action_runner.Rpc_server.t
+  }
 
 let runner t = t.runner
+let rpc_server t = t.rpc_server
 
 let find_in_path_exn prog =
   match Bin.which ~path:(Env_path.path Env.initial) prog with
@@ -25,7 +29,7 @@ let dune_prog () =
   else Path.of_filename_relative_to_initial_cwd prog
 ;;
 
-let create ~rpc_server ~where ~config ~sandbox_actions =
+let create ~where ~config ~sandbox_actions =
   let runner =
     let pid =
       let env =
@@ -76,9 +80,10 @@ let create ~rpc_server ~where ~config ~sandbox_actions =
         ~finally:(fun () -> Option.iter trace_fd ~f:Fd.close)
       |> Pid.of_int_exn
     in
-    Dune_engine.Action_runner.create rpc_server name pid
+    Dune_engine.Action_runner.create name pid
   in
-  { runner }
+  let rpc_server = Dune_engine.Action_runner.Rpc_server.create (`Enabled runner) in
+  { runner; rpc_server }
 ;;
 
 let parse_where where =

--- a/bin/action_runner.mli
+++ b/bin/action_runner.mli
@@ -2,12 +2,7 @@ open Import
 
 type t
 
-val create
-  :  rpc_server:Dune_engine.Action_runner.Rpc_server.t
-  -> where:Dune_rpc.Where.t
-  -> config:Dune_config.t
-  -> sandbox_actions:bool
-  -> t
-
+val create : where:Dune_rpc.Where.t -> config:Dune_config.t -> sandbox_actions:bool -> t
 val runner : t -> Dune_engine.Action_runner.t
+val rpc_server : t -> Dune_engine.Action_runner.Rpc_server.t
 val start_worker : name:string -> where:string -> trace_fd:string option -> unit Fiber.t

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1385,40 +1385,28 @@ let init_with_root_and_rpc ~(root : Workspace_root.t) ~rpc_build (builder : Buil
       let path = Path.external_ file in
       Dune_util.Gc.serialize ~path stat);
   let where = lazy (Dune_rpc_impl.Where.default ()) in
-  let action_runner_requested = action_runner_requested c in
-  (* The RPC server must start listening before the action runner is spawned:
-     the worker connects back to this server during initialization. Keep the
-     worker lazy so constructing the RPC server does not spawn it. *)
-  let rec action_runner =
+  let action_runner =
     lazy
-      (if action_runner_requested
+      (if action_runner_requested c
        then
          Some
            (Action_runner.create
-              ~rpc_server:(Lazy.force action_runner_server)
               ~where:(Lazy.force where)
               ~config
               ~sandbox_actions:c.builder.sandbox_actions)
        else None)
-  and engine_action_runner =
-    lazy (Lazy.force action_runner |> Option.map ~f:Action_runner.runner)
-  and worker =
-    lazy
-      (match Lazy.force engine_action_runner with
-       | Some action_runner -> action_runner
-       | None -> Code_error.raise "action runner unexpectedly disabled" [])
-  and action_runner_server =
-    lazy
-      (Dune_engine.Action_runner.Rpc_server.create
-         (if action_runner_requested then `Enabled worker else `Disabled))
   in
-  let action_runner_server = Lazy.force action_runner_server in
   let rpc =
     if c.builder.allow_builds
     then
       `Allow
         (lazy
-          (let rpc_build =
+          (let action_runner =
+             match Lazy.force action_runner with
+             | None -> Dune_engine.Action_runner.Rpc_server.create `Disabled
+             | Some action_runner -> Action_runner.rpc_server action_runner
+           in
+           let rpc_build =
              lazy
                (match rpc_build with
                 | `Disabled -> Dune_rpc_impl.Server.Disabled
@@ -1436,11 +1424,13 @@ let init_with_root_and_rpc ~(root : Workspace_root.t) ~rpc_build (builder : Buil
              ~root:root.dir
              ~build
              ~where:(Lazy.force where)
-             ~action_runner:action_runner_server
+             ~action_runner
              c.builder.watch))
     else `Forbid_builds
   in
-  let action_runner = engine_action_runner in
+  let action_runner =
+    lazy (Lazy.force action_runner |> Option.map ~f:Action_runner.runner)
+  in
   let c = { c with rpc; action_runner } in
   c, config
 ;;

--- a/bin/scheduler_setup.ml
+++ b/bin/scheduler_setup.ml
@@ -19,18 +19,12 @@ let go_without_rpc_server ~(common : Common.t) ~config:dune_config f =
 ;;
 
 let await_action_runner common =
-  if Common.action_runner_requested common
-  then
+  match Common.action_runner common with
+  | None -> Fiber.return ()
+  | Some action_runner ->
     let open Fiber.O in
-    (* [Common.action_runner] spawns a worker that immediately connects back to
-       Dune over RPC. With eager socket creation, the socket can be connectable
-       before the accept loop is running, so start the server before spawning
-       the worker. *)
     let* () = Dune_rpc_impl.Server.ensure_ready () in
-    match Common.action_runner common with
-    | None -> Fiber.return ()
-    | Some action_runner -> Dune_engine.Action_runner.ensure_ready action_runner
-  else Fiber.return ()
+    Dune_engine.Action_runner.ensure_ready action_runner
 ;;
 
 let go_with_rpc_server ~common ~config f =

--- a/src/dune_engine/action_runner.ml
+++ b/src/dune_engine/action_runner.ml
@@ -147,13 +147,13 @@ module Rpc_server = struct
   type nonrec t =
     | No_worker
     | Worker of
-        { worker : t Lazy.t
+        { worker : t
         ; pool : Fiber.Pool.t
         }
 
   let create = function
     | `Disabled -> No_worker
-    | `Enabled worker -> Worker { worker; pool = Fiber.Pool.create () }
+    | `Enabled worker -> Worker { worker; pool = worker.pool }
   ;;
 
   let run = function
@@ -165,13 +165,9 @@ module Rpc_server = struct
     | No_worker -> Fiber.return ()
     | Worker { worker; pool } ->
       let* () =
-        if Lazy.is_val worker
-        then (
-          let worker = Lazy.force worker in
-          match worker.status with
-          | Starting _ | Closed -> Fiber.return ()
-          | Initialized (Session session) -> Server.Session.close session)
-        else Fiber.return ()
+        match worker.status with
+        | Starting _ | Closed -> Fiber.return ()
+        | Initialized (Session session) -> Server.Session.close session
       in
       Fiber.Pool.close pool
   ;;
@@ -184,24 +180,22 @@ module Rpc_server = struct
   let ready t session ({ Request.Ready.name } : Request.Ready.t) =
     match t with
     | No_worker -> invalid_request "unexpected action runner"
+    | Worker { worker; pool = _ } when not (Action_runner_name.equal name worker.name) ->
+      invalid_request "unexpected action runner"
     | Worker { worker; pool } ->
-      let worker = Lazy.force worker in
-      if not (Action_runner_name.equal name worker.name)
-      then invalid_request "unexpected action runner"
-      else (
-        match worker.status with
-        | Closed -> invalid_request "disconnected earlier"
-        | Initialized _ -> invalid_request "already signalled readiness to the server"
-        | Starting { ready } ->
-          worker.status <- Initialized (Session session);
-          Dune_trace.emit Action (fun () ->
-            Dune_trace.Event.Action.Runner.runner_event ~name:worker.name Connected);
-          let* () =
-            Fiber.Pool.task pool ~f:(fun () ->
-              let* () = Server.Session.closed session in
-              disconnect worker)
-          in
-          Fiber.Ivar.fill ready ())
+      (match worker.status with
+       | Closed -> invalid_request "disconnected earlier"
+       | Initialized _ -> invalid_request "already signalled readiness to the server"
+       | Starting { ready } ->
+         worker.status <- Initialized (Session session);
+         Dune_trace.emit Action (fun () ->
+           Dune_trace.Event.Action.Runner.runner_event ~name:worker.name Connected);
+         let* () =
+           Fiber.Pool.task pool ~f:(fun () ->
+             let* () = Server.Session.closed session in
+             disconnect worker)
+         in
+         Fiber.Ivar.fill ready ())
   ;;
 
   let implement_handler t (handler : _ Root.Rpc.Server.Handler.t) =
@@ -211,19 +205,13 @@ module Rpc_server = struct
   ;;
 end
 
-let create (server : Rpc_server.t) name pid =
+let create name pid =
   Dune_trace.emit Action (fun () ->
     Dune_trace.Event.Action.Runner.runner_event ~name (Spawn pid));
-  let pool =
-    match server with
-    | Worker { pool; _ } -> pool
-    | No_worker ->
-      Code_error.raise "cannot create an action runner for a disabled RPC server" []
-  in
   { name
   ; status = Starting { ready = Fiber.Ivar.create () }
   ; pid
-  ; pool
+  ; pool = Fiber.Pool.create ()
   ; monitoring = false
   }
 ;;

--- a/src/dune_engine/action_runner.mli
+++ b/src/dune_engine/action_runner.mli
@@ -16,7 +16,7 @@ module Rpc_server : sig
     (** The server-side component responsible for orchestrating action runners. *)
     type t
 
-    val create : [ `Disabled | `Enabled of action_runner Lazy.t ] -> t
+    val create : [ `Disabled | `Enabled of action_runner ] -> t
 
     (** [implement_handler t handler] wires the action runner requests into an
       existing RPC handler. *)
@@ -30,7 +30,7 @@ module Rpc_server : sig
   end
   with type action_runner := t
 
-val create : Rpc_server.t -> Action_runner_name.t -> Pid.t -> t
+val create : Action_runner_name.t -> Pid.t -> t
 val ensure_ready : t -> unit Fiber.t
 
 (** [exec_process t ~run_id ~cancellation process] dispatches [process] to [t]

--- a/src/dune_engine/action_runner_worker.ml
+++ b/src/dune_engine/action_runner_worker.ml
@@ -90,11 +90,15 @@ let cancel_build t ~name ({ Request.Cancel_build.run_id } : Request.Cancel_build
     Fiber.Ivar.read active.drained)
 ;;
 
+let connect_retry_delay = Time.Span.of_secs 0.1
+
 let start ~name ~where =
   let t = create () in
   Dune_trace.emit Action (fun () ->
     Dune_trace.Event.Action.Runner.runner_event ~name Connection_start);
-  let* connection = Client.Connection.connect_exn where in
+  let* connection =
+    Client.Connection.connect_retrying_exn where ~retry_delay:connect_retry_delay
+  in
   Dune_trace.emit Action (fun () ->
     Dune_trace.Event.Action.Runner.runner_event ~name Connection_established);
   let private_menu : Client.proc list =

--- a/src/rpc/client.ml
+++ b/src/rpc/client.ml
@@ -18,6 +18,8 @@ include
 module Connection = struct
   type t = Csexp_rpc.Session.t
 
+  let connect_sock sock = Csexp_rpc.Client.create sock |> Csexp_rpc.Client.connect
+
   let connect where =
     match Where.to_socket where with
     | exception exn ->
@@ -28,9 +30,8 @@ module Connection = struct
               ; Exn.pp exn
               ]))
     | sock ->
-      let client = Csexp_rpc.Client.create sock in
-      let+ res = Csexp_rpc.Client.connect client in
-      (match res with
+      connect_sock sock
+      >>| (function
        | Ok s -> Ok s
        | Error exn ->
          Error
@@ -40,9 +41,26 @@ module Connection = struct
               ]))
   ;;
 
-  let connect_exn where =
-    let+ conn = connect where in
-    User_error.ok_exn conn
+  let connect_exn where = connect where >>| User_error.ok_exn
+
+  let is_retryable_connect_error { Exn_with_backtrace.exn; _ } =
+    match exn with
+    | Unix.Unix_error ((Unix.ENOENT | Unix.ECONNREFUSED), "connect", _) -> true
+    | _ -> false
+  ;;
+
+  let connect_retrying_exn where ~retry_delay =
+    let sock = Where.to_socket where in
+    let rec loop () =
+      connect_sock sock
+      >>= function
+      | Ok connection -> Fiber.return connection
+      | Error exn when is_retryable_connect_error exn ->
+        let* () = Dune_scheduler.Scheduler.sleep retry_delay in
+        loop ()
+      | Error exn -> Exn_with_backtrace.reraise exn
+    in
+    loop ()
   ;;
 end
 

--- a/src/rpc/client.mli
+++ b/src/rpc/client.mli
@@ -10,6 +10,9 @@ module Connection : sig
 
   (** like [connect] but fails with a nice error message for the user *)
   val connect_exn : Dune_rpc.Where.t -> t Fiber.t
+
+  (** Connect, retrying only [ENOENT] and [ECONNREFUSED] from [connect]. *)
+  val connect_retrying_exn : Dune_rpc.Where.t -> retry_delay:Time.Span.t -> t Fiber.t
 end
 
 (** [client t where init ~on_notification ~f] Establishes a client connection to


### PR DESCRIPTION
Have action-runner workers retry connecting to the parent RPC server every 0.1s until the server is ready, instead of failing immediately when the socket is not available yet.

Only retry ENOENT and ECONNREFUSED from the socket connect call. Other connection failures, including invalid RPC addresses, are reported immediately.

With connection retries in place, remove the lazy startup-order knot between spawning the worker and launching the RPC server.