### PR TITLE
refactor(action-runner): share RPC server state

### DIFF
--- a/bin/action_runner.ml
+++ b/bin/action_runner.ml
@@ -2,14 +2,6 @@ open Import
 
 let name = Action_runner_name.of_string "action-runner"
 
-type t =
-  { runner : Dune_engine.Action_runner.t
-  ; rpc_server : Dune_engine.Action_runner.Rpc_server.t
-  }
-
-let runner t = t.runner
-let rpc_server t = t.rpc_server
-
 let find_in_path_exn prog =
   match Bin.which ~path:(Env_path.path Env.initial) prog with
   | Some path -> path
@@ -30,60 +22,53 @@ let dune_prog () =
 ;;
 
 let create ~where ~config ~sandbox_actions =
-  let runner =
-    let pid =
-      let env =
-        let jobs =
-          let scheduler_config =
-            Dune_config.for_scheduler
-              config
-              ~watch_exclusions:[]
-              ~print_ctrl_c_warning:true
-          in
-          Int.to_string scheduler_config.concurrency
+  let pid =
+    let env =
+      let jobs =
+        let scheduler_config =
+          Dune_config.for_scheduler config ~watch_exclusions:[] ~print_ctrl_c_warning:true
         in
-        Env.add Env.initial ~var:"DUNE_JOBS" ~value:jobs
-        |> Env.add ~var:"DUNE_BUILD_DIR" ~value:(Path.Build.to_string Path.Build.root)
-        |> Env.to_unix
-        |> Spawn.Env.of_list
+        Int.to_string scheduler_config.concurrency
       in
-      let trace_fd = Dune_trace.duplicate_global_fd () in
-      let prog, argv =
-        let dune_prog = dune_prog () in
-        let worker_argv =
-          [ Path.to_string dune_prog
-          ; "internal"
-          ; "action-runner"
-          ; "start"
-          ; Action_runner_name.to_string name
-          ]
-        in
-        if sandbox_actions
-        then (
-          let { Bwrap.prog; argv } =
-            Bwrap.wrap ~cwd:(Path.to_absolute_filename Path.root) worker_argv
-          in
-          prog, argv)
-        else Path.to_string dune_prog, worker_argv
-      in
-      let argv =
-        let where = Dune_rpc.Where.to_string where in
-        argv
-        @ [ where ]
-        @
-        match trace_fd with
-        | Some fd -> [ "--trace-fd"; Int.to_string (Fd.unsafe_to_int fd) ]
-        | None -> []
-      in
-      Exn.protect
-        ~f:(fun () -> Spawn.spawn ~env ~prog ~argv ())
-        ~finally:(fun () -> Option.iter trace_fd ~f:Fd.close)
-      |> Pid.of_int_exn
+      Env.add Env.initial ~var:"DUNE_JOBS" ~value:jobs
+      |> Env.add ~var:"DUNE_BUILD_DIR" ~value:(Path.Build.to_string Path.Build.root)
+      |> Env.to_unix
+      |> Spawn.Env.of_list
     in
-    Dune_engine.Action_runner.create name pid
+    let trace_fd = Dune_trace.duplicate_global_fd () in
+    let prog, argv =
+      let dune_prog = dune_prog () in
+      let worker_argv =
+        [ Path.to_string dune_prog
+        ; "internal"
+        ; "action-runner"
+        ; "start"
+        ; Action_runner_name.to_string name
+        ]
+      in
+      if sandbox_actions
+      then (
+        let { Bwrap.prog; argv } =
+          Bwrap.wrap ~cwd:(Path.to_absolute_filename Path.root) worker_argv
+        in
+        prog, argv)
+      else Path.to_string dune_prog, worker_argv
+    in
+    let argv =
+      let where = Dune_rpc.Where.to_string where in
+      argv
+      @ [ where ]
+      @
+      match trace_fd with
+      | Some fd -> [ "--trace-fd"; Int.to_string (Fd.unsafe_to_int fd) ]
+      | None -> []
+    in
+    Exn.protect
+      ~f:(fun () -> Spawn.spawn ~env ~prog ~argv ())
+      ~finally:(fun () -> Option.iter trace_fd ~f:Fd.close)
+    |> Pid.of_int_exn
   in
-  let rpc_server = Dune_engine.Action_runner.Rpc_server.create (`Enabled runner) in
-  { runner; rpc_server }
+  Dune_engine.Action_runner.create name pid
 ;;
 
 let parse_where where =

--- a/bin/action_runner.mli
+++ b/bin/action_runner.mli
@@ -1,8 +1,9 @@
 open Import
 
-type t
+val create
+  :  where:Dune_rpc.Where.t
+  -> config:Dune_config.t
+  -> sandbox_actions:bool
+  -> Dune_engine.Action_runner.t
 
-val create : where:Dune_rpc.Where.t -> config:Dune_config.t -> sandbox_actions:bool -> t
-val runner : t -> Dune_engine.Action_runner.t
-val rpc_server : t -> Dune_engine.Action_runner.Rpc_server.t
 val start_worker : name:string -> where:string -> trace_fd:string option -> unit Fiber.t

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1401,12 +1401,7 @@ let init_with_root_and_rpc ~(root : Workspace_root.t) ~rpc_build (builder : Buil
     then
       `Allow
         (lazy
-          (let action_runner =
-             match Lazy.force action_runner with
-             | None -> Dune_engine.Action_runner.Rpc_server.create `Disabled
-             | Some action_runner -> Action_runner.rpc_server action_runner
-           in
-           let rpc_build =
+          (let rpc_build =
              lazy
                (match rpc_build with
                 | `Disabled -> Dune_rpc_impl.Server.Disabled
@@ -1424,12 +1419,9 @@ let init_with_root_and_rpc ~(root : Workspace_root.t) ~rpc_build (builder : Buil
              ~root:root.dir
              ~build
              ~where:(Lazy.force where)
-             ~action_runner
+             ~action_runner:(Lazy.force action_runner)
              c.builder.watch))
     else `Forbid_builds
-  in
-  let action_runner =
-    lazy (Lazy.force action_runner |> Option.map ~f:Action_runner.runner)
   in
   let c = { c with rpc; action_runner } in
   c, config

--- a/src/dune_engine/action_runner.ml
+++ b/src/dune_engine/action_runner.ml
@@ -143,67 +143,48 @@ let exec_process t ~run_id ~cancellation process =
   | Not_cancelled, Error exns -> Fiber.reraise_all exns
 ;;
 
-module Rpc_server = struct
-  type nonrec t =
-    | No_worker
-    | Worker of
-        { worker : t
-        ; pool : Fiber.Pool.t
-        }
+let run t = Fiber.Pool.run t.pool
 
-  let create = function
-    | `Disabled -> No_worker
-    | `Enabled worker -> Worker { worker; pool = worker.pool }
-  ;;
+let stop t =
+  let* () =
+    match t.status with
+    | Starting _ | Closed -> Fiber.return ()
+    | Initialized (Session session) -> Server.Session.close session
+  in
+  Fiber.Pool.close t.pool
+;;
 
-  let run = function
-    | No_worker -> Fiber.return ()
-    | Worker { pool; _ } -> Fiber.Pool.run pool
-  ;;
+let invalid_request message =
+  let error = Dune_rpc.Response.Error.create ~kind:Invalid_request ~message () in
+  raise (Dune_rpc.Response.Error.E error)
+;;
 
-  let stop = function
-    | No_worker -> Fiber.return ()
-    | Worker { worker; pool } ->
-      let* () =
-        match worker.status with
-        | Starting _ | Closed -> Fiber.return ()
-        | Initialized (Session session) -> Server.Session.close session
-      in
-      Fiber.Pool.close pool
-  ;;
+let ready t session ({ Request.Ready.name } : Request.Ready.t) =
+  match t with
+  | None -> invalid_request "unexpected action runner"
+  | Some worker when not (Action_runner_name.equal name worker.name) ->
+    invalid_request "unexpected action runner"
+  | Some worker ->
+    (match worker.status with
+     | Closed -> invalid_request "disconnected earlier"
+     | Initialized _ -> invalid_request "already signalled readiness to the server"
+     | Starting { ready } ->
+       worker.status <- Initialized (Session session);
+       Dune_trace.emit Action (fun () ->
+         Dune_trace.Event.Action.Runner.runner_event ~name:worker.name Connected);
+       let* () =
+         Fiber.Pool.task worker.pool ~f:(fun () ->
+           let* () = Server.Session.closed session in
+           disconnect worker)
+       in
+       Fiber.Ivar.fill ready ())
+;;
 
-  let invalid_request message =
-    let error = Dune_rpc.Response.Error.create ~kind:Invalid_request ~message () in
-    raise (Dune_rpc.Response.Error.E error)
-  ;;
-
-  let ready t session ({ Request.Ready.name } : Request.Ready.t) =
-    match t with
-    | No_worker -> invalid_request "unexpected action runner"
-    | Worker { worker; pool = _ } when not (Action_runner_name.equal name worker.name) ->
-      invalid_request "unexpected action runner"
-    | Worker { worker; pool } ->
-      (match worker.status with
-       | Closed -> invalid_request "disconnected earlier"
-       | Initialized _ -> invalid_request "already signalled readiness to the server"
-       | Starting { ready } ->
-         worker.status <- Initialized (Session session);
-         Dune_trace.emit Action (fun () ->
-           Dune_trace.Event.Action.Runner.runner_event ~name:worker.name Connected);
-         let* () =
-           Fiber.Pool.task pool ~f:(fun () ->
-             let* () = Server.Session.closed session in
-             disconnect worker)
-         in
-         Fiber.Ivar.fill ready ())
-  ;;
-
-  let implement_handler t (handler : _ Root.Rpc.Server.Handler.t) =
-    Server.Handler.declare_request handler Decl.exec;
-    Server.Handler.declare_request handler Decl.cancel_build;
-    Server.Handler.implement_request handler Decl.ready (ready t)
-  ;;
-end
+let implement_handler t (handler : _ Root.Rpc.Server.Handler.t) =
+  Server.Handler.declare_request handler Decl.exec;
+  Server.Handler.declare_request handler Decl.cancel_build;
+  Server.Handler.implement_request handler Decl.ready (ready t)
+;;
 
 let create name pid =
   Dune_trace.emit Action (fun () ->

--- a/src/dune_engine/action_runner.mli
+++ b/src/dune_engine/action_runner.mli
@@ -10,25 +10,15 @@ open Import
 
 type t
 
-module Rpc_server : sig
-    type action_runner
-
-    (** The server-side component responsible for orchestrating action runners. *)
-    type t
-
-    val create : [ `Disabled | `Enabled of action_runner ] -> t
-
-    (** [implement_handler t handler] wires the action runner requests into an
+(** [implement_handler t handler] wires the action runner requests into an
       existing RPC handler. *)
-    val implement_handler : t -> 'a Root.Rpc.Server.Handler.t -> unit
+val implement_handler : t option -> 'a Root.Rpc.Server.Handler.t -> unit
 
-    (** [run t] is to be run by the RPC server. *)
-    val run : t -> unit Fiber.t
+(** [run t] is to be run by the RPC server. *)
+val run : t -> unit Fiber.t
 
-    (** [stop t] is to be run by the RPC server. *)
-    val stop : t -> unit Fiber.t
-  end
-  with type action_runner := t
+(** [stop t] is to be run by the RPC server. *)
+val stop : t -> unit Fiber.t
 
 val create : Action_runner_name.t -> Pid.t -> t
 val ensure_ready : t -> unit Fiber.t

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -68,7 +68,7 @@ end
 
 type server =
   { lifecycle : Rpc.Server.Lifecycle.t
-  ; action_runner : Action_runner.Rpc_server.t
+  ; action_runner : Action_runner.t option
   ; registry : [ `Add | `Skip ]
   ; watch_mode : Watch_mode_config.t
   ; mutable clients : Clients.t
@@ -109,7 +109,10 @@ let () =
 
 let stop (t : t) =
   Fiber.fork_and_join_unit
-    (fun () -> Action_runner.Rpc_server.stop t.server.action_runner)
+    (fun () ->
+       match t.server.action_runner with
+       | None -> Fiber.return ()
+       | Some runner -> Action_runner.stop runner)
     (fun () -> Rpc.Server.Lifecycle.stop t.server.lifecycle)
 ;;
 
@@ -399,7 +402,7 @@ let handler (t : t Fdecl.t) action_runner_server : unit Handler.t =
     let f _ () = Fiber.return Path.Build.(to_string root) in
     Handler.implement_request rpc Procedures.Public.build_dir f
   in
-  Action_runner.Rpc_server.implement_handler action_runner_server rpc;
+  Action_runner.implement_handler action_runner_server rpc;
   Dune_rules_rpc.register rpc;
   rpc
 ;;
@@ -447,7 +450,10 @@ let run t =
   let run () =
     Fiber.fork_and_join_unit
       (fun () -> Rpc.Server.Lifecycle.run t.server.lifecycle)
-      (fun () -> Action_runner.Rpc_server.run t.server.action_runner)
+      (fun () ->
+         match t.server.action_runner with
+         | None -> Fiber.return ()
+         | Some runner -> Action_runner.run runner)
   in
   match t.server.registry with
   | `Skip -> run ()

--- a/src/dune_rpc_impl/server.mli
+++ b/src/dune_rpc_impl/server.mli
@@ -19,7 +19,7 @@ val create
   -> root:string
   -> build:build
   -> where:Dune_rpc.Where.t
-  -> action_runner:Dune_engine.Action_runner.Rpc_server.t
+  -> action_runner:Dune_engine.Action_runner.t option
   -> Watch_mode_config.t
   -> t
 


### PR DESCRIPTION
Represent the action-runner RPC server as the optional runner itself instead of duplicating the worker and pool in a separate record.