### PR TITLE
stdune: add Fd.dup

### DIFF
--- a/otherlibs/stdune/src/fd.ml
+++ b/otherlibs/stdune/src/fd.ml
@@ -13,6 +13,12 @@ let unsafe_to_unix_file_descr t = t.fd
 let unsafe_of_unix_file_descr fd = { fd; closed = false }
 let is_closed t = t.closed
 let unsafe_of_int fd = unsafe_of_unix_file_descr (unsafe_file_descr_of_int fd)
+
+let dup t =
+  assert (not t.closed);
+  unsafe_of_unix_file_descr (Unix.dup t.fd)
+;;
+
 let set_close_on_exec t = Unix.set_close_on_exec t.fd
 let clear_close_on_exec t = Unix.clear_close_on_exec t.fd
 

--- a/otherlibs/stdune/src/fd.mli
+++ b/otherlibs/stdune/src/fd.mli
@@ -6,6 +6,7 @@ val hash : t -> int
 val to_dyn : t -> Dyn.t
 val close : t -> unit
 val is_closed : t -> bool
+val dup : t -> t
 val set_nonblock : t -> unit
 val set_close_on_exec : t -> unit
 val clear_close_on_exec : t -> unit

--- a/src/dune_trace/dune_trace.ml
+++ b/src/dune_trace/dune_trace.ml
@@ -142,10 +142,7 @@ let duplicate_global_fd () =
     match global () with
     | None -> None
     | Some out ->
-      let fd =
-        Unix.dup (Fd.unsafe_to_unix_file_descr (Out.fd out))
-        |> Fd.unsafe_of_unix_file_descr
-      in
+      let fd = Fd.dup (Out.fd out) in
       Fd.clear_close_on_exec fd;
       Some fd)
 ;;


### PR DESCRIPTION
Add a small Fd wrapper around Unix.dup and use it when duplicating the global trace file descriptor for action-runner inheritance.