### PR TITLE
fix(utop): accept absolute paths to workspace directories

### DIFF
--- a/bin/ocaml/utop.ml
+++ b/bin/ocaml/utop.ml
@@ -28,7 +28,16 @@ let term =
   (* CR-someday Alizter: document this option *)
   and+ args = Arg.(value & pos_right 0 string [] (Arg.info [] ~docv:"ARGS" ~doc:None)) in
   let common, config = Common.init builder in
-  let dir = Common.prefix_target common dir in
+  let dir =
+    match Path.of_string dir with
+    | External _ as ext ->
+      (* Absolute path: if it's an external path inside the workspace, localize it.
+        Otherwise leave it external so the existing error handling kicks in *)
+      Path.Expert.try_localize_external ext |> Path.to_string
+    | _ ->
+      (* Relative path: account for the cwd when run from a subdirectory. *)
+      Common.prefix_target common dir
+  in
   if not (Fpath.is_directory (Path.to_string (Path.of_string dir)))
   then User_error.raise [ Pp.textf "cannot find directory: %s" (String.maybe_quoted dir) ];
   let env, utop_path =

--- a/doc/changes/fixed/15272.md
+++ b/doc/changes/fixed/15272.md
@@ -1,0 +1,2 @@
+- `dune utop` now accepts an absolute path to a workspace directory instead of
+  crashing with an internal error. (#15272, fixes #15108, @chizy7)

--- a/test/blackbox-tests/test-cases/absolute-paths/utop-absolute.t
+++ b/test/blackbox-tests/test-cases/absolute-paths/utop-absolute.t
@@ -20,13 +20,11 @@ A relative path works:
   $ dune utop lib -- init.ml
   foolib
 
-CR-someday Alizter: an absolute path pointing at the same directory should
-work identically to the relative form. Today it crashes with a Code_error
-because Path.Build.relative is called with an absolute string.
+An absolute path pointing at the same directory works identically to the
+relative form:
 
-  $ dune utop $PWD/lib -- init.ml 2>&1 | grep "Internal error"
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
-  [1]
+  $ dune utop $PWD/lib -- init.ml
+  foolib
 
 An absolute path that is genuinely outside the workspace should produce a
 clean user error rather than a crash.


### PR DESCRIPTION
Fixes #15108.

`dune utop $PWD/lib` crashed with an internal `Code_error` while `dune utop lib` worked. `Common.prefix_target` is a no-op on absolute strings, so the absolute path reached `Path.Build.relative`, which raises on absolute input.

This change localizes an absolute `DIR` argument with `Path.Expert.try_localize_external` before use. this is the same approach that `dune exec` (#12094) and `dune runtest` (#11936) already uses. A relative path still goes through `Common.prefix_target` so the run-from-a-subdirectory case is unchanged, and a part outside the workspace stays external and still produces the clean `Error: cannot find directory: ...` message.

Based on @Alizter's repro in #15116, the test was flipped from asserting the crash to checking the working `foolib` output.

questions I have:

* The issue suggests migrating `DIR` to `Arg.Workspace_path`. That converter doesn't exist yet, and a cmdliner conv can't localize at parse time since localization needs `Build.build_dir`, which is only set after `Common.init`. I went with the inline localization that `exec` and `runtest` already use. Happy to extract a shared `Arg.Workspace_path` for #15109/#15110 if thats preferred. Should that live in this PR or a follow-up?
* An absolute path pointing into `_build` would localize to an in-build path. `exec` handles that through `Path.relative_to_source_in_build_or_external`. This isn't covered by the repro or the issue's required behaviors, so I left it out for now. Let me know if you would like that included here.
* I also wasnt sure if there is a preferred place for sharing this localization logic across commands instead of keeping it inline.