### PR TITLE
Update mirage.yml to use latest opam commit

### DIFF
--- a/.github/workflows/mirage.yml
+++ b/.github/workflows/mirage.yml
@@ -21,7 +21,8 @@ jobs:
       with:
         ocaml-compiler: 4.14.x
         opam-depext: false
-    - run: opam repo set-url default git+https://github.com/ocaml/opam-repository#a7b8d1036328cf727af175b657f3d2b732b4d868
+        opam-repositories: |
+          default: git+https://github.com/ocaml/opam-repository#38b8d4531633db2f927868caf84e5a9b8992229e
     - run: sed -i s/1.3/2.7/ dune-project
     - run: opam pin add -n dune.dev git+https://github.com/ocaml/dune#$GITHUB_SHA
     - run: sudo apt install libseccomp-dev


### PR DESCRIPTION
With the release of the new 4.14 patch, the current opam pin is causing a dependency error on the -rc tests:

```
[ERROR] Package conflict!
  * Missing dependency:
    - (invariant) → ocaml-base-compiler = 4.14.4 → ocaml-base-compiler.4.14.4: no longer available
```

I believe this is because setup-ocaml knows the latest version is out, and sets that invariant for the switch, but then we override the opam repo to an older versions that doesn't have the required compiler version.