### PR TITLE
Add review-check agent skill

### DIFF
--- a/.agents/skills/review-check/SKILL.md
+++ b/.agents/skills/review-check/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: review-check
+description: >-
+  Review Dune commits, PRs, or working tree changes using the repository
+  review checklist. Use when the user asks for review-check, review checklist,
+  or a code review that should follow doc/dev/prompts/review-check.md.
+---
+
+Before reviewing, read `doc/dev/prompts/review-check.md` from the repository
+root and follow it as the checklist.
+
+Treat that file as authoritative. Do not duplicate the checklist here.


### PR DESCRIPTION
Define a repository skill that routes review requests to doc/dev/prompts/review-check.md and treats that checklist as authoritative.