### PR TITLE
fix(promote): exit 0 when --auto-promote applies all promotions

### DIFF
--- a/doc/changes/changed/15284.md
+++ b/doc/changes/changed/15284.md
@@ -1,0 +1,4 @@
+- `dune build --auto-promote` (and `dune fmt`) now exit with code 0 once they
+  have applied all the promotions, instead of exiting non-zero and forcing
+  callers to wrap the command in `|| true`. Genuine errors and non-promotable
+  diffs still fail. (#15284, fixes #785, @rgrinberg)

--- a/src/dune_engine/diff_action.ml
+++ b/src/dune_engine/diff_action.ml
@@ -73,26 +73,31 @@ let promotion source_file =
   }
 ;;
 
-let run_change loc ~patch_back (mode : Diff.Mode.t) = function
-  | Message messages -> User_error.raise ~loc messages
+let run_change loc ~patch_back ~fail (mode : Diff.Mode.t) = function
+  | Message messages ->
+    if fail
+    then User_error.raise ~loc messages
+    else (
+      Console.print_user_message (User_message.make ~loc messages);
+      Fiber.return ())
   | File_diff { source_file; file1; file2 } ->
     (match mode with
      | Text ->
-       Print_diff.print
-         ~patch_back
-         (promotion source_file)
-         file1
-         file2
-         ~skip_trailing_cr:Sys.win32
+       let print = if fail then Print_diff.print else Print_diff.print_no_fail in
+       print ~patch_back (promotion source_file) file1 file2 ~skip_trailing_cr:Sys.win32
      | Binary ->
-       User_error.raise
-         ~promotion:(promotion source_file)
-         ~loc
+       let message =
          [ Pp.textf
              "Files %s and %s differ."
              (Path.to_string_maybe_quoted file1)
              (Path.to_string_maybe_quoted file2)
-         ])
+         ]
+       in
+       if fail
+       then User_error.raise ~promotion:(promotion source_file) ~loc message
+       else (
+         Console.print_user_message (User_message.make ~loc message);
+         Fiber.return ()))
 ;;
 
 let register_promotions how promotions =
@@ -307,15 +312,26 @@ let exec_plan
     let target_is_copied_from_source_tree =
       is_copied_from_source_tree (Path.build file2)
     in
+    (* Whether these changes will be applied as promotions at the end of the build. *)
+    let will_promote =
+      match optional with
+      | false -> in_source_or_target && not target_is_copied_from_source_tree
+      | true -> in_source_or_target
+    in
+    let auto_promote =
+      match !Clflags.promote with
+      | Some Automatically -> true
+      | Some Never | None -> false
+    in
+    (* A diff that will be auto-promoted is displayed but must not fail the build. *)
+    let fail = not (will_promote && auto_promote) in
     Fiber.finalize
-      (fun () -> Fiber.parallel_iter changes ~f:(run_change loc ~patch_back mode))
+      (fun () -> Fiber.parallel_iter changes ~f:(run_change loc ~patch_back ~fail mode))
       ~finally:(fun () ->
         (match optional with
-         | false ->
-           if in_source_or_target && not target_is_copied_from_source_tree
-           then register_promotions `Copy promotions
+         | false -> if will_promote then register_promotions `Copy promotions
          | true ->
-           if in_source_or_target
+           if will_promote
            then register_promotions `Move promotions
            else remove_intermediate_target file2);
         Fiber.return ())

--- a/src/dune_engine/print_diff.ml
+++ b/src/dune_engine/print_diff.ml
@@ -252,24 +252,40 @@ let prepare ~skip_trailing_cr promotion path1 path2 =
   prepare_with_labels ~skip_trailing_cr ~dir loc promotion (label1, path1) (label2, path2)
 ;;
 
+let prepare_print ~skip_trailing_cr ~patch_back promotion path1 path2 =
+  match patch_back with
+  | None -> prepare ~skip_trailing_cr (Some promotion) path1 path2
+  | Some dir ->
+    let path1 = Path.source (Path.drop_optional_build_context_src_exn path1) in
+    let loc = Loc.in_file path1 in
+    let label1 = Path.to_string path1 in
+    let label2 = Path.to_string (Path.drop_optional_sandbox_root path2) in
+    prepare_with_labels
+      ~skip_trailing_cr
+      ~dir
+      loc
+      (Some promotion)
+      (label1, path1)
+      (label2, path2)
+;;
+
 let print ~skip_trailing_cr ~patch_back promotion path1 path2 =
-  let p =
-    match patch_back with
-    | None -> prepare ~skip_trailing_cr (Some promotion) path1 path2
-    | Some dir ->
-      let path1 = Path.source (Path.drop_optional_build_context_src_exn path1) in
-      let loc = Loc.in_file path1 in
-      let label1 = Path.to_string path1 in
-      let label2 = Path.to_string (Path.drop_optional_sandbox_root path2) in
-      prepare_with_labels
-        ~skip_trailing_cr
-        ~dir
-        loc
-        (Some promotion)
-        (label1, path1)
-        (label2, path2)
-  in
-  With_fallback.exec p
+  With_fallback.exec (prepare_print ~skip_trailing_cr ~patch_back promotion path1 path2)
+;;
+
+let print_no_fail ~skip_trailing_cr ~patch_back promotion path1 path2 =
+  let p = prepare_print ~skip_trailing_cr ~patch_back promotion path1 path2 in
+  let+ result = With_fallback.capture p in
+  (* Route the diff through [Console] so it is interleaved correctly with the
+     "Promoting ..." message printed when the promotion is applied. *)
+  match result with
+  | Ok { Diff.loc; output } ->
+    let diff =
+      Pp.map_tags (Ansi_color.parse output) ~f:(fun styles ->
+        User_message.Style.Ansi_styles styles)
+    in
+    Console.print_user_message (User_message.make ?loc [ diff ])
+  | Error msg -> Console.print_user_message msg
 ;;
 
 let get path1 path2 =

--- a/src/dune_engine/print_diff.mli
+++ b/src/dune_engine/print_diff.mli
@@ -9,6 +9,16 @@ val print
   -> Path.t
   -> _ Fiber.t
 
+(** Like [print], but displays the diff without raising. Used when the diff is
+    going to be auto-promoted, in which case it is not an error. *)
+val print_no_fail
+  :  skip_trailing_cr:bool
+  -> patch_back:Path.t option
+  -> User_message.Diff_annot.t
+  -> Path.t
+  -> Path.t
+  -> unit Fiber.t
+
 module Diff : sig
   type t
 

--- a/test/blackbox-tests/test-cases/cinaps/runtime-deps.t
+++ b/test/blackbox-tests/test-cases/cinaps/runtime-deps.t
@@ -26,6 +26,5 @@ Runtime dependencies for running cinaps
   -(*)
   +(*$ let f = open_in "foo" in print_endline (input_line f); close_in f *)hello world
   Promoting _build/default/test.ml.cinaps-corrected to test.ml.
-  [1]
   $ cat test.ml
   (*$ let f = open_in "foo" in print_endline (input_line f); close_in f *)hello world

--- a/test/blackbox-tests/test-cases/cinaps/simple.t
+++ b/test/blackbox-tests/test-cases/cinaps/simple.t
@@ -40,7 +40,6 @@ The cinaps stanza offers a promotion workflow:
    (*$*)
    let x = 1
   Promoting _build/default/test.ml.cinaps-corrected to test.ml.
-  [1]
 
   $ cat test.ml
   (*$ print_endline "\nhello" *)

--- a/test/blackbox-tests/test-cases/cram/cram-command-syntax-error-gh4230.t
+++ b/test/blackbox-tests/test-cases/cram/cram-command-syntax-error-gh4230.t
@@ -10,7 +10,6 @@ Syntax error inside a cram command
   File "t1.t", line 1, characters 0-0:
   Error: Files _build/default/t1.t and _build/default/t1.t.corrected differ.
   Promoting _build/default/t1.t.corrected to t1.t.
-  [1]
 
   $ cat >t1.t <<EOF
   >   $ exit 1
@@ -26,7 +25,6 @@ Syntax error inside a cram command
      $ echo foobar
   +  ***** UNREACHABLE *****
   Promoting _build/default/t1.t.corrected to t1.t.
-  [1]
   $ cat t1.t
     $ exit 1
     ***** UNREACHABLE *****

--- a/test/blackbox-tests/test-cases/cram/custom-build-dir.t
+++ b/test/blackbox-tests/test-cases/cram/custom-build-dir.t
@@ -35,7 +35,6 @@ path
   Promoting
     $TESTCASE_ROOT/tmp/default/foo.t.corrected
     to foo.t.
-  [1]
   $ cat foo.t
     $ echo "  $ echo bar" >bar.t
     $ if [ -e "$DUNE_BUILD_DIR/.rpc" ]; then

--- a/test/blackbox-tests/test-cases/cram/git-access.t
+++ b/test/blackbox-tests/test-cases/cram/git-access.t
@@ -17,7 +17,6 @@ Check that actions don't have access to the outer git repository.
   +  fatal: invalid gitfile format: $TESTCASE_ROOT/git/_build/.sandbox/.git
   +  [128]
   Promoting _build/default/test.t.corrected to test.t.
-  [1]
 
 The inner call to git shouldn't be able to access the outer git repo:
 

--- a/test/blackbox-tests/test-cases/cram/hg-access.t
+++ b/test/blackbox-tests/test-cases/cram/hg-access.t
@@ -25,7 +25,6 @@ enough for a few hg commands such as "hg root" to succeed:
   +  abort: repository requires features unknown to this Mercurial: Escaping the Dune sandbox
   +  (see https://mercurial-scm.org/wiki/MissingRequirement for more information)
   Promoting _build/default/test.t.corrected to test.t.
-  [1]
 
 The inner call to hg shouldn't be able to access the outer hg repo:
 

--- a/test/blackbox-tests/test-cases/formatting/fmt-no-promote.t
+++ b/test/blackbox-tests/test-cases/formatting/fmt-no-promote.t
@@ -39,7 +39,6 @@ Actually format the file
   +(rule
   + (write-file a b))
   Promoting _build/default/dune.corrected to dune.
-  [1]
 
 Now the output of `dune fmt --preview is empty`.
   $ dune fmt --preview

--- a/test/blackbox-tests/test-cases/formatting/format-alternative.t
+++ b/test/blackbox-tests/test-cases/formatting/format-alternative.t
@@ -21,7 +21,6 @@ Dune files names dune-file should be formatted
   +  foo
   +  (echo bar)))
   Promoting _build/default/dune-file.corrected to dune-file.
-  [1]
 
   $ cat dune-file
   (rule

--- a/test/blackbox-tests/test-cases/inline-tests/clicolor-force-inline-tests-github6607.t
+++ b/test/blackbox-tests/test-cases/inline-tests/clicolor-force-inline-tests-github6607.t
@@ -42,7 +42,6 @@ file.
   -  [%expect]
   +  [%expect {| Error: |}]
   Promoting _build/default/l.ml.corrected to l.ml.
-  [1]
   $ < l.ml tr '\033' '?'
   open[@ocaml.alert "-unstable"] Stdune
   
@@ -61,7 +60,6 @@ file.
   -  [%expect {| Error: |}]
   +  [%expect {| Error: |}]
   Promoting _build/default/l.ml.corrected to l.ml.
-  [1]
   $ < l.ml tr '\033' '?'
   open[@ocaml.alert "-unstable"] Stdune
   

--- a/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
+++ b/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
@@ -15,7 +15,6 @@ Case 0: package does not declare menhir. Dune does not add it.
   > EOF
 
   $ dune build @opam --auto-promote > /dev/null 2>&1
-  [1]
   $ grep menhir foo.opam
   [1]
 
@@ -32,7 +31,6 @@ Case 1: bare [(depends menhir)]. Dune fills in the lower bound.
   > EOF
 
   $ dune build @opam --auto-promote > /dev/null 2>&1
-  [1]
   $ grep menhir foo.opam
     "menhir" {>= "20180523"}
 
@@ -49,7 +47,6 @@ Case 2: user-written version bound is preserved verbatim.
   > EOF
 
   $ dune build @opam --auto-promote > /dev/null 2>&1
-  [1]
   $ grep menhir foo.opam
     "menhir" {>= "20211128"}
 
@@ -68,7 +65,6 @@ for an unrelated reason (e.g. runtime).
   > EOF
 
   $ dune build @opam --auto-promote > /dev/null 2>&1
-  [1]
   $ grep menhir foo.opam
     "menhir"
 
@@ -89,7 +85,6 @@ bound; [bar.opam] has no [menhir] line at all.
   > EOF
 
   $ dune build @opam --auto-promote > /dev/null 2>&1
-  [1]
   $ grep menhir foo.opam
     "menhir" {>= "20180523"}
   $ test -f bar.opam && grep -c '^opam-version' bar.opam
@@ -117,6 +112,5 @@ stanza for the existing opam file.
   > EOF
 
   $ dune build @opam --auto-promote > /dev/null 2>&1
-  [1]
   $ grep menhir foo.opam
     "menhir" {with-test}

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/fmt-lockdir-behavior-gh11037.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/fmt-lockdir-behavior-gh11037.t
@@ -48,7 +48,6 @@ attempt to build the package "foo".
    let () = print_endline "Hello, world"
   +(* formatted with fake ocamlformat *)
   Promoting _build/default/foo.ml.corrected to foo.ml.
-  [1]
   $ cat foo.ml
   let () = print_endline "Hello, world"
   (* formatted with fake ocamlformat *)

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-taking-from-project-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-taking-from-project-deps.t
@@ -53,7 +53,6 @@ dev-tool (0.26.3).
   -let () = print_endline "Hello, world"
   +formatted with version 0.26.3
   Promoting _build/default/foo.ml.corrected to foo.ml.
-  [1]
   $ cat foo.ml
   formatted with version 0.26.3
 

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-ignore.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-ignore.t
@@ -55,7 +55,6 @@ Check without the feature when ".ocamlformat-ignore" file exists.
   +ignoring some files
   +fake ocamlformat from PATH
   Promoting _build/default/foo.ml.corrected to foo.ml.
-  [1]
   $ ls _build/default/.ocamlformat-ignore
   _build/default/.ocamlformat-ignore
   $ cat foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-patch-extra-files.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-patch-extra-files.t
@@ -68,7 +68,6 @@ First run of 'dune fmt' is supposed to format the fail.
   -let () = print_endline "Hello, world"
   +formatted with version 0.26.2
   Promoting _build/default/foo.ml.corrected to foo.ml.
-  [1]
 
 The foo.ml file is now formatted with the patched version of ocamlformat.
   $ cat foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
@@ -37,7 +37,6 @@ This should choose the 0.24+foo version:
    let () = print_endline "Hello, world"
   +(* formatted with fake ocamlformat 0.24+foo *)
   Promoting _build/default/foo.ml.corrected to foo.ml.
-  [1]
   $ cat foo.ml
   let () = print_endline "Hello, world"
   (* formatted with fake ocamlformat 0.24+foo *)
@@ -56,7 +55,6 @@ This should choose the 0.24+bar version:
    (* formatted with fake ocamlformat 0.24+foo *)
   +(* formatted with fake ocamlformat 0.25+bar *)
   Promoting _build/default/foo.ml.corrected to foo.ml.
-  [1]
   $ cat foo.ml
   let () = print_endline "Hello, world"
   (* formatted with fake ocamlformat 0.24+foo *)

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-rerun-on-source-change-gh10991.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-rerun-on-source-change-gh10991.t
@@ -27,7 +27,6 @@ Initial file:
    let () = print_endline "Hello, world"
   +(* formatted with fake ocamlformat *)
   Promoting _build/default/foo.ml.corrected to foo.ml.
-  [1]
 
 After formatting the fake ocamlformat has added a suffix:
   $ cat foo.ml
@@ -47,7 +46,6 @@ Update the file:
    let () = print_endline "Hello, ocaml!"
   +(* formatted with fake ocamlformat *)
   Promoting _build/default/foo.ml.corrected to foo.ml.
-  [1]
 
 The update to the file persists after formatting it a second time:
   $ cat foo.ml

--- a/test/blackbox-tests/test-cases/promote/auto-promote-exit-code.t
+++ b/test/blackbox-tests/test-cases/promote/auto-promote-exit-code.t
@@ -1,9 +1,8 @@
 Regression test for https://github.com/ocaml/dune/issues/785.
 
-`dune build --auto-promote` applies the promotion but currently still exits
-with a non-zero code, forcing callers to wrap the command in `|| true`. This
-test captures that behaviour; once #785 is fixed the build should exit 0 once
-the promotion has been applied (a fixpoint is reached).
+`dune build --auto-promote` applies the promotion and now exits with code 0
+once the promotion has been applied (a fixpoint is reached), instead of
+exiting non-zero and forcing callers to wrap the command in `|| true`.
 
   $ make_dune_project 3.25
 
@@ -17,8 +16,7 @@ the promotion has been applied (a fixpoint is reached).
 
   $ printf titi > x
 
-The diff is shown and the file is promoted, but the build still exits with
-code 1 -- this is the bug tracked by #785:
+The diff is shown and the file is promoted, and the build now exits 0:
 
   $ dune build @blah --auto-promote
   File "x", line 1, characters 0-0:
@@ -30,7 +28,6 @@ code 1 -- this is the bug tracked by #785:
   +toto
   \ No newline at end of file
   Promoting _build/default/x.gen to x.
-  [1]
   $ cat x
   toto
 

--- a/test/blackbox-tests/test-cases/promote/old-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/promote/old-tests.t/run.t
@@ -65,7 +65,6 @@ Otherwise this test fails on OSX
   +toto
   \ No newline at end of file
   Promoting _build/default/x.gen to x.
-  [1]
   $ cat x
   toto
   $ dune build @blah

--- a/test/blackbox-tests/test-cases/stanzas/mdx-stanza/env-variables.t
+++ b/test/blackbox-tests/test-cases/stanzas/mdx-stanza/env-variables.t
@@ -30,7 +30,6 @@ variable. This is only the case since mdx 2.1.0.
    
    ```ocaml non-deterministic
   Promoting _build/default/.mdx/README.md.corrected to README.md.
-  [1]
 
   $ cat README.md
   ```ocaml
@@ -55,7 +54,6 @@ variable. This is only the case since mdx 2.1.0.
   +- : string = "b"
    ```
   Promoting _build/default/.mdx/README.md.corrected to README.md.
-  [1]
 
   $ cat README.md
   ```ocaml

--- a/test/blackbox-tests/test-cases/stanzas/mdx-stanza/mdx-prelude-runtime-deps-github7077.t
+++ b/test/blackbox-tests/test-cases/stanzas/mdx-stanza/mdx-prelude-runtime-deps-github7077.t
@@ -33,7 +33,6 @@ run time. This test makes sure that this is recorded as a dependency.
   +- : int = 2
    ```
   Promoting _build/default/.mdx/README.md.corrected to README.md.
-  [1]
 
   $ cat README.md
   ```ocaml


### PR DESCRIPTION
Fixes #785.

`dune build --auto-promote` (and `dune fmt`, which is `dune build
--auto-promote @fmt`) used to exit with a non-zero code even after successfully
promoting the diffs, forcing callers to wrap the command in `|| true`.

A diff that is going to be auto-promoted is no longer treated as an error: it is
still displayed, but the build succeeds. The change is scoped to diffs that are
actually promoted, so genuine errors and non-promotable diffs (e.g. a `diff`
between two build artifacts) still fail.

## Implementation

- `Diff_action.exec_plan` already knows whether a change will be registered as a
  promotion (`in_source_or_target` / `target_is_copied_from_source_tree`). When
  that holds and `--auto-promote` is set, `run_change` is told not to raise.
- `Print_diff.print_no_fail` displays the captured diff through `Console`
  (so it is ordered correctly with the later `Promoting ...` message) instead of
  raising.

## Test

This flips the cram test added in #15283 from recording the buggy `[1]` to a
successful exit, and updates the other `--auto-promote` / `dune fmt` golden
outputs (each loses a trailing `[1]`; non-promotable and `--preview` cases keep
theirs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)