### PR TITLE
fix(exec): stop scheduler before exec emulation

### DIFF
--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -279,7 +279,17 @@ let build_prog_via_rpc_if_necessary ~dir ~no_rebuild builder lock_held_by prog =
     else not_found ~hints:[] ~prog
 ;;
 
-let exec_building_via_rpc_server ~common ~prog ~args ~no_rebuild builder lock_held_by =
+type prepared_exec =
+  { prog : string
+  ; args : string list
+  ; env : Env.t
+  }
+
+let run_prepared_exec { prog; args; env } ~(root : Workspace_root.t) =
+  Util.restore_cwd_and_execve root prog args env
+;;
+
+let prepare_exec_via_rpc_server ~common ~prog ~args ~no_rebuild builder lock_held_by =
   let open Fiber.O in
   let ensure_terminal v =
     match (v : Cmd_arg.t) with
@@ -301,7 +311,7 @@ let exec_building_via_rpc_server ~common ~prog ~args ~no_rebuild builder lock_he
     build_prog_via_rpc_if_necessary ~dir ~no_rebuild builder lock_held_by prog
   in
   let env = extend_with_staging_env context Env.initial in
-  Util.restore_cwd_and_execve (Common.root common) prog args env
+  { prog; args; env }
 ;;
 
 let exec_building_directly ~common ~config ~context ~prog ~args ~no_rebuild =
@@ -326,21 +336,24 @@ let exec_building_directly ~common ~config ~context ~prog ~args ~no_rebuild =
         ~action_runner:(Common.action_runner common)
         ~sticky_goal)
   | No ->
-    Scheduler_setup.go_with_rpc_server ~common ~config
-    @@ fun () ->
-    Build.build_memo_exn (fun () ->
-      let open Memo.O in
-      let* setup = Util.setup () in
-      let sctx = Dune_rules.Main.find_scontext_exn setup ~name:context in
-      let* env = Super_context.context_env sctx
-      and* prog =
-        let* prog = Cmd_arg.expand ~root:(Common.root common) ~sctx prog in
-        get_path_and_build_if_necessary common sctx ~no_rebuild ~prog >>| Path.to_string
-      and* args =
-        Memo.parallel_map ~f:(Cmd_arg.expand ~root:(Common.root common) ~sctx) args
-      in
-      let env = extend_with_staging_env context env in
-      Util.restore_cwd_and_execve (Common.root common) prog args env)
+    let prepared_exec =
+      Scheduler_setup.go_with_rpc_server ~common ~config
+      @@ fun () ->
+      Build.build_memo_exn (fun () ->
+        let open Memo.O in
+        let* setup = Util.setup () in
+        let sctx = Dune_rules.Main.find_scontext_exn setup ~name:context in
+        let* env = Super_context.context_env sctx
+        and* prog =
+          let* prog = Cmd_arg.expand ~root:(Common.root common) ~sctx prog in
+          get_path_and_build_if_necessary common sctx ~no_rebuild ~prog >>| Path.to_string
+        and* args =
+          Memo.parallel_map ~f:(Cmd_arg.expand ~root:(Common.root common) ~sctx) args
+        in
+        let env = extend_with_staging_env context env in
+        Memo.return { prog; args; env })
+    in
+    run_prepared_exec prepared_exec ~root:(Common.root common)
 ;;
 
 let term : unit Term.t =
@@ -375,9 +388,12 @@ let term : unit Term.t =
               | Pid_from_lockfile pid -> sprintf " (pid: %d)" pid)
          ]
      | No ->
-       Scheduler_setup.go_without_rpc_server ~common ~config
-       @@ fun () ->
-       exec_building_via_rpc_server ~common ~prog ~args ~no_rebuild builder lock_held_by)
+       let prepared_exec =
+         Scheduler_setup.go_without_rpc_server ~common ~config
+         @@ fun () ->
+         prepare_exec_via_rpc_server ~common ~prog ~args ~no_rebuild builder lock_held_by
+       in
+       run_prepared_exec prepared_exec ~root:(Common.root common))
   | Ok () -> exec_building_directly ~common ~config ~context ~prog ~args ~no_rebuild
 ;;
 


### PR DESCRIPTION
On Windows, restore_cwd_and_execve emulates exec by running at_exit handlers before spawning the replacement process. Those handlers include Unix cleanup, which calls WSACleanup. Make dune exec prepare the executable path and environment inside the scheduler, then leave the scheduler/RPC scope before invoking restore_cwd_and_execve.