### PR TITLE
doc: add changelog for Windows watch sync fix

### DIFF
--- a/doc/changes/fixed/14678.md
+++ b/doc/changes/fixed/14678.md
@@ -1,0 +1,3 @@
+- Fix watch mode on Windows by creating the file-watcher sync directory before
+  using it, avoiding `open(_build/.sync\0): No such file or directory` when an
+  RPC client requests a build. (#14678, fixes #14632, @rgrinberg)


### PR DESCRIPTION
Add the missing changelog entry for #14678, which fixes #14632.\n\nI checked the release tags: the fix is on main but is not present in 3.24.0, so this entry documents it for the next release.