### PR TITLE
fix(watch): simplify restart status line

### DIFF
--- a/bin/monitor.ml
+++ b/bin/monitor.ml
@@ -84,10 +84,6 @@ end = struct
     Pp.seq message (Pp.verbatim ", waiting for filesystem changes...")
   ;;
 
-  let restarting_current_build message =
-    Pp.seq message (Pp.verbatim ", restarting current build...")
-  ;;
-
   let had_errors state =
     match Diagnostic_id_map.cardinal state.diagnostics with
     | 1 -> Pp.verbatim "Had 1 error"
@@ -102,9 +98,7 @@ end = struct
            | Waiting -> Pp.verbatim "Initializing..."
            | In_progress { complete; remaining; failed } ->
              done_status ~complete ~remaining ~failed state
-           | Interrupted ->
-             Pp.tag User_message.Style.Error (Pp.verbatim "Source files changed")
-             |> restarting_current_build
+           | Interrupted -> Pp.verbatim "Restarting current build..."
            | Success ->
              Pp.tag User_message.Style.Success (Pp.verbatim "Success")
              |> waiting_for_file_system_changes

--- a/doc/changes/fixed/15289.md
+++ b/doc/changes/fixed/15289.md
@@ -1,0 +1,4 @@
+- Fix watch-mode status lines after source changes interrupt a build. Dune now
+  shows the restart status while cancelling the current build and resumes the
+  normal progress counter when the next build starts. (#15289, fixes #11134,
+  @rgrinberg)

--- a/otherlibs/stdune/src/console.ml
+++ b/otherlibs/stdune/src/console.ml
@@ -199,6 +199,9 @@ module Status_line = struct
   let add_overlay t =
     let id = Id.gen () in
     stack := (id, t) :: !stack;
+    (match t with
+     | Live _ -> ()
+     | Constant pp -> print_if_no_status_line pp);
     refresh ();
     id
   ;;

--- a/src/dune_engine/build_loop.ml
+++ b/src/dune_engine/build_loop.ml
@@ -52,6 +52,7 @@ type t =
   { mutable status : status
   ; mutable pending_reset : Memo.Invalidation.t option
   ; mutable watch_restart_started_at : Time.t option
+  ; mutable status_overlay : Console.Status_line.overlay option
   ; mutable wakeup : Trigger.t
   ; mutable wakeup_generation : int
   ; mutable input_change_generation : int
@@ -62,7 +63,17 @@ type t =
   ; mutable state : [ `Awaiting_init | `Init ]
   }
 
-let build_finish (build_result : Build_outcome.t) =
+let clear_status_overlay t =
+  Option.iter t.status_overlay ~f:Console.Status_line.remove_overlay;
+  t.status_overlay <- None
+;;
+
+let set_status_overlay t message =
+  clear_status_overlay t;
+  t.status_overlay <- Some (Console.Status_line.add_overlay message)
+;;
+
+let build_finish t (build_result : Build_outcome.t) =
   let message =
     match build_result with
     | Success -> Pp.tag User_message.Style.Success (Pp.verbatim "Success")
@@ -77,7 +88,8 @@ let build_finish (build_result : Build_outcome.t) =
       in
       Pp.tag User_message.Style.Error failure_message
   in
-  Console.Status_line.set
+  set_status_overlay
+    t
     (Constant (Pp.seq message (Pp.verbatim ", waiting for filesystem changes...")))
 ;;
 
@@ -88,27 +100,6 @@ let invalidation_of_file_events events =
       (match (event : Event.File_watcher_event.t) with
        | Fs_memo_event event -> Fs_memo.handle_fs_event event
        | Queue_overflow -> Memo.Invalidation.clear_caches ~reason:Event_queue_overflow))
-;;
-
-let show_build_interrupted_status_line () =
-  Console.Status_line.set
-    (Live
-       (fun () ->
-         let progress =
-           match Fiber.Svar.read Build_system.state with
-           | Initializing
-           | Restarting_current_build
-           | Build_succeeded__now_waiting_for_changes
-           | Build_failed__now_waiting_for_changes -> Build_system.Progress.init
-           | Building progress -> progress
-         in
-         Pp.seq
-           (Pp.tag User_message.Style.Error (Pp.verbatim "Source files changed"))
-           (Pp.verbatim
-              (sprintf
-                 ", restarting current build... (%u/%u)"
-                 progress.number_of_rules_executed
-                 progress.number_of_rules_discovered))))
 ;;
 
 let next_watch_run_id t =
@@ -156,9 +147,17 @@ let request_restart t invalidation =
     t.input_change_generation <- t.input_change_generation + 1;
     let* () =
       match t.status with
-      | Restarting_build _ | Standing_by -> Fiber.return ()
+      | Restarting_build _ -> Fiber.return ()
+      | Standing_by ->
+        clear_status_overlay t;
+        Fiber.return ()
       | Building run_id ->
-        show_build_interrupted_status_line ();
+        set_status_overlay
+          t
+          (Live
+             (fun () ->
+               let elapsed = Time.diff (Time.now ()) now |> Time.Span.to_secs in
+               Pp.textf "Restarting current build... (%.1fs)" elapsed));
         t.status <- Restarting_build run_id;
         let+ () = Process.Build.cancel_current () in
         Dune_trace.emit Build (fun () ->
@@ -185,6 +184,7 @@ let create () =
   { status = Standing_by
   ; pending_reset = None
   ; watch_restart_started_at = None
+  ; status_overlay = None
   ; wakeup = Trigger.create ()
   ; wakeup_generation = 0
   ; input_change_generation = 0
@@ -202,13 +202,16 @@ let run t f =
   match Scheduler.file_watcher () with
   | None ->
     ignore (Fs_memo.init ~dune_file_watcher:None : Memo.Invalidation.t);
-    f ()
+    Fiber.finalize f ~finally:(fun () ->
+      clear_status_overlay t;
+      Fiber.return ())
   | Some file_watcher ->
     Fs_memo.init ~dune_file_watcher:(Some file_watcher) |> Memo.reset;
     Fiber.fork_and_join_unit
       (fun () -> handle_file_events t file_watcher)
       (fun () ->
          Fiber.finalize f ~finally:(fun () ->
+           clear_status_overlay t;
            File_watcher.close file_watcher;
            Fiber.return ()))
 ;;
@@ -236,6 +239,7 @@ let run_current_build
    | Building _ -> assert false
    | Standing_by | Restarting_build _ -> ());
   t.status <- Building run_id;
+  clear_status_overlay t;
   let* outcome =
     let build_ctx =
       Process.Build.create ~action_runner ~run_id ~cancellation:(Fiber.Cancel.create ())
@@ -371,7 +375,7 @@ let rpc_poll_iter t ~action_runner ~sticky_goal ~sticky_built_at =
                  t.rpc_requests <- Rpc_request_id.Map.remove t.rpc_requests id;
                  Fiber.Ivar.fill ivar outcome)
            in
-           build_finish outcome
+           build_finish t outcome
          in
          { wakeup_generation
          ; sticky_built_at =

--- a/test/expect-tests/dune_console/dune_console_tests.ml
+++ b/test/expect-tests/dune_console/dune_console_tests.ml
@@ -65,6 +65,14 @@ let test_status_line_overwrite (module Console : New_console) =
   Status_line.clear ()
 ;;
 
+let test_status_line_constant_overlay (module Console : New_console) =
+  let open Console in
+  let overlay =
+    Status_line.add_overlay (Status_line.Constant (Pp.text "Here is an overlay"))
+  in
+  Status_line.remove_overlay overlay
+;;
+
 let test_status_line_section (module Console : New_console) =
   let open Console in
   Status_line.set (Status_line.Live (fun () -> Pp.text "Done: 50%"));
@@ -137,6 +145,17 @@ let%expect_test "dumb backend: status line overwriting" =
     {|
 Here is a status line
 Here is another status line
+  |}]
+;;
+
+let%expect_test "dumb backend: constant status line overlay" =
+  let module Console = New () in
+  Console.Backend.set Console.Backend.dumb;
+  test_status_line_constant_overlay (module Console);
+  escape [%expect.output];
+  [%expect
+    {|
+Here is an overlay
   |}]
 ;;
 


### PR DESCRIPTION
Show a plain restart status while an interrupted watch build is being cancelled, then clear it when the next build starts so the normal progress counter resumes. Keep the waiting-for-changes status as an overlay, update the RPC monitor wording, and make constant overlays visible on dumb consoles.