### PR TITLE
Short-circuit boolean expressions in blang

### DIFF
--- a/doc/changes/fixed/15291.md
+++ b/doc/changes/fixed/15291.md
@@ -1,0 +1,3 @@
+- Short-circuit AND and OR expressions in blang. This makes their evaluation
+  lazy by default.
+  (#15291, @Sudha247)

--- a/src/source/blang_expand.ml
+++ b/src/source/blang_expand.ml
@@ -12,8 +12,28 @@ let rec eval (t : Blang.t) ~dir ~f =
      | _ ->
        let loc = String_with_vars.loc sw in
        User_error.raise ~loc [ Pp.text "This value must be either true or false" ])
-  | And xs -> Memo.List.map xs ~f:(eval ~f ~dir) >>| List.for_all ~f:Fun.id
-  | Or xs -> Memo.List.map xs ~f:(eval ~f ~dir) >>| List.exists ~f:Fun.id
+  | And xs ->
+      let rec loop = function
+      | [] -> Memo.return true
+      | x :: xs ->
+        let* x = eval ~f ~dir x in
+        match x with
+        | true -> loop xs
+        | false ->
+          (* stop evaluating when a false case is reached *)
+          Memo.return false
+      in loop xs
+  | Or xs ->
+      let rec loop = function
+      | [] -> Memo.return false
+      | x :: xs ->
+        let* x = eval ~f ~dir x in
+        match x with
+        | false -> loop xs
+        | true ->
+          (* stop evaluating when a true case is reached *)
+          Memo.return true
+      in loop xs
   | Not t -> eval t ~f ~dir >>| not
   | Compare (op, x, y) ->
     let+ x = String_expander.Memo.expand x ~mode:Many ~dir ~f

--- a/src/source/blang_expand.ml
+++ b/src/source/blang_expand.ml
@@ -12,28 +12,8 @@ let rec eval (t : Blang.t) ~dir ~f =
      | _ ->
        let loc = String_with_vars.loc sw in
        User_error.raise ~loc [ Pp.text "This value must be either true or false" ])
-  | And xs ->
-      let rec loop = function
-      | [] -> Memo.return true
-      | x :: xs ->
-        let* x = eval ~f ~dir x in
-        match x with
-        | true -> loop xs
-        | false ->
-          (* stop evaluating when a false case is reached *)
-          Memo.return false
-      in loop xs
-  | Or xs ->
-      let rec loop = function
-      | [] -> Memo.return false
-      | x :: xs ->
-        let* x = eval ~f ~dir x in
-        match x with
-        | false -> loop xs
-        | true ->
-          (* stop evaluating when a true case is reached *)
-          Memo.return true
-      in loop xs
+  | And xs -> Memo.List.for_all xs ~f:(fun x -> eval ~f ~dir x)
+  | Or xs -> Memo.List.exists xs ~f:(fun x -> eval ~f ~dir x)
   | Not t -> eval t ~f ~dir >>| not
   | Compare (op, x, y) ->
     let+ x = String_expander.Memo.expand x ~mode:Many ~dir ~f

--- a/test/blackbox-tests/test-cases/enabled_if/short-circuit.t
+++ b/test/blackbox-tests/test-cases/enabled_if/short-circuit.t
@@ -1,7 +1,6 @@
 Test that `and` and `or` in enabled_if should short-circuit.
 
 When the first conjunct of `and` is false, the second should not be evaluated.
-Currently this is broken: both are evaluated eagerly, causing spurious errors.
 
   $ make_dune_project 3.0
 
@@ -16,15 +15,8 @@ Currently this is broken: both are evaluated eagerly, causing spurious errors.
   > EOF
 
 The rule should simply be disabled (lib-available is false), not error out.
-But due to missing short-circuit evaluation, version expansion fails:
 
   $ dune build @foo
-  File "dune", line 6, characters 7-37:
-  6 |    (>= %{version:nonexistent-library} 1.0)))
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: Package "nonexistent-library" doesn't exist in the current project and
-  isn't installed either.
-  [1]
 
 Similarly, `or` should short-circuit when the first disjunct is true:
 
@@ -39,9 +31,4 @@ Similarly, `or` should short-circuit when the first disjunct is true:
   > EOF
 
   $ dune build @bar
-  File "dune", line 6, characters 7-37:
-  6 |    (>= %{version:nonexistent-library} 1.0)))
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: Package "nonexistent-library" doesn't exist in the current project and
-  isn't installed either.
-  [1]
+  this should run


### PR DESCRIPTION
Makes the `and` and `or` expressions in blang short-circuit, instead of eagerly evaluating it. This fixes the test in `enabled_if/short-circuit.t`. This issue was discussed in #9943.