### PR TITLE
fix(odoc): handle build-dir cmti paths in @doc-new fallback (#15290)

### DIFF
--- a/src/dune_rules/odoc/odoc_new.ml
+++ b/src/dune_rules/odoc/odoc_new.ml
@@ -1183,11 +1183,10 @@ let modules_of_dir d : (Module_name.t * (Path.t * [ `Cmti | `Cmt | `Cmi ])) list
     List.find_map extensions ~f:(fun (ext', ty) ->
       Option.some_if (Filename.Extension.equal ext ext') ty)
   in
-  Fs_memo.dir_contents (Path.as_outside_build_dir_exn d)
+  Fs.dir_contents d
   >>| function
   | Error _ -> []
-  | Ok dc ->
-    let list = Fs_memo.Dir_contents.to_list dc in
+  | Ok list ->
     List.filter_map list ~f:(fun (x, ty) ->
       match ty, Filename.extension x |> Filename.Extension.Or_empty.extension with
       | Unix.S_REG, Some ext when Option.is_some (ty_of_ext ext) ->

--- a/test/blackbox-tests/test-cases/pkg/doc-new-with-locked-lib.t
+++ b/test/blackbox-tests/test-cases/pkg/doc-new-with-locked-lib.t
@@ -1,9 +1,13 @@
-Reproduction for https://github.com/ocaml/dune/issues/15290
+Regression test for https://github.com/ocaml/dune/issues/15290.
 
-Building @doc-new with package management enabled crashes when a locked
-package installs a library via a META file (without a dune-package), because
-the odoc rules classify it as a "fallback" directory and try to read the
-cmti directory as if it were outside the build tree.
+The lock-dir package below installs a library via a META file only,
+without a dune-package. @doc-new therefore handles it through the
+fallback odoc rules.
+
+Before the fix, those rules tried to list the generated cmti directory
+as if it were outside the build tree and crashed in
+Path.as_outside_build_dir_exn. The build below now reaches odoc instead;
+the expected warnings come from odoc indexing the empty fake library.
 
   $ mkdir external_sources
 
@@ -48,6 +52,8 @@ cmti directory as if it were outside the build tree.
 
   $ touch foo.ml
 
-  $ dune build @doc-new 2>&1 | grep "Internal error"
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
-  [1]
+  $ dune build @doc-new
+  File "fakefmt.mld", line 7, characters 0-11:
+  Warning: '{!modules ...}' should not be empty.
+  File "page-fakefmt.odoc":
+  Warning: Failed to lookup child page dummy


### PR DESCRIPTION
## Summary

Fixes [#15290](https://github.com/ocaml/dune/issues/15290).

`Odoc_new.modules_of_dir` listed cmti files via `Fs_memo.dir_contents (Path.as_outside_build_dir_exn d)`. For libraries installed by a lock-dir package, the cmti directory lives under `_build/_private/.../target/lib/<lib>`, so `as_outside_build_dir_exn` raised a `Code_error` and aborted the build.

Switching to `Fs.dir_contents` (already used elsewhere, e.g. in `Findlib.Findlib_dir`) handles both cases: it watches outside-build paths via `Fs_memo`, and for inside-build paths it waits on `Build_system.build_dir` so the locked package's install action has finished before we enumerate its modules.

Builds on top of #15292 (the cram reproduction). The test there is updated to drop the `grep "Internal error"` and assert the now-clean `dune build @doc-new` output.

## Test plan

- [ ] `dune runtest test/blackbox-tests/test-cases/pkg/doc-new-with-locked-lib.t`
- [ ] `dune build @check @fmt @runtest`