### PR TITLE
ci: pin js/wasm_of_ocaml-compiler below 6.4

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -368,7 +368,7 @@ jobs:
         run: opam install --fake binaryen-bin
 
       - name: Install Wasm_of_ocaml
-        run: opam install "wasm_of_ocaml-compiler>=6.1" csexp pp re spawn uutf ppx_expect
+        run: opam install wasm_of_ocaml-compiler.6.3.2 csexp pp re spawn uutf ppx_expect
 
       - name: Set Git User
         run: |

--- a/.github/workflows/workflow.yml.in
+++ b/.github/workflows/workflow.yml.in
@@ -367,7 +367,7 @@ jobs:
         run: opam install --fake binaryen-bin
 
       - name: Install Wasm_of_ocaml
-        run: opam install "wasm_of_ocaml-compiler>=6.1" csexp pp re spawn uutf ppx_expect
+        run: opam install wasm_of_ocaml-compiler.6.3.2 csexp pp re spawn uutf ppx_expect
 
       - name: Set Git User
         run: |

--- a/opam/dune.opam
+++ b/opam/dune.opam
@@ -50,8 +50,8 @@ depends: [
   "lwt" { with-dev-setup & os != "win32" }
   "cinaps" { with-dev-setup }
   "csexp" { with-dev-setup & >= "1.3.0" }
-  "js_of_ocaml" { with-dev-setup & >= "6.1.0" & os != "win32" }
-  "js_of_ocaml-compiler" { with-dev-setup & >= "6.1.0" & os != "win32" }
+  "js_of_ocaml" { with-dev-setup & >= "6.1.0" & < "6.4" & os != "win32" }
+  "js_of_ocaml-compiler" { with-dev-setup & >= "6.1.0" & < "6.4" & os != "win32" }
   "mdx" { with-dev-setup & >= "2.3.0" & os != "win32" }
   "menhir" { with-dev-setup & os != "win32" }
   "ocamlfind" { with-dev-setup & os != "win32" }

--- a/opam/dune.opam.template
+++ b/opam/dune.opam.template
@@ -11,8 +11,8 @@ depends: [
   "lwt" { with-dev-setup & os != "win32" }
   "cinaps" { with-dev-setup }
   "csexp" { with-dev-setup & >= "1.3.0" }
-  "js_of_ocaml" { with-dev-setup & >= "6.1.0" & os != "win32" }
-  "js_of_ocaml-compiler" { with-dev-setup & >= "6.1.0" & os != "win32" }
+  "js_of_ocaml" { with-dev-setup & >= "6.1.0" & < "6.4" & os != "win32" }
+  "js_of_ocaml-compiler" { with-dev-setup & >= "6.1.0" & < "6.4" & os != "win32" }
   "mdx" { with-dev-setup & >= "2.3.0" & os != "win32" }
   "menhir" { with-dev-setup & os != "win32" }
   "ocamlfind" { with-dev-setup & os != "win32" }


### PR DESCRIPTION
## Summary

`js_of_ocaml-compiler`/`wasm_of_ocaml-compiler` 6.4.0 broke our CI two ways:

- The wasm job fails outright on `wasm_of_ocaml-compiler` 6.4.0.
- The jsoo cram tests on the macOS test matrix fail because 6.4 moved the artifact path from `.js/default/...` to `.js/effects=disabled/...`.

Pinning is done in two places:

- `opam/dune.opam.template` — add `< "6.4"` upper bound on the existing `js_of_ocaml`/`js_of_ocaml-compiler` `with-dev-setup` deps, and add `wasm_of_ocaml-compiler` as a `with-dev-setup` dep with the same bound. This is what `make dev-deps` (and therefore the main test matrix) solves against.
- `.github/workflows/workflow.yml.in` — the wasm job installs `wasm_of_ocaml-compiler` directly (not via `--with-dev-setup`), so it gets an explicit `.6.3.2` pin.

`dune-project`/`dune.opam` conflicts are intentionally not touched — they'd propagate to nix bounds.

## Test plan

- [x] wasm CI job goes green
- [x] macOS test matrix goes green