### PR TITLE
show env: accept absolute workspace paths

### DIFF
--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -93,7 +93,10 @@ let term =
     Build.build_memo_exn (fun () ->
       let open Memo.O in
       let* setup = Util.setup () in
-      let dir = Path.of_string dir in
+      let dir = 
+        Path.of_string dir 
+        |> Path.Expert.try_localize_external
+      in
       let checked = Util.check_path setup.contexts dir in
       let request =
         Action_builder.all

--- a/test/blackbox-tests/test-cases/absolute-paths/show-env-absolute.t
+++ b/test/blackbox-tests/test-cases/absolute-paths/show-env-absolute.t
@@ -22,24 +22,22 @@ work identically to the relative form. Today it errors as if the path were
 outside the project.
 
   $ dune show env $PWD --field flags
-  Error: Environment is not defined for external paths
-  [1]
+  (flags
+   (-short-paths -keep-locs -warn-error +a -w +27))
 
 CR-someday Alizter: the same call from a subdirectory should also resolve.
 (--root is required because INSIDE_DUNE disables workspace auto-detection.)
 
   $ (cd subdir && dune show env --root .. $PWD --field flags)
-  Entering directory '..'
-  Error: Environment is not defined for external paths
-  Leaving directory '..'
-  [1]
+  (flags
+   (-short-paths -keep-locs -warn-error +a -w +27))
 
 CR-someday Alizter: absolute paths to subdirectories of the workspace
 should be accepted.
 
   $ dune show env $PWD/subdir --field flags
-  Error: Environment is not defined for external paths
-  [1]
+  (flags
+   (-short-paths -keep-locs -warn-error +a -w +27))
 
 Absolute paths that are genuinely outside the workspace must continue to
 fail with a clean error. This behaviour must not regress.


### PR DESCRIPTION
Fixes #15104.

`dune describe env` currently rejects absolute paths even when they point inside the workspace because the argument is classified as `External` immediately after `Path.of_string`.

This change localizes workspace-relative absolute paths using `Path.Expert.try_localize_external` before calling `Util.check_path`.

Verified behavior:

- `dune describe env .` continues to work
- `dune describe env "$PWD"` now works
- `dune describe env "$PWD/subdir"` now works
- `dune describe env /tmp` continues to report `Environment is not defined for external paths`

The issue can be reproduced on current `main` and is resolved by this change.