### PR TITLE
nix: stop pinning source dune in the ox devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -637,7 +637,6 @@
               oself: osuper:
               (oxPackageSet oself osuper)
               // {
-                dune_3 = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
                 ocaml = oxcamlCompiler;
               };
             meta.description = ''


### PR DESCRIPTION
The `ox` shell overrode `dune_3` to `self.packages.<system>.default`, so every OCaml package in its closure was re-hashed on every source change. The cache-nix-action restore in CI then fell back to a stale prefix match and rebuilt the OxCaml compiler and dependent packages from scratch.

Drop the override so the closure rebuilds dune from upstream nixpkgs against the OxCaml compiler, like `ox-minimal` already does. The shell still picks up the local build via `_boot/dune.exe` through the `duneScript` wrapper on PATH.