### PR TITLE
test(clean): demonstrate that clean rejects source directories (#2288)

### DIFF
--- a/test/blackbox-tests/test-cases/clean.t
+++ b/test/blackbox-tests/test-cases/clean.t
@@ -35,3 +35,31 @@ We can clean the entire workspace to re-run everything:
   $ runtest
   foo
   bar
+
+Issue #2288: unlike `dune build`, `dune clean` does not accept source
+directories (or package names); it only accepts paths inside the build
+directory. So cleaning a source directory, or the project root, is rejected.
+
+  $ mkdir sub
+  $ cat >sub/dune <<EOF
+  > (rule
+  >  (targets baz)
+  >  (action (bash "touch baz && echo baz")))
+  > EOF
+
+`dune build` accepts the source directory:
+
+  $ dune build sub
+  baz
+
+But `dune clean` rejects it:
+
+  $ dune clean sub
+  Error: sub is not inside the build directory
+  [1]
+
+The project root is rejected too:
+
+  $ dune clean .
+  Error: . is not inside the build directory
+  [1]


### PR DESCRIPTION
Reproduces #2288: `dune clean` does not accept source directories (or package
names) the way `dune build`/`dune runtest` do — it only accepts paths inside
the build directory (a capability added in #13875).

This adds a test to `clean.t` documenting the current behaviour:

- `dune build sub` accepts the source directory
- `dune clean sub` fails with `Error: sub is not inside the build directory`
- `dune clean .` fails likewise

No behaviour change — the test pins the status quo so it will flip to the
desired output if/when `dune clean` learns to accept source directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
