### PR TITLE
docs: correct include_dirs field name in foreign docs

### DIFF
--- a/doc/reference/foreign-archives.rst
+++ b/doc/reference/foreign-archives.rst
@@ -34,13 +34,19 @@ described in :ref:`foreign-sandboxing`, or ask Dune to build it via the
      (enabled_if true)
      (names src4 src5)
      (extra_objects obj1)
-     (include_dir headers))
+     (include_dirs headers))
 
 This asks Dune to compile C source files ``src4`` and ``src5`` with
 headers tracked in the ``headers`` directory and put the resulting
 object files into an archive ``arch1``, whose full name is typically
 ``libarch1.a`` for static linking and ``dllarch1.so`` for dynamic
 linking.
+
+By default, Dune builds and installs both the static (``lib*.a``) and dynamic
+(``dll*.so``) versions of a foreign archive. To statically link all foreign
+archives into the runtime system instead (so no ``dll*.so`` is produced), set
+``(disable_dynamically_linked_foreign_archives true)`` in your
+:doc:`/reference/dune-workspace/context`.
 
 The ``foreign_library`` stanza supports all :doc:`foreign-stubs` fields.
 The ``archive_name`` field specifies the archive's name. You can refer

--- a/doc/reference/foreign-stubs.rst
+++ b/doc/reference/foreign-stubs.rst
@@ -60,7 +60,7 @@ Here is a complete list of supported subfields:
     the library ``lib3``, the directory ``dir4``, and the result of recursively
     including the contents of the file ``inc2``.
     The contents of included directories are tracked recursively, e.g., if you
-    use ``(include_dir dir)`` and have headers ``dir/base.h`` and
+    use ``(include_dirs dir)`` and have headers ``dir/base.h`` and
     ``dir/lib/lib.h``, they both will be tracked as dependencies.
 - ``extra_deps`` specifies any other dependencies that should be tracked.  This
     is useful when dealing with ``#include`` statements that escape into a


### PR DESCRIPTION
Fixes #3328.

#3328 reported that the docs mention `include_dir` but dune rejects it. The actual field is `include_dirs` (plural) — `src/dune_rules/foreign.ml` only decodes `"include_dirs"`; there is no singular `include_dir`. The docs still carried the wrong name in two places:

- `doc/reference/foreign-archives.rst` (the `foreign_library` example)
- `doc/reference/foreign-stubs.rst` (the recursive header-tracking note)

This corrects both. It also addresses the issue's "only static linking?" question by cross-linking `disable_dynamically_linked_foreign_archives` (documented under the workspace context) from the foreign archives page, where static vs dynamic (`.a` vs `.so`) linking is discussed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)