### PR TITLE
refactor(nix): extract dune-package.nix from flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -153,75 +153,14 @@
       packages = forAllSystems (
         pkgs:
         let
-          lib = pkgs.lib;
-          dune-source = lib.cleanSourceWith {
+          dune-package = import ./nix/dune-package.nix {
+            inherit nixpkgs ocaml-overlays pkgs;
             src = ./.;
-            filter = pkgs.nix-gitignore.gitignoreFilterPure (_: _: true) [
-              ".git"
-              ./.gitignore
-            ] ./.;
           };
-          dune-build-files =
-            let
-              fs = lib.fileset;
-            in
-            fs.intersection (fs.fromSource dune-source) (
-              fs.unions [
-                ./bin
-                ./boot
-                ./configure
-                ./dune-project
-                ./dune-file
-                ./src
-                ./plugin
-                ./vendor
-                ./otherlibs
-                ./Makefile
-                (fs.fileFilter (file: file.hasExt "opam" || file.hasExt "template") ./.)
-              ]
-            );
-          dune-static-overlay = self: super: {
-            ocamlPackages = super.ocaml-ng.ocamlPackages_5_4.overrideScope (
-              oself: osuper: {
-                dune_3 = osuper.dune_3.overrideAttrs (a: {
-                  src = dune-source;
-                  preBuild = "ocaml boot/bootstrap.ml --static";
-                });
-              }
-            );
-          };
-          pkgs-static = nixpkgs.legacyPackages.${pkgs.stdenv.hostPlatform.system}.appendOverlays [
-            ocaml-overlays.overlays.default
-            dune-static-overlay
-          ];
-
         in
         {
-          default =
-            with pkgs;
-            stdenv.mkDerivation {
-              pname = "dune";
-              version = "3.x-n/a";
-              src = lib.fileset.toSource {
-                root = ./.;
-                fileset = dune-build-files;
-              };
-              nativeBuildInputs = with ocamlPackages; [
-                ocaml
-                findlib
-              ];
-              strictDeps = true;
-              buildFlags = [ "release" ];
-              dontAddPrefix = true;
-              dontAddStaticConfigureFlags = true;
-              configurePlatforms = [ ];
-              installFlags = [
-                "PREFIX=${placeholder "out"}"
-                "LIBDIR=$(OCAMLFIND_DESTDIR)"
-              ];
-            };
+          inherit (dune-package) default dune-static;
           dune = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
-          dune-static = pkgs-static.pkgsCross.musl64.ocamlPackages.dune;
           oxcaml-trunk-build =
             let
               dune-version =

--- a/nix/dune-package.nix
+++ b/nix/dune-package.nix
@@ -1,0 +1,82 @@
+# The dune package, built from the source tree at `src`.
+#
+# Returns `default` (native build) and `dune-static` (musl64 cross build).
+{
+  nixpkgs,
+  ocaml-overlays,
+  pkgs,
+  src,
+}:
+let
+  inherit (pkgs) lib;
+
+  dune-source = lib.cleanSourceWith {
+    inherit src;
+    filter = pkgs.nix-gitignore.gitignoreFilterPure (_: _: true) [
+      ".git"
+      (src + "/.gitignore")
+    ] src;
+  };
+
+  dune-build-files =
+    let
+      fs = lib.fileset;
+    in
+    fs.intersection (fs.fromSource dune-source) (
+      fs.unions [
+        (src + "/bin")
+        (src + "/boot")
+        (src + "/configure")
+        (src + "/dune-project")
+        (src + "/dune-file")
+        (src + "/src")
+        (src + "/plugin")
+        (src + "/vendor")
+        (src + "/otherlibs")
+        (src + "/Makefile")
+        (fs.fileFilter (file: file.hasExt "opam" || file.hasExt "template") src)
+      ]
+    );
+
+  dune-static-overlay = self: super: {
+    ocamlPackages = super.ocaml-ng.ocamlPackages_5_4.overrideScope (
+      oself: osuper: {
+        dune_3 = osuper.dune_3.overrideAttrs (a: {
+          src = dune-source;
+          preBuild = "ocaml boot/bootstrap.ml --static";
+        });
+      }
+    );
+  };
+
+  pkgs-static = nixpkgs.legacyPackages.${pkgs.stdenv.hostPlatform.system}.appendOverlays [
+    ocaml-overlays.overlays.default
+    dune-static-overlay
+  ];
+in
+{
+  default =
+    with pkgs;
+    stdenv.mkDerivation {
+      pname = "dune";
+      version = "3.x-n/a";
+      src = lib.fileset.toSource {
+        root = src;
+        fileset = dune-build-files;
+      };
+      nativeBuildInputs = with ocamlPackages; [
+        ocaml
+        findlib
+      ];
+      strictDeps = true;
+      buildFlags = [ "release" ];
+      dontAddPrefix = true;
+      dontAddStaticConfigureFlags = true;
+      configurePlatforms = [ ];
+      installFlags = [
+        "PREFIX=${placeholder "out"}"
+        "LIBDIR=$(OCAMLFIND_DESTDIR)"
+      ];
+    };
+  dune-static = pkgs-static.pkgsCross.musl64.ocamlPackages.dune;
+}


### PR DESCRIPTION
Move `dune-source`, `dune-build-files`, the static overlay, and the `packages.{default,dune-static}` derivations out into their own module under `nix/`. Matches the shape of the existing `nix/revdeps.nix`, `nix/menhir.nix`, and `nix/ox-package-set.nix` helpers.

Hash-stable: `nix eval .#packages.<system>.default.outPath` produces the same store path before and after.