### PR TITLE
refactor(nix): inline nixpkgs-old into bootstrap-check

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -236,9 +236,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "nixpkgs-old": [
-          "nixpkgs-old"
-        ],
+        "nixpkgs-old": "nixpkgs-old",
         "ocaml-overlays": [
           "ocaml-overlays"
         ],
@@ -274,7 +272,6 @@
         "melange": "melange",
         "menhir-src": "menhir-src",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-old": "nixpkgs-old",
         "ocaml-overlays": "ocaml-overlays",
         "odoc-src": "odoc-src",
         "oxcaml": "oxcaml",

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,6 @@
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    nixpkgs-old.url = "github:nixos/nixpkgs/7f50d4b33363d3948543f6a02b90a2c66852a453";
     melange = {
       url = "github:melange-re/melange/v6-54";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -24,7 +23,6 @@
     revdeps-dune = {
       url = "github:ocaml/dune";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.nixpkgs-old.follows = "nixpkgs-old";
       inputs.odoc-src.follows = "odoc-src";
       inputs.oxcaml.follows = "oxcaml";
       inputs.ocaml-overlays.follows = "ocaml-overlays";
@@ -48,7 +46,6 @@
     {
       self,
       nixpkgs,
-      nixpkgs-old,
       melange,
       ocaml-overlays,
       odoc-src,
@@ -222,10 +219,6 @@
             passthru = (old.passthru or { }) // pkgs.ocamlPackages.ocaml.passthru;
             meta = (old.meta or { }) // pkgs.ocamlPackages.ocaml.meta;
           });
-          # Older nixpkgs for OCaml 4.02 support
-          pkgs-old = nixpkgs-old.legacyPackages.${pkgs.stdenv.hostPlatform.system}.appendOverlays [
-            ocaml-overlays.overlays.default
-          ];
           ocamlformat =
             let
               lists = pkgs.lib.lists;
@@ -366,17 +359,30 @@
             '';
           };
 
-          bootstrap-check = pkgs.mkShell {
-            inherit INSIDE_NIX;
-            buildInputs = [
-              pkgs.gnumake
-              pkgs-old.ocaml-ng.ocamlPackages_4_02.ocaml
-            ];
-            meta.description = ''
-              Provides a minimal shell environment with OCaml 4.02 in order
-              to test the bootstrapping script.
-            '';
-          };
+          bootstrap-check =
+            let
+              # Older nixpkgs needed only to source OCaml 4.02.
+              pkgs_4_02 =
+                import
+                  (builtins.fetchTree {
+                    type = "github";
+                    owner = "nixos";
+                    repo = "nixpkgs";
+                    rev = "7f50d4b33363d3948543f6a02b90a2c66852a453";
+                  })
+                  { inherit (pkgs.stdenv.hostPlatform) system; };
+            in
+            pkgs.mkShell {
+              inherit INSIDE_NIX;
+              buildInputs = [
+                pkgs.gnumake
+                pkgs_4_02.ocaml-ng.ocamlPackages_4_02.ocaml
+              ];
+              meta.description = ''
+                Provides a minimal shell environment with OCaml 4.02 in order
+                to test the bootstrapping script.
+              '';
+            };
 
           bootstrap-check_4_14 = pkgs.mkShell {
             inherit INSIDE_NIX;


### PR DESCRIPTION
`nixpkgs-old` is pinned to a single rev for OCaml 4.02 support and consumed by exactly one buildInput in `bootstrap-check`. Drop the flake input and inline the `fetchTree` + `import` in a `let` adjacent to bootstrap-check itself. No top-level binding, no intermediate `pkgs-old` overlay (the `ocaml-overlays` overlay previously applied on top of `nixpkgs-old.legacyPackages` had no effect on `ocaml-ng.ocamlPackages_4_02.ocaml`).

Removes the corresponding `follows` entry in `revdeps-dune`; revdeps-dune resolves its own pin from its own flake.lock.

Hash-stable: `bootstrap-check` resolves to the same store path before and after.