### PR TITLE
docs: clarify dune install --prefix directory layout

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -500,12 +500,32 @@ For a given build context, the installation directories are determined with a
 single scheme for all installation sections. Taking the ``lib`` installation
 section as an example, the priorities of this scheme are as follows:
 
-#. if an explicit ``--lib <path>`` argument is passed, use this path
+#. if an explicit ``--libdir <path>`` argument is passed, use this path
 #. if an explicit ``--prefix <path>`` argument is passed, use ``<path>/lib``
-#. if ``--lib <path>`` argument is passed before during dune compilation to
-   ``./configure``, use this paths
-#. if ``OPAM_SWITCH_PREFIX`` is present in the environment use ``$OPAM_SWITCH_PREFIX/lib``
+#. if a ``--libdir <path>`` argument was passed during Dune's compilation to
+   ``./configure``, use this path
+#. if ``OPAM_SWITCH_PREFIX`` is present in the environment, use
+   ``$OPAM_SWITCH_PREFIX/lib``
 #. otherwise, fail
+
+The same scheme applies to every section, each with its own flag: ``--bindir``,
+``--sbindir``, ``--libexecdir``, ``--datadir`` (the ``share`` section),
+``--docdir``, ``--etcdir``, and ``--mandir``. The directories derived from
+``--prefix`` follow the opam layout: in particular ``man`` becomes
+``<prefix>/man`` and ``doc`` becomes ``<prefix>/doc`` -- they are *not* placed
+under ``<prefix>/share``.
+
+Note that ``--prefix`` (priority 2 above) takes precedence over a directory
+configured at build time via ``./configure`` (priority 3). Passing ``--prefix``
+therefore overrides a ``--mandir`` (or ``--docdir``, etc.) that was set at
+configure time. A system installation following the `Filesystem Hierarchy
+Standard <https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html>`_, which
+expects ``<prefix>/share/man`` and ``<prefix>/share/doc``, should pass the
+per-section flags explicitly:
+
+.. code:: console
+
+    $ dune install --prefix /usr --mandir /usr/share/man --docdir /usr/share/doc PACKAGE
 
 Relocation Mode
 ---------------


### PR DESCRIPTION
Documents the directory-layout behavior reported in #5733.

`dune install --prefix=P` derives per-section directories using the opam layout — notably `man` → `<prefix>/man` and `doc` → `<prefix>/doc` (*not* under `<prefix>/share`) — and `--prefix` takes precedence over directories configured at build time via `./configure`. This is by design (it matches opam's own layout), but it surprises distribution packagers doing FHS system installs, who expect `<prefix>/share/man` etc.

This clarifies the *Destination Directory* section of the manual: it lists the per-section flags, documents the opam-style `--prefix` defaults, notes the `--prefix`-over-`./configure` precedence, and shows the explicit `--mandir`/`--docdir` invocation that produces the FHS layout. It also fixes a stale flag name (`--lib` → `--libdir`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)