### PR TITLE
refactor(nix): source odoc and odoc-parser from nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -240,9 +240,7 @@
         "ocaml-overlays": [
           "ocaml-overlays"
         ],
-        "odoc-src": [
-          "odoc-src"
-        ],
+        "odoc-src": "odoc-src",
         "oxcaml": [
           "oxcaml"
         ],
@@ -273,7 +271,6 @@
         "menhir-src": "menhir-src",
         "nixpkgs": "nixpkgs",
         "ocaml-overlays": "ocaml-overlays",
-        "odoc-src": "odoc-src",
         "oxcaml": "oxcaml",
         "oxcaml-opam-repository": "oxcaml-opam-repository",
         "revdeps-dune": "revdeps-dune"

--- a/flake.nix
+++ b/flake.nix
@@ -9,10 +9,6 @@
       url = "github:nix-ocaml/nix-overlays";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    odoc-src = {
-      url = "github:ocaml/odoc/6427579346781df958b3bdfe8ac6d4550194012a";
-      flake = false;
-    };
     oxcaml = {
       url = "github:oxcaml/oxcaml/5.2.0minus-31";
     };
@@ -23,7 +19,6 @@
     revdeps-dune = {
       url = "github:ocaml/dune";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.odoc-src.follows = "odoc-src";
       inputs.oxcaml.follows = "oxcaml";
       inputs.ocaml-overlays.follows = "ocaml-overlays";
       inputs.melange.follows = "melange";
@@ -48,7 +43,6 @@
       nixpkgs,
       melange,
       ocaml-overlays,
-      odoc-src,
       oxcaml,
       oxcaml-opam-repository,
       revdeps-dune,
@@ -60,6 +54,9 @@
         nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (
           system:
           let
+            # Vanilla nixpkgs scope used to source packages we want to take
+            # ahead of what `ocaml-overlays` ships (e.g. odoc 3.2.1).
+            nixpkgsOcaml = nixpkgs.legacyPackages.${system}.ocaml-ng.ocamlPackages_5_4;
             pkgs = nixpkgs.legacyPackages.${system}.appendOverlays [
               ocaml-overlays.overlays.default
               (self: super: {
@@ -76,13 +73,11 @@
                       dontGzipMan = true;
                     };
                     odoc-parser = osuper.odoc-parser.overrideAttrs (old: {
-                      version = "3.2.1";
-                      src = odoc-src;
+                      inherit (nixpkgsOcaml.odoc-parser) version src;
                       doCheck = false;
                     });
                     odoc = osuper.odoc.overrideAttrs (old: {
-                      version = "3.2.1";
-                      src = odoc-src;
+                      inherit (nixpkgsOcaml.odoc) version src;
                       doCheck = false;
                     });
                     rocq-core = super.rocqPackages_9_2.rocq-core.override {


### PR DESCRIPTION
`ocaml-overlays` still ships odoc 3.1.0; the override that bumped it to 3.2.1 sourced its content from a separately pinned `odoc-src` flake input. Vanilla nixpkgs now ships odoc 3.2.1 directly, so the override can take both `version` and `src` from there instead.

Drops the `odoc-src` flake input and the corresponding `follows` entry in `revdeps-dune`. Future nixpkgs bumps to odoc will be picked up automatically; no need to manually update a separate input rev.

The final `pkgs.ocamlPackages.odoc.version` remains 3.2.1.