### PR TITLE
refactor(nix): inline menhir-src as a fetchTree source

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -230,9 +230,7 @@
         "melange": [
           "melange"
         ],
-        "menhir-src": [
-          "menhir-src"
-        ],
+        "menhir-src": "menhir-src",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -268,7 +266,6 @@
     "root": {
       "inputs": {
         "melange": "melange",
-        "menhir-src": "menhir-src",
         "nixpkgs": "nixpkgs",
         "ocaml-overlays": "ocaml-overlays",
         "oxcaml": "oxcaml",

--- a/flake.nix
+++ b/flake.nix
@@ -23,12 +23,7 @@
       inputs.ocaml-overlays.follows = "ocaml-overlays";
       inputs.melange.follows = "melange";
       inputs.oxcaml-opam-repository.follows = "oxcaml-opam-repository";
-      inputs.menhir-src.follows = "menhir-src";
       inputs.revdeps-dune.follows = "revdeps-dune";
-    };
-    menhir-src = {
-      url = "gitlab:fpottier/menhir/20231231?host=gitlab.inria.fr";
-      flake = false;
     };
   };
 
@@ -46,9 +41,16 @@
       oxcaml,
       oxcaml-opam-repository,
       revdeps-dune,
-      menhir-src,
     }:
     let
+      # Pinned menhir snapshot required by OxCaml.
+      menhir-src = builtins.fetchTree {
+        type = "gitlab";
+        host = "gitlab.inria.fr";
+        owner = "fpottier";
+        repo = "menhir";
+        rev = "d3d815e4f554da68b8c247241c8f8678926eecaa";
+      };
       forAllSystems =
         f:
         nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (


### PR DESCRIPTION
`menhir-src` is a date-pinned snapshot (20231231) required by OxCaml and is consumed only by `nix/menhir.nix`. Drop the flake input and fetch the source inline. Removes the corresponding `follows` entry in `revdeps-dune`.

Hash-stable: `oxcaml-trunk-build` and the `ox-trunk` shell (the two outputs that consume menhir-src via `nix/menhir.nix`) produce the same store paths before and after.