### PR TITLE
refactor(nix): extract oxcaml.nix from flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,6 +84,7 @@
     "nix-github-actions": {
       "inputs": {
         "nixpkgs": [
+          "revdeps-dune",
           "oxcaml",
           "nixpkgs"
         ]
@@ -239,12 +240,8 @@
           "ocaml-overlays"
         ],
         "odoc-src": "odoc-src",
-        "oxcaml": [
-          "oxcaml"
-        ],
-        "oxcaml-opam-repository": [
-          "oxcaml-opam-repository"
-        ],
+        "oxcaml": "oxcaml",
+        "oxcaml-opam-repository": "oxcaml-opam-repository",
         "revdeps-dune": [
           "revdeps-dune"
         ]
@@ -268,8 +265,6 @@
         "melange": "melange",
         "nixpkgs": "nixpkgs",
         "ocaml-overlays": "ocaml-overlays",
-        "oxcaml": "oxcaml",
-        "oxcaml-opam-repository": "oxcaml-opam-repository",
         "revdeps-dune": "revdeps-dune"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -9,20 +9,11 @@
       url = "github:nix-ocaml/nix-overlays";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    oxcaml = {
-      url = "github:oxcaml/oxcaml/5.2.0minus-31";
-    };
-    oxcaml-opam-repository = {
-      url = "github:oxcaml/opam-repository/231c88c2e564fdca40e15e750aacad5fb0887435";
-      flake = false;
-    };
     revdeps-dune = {
       url = "github:ocaml/dune";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.oxcaml.follows = "oxcaml";
       inputs.ocaml-overlays.follows = "ocaml-overlays";
       inputs.melange.follows = "melange";
-      inputs.oxcaml-opam-repository.follows = "oxcaml-opam-repository";
       inputs.revdeps-dune.follows = "revdeps-dune";
     };
   };
@@ -38,19 +29,9 @@
       nixpkgs,
       melange,
       ocaml-overlays,
-      oxcaml,
-      oxcaml-opam-repository,
       revdeps-dune,
     }:
     let
-      # Pinned menhir snapshot required by OxCaml.
-      menhir-src = builtins.fetchTree {
-        type = "gitlab";
-        host = "gitlab.inria.fr";
-        owner = "fpottier";
-        repo = "menhir";
-        rev = "d3d815e4f554da68b8c247241c8f8678926eecaa";
-      };
       forAllSystems =
         f:
         nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (
@@ -151,6 +132,7 @@
             inherit nixpkgs ocaml-overlays pkgs;
             src = ./.;
           };
+          oxcaml-setup = import ./nix/oxcaml.nix { inherit pkgs; };
         in
         {
           inherit (dune-package) default dune-static;
@@ -169,7 +151,8 @@
                 '';
               };
               menhirPackages = import ./nix/menhir.nix {
-                inherit pkgs menhir-src;
+                inherit pkgs;
+                menhir-src = oxcaml-setup.menhir-src;
               };
             in
             # nix build .#oxcaml-trunk-build --no-link --impure
@@ -206,16 +189,7 @@
         pkgs:
         let
           INSIDE_NIX = "true";
-          oxPackageSet = import ./nix/ox-package-set.nix {
-            inherit pkgs;
-            lib = pkgs.lib;
-            oxcamlOpamRepo = oxcaml-opam-repository;
-          };
-          oxcamlCompiler = oxcaml.packages.${pkgs.stdenv.hostPlatform.system}.default.overrideAttrs (old: {
-            NIX_CFLAGS_COMPILE = "-std=gnu17";
-            passthru = (old.passthru or { }) // pkgs.ocamlPackages.ocaml.passthru;
-            meta = (old.meta or { }) // pkgs.ocamlPackages.ocaml.meta;
-          });
+          oxcaml-setup = import ./nix/oxcaml.nix { inherit pkgs; };
           ocamlformat =
             let
               lists = pkgs.lib.lists;
@@ -397,7 +371,7 @@
             inherit INSIDE_NIX;
             buildInputs = [
               pkgs.gnumake
-              oxcamlCompiler
+              oxcaml-setup.compiler
             ];
             meta.description = ''
               Provides a minimal shell environment with OxCaml in order to
@@ -409,9 +383,9 @@
             includeTestDeps = false;
             packageOverrides =
               oself: osuper:
-              (oxPackageSet oself osuper)
+              (oxcaml-setup.packageSet oself osuper)
               // {
-                ocaml = oxcamlCompiler;
+                ocaml = oxcaml-setup.compiler;
               };
             meta.description = ''
               Provides a minimal shell environment with OxCaml in order to
@@ -422,7 +396,8 @@
           ox-trunk =
             let
               menhirPackages = import ./nix/menhir.nix {
-                inherit pkgs menhir-src;
+                inherit pkgs;
+                menhir-src = oxcaml-setup.menhir-src;
               };
             in
             pkgs.mkShell {
@@ -459,9 +434,9 @@
               ]);
             packageOverrides =
               oself: osuper:
-              (oxPackageSet oself osuper)
+              (oxcaml-setup.packageSet oself osuper)
               // {
-                ocaml = oxcamlCompiler;
+                ocaml = oxcaml-setup.compiler;
               };
             meta.description = ''
               Provides a full shell environment with the OxCaml compiler to

--- a/nix/oxcaml.nix
+++ b/nix/oxcaml.nix
@@ -1,0 +1,86 @@
+# OxCaml setup for this flake.
+#
+# Three pins live here. They need to be coordinated when bumping
+# OxCaml; eval-time failures drive the next step:
+#
+#   1. Bump `oxcaml-opam-repository.rev`.
+#      → fail: narHash mismatch.
+#   2. Update `oxcaml-opam-repository.narHash` to whatever nix prints.
+#      Re-evaluate; the parsed `oxcamlTag` from the opam file may now
+#      be a different tag.
+#   3. Bump `oxcaml.rev` to the upstream OxCaml commit for that tag,
+#      and update `oxcaml.narHash` to match. Resolve both via:
+#        nix flake metadata --json github:oxcaml/oxcaml/<new-tag>
+#
+# `oxcamlTag` is parsed from the opam file purely so a reader can see
+# the tag the rev below corresponds to, and so a `throw` fires if the
+# pin gets out of sync with what the opam-repo expects.
+{ pkgs }:
+
+let
+  lib = pkgs.lib;
+
+  oxcaml-opam-repository = builtins.fetchTree {
+    type = "github";
+    owner = "oxcaml";
+    repo = "opam-repository";
+    rev = "231c88c2e564fdca40e15e750aacad5fb0887435";
+    narHash = "sha256-+9ZQF2VH0O0G8RtN0hTf4k+w6yL63g6tblq3uzTKzG8=";
+  };
+
+  # Parsed for documentation / sanity-check; not used in the getFlake
+  # URL (pure mode needs rev, not tag).
+  compilerPkgDir = "${oxcaml-opam-repository}/packages/oxcaml-compiler";
+  compilerVersion = lib.last (lib.naturalSort (builtins.attrNames (builtins.readDir compilerPkgDir)));
+  compilerOpamFile = builtins.readFile "${compilerPkgDir}/${compilerVersion}/opam";
+  oxcamlTag =
+    let
+      match = builtins.match ''.*archive/refs/tags/([^"]+)\.tar\.gz.*'' compilerOpamFile;
+    in
+    if match == null then
+      throw "could not parse OxCaml tag from ${compilerPkgDir}/${compilerVersion}/opam"
+    else
+      builtins.head match;
+
+  # The upstream OxCaml flake at the commit corresponding to oxcamlTag.
+  # See the file header for how to resolve rev+narHash.
+  oxcaml = builtins.getFlake "github:oxcaml/oxcaml/7d714cfb3f1c79c9b1e2a9c40ac60ba0c44cafd7?narHash=sha256-JwVNRca8q1WfmuFLPOK3hL1DxmaKRYd%2BgJgV9xTDUhI%3D";
+
+  # Sanity: the tag in the opam-repo matches the tag this rev was
+  # resolved from. Documentation more than enforcement — the assert
+  # fires if a reader bumps one of the three pins above without the
+  # others.
+  expectedTag = "5.2.0minus-31";
+  _tagOk =
+    if oxcamlTag == expectedTag then
+      null
+    else
+      throw "oxcaml-opam-repository expects tag '${oxcamlTag}' but the oxcaml pin in this file targets '${expectedTag}'. Update one or the other.";
+
+  oxPackageSet = import ./ox-package-set.nix {
+    inherit pkgs lib;
+    oxcamlOpamRepo = oxcaml-opam-repository;
+  };
+in
+{
+  compiler = builtins.seq _tagOk (
+    oxcaml.packages.${pkgs.stdenv.hostPlatform.system}.default.overrideAttrs (old: {
+      NIX_CFLAGS_COMPILE = "-std=gnu17";
+      passthru = (old.passthru or { }) // pkgs.ocamlPackages.ocaml.passthru;
+      meta = (old.meta or { }) // pkgs.ocamlPackages.ocaml.meta;
+    })
+  );
+
+  packageSet = oxPackageSet;
+
+  # Pinned menhir snapshot required by OxCaml trunk builds. Same rev
+  # as the `init-menhir.tar.gz` extra-source in the oxcaml-compiler
+  # opam recipe.
+  menhir-src = builtins.fetchTree {
+    type = "gitlab";
+    host = "gitlab.inria.fr";
+    owner = "fpottier";
+    repo = "menhir";
+    rev = "d3d815e4f554da68b8c247241c8f8678926eecaa";
+  };
+}


### PR DESCRIPTION
Bundle the OxCaml-related pins and setup behind a single module:

  - oxcaml-opam-repository (was a flake input)
  - oxcaml (was a flake input)
  - the compiler derivation (NIX_CFLAGS / passthru / meta wiring)
  - the OxCaml-flavoured ocamlPackages overlay
  - the menhir snapshot used by trunk builds

All three rev pins (opam-repo, oxcaml, menhir) now live adjacent in `nix/oxcaml.nix`. The opam-repo's `oxcaml-compiler/<latest>/opam` is parsed at eval time to recover the upstream OxCaml tag, and an assertion checks it matches the `expectedTag` constant — so a bump to the opam-repo that targets a different compiler tag fails loudly, prompting the user to update the oxcaml rev/narHash and expectedTag together.

`getFlake` uses rev+narHash for the OxCaml flake so evaluation stays pure: no `--impure` needed for any devShell.