### PR TITLE
refactor(nix): drop unused ox-trunk devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -393,28 +393,6 @@
             '';
           };
 
-          ox-trunk =
-            let
-              menhirPackages = import ./nix/menhir.nix {
-                inherit pkgs;
-                menhir-src = oxcaml-setup.menhir-src;
-              };
-            in
-            pkgs.mkShell {
-              inherit INSIDE_NIX;
-              shellHook = ''
-                export DUNE_SOURCE_ROOT=$PWD
-              '';
-              inputsFrom = [ pkgs.ocamlPackages.dune_3 ];
-              nativeBuildInputs = [
-                pkgs.autoconf
-                menhirPackages.menhir
-              ];
-              meta.description = ''
-                Provides a shell environment with upstream OCaml and menhir 20231231
-                for building the OxCaml trunk.
-              '';
-            };
           ox = makeDuneDevShell {
             excludeTestNativeBuildInputs = [ "opam" ];
             excludeOcamlLibs = [


### PR DESCRIPTION
`ox-trunk` is not referenced by any CI workflow, Makefile target, docs page, or shell script in the repo. Grepping the tree for `ox-trunk` and `nix develop .#ox` confirms zero consumers.

Drop the shell. The `oxcaml-trunk-build` package (which IS used by `.github/workflows/revdeps-dev-build.yml`) still pulls in menhir-20231231 via the same `nix/menhir.nix` for now; the next commit folds that into the upstream OxCaml derivation it overrides.