### PR TITLE
feat(nix): add extraOCamlOverlays parameter to makeDuneDevShell

### DIFF
--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -18,11 +18,15 @@
   excludeTestNativeBuildInputs ? [ ],
   excludeOcamlLibs ? [ ],
   packageOverrides ? (oself: osuper: { }),
+  # Extra overlays to compose on top of `ocamlPackages` after the base
+  # branch above. Each is an `oself: osuper: { ... }` overlay; they're
+  # applied in list order via successive `overrideScope` calls.
+  extraOCamlOverlays ? [ ],
 }:
 let
   hasOcamlOverride = (packageOverrides { } { ocaml = null; }) ? ocaml;
 
-  pkgs' =
+  pkgs'-base =
     if hasOcamlOverride then
       pkgs.extend (
         pself: psuper: {
@@ -74,6 +78,18 @@ let
       )
     else
       pkgs;
+
+  pkgs' =
+    if extraOCamlOverlays == [ ] then
+      pkgs'-base
+    else
+      pkgs'-base.extend (
+        pself: psuper: {
+          ocamlPackages = builtins.foldl' (
+            acc: o: acc.overrideScope o
+          ) psuper.ocamlPackages extraOCamlOverlays;
+        }
+      );
 
   inherit (pkgs') writeScriptBin stdenv;
 


### PR DESCRIPTION
`makeDuneDevShell` previously only exposed `packageOverrides`, a single overlay function composed into one `overrideScope` call on `ocamlPackages`. Some shells want to layer multiple overlays on top of the base scope (whether produced by `hasOcamlOverride`, `duneFromScope`, or the plain pkgs branch).

Add `extraOCamlOverlays ? [ ]`: a list of `oself: osuper: { ... }` overlays applied in list order via successive `overrideScope` calls after the base branch. Empty default makes the change a no-op for existing callers — verified hash-stable for `default`, `slim`, `rocq`, `ox-minimal`, `ox`, `bootstrap-check`, and `scope` (one shell per branch).