### PR TITLE
action-runner: clean up escaped subreaper children

### DIFF
--- a/bin/build.ml
+++ b/bin/build.ml
@@ -18,7 +18,16 @@ let run_build_system ~action_runner ~run_id ~request =
     |> List.singleton
     |> Dune_engine.Build_system.Request.create
   in
-  Dune_engine.Build_system.run_build_requests ~build request
+  Fiber.finalize
+    (fun () -> Dune_engine.Build_system.run_build_requests ~build request)
+    ~finally:(fun () ->
+      match action_runner with
+      | None -> Fiber.return ()
+      | Some action_runner ->
+        Dune_engine.Action_runner.complete_build
+          action_runner
+          ~run_id
+          ~cancellation:(Dune_engine.Process.Build.cancellation build))
 ;;
 
 let run_build_command_poll ~(common : Common.t) ~config ~sticky_goal : unit =

--- a/src/dune_engine/action_runner.ml
+++ b/src/dune_engine/action_runner.ml
@@ -94,6 +94,18 @@ let cancel_build t ~run_id =
   send_request ~request:Decl.cancel_build ~payload t
 ;;
 
+let finish_build t ~run_id =
+  let* () = ensure_ready t in
+  let payload = { Request.Finish_build.run_id } in
+  send_request ~request:Decl.finish_build ~payload t
+;;
+
+let complete_build t ~run_id ~cancellation =
+  if Fiber.Cancel.fired cancellation
+  then cancel_build t ~run_id
+  else finish_build t ~run_id
+;;
+
 let exec_process_uncancelled t ~run_id process =
   let* () = ensure_ready t in
   Dune_trace.emit Action (fun () ->
@@ -176,12 +188,14 @@ let ready t session ({ Request.Ready.name } : Request.Ready.t) =
 let implement_handler t (handler : _ Root.Rpc.Server.Handler.t) =
   Server.Handler.declare_request handler Decl.exec;
   Server.Handler.declare_request handler Decl.cancel_build;
+  Server.Handler.declare_request handler Decl.finish_build;
   Server.Handler.implement_request handler Decl.ready (ready t)
 ;;
 
 let create name pid =
   Dune_trace.emit Action (fun () ->
     Dune_trace.Event.Action.Runner.runner_event ~name (Spawn pid));
+  Scheduler.preserve_child_process pid;
   { name
   ; status = Starting { ready = Fiber.Ivar.create () }
   ; pid

--- a/src/dune_engine/action_runner.mli
+++ b/src/dune_engine/action_runner.mli
@@ -32,3 +32,5 @@ val exec_process
   -> cancellation:Fiber.Cancel.t
   -> Process_runner.request
   -> Process_runner.response Fiber.t
+
+val complete_build : t -> run_id:Run_id.t -> cancellation:Fiber.Cancel.t -> unit Fiber.t

--- a/src/dune_engine/action_runner_protocol.ml
+++ b/src/dune_engine/action_runner_protocol.ml
@@ -19,6 +19,10 @@ module Request = struct
   module Cancel_build = struct
     type t = { run_id : Run_id.t }
   end
+
+  module Finish_build = struct
+    type t = { run_id : Run_id.t }
+  end
 end
 
 module Decl = struct
@@ -64,7 +68,19 @@ module Decl = struct
     ;;
   end
 
+  module Finish_build = struct
+    let decl =
+      let v1 =
+        Decl.Request.make_current_gen ~req:(marshal ()) ~resp:Conv.unit ~version:1
+      in
+      Decl.Request.make
+        ~method_:(Dune_rpc.Method.Name.of_string "action/finish-build")
+        ~generations:[ v1 ]
+    ;;
+  end
+
   let exec = Exec.decl
   let ready = Ready.decl
   let cancel_build = Cancel_build.decl
+  let finish_build = Finish_build.decl
 end

--- a/src/dune_engine/action_runner_protocol.mli
+++ b/src/dune_engine/action_runner_protocol.mli
@@ -19,10 +19,15 @@ module Request : sig
   module Cancel_build : sig
     type t = { run_id : Run_id.t }
   end
+
+  module Finish_build : sig
+    type t = { run_id : Run_id.t }
+  end
 end
 
 module Decl : sig
   val exec : (Request.Exec.t, Request.Exec.response) Dune_rpc.Decl.Request.t
   val ready : (Request.Ready.t, unit) Dune_rpc.Decl.Request.t
   val cancel_build : (Request.Cancel_build.t, unit) Dune_rpc.Decl.Request.t
+  val finish_build : (Request.Finish_build.t, unit) Dune_rpc.Decl.Request.t
 end

--- a/src/dune_engine/action_runner_worker.ml
+++ b/src/dune_engine/action_runner_worker.ml
@@ -50,11 +50,11 @@ let start_build t run_id =
     build
 ;;
 
-let finish_build t run_id =
+let finish_exec t run_id =
   match Table.find t.active_builds run_id with
   | None ->
     Code_error.raise
-      "action runner finished a build that was not recorded as active"
+      "action runner finished an exec request that was not recorded as active"
       [ "run_id", Run_id.to_dyn run_id ]
   | Some active when active.count > 1 ->
     active.count <- active.count - 1;
@@ -70,7 +70,7 @@ let exec_process t ({ Request.Exec.run_id; process } : Request.Exec.t) =
   else (
     let build = start_build t run_id in
     Fiber.finalize
-      ~finally:(fun () -> finish_build t run_id)
+      ~finally:(fun () -> finish_exec t run_id)
       (fun () ->
          let+ response = Process.exec_locally ~build process in
          Request.Exec.Completed response))
@@ -85,9 +85,23 @@ let cancel_build t ~name ({ Request.Cancel_build.run_id } : Request.Cancel_build
     |> List.filter ~f:(fun active ->
       Run_id.compare (Process.Build.run_id active.build) run_id <> Gt)
   in
-  Fiber.parallel_iter active_builds ~f:(fun active ->
-    let* () = Fiber.Cancel.fire (Process.Build.cancellation active.build) in
-    Fiber.Ivar.read active.drained)
+  let* () =
+    Fiber.parallel_iter active_builds ~f:(fun active ->
+      let* () = Fiber.Cancel.fire (Process.Build.cancellation active.build) in
+      Fiber.Ivar.read active.drained)
+  in
+  Scheduler.cleanup_subreaper_child_processes ()
+;;
+
+let finish_build t ({ Request.Finish_build.run_id } : Request.Finish_build.t) =
+  let* () =
+    match
+      Table.find t.active_builds run_id |> Option.map ~f:(fun active -> active.drained)
+    with
+    | None -> Fiber.return ()
+    | Some drained -> Fiber.Ivar.read drained
+  in
+  Scheduler.cleanup_subreaper_child_processes ()
 ;;
 
 let connect_retry_delay = Time.Span.of_secs 0.1
@@ -105,6 +119,7 @@ let start ~name ~where =
     [ Client.Request Decl.ready
     ; Handle_request (Decl.exec, exec_process t)
     ; Handle_request (Decl.cancel_build, cancel_build t ~name)
+    ; Handle_request (Decl.finish_build, finish_build t)
     ]
   in
   let initialize =

--- a/src/dune_engine/build_loop.ml
+++ b/src/dune_engine/build_loop.ml
@@ -239,8 +239,18 @@ let run_current_build
     let build_ctx =
       Process.Build.create ~action_runner ~run_id ~cancellation:(Fiber.Cancel.create ())
     in
-    Process.Build.with_ build_ctx (fun () ->
-      Build_system.run_build_requests ?restart_started_at ~build:build_ctx request)
+    Fiber.finalize
+      (fun () ->
+         Process.Build.with_ build_ctx (fun () ->
+           Build_system.run_build_requests ?restart_started_at ~build:build_ctx request))
+      ~finally:(fun () ->
+        match action_runner with
+        | None -> Fiber.return ()
+        | Some action_runner ->
+          Action_runner.complete_build
+            action_runner
+            ~run_id
+            ~cancellation:(Process.Build.cancellation build_ctx))
   in
   let+ () = Scheduler.cleanup_subreaper_child_processes () in
   let next =

--- a/test/blackbox-tests/test-cases/actions/subreaper.t
+++ b/test/blackbox-tests/test-cases/actions/subreaper.t
@@ -145,3 +145,88 @@ is terminated before Dune exits.
   >   echo "SUCCESS: escaped process was cleaned up during shutdown"
   > fi
   SUCCESS: escaped process was cleaned up during shutdown
+Action runner workers are Dune-owned child processes, not escaped action
+children. Subreaper cleanup must preserve workers but still clean escaped
+children adopted by the worker at the end of a build.
+
+  $ action_runner_pid_file=$TMPDIR/action-runner-pid
+  $ action_runner_wait_started=$TMPDIR/action-runner-wait-started
+  $ action_runner_release=$TMPDIR/action-runner-release
+  $ action_runner_cancel_pid_file=$TMPDIR/action-runner-cancel-pid
+  $ action_runner_cancel_started=$TMPDIR/action-runner-cancel-started
+  $ cat >>dune <<EOF
+  > (rule
+  >  (target third)
+  >  (action
+  >   (progn
+  >    (run %{exe:bin/sub_process.exe} setsid "$action_runner_pid_file")
+  >    (bash "touch '$action_runner_wait_started'; while [ ! -e '$action_runner_release' ]; do sleep 0.01; done")
+  >    (with-stdout-to third (echo done)))))
+  > (rule
+  >  (target seventh)
+  >  (action
+  >   (progn
+  >    (run %{exe:bin/sub_process.exe} setsid "$action_runner_cancel_pid_file")
+  >    (bash "touch '$action_runner_cancel_started'; while true; do sleep 1; done")
+  >    (with-stdout-to seventh (echo done)))))
+  > EOF
+
+  $ start_dune --action-runner
+
+  $ dune rpc build --wait third >action-runner-build.out 2>&1 &
+  $ action_runner_build=$!
+  $ with_timeout dune_cmd wait-for-file-to-appear "$action_runner_pid_file"
+  $ with_timeout dune_cmd wait-for-file-to-appear "$action_runner_wait_started"
+  $ action_runner_child_pid=$(cat "$action_runner_pid_file")
+  $ if kill -0 "$action_runner_child_pid" 2>/dev/null; then
+  >   echo "SUCCESS: escaped action-runner process is still running during the build"
+  > else
+  >   echo "FAILURE: escaped action-runner process was killed before the build ended"
+  > fi
+  SUCCESS: escaped action-runner process is still running during the build
+
+  $ touch "$action_runner_release"
+  $ wait_for_pid_to_exit_with_timeout "$action_runner_build" 200 || (cat action-runner-build.out; false)
+  $ wait "$action_runner_build"
+  $ cat action-runner-build.out
+  Success
+
+  $ if kill -0 "$action_runner_child_pid" 2>/dev/null; then
+  >   kill "$action_runner_child_pid" 2>/dev/null || true
+  >   wait_for_pid_to_exit_with_timeout "$action_runner_child_pid" 200 || true
+  >   echo "FAILURE: escaped action-runner process is still running after the build"
+  > else
+  >   echo "SUCCESS: escaped action-runner process was killed after the build"
+  > fi
+  SUCCESS: escaped action-runner process was killed after the build
+
+Action-runner cancellation also cleans escaped children.
+
+This test observes eventual cleanup after cancelling the RPC client. We would
+like to test the stronger property that cleanup has completed before the action
+runner's cancel-build response returns.
+
+  $ dune rpc build --wait seventh >action-runner-cancel.out 2>&1 &
+  $ action_runner_cancel_build=$!
+  $ with_timeout dune_cmd wait-for-file-to-appear "$action_runner_cancel_pid_file"
+  $ with_timeout dune_cmd wait-for-file-to-appear "$action_runner_cancel_started"
+  $ action_runner_cancel_child_pid=$(cat "$action_runner_cancel_pid_file")
+  $ if kill -0 "$action_runner_cancel_child_pid" 2>/dev/null; then
+  >   echo "SUCCESS: escaped action-runner process is still running before cancellation"
+  > else
+  >   echo "FAILURE: escaped action-runner process was not running before cancellation"
+  > fi
+  SUCCESS: escaped action-runner process is still running before cancellation
+
+  $ kill "$action_runner_cancel_build"
+  $ wait "$action_runner_cancel_build" || true
+  $ if wait_for_pid_to_exit_with_timeout "$action_runner_cancel_child_pid" 200; then
+  >   echo "SUCCESS: escaped action-runner process was killed after cancellation"
+  > else
+  >   kill "$action_runner_cancel_child_pid" 2>/dev/null || true
+  >   wait_for_pid_to_exit_with_timeout "$action_runner_cancel_child_pid" 200 || true
+  >   echo "FAILURE: escaped action-runner process is still running after cancellation"
+  > fi
+  SUCCESS: escaped action-runner process was killed after cancellation
+
+  $ stop_dune_quiet


### PR DESCRIPTION
Add an action-runner finish-build request for normal build completion. The worker waits for active actions from that run to drain, then runs Linux subreaper child cleanup so escaped descendants adopted by the worker are removed at explicit build boundaries.

Also make cancel-build drain active actions and run the same cleanup before the cancellation response completes.

Extend the Linux subreaper blackbox test with action-runner build-boundary and cancellation coverage.



refactor(action-runner): centralize build completion request