### PR TITLE
test: share wait-for-line cram helpers

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -1451,6 +1451,25 @@ wait_for_pid_to_exit_with_timeout () {
     done
 }
 
+wait_for_line_with_timeout () {
+    output="$1"
+    line="$2"
+    iterations="$3"
+    while ! grep -qx "$line" "$output" 2>/dev/null
+    do
+        if [ "$iterations" = 0 ]
+        then
+            return 124
+        fi
+        iterations=$((iterations - 1))
+        sleep 0.01
+    done
+}
+
+wait_for_success_with_timeout () {
+    wait_for_line_with_timeout "$1" Success "$2"
+}
+
 stop_dune () {
     shutdown_dune;
     wait_for_dune_exit;

--- a/test/blackbox-tests/test-cases/watching/rpc-build-auto-promote-restart.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-auto-promote-restart.t
@@ -28,17 +28,6 @@ watch loop to rebuild the alias successfully.
 Unrelated RPC requests may complete before a later auto-promotion restart caused
 by another request in the same batch.
 
-  $ wait_for_line_with_timeout () {
-  >   output="$1"
-  >   line="$2"
-  >   iterations="$3"
-  >   while ! grep -qx "$line" "$output" 2>/dev/null
-  >   do
-  >     if [ "$iterations" = 0 ]; then return 124; fi
-  >     iterations=$((iterations - 1))
-  >     sleep 0.01
-  >   done
-  > }
   $ cat > source2 <<EOF
   > old
   > EOF

--- a/test/blackbox-tests/test-cases/watching/rpc-build-concurrent-finish.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-concurrent-finish.t
@@ -19,16 +19,6 @@ Concurrent RPC build requests currently finish together even if one target is do
   >     done
   >   ' bash "$jq_program" "$expected" "$dune"
   > }
-  $ wait_for_success_with_timeout () {
-  >   output="$1"
-  >   iterations="$2"
-  >   while ! grep -qx Success "$output" 2>/dev/null
-  >   do
-  >     if [ "$iterations" = 0 ]; then return 124; fi
-  >     iterations=$((iterations - 1))
-  >     sleep 0.01
-  >   done
-  > }
 
   $ fast_started="$(mktemp -u)"
   $ slow_started="$(mktemp -u)"


### PR DESCRIPTION
Move common cram polling helpers into the blackbox setup script so watching tests can reuse them.