### PR TITLE
refactor(nix): drop dead mdx override

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,9 +49,6 @@
                       flambdaSupport = false;
                       framePointerSupport = true;
                     };
-                    mdx = osuper.mdx.override {
-                      logs = oself.logs;
-                    };
                     utop = osuper.utop.overrideAttrs {
                       dontGzipMan = true;
                     };


### PR DESCRIPTION
`mdx = osuper.mdx.override { logs = oself.logs; }` was a no-op: `overrideScope` already propagates `oself.logs` to `mdx`'s build function through normal nix evaluation, and the resulting `mdx` store path is identical with or without this line (verified against the full overlay context).

Likely a historical workaround from when mdx in
nixpkgs/ocaml-overlays wasn't picking `logs` up correctly from the scope.

Hash-stable across all sampled devShells.