### PR TITLE
ci: cap melange below 7.0

### DIFF
--- a/opam/dune.opam
+++ b/opam/dune.opam
@@ -63,7 +63,7 @@ depends: [
   "ppxlib" { with-dev-setup & >= "0.37.0" & os != "win32" }
   "ctypes" { with-dev-setup & os != "win32" }
   "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
-  "melange" { with-dev-setup & >= "5.1.0-51" & os != "win32" }
+  "melange" { with-dev-setup & >= "5.1.0-51" & < "7.0" & os != "win32" }
   "uutf" { with-dev-setup }
   # the rev store negotiation test launches a git daemon, needs it to be
   # installed on some distributions

--- a/opam/dune.opam.template
+++ b/opam/dune.opam.template
@@ -24,7 +24,7 @@ depends: [
   "ppxlib" { with-dev-setup & >= "0.37.0" & os != "win32" }
   "ctypes" { with-dev-setup & os != "win32" }
   "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
-  "melange" { with-dev-setup & >= "5.1.0-51" & os != "win32" }
+  "melange" { with-dev-setup & >= "5.1.0-51" & < "7.0" & os != "win32" }
   "uutf" { with-dev-setup }
   # the rev store negotiation test launches a git daemon, needs it to be
   # installed on some distributions


### PR DESCRIPTION
melange 7.0.0-54 was released and breaks the melange cram tests on main: the compiler now emits extra Hint: lines on warnings (e.g. 'illegal-backslash') that the expected outputs don't include.

Cap the with-dev-setup melange dep in dune.opam.template at < "7.0" so make dev-deps stays on the 6.x line until the cram tests are updated.

cc @anmonteiro 