### PR TITLE
ci: cap melange below 7.0

### DIFF
--- a/opam/dune.opam
+++ b/opam/dune.opam
@@ -63,7 +63,7 @@ depends: [
   "ppxlib" { with-dev-setup & >= "0.37.0" & os != "win32" }
   "ctypes" { with-dev-setup & os != "win32" }
   "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
-  "melange" { with-dev-setup & >= "5.1.0-51" & os != "win32" }
+  "melange" { with-dev-setup & >= "5.1.0-51" & < "7.0" & os != "win32" }
   "uutf" { with-dev-setup }
   # the rev store negotiation test launches a git daemon, needs it to be
   # installed on some distributions

--- a/opam/dune.opam.template
+++ b/opam/dune.opam.template
@@ -24,7 +24,7 @@ depends: [
   "ppxlib" { with-dev-setup & >= "0.37.0" & os != "win32" }
   "ctypes" { with-dev-setup & os != "win32" }
   "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
-  "melange" { with-dev-setup & >= "5.1.0-51" & os != "win32" }
+  "melange" { with-dev-setup & >= "5.1.0-51" & < "7.0" & os != "win32" }
   "uutf" { with-dev-setup }
   # the rev store negotiation test launches a git daemon, needs it to be
   # installed on some distributions


### PR DESCRIPTION
## Summary

melange `7.0.0-54` was released in opam-repository and broke the melange cram tests on `main`: the new version emits extra `Hint:` lines on warnings (e.g. `warning 14 [illegal-backslash]`) that the expected outputs don't capture. Example diff from a recent main CI run:

```
Error (warning 14 [illegal-backslash]): illegal backslash escape in string.
+ Hint: Single backslashes \ are reserved for escape sequences (\n, \r, ...).
+ Did you check the list of OCaml escape sequences?
+ To get a backslash character, escape it with a second backslash: \\.
```

Confirmed by comparing two CI runs on the same OCaml compiler (5.4.1): yesterday's green run had `melange.6.0.1-54`, today's red run has `melange.7.0.0-54`. All failing test cases are under `test/blackbox-tests/test-cases/melange/`.

Cap the `with-dev-setup` melange dep in `opam/dune.opam.template` at `< "7.0"` so `make dev-deps` stays on 6.x until the cram tests are updated for the new compiler messages.

## Test plan

- [ ] `Build (opam) (5.4.x, ..., ubuntu-latest, true)` goes green
- [ ] `Build (opam) (5.4.x, ..., macos-latest, true)` goes green