### PR TITLE
refactor(action-ext): move action extension helper into dune_engine

### DIFF
--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -329,12 +329,6 @@ let local_libraries =
     ; special_builtin_support = None
     ; root_module = None
     }
-  ; { path = "src/action_ext"
-    ; main_module_name = Some "Action_ext"
-    ; include_subdirs = No
-    ; special_builtin_support = None
-    ; root_module = None
-    }
   ; { path = "src/dune_threaded_console"
     ; main_module_name = Some "Dune_threaded_console"
     ; include_subdirs = No

--- a/src/action_ext/dune
+++ b/src/action_ext/dune
@@ -1,3 +1,0 @@
-(library
- (name action_ext)
- (libraries dune_engine dune_trace fiber stdune unix))

--- a/src/dune_engine/action_ext.ml
+++ b/src/dune_engine/action_ext.ml
@@ -1,7 +1,5 @@
-open Stdune
-module Action = Dune_engine.Action
-module Done_or_more_deps = Dune_engine.Done_or_more_deps
-open Dune_engine.Action.Ext
+open Import
+open Action.Ext
 
 module Make (S : sig
     type ('path, 'target) t

--- a/src/dune_engine/action_ext.mli
+++ b/src/dune_engine/action_ext.mli
@@ -1,5 +1,5 @@
-open Stdune
-open Dune_engine.Action.Ext
+open Import
+open Action.Ext
 
 module Make (S : sig
     type ('path, 'target) t
@@ -18,5 +18,5 @@ module Make (S : sig
       -> eenv:Exec.env
       -> unit Fiber.t
   end) : sig
-  val action : (Path.t, Path.Build.t) S.t -> Dune_engine.Action.t
+  val action : (Path.t, Path.Build.t) S.t -> Action.t
 end

--- a/src/dune_engine/dune_engine.ml
+++ b/src/dune_engine/dune_engine.ml
@@ -4,6 +4,7 @@ module Corrections = Corrections
 module Action_builder = Action_builder
 module Dep = Dep
 module Action = Action
+module Action_ext = Action_ext
 module Action_plugin = Action_plugin
 module Done_or_more_deps = Done_or_more_deps
 module Utils = Utils

--- a/src/dune_patch/dune
+++ b/src/dune_patch/dune
@@ -1,3 +1,3 @@
 (library
  (name dune_patch)
- (libraries stdune fiber dune_engine action_ext re patch))
+ (libraries stdune fiber dune_engine re patch))

--- a/src/dune_patch/dune_patch.ml
+++ b/src/dune_patch/dune_patch.ml
@@ -174,7 +174,7 @@ let exec ~loc ~dir ~patch =
   Io.read_file patch |> parse_patches ~loc ~patch_file:patch |> apply_patches ~dir
 ;;
 
-module Action = Action_ext.Make (struct
+module Action = Dune_engine.Action_ext.Make (struct
     open Dune_engine
 
     type ('path, 'target) t = 'path

--- a/src/dune_rules/dune
+++ b/src/dune_rules/dune
@@ -3,7 +3,6 @@
 (library
  (name dune_rules)
  (libraries
-  action_ext
   build_path_prefix_map
   csexp
   dune_action_plugin

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -52,6 +52,7 @@ include struct
   module Sandbox_config = Sandbox_config
   module Sandbox_mode = Sandbox_mode
   module Action = Action
+  module Action_ext = Action_ext
   module Action_plugin = Action_plugin
   module Process = Process
   module Execution_parameters = Execution_parameters


### PR DESCRIPTION
Move Action_ext into dune_engine and expose it as Dune_engine.Action_ext. Remove the separate action_ext library and update dune_rules and dune_patch to use the engine module.