### PR TITLE
refactor(nix): drop odoc/odoc-parser overrides

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,9 +37,6 @@
         nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (
           system:
           let
-            # Vanilla nixpkgs scope used to source packages we want to take
-            # ahead of what `ocaml-overlays` ships (e.g. odoc 3.2.1).
-            nixpkgsOcaml = nixpkgs.legacyPackages.${system}.ocaml-ng.ocamlPackages_5_4;
             pkgs = nixpkgs.legacyPackages.${system}.appendOverlays [
               ocaml-overlays.overlays.default
               (self: super: {
@@ -52,14 +49,6 @@
                     utop = osuper.utop.overrideAttrs {
                       dontGzipMan = true;
                     };
-                    odoc-parser = osuper.odoc-parser.overrideAttrs (old: {
-                      inherit (nixpkgsOcaml.odoc-parser) version src;
-                      doCheck = false;
-                    });
-                    odoc = osuper.odoc.overrideAttrs (old: {
-                      inherit (nixpkgsOcaml.odoc) version src;
-                      doCheck = false;
-                    });
                     # Templates the cross-compiled dune binary used by
                     # `windows-static`. Lives at the top-level scope so
                     # `nix-overlays`' cross-overlay sees it during scope


### PR DESCRIPTION
`ocaml-overlays` now ships `odoc 3.2.1` and `odoc-parser 3.2.1` directly (rev 141b591b), matching what our overrides were yanking from vanilla nixpkgs. The override (plus the `nixpkgsOcaml` let-binding it relied on) is dead.

Shell hashes that touch odoc drift because the src derivation now comes via nix-overlays' fetcher rather than nixpkgs', but the resulting `odoc` is the same upstream 3.2.1.