### PR TITLE
ci: use cachix for all nix jobs

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -52,6 +52,10 @@ jobs:
             nix-${{ runner.os }}-${{ github.job }}-${{ matrix.name }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-${{ matrix.name }}--
           gc-max-store-size-linux: 2G
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: echo "(version $(git describe --always --dirty --abbrev=7))" >> dune-project
       - run: nix build ${{ matrix.installable }}
       - if: ${{ inputs.upload }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,6 +34,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: nixbuild/nix-quick-install-action@v35
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix build
 
   nix-test:
@@ -47,6 +51,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: nixbuild/nix-quick-install-action@v35
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix develop -i -s CI true -c make test
 
   fmt:
@@ -55,6 +63,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: nixbuild/nix-quick-install-action@v35
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix develop .#fmt -c make fmt-preview
 
   diff-on-checkout:
@@ -70,6 +82,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: nixbuild/nix-quick-install-action@v35
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix develop .#doc -c make doc
         env:
           LC_ALL: C
@@ -85,6 +101,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: nixbuild/nix-quick-install-action@v35
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix develop -i .#bootstrap-check -c make test-bootstrap-script
 
   nix-build-4-14:
@@ -104,6 +124,10 @@ jobs:
             nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix develop -i .#bootstrap-check_4_14 -c make release
 
   nix-build-ox:
@@ -125,6 +149,10 @@ jobs:
             nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix develop -i .#bootstrap-ox -c make release
 
 #
@@ -314,6 +342,10 @@ jobs:
             nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 5G
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix develop .#rocq -c make test-rocq
 
   rocq-native:
@@ -329,6 +361,10 @@ jobs:
             nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 5G
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix develop .#rocq-native -c make test-rocq-native
 
   wasm:
@@ -463,6 +499,10 @@ jobs:
             nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - name: Build and test with OxCaml
         run: nix develop -i .#ox -c make test-ox
 
@@ -501,6 +541,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: nixbuild/nix-quick-install-action@v35
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix develop .#microbench -c make dune build bench/micro
 
   utop-dev-tool-test:
@@ -515,6 +559,10 @@ jobs:
             nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - name: Set up a project, install utop as a dev tool, and run it
         shell: nix shell -c bash -e {0}
         run: |

--- a/.github/workflows/workflow.yml.in
+++ b/.github/workflows/workflow.yml.in
@@ -33,6 +33,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: nixbuild/nix-quick-install-action@v35
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix build
 
   nix-test:
@@ -46,6 +50,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: nixbuild/nix-quick-install-action@v35
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix develop -i -s CI true -c make test
 
   fmt:
@@ -54,6 +62,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: nixbuild/nix-quick-install-action@v35
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix develop .#fmt -c make fmt-preview
 
   diff-on-checkout:
@@ -69,6 +81,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: nixbuild/nix-quick-install-action@v35
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix develop .#doc -c make doc
         env:
           LC_ALL: C
@@ -84,6 +100,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: nixbuild/nix-quick-install-action@v35
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix develop -i .#bootstrap-check -c make test-bootstrap-script
 
   nix-build-4-14:
@@ -103,6 +123,10 @@ jobs:
             nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix develop -i .#bootstrap-check_4_14 -c make release
 
   nix-build-ox:
@@ -124,6 +148,10 @@ jobs:
             nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix develop -i .#bootstrap-ox -c make release
 
 #
@@ -313,6 +341,10 @@ jobs:
             nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 5G
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix develop .#rocq -c make test-rocq
 
   rocq-native:
@@ -328,6 +360,10 @@ jobs:
             nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 5G
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix develop .#rocq-native -c make test-rocq-native
 
   wasm:
@@ -462,6 +498,10 @@ jobs:
             nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - name: Build and test with OxCaml
         run: nix develop -i .#ox -c make test-ox
 
@@ -500,6 +540,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: nixbuild/nix-quick-install-action@v35
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - run: nix develop .#microbench -c make dune build bench/micro
 
   utop-dev-tool-test:
@@ -514,6 +558,10 @@ jobs:
             nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ocaml-dune
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_OCAML_DUNE }}
       - name: Set up a project, install utop as a dev tool, and run it
         shell: nix shell -c bash -e {0}
         run: |


### PR DESCRIPTION
## Summary

- Replace `nix-community/cache-nix-action@v7` with `cachix/cachix-action@v15` (cache name `ocaml-dune`, authed via `CACHIX_AUTH_TOKEN_OCAML_DUNE`) on all six nix jobs that had it: `nix-build-4-14`, `nix-build-ox`, `rocq`, `rocq-native`, `nix-oxcaml`, `utop-dev-tool-test`.
- Add the same cachix step to six nix jobs that previously had no caching: `nix-build`, `nix-test`, `fmt`, `doc`, `bootstrap`, `build-microbench`.

## Why

The GitHub Actions cache backend repeatedly hit its per-repo spending limit (\`Cache reservation failed: You have reached your configured budget, your cache is now read only to prevent additional charges.\`). Once the budget was exhausted, `cache-nix-action` saves silently failed and subsequent runs fell back via `restore-prefixes-first-match` to whatever stale entry was still around — which is why `nix-oxcaml` on main kept restoring a 626 MiB pre-#15299 cache and re-downloading the OxCaml closure on every run.

Independently, `cache-nix-action` never purged old prefix-matched entries on save, so each distinct `**/*.nix`/`flake.lock` hash accumulated a full-sized entry. A snapshot before this PR showed ~3.6 GiB of duplicate `rocq` / `rocq-native` / `nix-build-4-14` caches alone.

Cachix has no per-repo budget, is shared across branches and PRs, and avoids both problems.

## Test plan

- [ ] First run on this branch warms the `ocaml-dune` cachix cache.
- [ ] A second run (rerun or follow-up commit that doesn't touch `*.nix`) shows cachix hits in the logs and faster `nix develop` startup for the heavier jobs (`nix-oxcaml`, `nix-build-ox`, `rocq*`).
- [ ] No \`Cache reservation failed\` annotation on the run.