### PR TITLE
refactor(watch): move RPC request goals into build system

### DIFF
--- a/bin/build.ml
+++ b/bin/build.ml
@@ -12,7 +12,13 @@ let run_build_system ~action_runner ~run_id ~request =
       ~run_id
       ~cancellation:(Fiber.Cancel.create ())
   in
-  Dune_engine.Build_system.run_action_builder ~build (action_builder_of_request request)
+  let request =
+    action_builder_of_request request
+    |> Dune_engine.Build_system.Request.Goal.create
+    |> List.singleton
+    |> Dune_engine.Build_system.Request.create
+  in
+  Dune_engine.Build_system.run_build_requests ~build request
 ;;
 
 let run_build_command_poll ~(common : Common.t) ~config ~sticky_goal : unit =

--- a/src/dune_engine/build_loop.ml
+++ b/src/dune_engine/build_loop.ml
@@ -43,11 +43,6 @@ module Rpc_request_id = struct
   module Map = C.Map
 end
 
-type rpc_request =
-  { build : unit Action_builder.t
-  ; outcome : Build_outcome.t Fiber.Ivar.t
-  }
-
 type t =
   { mutable status : status
   ; mutable pending_reset : Memo.Invalidation.t option
@@ -59,7 +54,7 @@ type t =
     (* Incremented whenever an invalidation is recorded. This lets waiters
        distinguish input changes from other wakeups. *)
   ; mutable next_run_id : int
-  ; mutable rpc_requests : rpc_request Rpc_request_id.Map.t
+  ; mutable rpc_requests : Build_system.Request.Goal.t Rpc_request_id.Map.t
   ; mutable state : [ `Awaiting_init | `Init ]
   }
 
@@ -232,7 +227,7 @@ let run_current_build
        } as t)
       ~action_runner
       ~run_id
-      build
+      request
   =
   let* () = reset_wakeup t in
   (match t.status with
@@ -245,7 +240,7 @@ let run_current_build
       Process.Build.create ~action_runner ~run_id ~cancellation:(Fiber.Cancel.create ())
     in
     Process.Build.with_ build_ctx (fun () ->
-      Build_system.run_action_builder ?restart_started_at ~build:build_ctx build)
+      Build_system.run_build_requests ?restart_started_at ~build:build_ctx request)
   in
   let+ () = Scheduler.cleanup_subreaper_child_processes () in
   let next =
@@ -280,8 +275,8 @@ let cancel_rpc_requests t ~f =
     List.iter to_cancel ~f:(fun (id, _) ->
       t.rpc_requests <- Rpc_request_id.Map.remove t.rpc_requests id);
     let* () =
-      Fiber.parallel_iter to_cancel ~f:(fun (_, { outcome; _ }) ->
-        Fiber.Ivar.fill outcome Failure)
+      Fiber.parallel_iter to_cancel ~f:(fun (_, request) ->
+        Build_system.Request.Goal.complete request Failure)
     in
     request_rebuild_due_to_rpc_request t
 ;;
@@ -294,7 +289,7 @@ let cancel_rpc_requests_by_session t ~session_id =
 let cancel_all_rpc_requests t = cancel_rpc_requests t ~f:(fun _ _ -> true)
 
 let submit_rpc_request t ~session_id ~request_id ~build =
-  let outcome = Fiber.Ivar.create () in
+  let request = Build_system.Request.Goal.create build in
   let id = Rpc_request_id.create ~session_id ~request_id in
   let* () = Fiber.return () in
   (match Rpc_request_id.Map.find t.rpc_requests id with
@@ -302,10 +297,9 @@ let submit_rpc_request t ~session_id ~request_id ~build =
      Code_error.raise
        "RPC build request with this id is already active"
        [ "id", Rpc_request_id.to_dyn id ]
-   | None ->
-     t.rpc_requests <- Rpc_request_id.Map.add_exn t.rpc_requests id { build; outcome });
+   | None -> t.rpc_requests <- Rpc_request_id.Map.add_exn t.rpc_requests id request);
   let* () = request_rebuild_due_to_rpc_request t in
-  Fiber.Ivar.read outcome
+  Build_system.Request.Goal.await request
 ;;
 
 type rpc_poll_iter_result =
@@ -338,11 +332,15 @@ let rpc_poll_iter t ~action_runner ~sticky_goal ~sticky_built_at =
       Fiber.return { wakeup_generation = t.wakeup_generation; sticky_built_at = None }
     | _ ->
       let* res, next, input_change_generation, wakeup_generation =
-        let build =
-          let builds = List.map rpc_requests ~f:(fun (_, { build; _ }) -> build) in
-          match sticky_goal_to_build with
-          | None -> Action_builder.all_unit builds
-          | Some sticky_goal -> Action_builder.all_unit (sticky_goal :: builds)
+        let rpc_requests_in_build = List.map rpc_requests ~f:snd in
+        let request =
+          let goals =
+            match sticky_goal_to_build with
+            | None -> rpc_requests_in_build
+            | Some sticky_goal ->
+              Build_system.Request.Goal.create sticky_goal :: rpc_requests_in_build
+          in
+          Build_system.Request.create goals
         in
         let run_id = next_watch_run_id t in
         let () =
@@ -356,7 +354,7 @@ let rpc_poll_iter t ~action_runner ~sticky_goal ~sticky_built_at =
               Console.maybe_clear_screen ~details_hum);
             Memo.reset invalidation
         in
-        run_current_build t ~action_runner ~run_id build
+        run_current_build t ~action_runner ~run_id request
       in
       (match next with
        | `Restart -> loop ()
@@ -371,9 +369,9 @@ let rpc_poll_iter t ~action_runner ~sticky_goal ~sticky_built_at =
              Fiber.sequential_iter rpc_requests ~f:(fun (id, _) ->
                match Rpc_request_id.Map.find t.rpc_requests id with
                | None -> Fiber.return ()
-               | Some { outcome = ivar; _ } ->
+               | Some request ->
                  t.rpc_requests <- Rpc_request_id.Map.remove t.rpc_requests id;
-                 Fiber.Ivar.fill ivar outcome)
+                 Build_system.Request.Goal.complete request outcome)
            in
            build_finish t outcome
          in

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1218,10 +1218,39 @@ let run_exn f =
   | Error `Already_reported -> raise Dune_util.Report_error.Already_reported
 ;;
 
-let run_action_builder ?restart_started_at ?build request =
+module Request = struct
+  module Goal = struct
+    type t =
+      { build : unit Action_builder.t
+      ; outcome : Build_outcome.t Fiber.Ivar.t
+      }
+
+    let create build = { build; outcome = Fiber.Ivar.create () }
+    let await t = Fiber.Ivar.read t.outcome
+
+    let complete t outcome =
+      Fiber.of_thunk (fun () ->
+        match Fiber.Ivar.peek t.outcome with
+        | Some _ -> Fiber.return ()
+        | None -> Fiber.Ivar.fill t.outcome outcome)
+    ;;
+
+    let build t = t.build
+  end
+
+  type t = { goals : Goal.t list }
+
+  let create goals = { goals }
+  let goals t = t.goals
+end
+
+let run_build_requests ?restart_started_at ?build request =
   run ?restart_started_at ?build (fun () ->
+    let build =
+      Request.goals request |> List.map ~f:Request.Goal.build |> Action_builder.all_unit
+    in
     let+ (), (_ : Dep.Fact.t Dep.Map.t) =
-      Action_builder.evaluate_and_collect_facts request
+      Action_builder.evaluate_and_collect_facts build
     in
     ())
 ;;

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -60,10 +60,24 @@ val run
 (** A variant of [run] that raises an [Already_reported] exception on error. *)
 val run_exn : (unit -> 'a Memo.t) -> 'a Fiber.t
 
-val run_action_builder
+module Request : sig
+  module Goal : sig
+    type t
+
+    val create : unit Action_builder.t -> t
+    val await : t -> Build_outcome.t Fiber.t
+    val complete : t -> Build_outcome.t -> unit Fiber.t
+  end
+
+  type t
+
+  val create : Goal.t list -> t
+end
+
+val run_build_requests
   :  ?restart_started_at:Time.t
   -> ?build:Process.Build.t
-  -> unit Action_builder.t
+  -> Request.t
   -> (unit, [ `Already_reported ]) result Fiber.t
 
 (** {2 Misc} *)


### PR DESCRIPTION
Introduce Build_system.Request and Request.Goal, and use them for both ordinary build commands and watch-mode RPC builds. This keeps the old batching behavior: goals are still evaluated as one combined action builder and RPC requests are completed only when the build iteration finishes.