### PR TITLE
refactor(console): make terminal signal masking explicit

### DIFF
--- a/otherlibs/stdune/src/terminal_signals.ml
+++ b/otherlibs/stdune/src/terminal_signals.ml
@@ -5,8 +5,22 @@ let signals : Signal.t list =
   ]
 ;;
 
+let signal_numbers = lazy (List.map ~f:Signal.to_int signals)
+
+type mask = int list option
+
+let block () =
+  if Sys.win32
+  then None
+  else Some (Unix.sigprocmask SIG_BLOCK (Lazy.force signal_numbers))
+;;
+
+let restore = function
+  | None -> ()
+  | Some mask -> ignore (Unix.sigprocmask SIG_SETMASK mask : int list)
+;;
+
 let unblock () =
   if not Sys.win32
-  then
-    ignore (Unix.sigprocmask SIG_UNBLOCK (List.map ~f:Signal.to_int signals) : int list)
+  then ignore (Unix.sigprocmask SIG_UNBLOCK (Lazy.force signal_numbers) : int list)
 ;;

--- a/otherlibs/stdune/src/terminal_signals.mli
+++ b/otherlibs/stdune/src/terminal_signals.mli
@@ -2,4 +2,8 @@
     events. *)
 val signals : Signal.t list
 
+type mask
+
+val block : unit -> mask
+val restore : mask -> unit
 val unblock : unit -> unit

--- a/src/dune_threaded_console/dune_threaded_console.ml
+++ b/src/dune_threaded_console/dune_threaded_console.ml
@@ -15,13 +15,17 @@ let make ~frames_per_second (module Base : S) : (module Console.Backend) =
       }
     ;;
 
+    let terminal_signal_mask = ref None
+
     let finish () =
       Mutex.protect mutex (fun () ->
         state.dirty <- true;
         state.finish_requested <- true;
         while not state.finished do
           Condition.wait finish_cv mutex
-        done)
+        done;
+        Option.iter !terminal_signal_mask ~f:Terminal_signals.restore;
+        terminal_signal_mask := None)
     ;;
 
     let print_user_message m =
@@ -62,6 +66,7 @@ let make ~frames_per_second (module Base : S) : (module Console.Backend) =
 
     let start () =
       Base.start ();
+      terminal_signal_mask := Some (Terminal_signals.block ());
       Scheduler.spawn_thread ~name:"console"
       @@ fun () ->
       Terminal_signals.unblock ();

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -126,7 +126,7 @@ let%expect_test "threaded console handles terminal signals in the console thread
   [%expect
     {|
     main before start blocked: false
-    main after start blocked: false
+    main after start blocked: true
     console thread blocked: false
     |}]
 ;;


### PR DESCRIPTION
Add Terminal_signals.block/restore so callers can temporarily block terminal signals and later restore the previous mask.

Use this when starting the threaded console: the main thread blocks terminal signals while the console thread unblocks them, then restores the original mask when the console finishes.