### PR TITLE
fix(rpc): exit nonzero for failed rpc builds

### DIFF
--- a/bin/rpc/rpc_build.ml
+++ b/bin/rpc/rpc_build.ml
@@ -14,7 +14,9 @@ let term =
   in
   match response with
   | Success -> print_endline "Success"
-  | Failure _ -> print_endline "Failure"
+  | Failure _ ->
+    print_endline "Failure";
+    raise Dune_util.Report_error.Already_reported
 ;;
 
 let info =

--- a/doc/changes/changed/15341.md
+++ b/doc/changes/changed/15341.md
@@ -1,0 +1,2 @@
+- In watch mode, `$ dune rpc build` now exits with status 1 when the
+  requested build fails. (#15341, @rgrinberg)

--- a/test/blackbox-tests/test-cases/watching/basic.t
+++ b/test/blackbox-tests/test-cases/watching/basic.t
@@ -43,11 +43,13 @@ Basic tests for the file-watching mode.
   $ mv x z
   $ build y
   Failure
+  [1]
 
   $ echo new-contents3 > z
 
   $ build y
   Failure
+  [1]
 
   $ mv z x
   $ build y

--- a/test/blackbox-tests/test-cases/watching/direct-promotion.t
+++ b/test/blackbox-tests/test-cases/watching/direct-promotion.t
@@ -8,6 +8,7 @@ Demonstrate running "dune promote" concurrently with a passive rpc server
 The test expectedly fails (see errors at the end of this file)
   $ build "(alias my_test)"
   Failure
+  [1]
 
 Promotion happens on the running RPC server.
   $ dune promote

--- a/test/blackbox-tests/test-cases/watching/multiple-errors.t
+++ b/test/blackbox-tests/test-cases/watching/multiple-errors.t
@@ -27,6 +27,7 @@ We test the behavior of watch mode when we have multiple errors
 
   $ build w
   Failure
+  [1]
 
   $ stop_dune
   File "x", line 1, characters 0-0:

--- a/test/blackbox-tests/test-cases/watching/rpc-build-concurrent-finish.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-concurrent-finish.t
@@ -131,8 +131,10 @@ requests.
   $ printf '.\n' > "$slow_release"
   $ wait_for_pid_to_exit_with_timeout "$FAIL" 200 || (cat fail.out; false)
   $ wait "$FAIL"
+  [1]
   $ wait_for_pid_to_exit_with_timeout "$SLOW" 200 || (cat slow-after-fail.out; false)
   $ wait "$SLOW"
+  [1]
   $ cat fail.out slow-after-fail.out | sort
   Failure
   Failure
@@ -170,6 +172,7 @@ failure.
   $ printf '.\n' > "$fail_release"
   $ wait_for_pid_to_exit_with_timeout "$FAIL" 200 || (cat fail-stop.out; false)
   $ wait "$FAIL"
+  [1]
   $ cat fail-stop.out
   Failure
   $ with_timeout dune_cmd wait-for-file-to-appear "$cancelled"

--- a/test/blackbox-tests/test-cases/watching/rpc-build-stop.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-stop.t
@@ -99,4 +99,5 @@ RPC build failures are reported to the client.
   $ start_dune
   $ dune rpc build --wait fail
   Failure
+  [1]
   $ stop_dune_quiet

--- a/test/blackbox-tests/test-cases/watching/target-promotion.t
+++ b/test/blackbox-tests/test-cases/watching/target-promotion.t
@@ -56,6 +56,7 @@ Now switch the mode to standard. Dune reports an error about multiple rules for
 
   $ build result
   Failure
+  [1]
   $ wait_for_line_with_timeout .#dune-output "Hint: rm -f promoted" 200
   $ grep -A3 "Error: Multiple rules generated for _build/default/promoted:" .#dune-output
   Error: Multiple rules generated for _build/default/promoted:


### PR DESCRIPTION
Make dune rpc build return exit status 1 when the requested build fails, while still printing Failure for compatibility with existing output checks.