### PR TITLE
fix(nix): quote args expansion to pass args faithfully

### DIFF
--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -95,7 +95,7 @@ let
 
   duneScript = writeScriptBin "dune" ''
     #!${stdenv.shell}
-    "$DUNE_SOURCE_ROOT"/_boot/dune.exe $@
+    "$DUNE_SOURCE_ROOT"/_boot/dune.exe "$@"
   '';
 
   baseInputs =


### PR DESCRIPTION
The wrapper script around _boot/dune.exe used `$@` directly which caused invocations such as `dune build '(alias foo)'` to get interpreted as having two args `'(alias` and `foo)'`. This can be fixed by double-quoting the args variable.