### PR TITLE
fix: blake3 foreign_library conflict on cygwin

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -396,14 +396,8 @@ jobs:
         uses: cygwin/cygwin-install-action@v6
         with:
           packages: ocaml gcc-core make
-      - name: Bootstrap Dune
-        run: make bootstrap
-      ## In order to build dune locally we need to have the re library
-      ## available. Even if we do, it is likely that our vendored blake3 rules
-      ## will miss cygwin support. So for now, we don't enable the rest.
-
-      # - name: Build Dune
-      # run: _boot/dune build dune.install
+      - name: Build Dune
+        run: make release
 
   oxcaml:
     name: OxCaml Tests (opam)

--- a/.github/workflows/workflow.yml.in
+++ b/.github/workflows/workflow.yml.in
@@ -395,14 +395,8 @@ jobs:
         uses: cygwin/cygwin-install-action@v6
         with:
           packages: ocaml gcc-core make
-      - name: Bootstrap Dune
-        run: make bootstrap
-      ## In order to build dune locally we need to have the re library
-      ## available. Even if we do, it is likely that our vendored blake3 rules
-      ## will miss cygwin support. So for now, we don't enable the rest.
-
-      # - name: Build Dune
-      # run: _boot/dune build dune.install
+      - name: Build Dune
+        run: make release
 
   oxcaml:
     name: OxCaml Tests (opam)

--- a/src/ocaml-blake3-mini/dune
+++ b/src/ocaml-blake3-mini/dune
@@ -13,9 +13,15 @@
 
 ; 1. Handwritten assembly for x86_64
 
+; Cygwin is amd64 but the assembly rules below don't target it; without
+; this os_type guard it would also enable the portable stanza, and both
+; would clash on (names blake3 ...). Matches boot/duneboot.ml [keep_asm].
+
 (foreign_library
  (enabled_if
-  (= %{architecture} "amd64"))
+  (and
+   (= %{architecture} "amd64")
+   (<> %{os_type} "Cygwin")))
  (archive_name blake3)
  (language c)
  (names blake3 blake3_portable blake3_dispatch)


### PR DESCRIPTION
- Fixes #15340 

Also update the workflow so that we exercise `make release` rather than `make bootstrap`.