### PR TITLE
fix(watch): debounce file events before rebuilding

### DIFF
--- a/doc/changes/changed/15344.md
+++ b/doc/changes/changed/15344.md
@@ -1,0 +1,1 @@
+- Debounce file change events in watch mode (#15344, @rgrinberg)

--- a/src/dune_engine/build_loop.ml
+++ b/src/dune_engine/build_loop.ml
@@ -48,6 +48,7 @@ type t =
   ; mutable pending_reset : Memo.Invalidation.t option
   ; mutable watch_restart_started_at : Time.t option
   ; mutable status_overlay : Console.Status_line.overlay option
+  ; file_event_debouncer : Debouncer.t
   ; mutable wakeup : Trigger.t
   ; mutable wakeup_generation : int
   ; mutable input_change_generation : int
@@ -146,7 +147,7 @@ let request_restart t invalidation =
       match t.status with
       | Restarting_build _ -> Fiber.return ()
       | Standing_by ->
-        clear_status_overlay t;
+        if not (Debouncer.is_pending t.file_event_debouncer) then clear_status_overlay t;
         Fiber.return ()
       | Building run_id ->
         set_status_overlay
@@ -166,6 +167,42 @@ let request_restart t invalidation =
     trigger_wakeup t)
 ;;
 
+let file_event_debounce_interval =
+  Config.make
+    ~name:"file_event_debounce"
+    ~default:(Time.Span.of_secs 0.1)
+    ~of_string:(fun value ->
+      match Float.of_string value with
+      | Some secs when secs >= 0. -> Ok (Time.Span.of_secs secs)
+      | Some _ | None -> Error "expected a non-negative number of seconds")
+;;
+
+let wait_for_file_event_debounce t =
+  let started_at = Time.now () in
+  set_status_overlay
+    t
+    (Live
+       (fun () ->
+         let elapsed = Time.diff (Time.now ()) started_at |> Time.Span.to_secs in
+         Pp.textf "Waiting for filesystem changes to settle... (%.1fs)" elapsed));
+  let rec loop () =
+    match Debouncer.latest t.file_event_debouncer with
+    | None -> Fiber.return ()
+    | Some token ->
+      let* () = Scheduler.sleep (Config.get file_event_debounce_interval) in
+      ignore (Debouncer.take_if_latest t.file_event_debouncer token : bool);
+      loop ()
+  in
+  Fiber.finalize loop ~finally:(fun () ->
+    clear_status_overlay t;
+    Fiber.return ())
+;;
+
+let flush_file_watcher t =
+  let* () = Scheduler.flush_file_watcher () in
+  wait_for_file_event_debounce t
+;;
+
 let rec handle_file_events t file_watcher =
   File_watcher.read file_watcher
   >>= function
@@ -173,7 +210,25 @@ let rec handle_file_events t file_watcher =
     Scheduler.shutdown `Ok;
     Fiber.return ()
   | Some events ->
-    let* () = request_restart t (invalidation_of_file_events events) in
+    let invalidation = invalidation_of_file_events events in
+    let () =
+      let invalidation_empty = Memo.Invalidation.is_empty invalidation in
+      let pending_before = Debouncer.is_pending t.file_event_debouncer in
+      if (not invalidation_empty) || pending_before
+      then (
+        if pending_before
+        then (
+          Dune_trace.emit File_watcher (fun () ->
+          let files =
+            List.filter_map events ~f:(fun event ->
+              match (event : Event.File_watcher_event.t) with
+              | Queue_overflow -> None
+              | Fs_memo_event { path; kind } -> Some (path, kind))
+          in
+            Dune_trace.File_watcher_event.debounce_extend ~files ~invalidation_empty));
+        ignore (Debouncer.push t.file_event_debouncer : _))
+    in
+    let* () = request_restart t invalidation in
     handle_file_events t file_watcher
 ;;
 
@@ -182,6 +237,7 @@ let create () =
   ; pending_reset = None
   ; watch_restart_started_at = None
   ; status_overlay = None
+  ; file_event_debouncer = Debouncer.create ()
   ; wakeup = Trigger.create ()
   ; wakeup_generation = 0
   ; input_change_generation = 0
@@ -355,8 +411,15 @@ let rpc_poll_iter t ~action_runner ~sticky_goal ~sticky_built_at =
            -> None
          | None | Some _ -> Some sticky_goal)
     in
-    match sticky_goal_to_build, rpc_requests with
-    | None, [] ->
+    let should_wait_for_debounce = Debouncer.is_pending t.file_event_debouncer in
+    match should_wait_for_debounce, sticky_goal_to_build, rpc_requests with
+    | true, _, _ ->
+      (* Wait for a quiet period before starting the next build. Otherwise, an
+         editor save implemented as delete/create can make us observe the
+         source tree between the two events. *)
+      let* () = wait_for_file_event_debounce t in
+      loop ()
+    | false, None, [] ->
       (match t.status with
        | Restarting_build _ ->
          t.status <- Standing_by;
@@ -364,7 +427,7 @@ let rpc_poll_iter t ~action_runner ~sticky_goal ~sticky_built_at =
        | Standing_by | Building _ -> ());
       let* () = reset_wakeup t in
       Fiber.return { wakeup_generation = t.wakeup_generation; sticky_built_at = None }
-    | _ ->
+    | false, _, _ ->
       let* res, next, input_change_generation, wakeup_generation =
         let request =
           Build_system.Request.create

--- a/src/dune_engine/build_loop.mli
+++ b/src/dune_engine/build_loop.mli
@@ -25,6 +25,11 @@ val cancel_rpc_requests_by_session
 
 val cancel_all_rpc_requests : t -> unit Fiber.t
 
+(** [flush_file_watcher t] waits until file-watcher notifications that precede
+    the flush have been applied to [t], including any active debounce quiet
+    period. *)
+val flush_file_watcher : t -> unit Fiber.t
+
 (** [poll t ~action_runner ~sticky_goal] runs the watch loop managed by [t].
     [action_runner] is used for each build started by the loop. [sticky_goal] is
     rebuilt after file changes and is also included in builds started for

--- a/src/dune_engine/debouncer.ml
+++ b/src/dune_engine/debouncer.ml
@@ -1,0 +1,28 @@
+type token = int
+
+type t =
+  { mutable generation : token
+  ; mutable pending : bool
+  }
+
+let create () = { generation = 0; pending = false }
+
+let push t =
+  t.generation <- t.generation + 1;
+  t.pending <- true;
+  t.generation
+;;
+
+let latest t = if t.pending then Some t.generation else None
+
+let take_if_latest t token =
+  if token <> t.generation
+  then false
+  else if t.pending
+  then (
+    t.pending <- false;
+    true)
+  else false
+;;
+
+let is_pending t = t.pending

--- a/src/dune_engine/debouncer.mli
+++ b/src/dune_engine/debouncer.mli
@@ -1,0 +1,22 @@
+(** Track pending work and let only the latest debounce timer consume it. *)
+
+type t
+type token
+
+(** [create ()] returns a debouncer with no pending work. *)
+val create : unit -> t
+
+(** [push t] marks work as pending and returns a token for the new debounce
+    generation. Any earlier token can no longer consume the pending work. *)
+val push : t -> token
+
+(** [latest t] returns the latest token if [t] has pending work. *)
+val latest : t -> token option
+
+(** [take_if_latest t token] clears pending work and returns [true] iff [token]
+    is the latest generation and [t] has pending work. It returns [false]
+    without changing [t] for stale tokens or when no work is pending. *)
+val take_if_latest : t -> token -> bool
+
+(** [is_pending t] is [true] iff [t] has pending work. *)
+val is_pending : t -> bool

--- a/src/dune_engine/dune_engine.ml
+++ b/src/dune_engine/dune_engine.ml
@@ -44,3 +44,7 @@ module Running_jobs = Running_jobs
 module Rule_cache = Rule_cache
 module Build_outcome = Build_outcome
 module Fs = Fs
+
+module For_tests = struct
+  module Debouncer = Debouncer
+end

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -303,7 +303,11 @@ let handler (t : t Fdecl.t) action_runner_server : unit Handler.t =
       match t.server.watch_mode with
       | No -> Fiber.return `Not_in_watch_mode
       | Yes _ ->
-        let+ () = Scheduler.flush_file_watcher () in
+        let+ () =
+          match t.build with
+          | Disabled -> Scheduler.flush_file_watcher ()
+          | Enabled { build_loop; _ } -> Build_loop.flush_file_watcher build_loop
+        in
         `Ok
     in
     Handler.implement_request rpc Procedures.Public.flush_file_watcher f

--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -785,7 +785,7 @@ let run_and_produce_output
       ~setup_scripts
       shell
   =
-    let open Fiber.O in
+  let open Fiber.O in
   let* commands =
     let+ cram_to_output =
       let cram_stanzas =

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -288,6 +288,7 @@ module File_watcher_event : sig
 
   val kind_repr : kind Repr.t
   val to_event : t -> Event.t
+  val debounce_extend : files:(Path.t * kind) list -> invalidation_empty:bool -> Event.t
 end
 
 module Out : sig

--- a/src/dune_trace/file_watcher_event.ml
+++ b/src/dune_trace/file_watcher_event.ml
@@ -50,3 +50,20 @@ let to_event event =
   in
   Event.Event.instant ~name ~args now File_watcher
 ;;
+
+let file_arg (path, kind) =
+  Event.Arg.record
+    [ "path", Event.Arg.path path; "kind", Event.Arg.string (kind_to_trace_name kind) ]
+  |> Event.Arg.list
+;;
+
+let debounce_extend ~files ~invalidation_empty =
+  Event.Event.instant
+    ~name:"debounce-extend"
+    ~args:
+      [ "files", Event.Arg.list (List.map files ~f:file_arg)
+      ; "invalidation_empty", Event.Arg.bool invalidation_empty
+      ]
+    (Time.now ())
+    Category.File_watcher
+;;

--- a/src/dune_trace/file_watcher_event.mli
+++ b/src/dune_trace/file_watcher_event.mli
@@ -15,3 +15,4 @@ type t =
 
 val kind_repr : kind Repr.t
 val to_event : t -> Event.t
+val debounce_extend : files:(Path.t * kind) list -> invalidation_empty:bool -> Event.t

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -3,6 +3,7 @@
   (env-vars
    (DUNE_CONFIG__BACKGROUND_SANDBOXES disabled)
    (DUNE_CONFIG__BACKGROUND_DIGESTS disabled)
+   (DUNE_CONFIG__FILE_EVENT_DEBOUNCE 0)
    (DUNE_JOBS 1)
    ;; We set ocaml to always be colored since it changes the output of
    ;; ocamlc error messages. See https://github.com/ocaml/ocaml/issues/14144

--- a/test/blackbox-tests/test-cases/watching/rpc-build-during-eager-build.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-during-eager-build.t
@@ -24,8 +24,14 @@ iteration and restart it with the RPC request incorporated.
 
 The eager loop still reacts to filesystem changes after the RPC build has run.
 
-  $ echo '(rule (alias default) (action (echo changed)))' > dune
+  $ changed_marker="$marker_dir/eager-build-restarted"
+  $ cat > dune <<EOF
+  > (rule
+  >  (alias default)
+  >  (action (bash "touch '$changed_marker'; echo changed")))
+  > EOF
   $ with_timeout dune rpc flush-file-watcher --wait
+  $ with_timeout dune_cmd wait-for-file-to-appear "$changed_marker"
   $ stop_dune > /dev/null
 
   $ dune trace cat | jq_dune -s '

--- a/test/expect-tests/debouncer_tests.ml
+++ b/test/expect-tests/debouncer_tests.ml
@@ -1,0 +1,97 @@
+open Stdune
+module Debouncer = Dune_engine.For_tests.Debouncer
+
+let print_latest t =
+  print_endline
+    (match Debouncer.latest t with
+     | None -> "None"
+     | Some _ -> "Some")
+;;
+
+let%expect_test "empty debouncer has no latest token" =
+  let t = Debouncer.create () in
+  print_latest t;
+  [%expect {| None |}]
+;;
+
+let%expect_test "latest token can consume pending work" =
+  let t = Debouncer.create () in
+  let (_ : Debouncer.token) = Debouncer.push t in
+  (match Debouncer.latest t with
+   | None -> print_endline "None"
+   | Some token ->
+     printfn "%b" (Debouncer.take_if_latest t token);
+     printfn "%b" (Debouncer.is_pending t));
+  [%expect
+    {|
+    true
+    false
+    |}]
+;;
+
+let%expect_test "only the latest token consumes pending work" =
+  let t = Debouncer.create () in
+  let first = Debouncer.push t in
+  let second = Debouncer.push t in
+  printfn "%b" (Debouncer.take_if_latest t first);
+  [%expect {| false |}];
+  print_latest t;
+  [%expect {| Some |}];
+  printfn "%b" (Debouncer.take_if_latest t second);
+  [%expect {| true |}];
+  print_latest t;
+  [%expect {| None |}];
+  printfn "%b" (Debouncer.take_if_latest t second);
+  [%expect {| false |}]
+;;
+
+let%expect_test "can be reused after pending work is consumed" =
+  let t = Debouncer.create () in
+  let first = Debouncer.push t in
+  printfn "%b" (Debouncer.take_if_latest t first);
+  [%expect {| true |}];
+  printfn "%b" (Debouncer.is_pending t);
+  [%expect {| false |}];
+  let second = Debouncer.push t in
+  printfn "%b" (Debouncer.is_pending t);
+  [%expect {| true |}];
+  printfn "%b" (Debouncer.take_if_latest t first);
+  [%expect {| false |}];
+  printfn "%b" (Debouncer.take_if_latest t second);
+  [%expect {| true |}];
+  printfn "%b" (Debouncer.is_pending t);
+  [%expect {| false |}]
+;;
+
+let%expect_test "multiple stale tokens do not consume pending work" =
+  let t = Debouncer.create () in
+  let first = Debouncer.push t in
+  let second = Debouncer.push t in
+  let third = Debouncer.push t in
+  printfn "%b" (Debouncer.take_if_latest t first);
+  [%expect {| false |}];
+  printfn "%b" (Debouncer.take_if_latest t second);
+  [%expect {| false |}];
+  printfn "%b" (Debouncer.is_pending t);
+  [%expect {| true |}];
+  printfn "%b" (Debouncer.take_if_latest t third);
+  [%expect {| true |}];
+  printfn "%b" (Debouncer.is_pending t);
+  [%expect {| false |}]
+;;
+
+let%expect_test "pending state" =
+  let t = Debouncer.create () in
+  printfn "%b" (Debouncer.is_pending t);
+  let token = Debouncer.push t in
+  printfn "%b" (Debouncer.is_pending t);
+  [%expect
+    {|
+    false
+    true
+    |}];
+  printfn "%b" (Debouncer.take_if_latest t token);
+  [%expect {| true |}];
+  printfn "%b" (Debouncer.is_pending t);
+  [%expect {| false |}]
+;;


### PR DESCRIPTION
Apply file watcher invalidations as soon as events are received, but require a short quiet period before starting the next watch build. This prevents editor save sequences such as delete/create from being observed midway through by a rebuild.

Empty invalidations do not interrupt the current build; they only extend an already-active quiet period.

Add a small engine-local debouncer helper with expect tests.