### PR TITLE
refactor(rpc): move client status into lifecycle

### DIFF
--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -55,7 +55,6 @@ module Clients = struct
     Session.Id.Map.remove t id
   ;;
 
-  let cardinal = Session.Id.Map.cardinal
   let to_list = Session.Id.Map.to_list
   let to_list_map = Session.Id.Map.to_list_map
 
@@ -69,7 +68,6 @@ end
 type server =
   { lifecycle : Rpc.Server.Lifecycle.t
   ; action_runner : Action_runner.t option
-  ; registry : [ `Add | `Skip ]
   ; watch_mode : Watch_mode_config.t
   ; mutable clients : Clients.t
   }
@@ -85,20 +83,6 @@ type t =
   { server : server
   ; build : build
   }
-
-let client_count t = Clients.cardinal t.server.clients
-
-let pp_client_count t =
-  match client_count t with
-  | 0 -> Pp.nop
-  | count -> Pp.textf "[rpc %d]" count
-;;
-
-let refresh_client_count_status_line t =
-  match t.server.registry with
-  | `Skip -> ()
-  | `Add -> Console.Status_line.refresh ()
-;;
 
 let () =
   Debug.register ~name:"rpc" (fun () ->
@@ -159,15 +143,12 @@ let cancel_all_build_requests t =
 let handler (t : t Fdecl.t) action_runner_server : unit Handler.t =
   let on_init session (_ : Initialize.Request.t) =
     let t = Fdecl.get t in
-    let client = () in
     t.server.clients <- Clients.add_session t.server.clients session;
-    refresh_client_count_status_line t;
-    Fiber.return client
+    Fiber.return ()
   in
   let on_terminate session =
     let t = Fdecl.get t in
     t.server.clients <- Clients.remove_session t.server.clients session;
-    refresh_client_count_status_line t;
     cancel_build_requests_for_session t session
   in
   let rpc = Handler.create ~on_terminate ~on_init ~version:Dune_rpc.Version.latest () in
@@ -410,7 +391,7 @@ let handler (t : t Fdecl.t) action_runner_server : unit Handler.t =
 let create ~registry ~root ~build ~where ~action_runner watch_mode =
   Global_lock.lock_exn ();
   let t = Fdecl.create Dyn.opaque in
-  let config =
+  let action_runner, lifecycle =
     let server =
       lazy
         (let socket_file = Where.rpc_socket_file () in
@@ -436,10 +417,7 @@ let create ~registry ~root ~build ~where ~action_runner watch_mode =
     let lifecycle = Rpc.Server.Lifecycle.create ~handler ~root ~where ~registry ~server in
     action_runner, lifecycle
   in
-  let action_runner, lifecycle = config in
-  let server =
-    { lifecycle; action_runner; registry; watch_mode; clients = Clients.empty }
-  in
+  let server = { lifecycle; action_runner; watch_mode; clients = Clients.empty } in
   let res = { server; build } in
   current := Some server;
   Fdecl.set t res;
@@ -447,19 +425,10 @@ let create ~registry ~root ~build ~where ~action_runner watch_mode =
 ;;
 
 let run t =
-  let run () =
-    Fiber.fork_and_join_unit
-      (fun () -> Rpc.Server.Lifecycle.run t.server.lifecycle)
-      (fun () ->
-         match t.server.action_runner with
-         | None -> Fiber.return ()
-         | Some runner -> Action_runner.run runner)
-  in
-  match t.server.registry with
-  | `Skip -> run ()
-  | `Add ->
-    let section = Console.Status_line.add_section (Live (fun () -> pp_client_count t)) in
-    Fiber.finalize run ~finally:(fun () ->
-      Console.Status_line.remove_section section;
-      Fiber.return ())
+  Fiber.fork_and_join_unit
+    (fun () -> Rpc.Server.Lifecycle.run t.server.lifecycle)
+    (fun () ->
+       match t.server.action_runner with
+       | None -> Fiber.return ()
+       | Some runner -> Action_runner.run runner)
 ;;

--- a/src/rpc/registry.ml
+++ b/src/rpc/registry.ml
@@ -8,6 +8,7 @@ type t =
   }
 
 let create ~root ~where registry = { root; where; registry; path = None }
+let mode t = t.registry
 
 let cleanup t =
   match t.path with

--- a/src/rpc/registry.mli
+++ b/src/rpc/registry.mli
@@ -3,5 +3,6 @@ open Import
 type t
 
 val create : root:string -> where:Dune_rpc.Where.t -> [ `Add | `Skip ] -> t
+val mode : t -> [ `Add | `Skip ]
 val register : t -> unit
 val cleanup : t -> unit

--- a/src/rpc/server.ml
+++ b/src/rpc/server.ml
@@ -846,6 +846,7 @@ let new_session
 let close_all active_sessions =
   let sessions = Table.values active_sessions in
   Table.clear active_sessions;
+  Console.Status_line.refresh ();
   Fiber.parallel_iter sessions ~f:(fun { close; _ } -> close)
 ;;
 
@@ -859,6 +860,7 @@ module Make (S : Session) = struct
         new_session server ~name ((module S), session)
       in
       Table.set active_sessions session.id session;
+      Console.Status_line.refresh ();
       Fiber.finalize
         (fun () ->
            let id = session.id in
@@ -888,6 +890,7 @@ module Make (S : Session) = struct
              ())
         ~finally:(fun () ->
           Table.remove active_sessions session.id;
+          Console.Status_line.refresh ();
           Fiber.return ()))
   ;;
 
@@ -920,8 +923,8 @@ module Lifecycle = struct
     ; active_sessions : (Session.Id.t, served_session) Table.t
     }
 
-  let create ~handler ~root ~where ~registry ~server =
-    let registry = Rpc_registry.create ~root ~where registry in
+  let create ~handler ~root ~where ~registry:registry_mode ~server =
+    let registry = Rpc_registry.create ~root ~where registry_mode in
     Rpc_registry.register registry;
     { handler; registry; server; active_sessions = Table.create (module Session.Id) 16 }
   ;;
@@ -930,22 +933,39 @@ module Lifecycle = struct
     Console.print [ Pp.text "Uncaught RPC Error"; Exn_with_backtrace.pp exn ]
   ;;
 
+  let pp_active_sessions t =
+    match Table.length t.active_sessions with
+    | 0 -> Pp.nop
+    | count -> Pp.textf "[rpc %d]" count
+  ;;
+
   let run t =
-    let run () =
+    let run_server () =
       let* sessions = Csexp_rpc.Server.serve t.server in
       serve_with_active_sessions t.active_sessions sessions t.handler
     in
-    Fiber.finalize
-      (fun () ->
-         Fiber.with_error_handler run ~on_error:(fun exn ->
-           print_uncaught_rpc_error exn;
-           Exn_with_backtrace.reraise exn))
-      ~finally:(fun () ->
-        Fiber.finalize
-          (fun () -> close_all t.active_sessions)
-          ~finally:(fun () ->
-            Rpc_registry.cleanup t.registry;
-            Fiber.return ()))
+    let run_with_cleanup () =
+      Fiber.finalize
+        (fun () ->
+           Fiber.with_error_handler run_server ~on_error:(fun exn ->
+             print_uncaught_rpc_error exn;
+             Exn_with_backtrace.reraise exn))
+        ~finally:(fun () ->
+          Fiber.finalize
+            (fun () -> close_all t.active_sessions)
+            ~finally:(fun () ->
+              Rpc_registry.cleanup t.registry;
+              Fiber.return ()))
+    in
+    match Rpc_registry.mode t.registry with
+    | `Skip -> run_with_cleanup ()
+    | `Add ->
+      let section =
+        Console.Status_line.add_section (Live (fun () -> pp_active_sessions t))
+      in
+      Fiber.finalize run_with_cleanup ~finally:(fun () ->
+        Console.Status_line.remove_section section;
+        Fiber.return ())
   ;;
 
   let stop t =


### PR DESCRIPTION
Have Rpc.Server.Lifecycle own the [rpc n] status-line section when the RPC registry is active. Count clients from the lifecycle active_sessions table so dune_rpc_impl no longer keeps separate registry/status-line bookkeeping.