### PR TITLE
fix(rpc): show client count for batch servers

### DIFF
--- a/src/rpc/registry.ml
+++ b/src/rpc/registry.ml
@@ -8,7 +8,6 @@ type t =
   }
 
 let create ~root ~where registry = { root; where; registry; path = None }
-let mode t = t.registry
 
 let cleanup t =
   match t.path with

--- a/src/rpc/registry.mli
+++ b/src/rpc/registry.mli
@@ -3,6 +3,5 @@ open Import
 type t
 
 val create : root:string -> where:Dune_rpc.Where.t -> [ `Add | `Skip ] -> t
-val mode : t -> [ `Add | `Skip ]
 val register : t -> unit
 val cleanup : t -> unit

--- a/src/rpc/server.ml
+++ b/src/rpc/server.ml
@@ -957,15 +957,12 @@ module Lifecycle = struct
               Rpc_registry.cleanup t.registry;
               Fiber.return ()))
     in
-    match Rpc_registry.mode t.registry with
-    | `Skip -> run_with_cleanup ()
-    | `Add ->
-      let section =
-        Console.Status_line.add_section (Live (fun () -> pp_active_sessions t))
-      in
-      Fiber.finalize run_with_cleanup ~finally:(fun () ->
-        Console.Status_line.remove_section section;
-        Fiber.return ())
+    let section =
+      Console.Status_line.add_section (Live (fun () -> pp_active_sessions t))
+    in
+    Fiber.finalize run_with_cleanup ~finally:(fun () ->
+      Console.Status_line.remove_section section;
+      Fiber.return ())
   ;;
 
   let stop t =

--- a/test/blackbox-tests/test-cases/watching/rpc-build-status-line.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-status-line.t
@@ -22,3 +22,48 @@ Forwarded builds display a rich status line once connected over RPC.
   [rpc 1]
 
   $ stop_dune_quiet
+
+Batch builds also display the client count while their temporary RPC server is
+running.
+
+  $ STARTED="$PWD/batch-started"
+  $ RELEASE="$PWD/batch-release"
+  $ CLIENT_CONNECTED="$PWD/batch-client-connected"
+  $ cat > dune <<EOF
+  > (rule
+  >  (target batch-target)
+  >  (action
+  >   (progn
+  >    (system "touch '$STARTED'; while test ! -f '$RELEASE'; do sleep 0.1; done")
+  >    (write-file %{target} ok))))
+  > EOF
+
+  $ INSIDE_EMACS=1 DUNE_CONFIG__THREADED_CONSOLE=disabled \
+  >   dune build --display progress batch-target > batch-output 2>&1 &
+  $ BATCH_PID=$!
+  $ with_timeout dune_cmd wait-for-file-to-appear "$STARTED"
+
+  $ dune_cmd hold-rpc-client _build/.rpc/dune "$CLIENT_CONNECTED" &
+  $ CLIENT_PID=$!
+  $ with_timeout dune_cmd wait-for-file-to-appear "$CLIENT_CONNECTED"
+  $ i=200
+  $ while [ "$i" != 0 ]; do
+  >   tr '\r' '\n' < batch-output | grep -a -q "\[rpc 1\]" && break
+  >   i=$((i - 1))
+  >   sleep 0.01
+  > done
+  $ tr '\r' '\n' < batch-output | grep -a -m 1 -o "\[rpc 1\]"
+  [rpc 1]
+
+  $ touch "$RELEASE"
+  $ if wait_for_pid_to_exit_with_timeout "$BATCH_PID" 200; then
+  >   wait "$BATCH_PID"
+  > else
+  >   echo "batch build did not exit"
+  > fi
+  $ kill "$CLIENT_PID" 2>/dev/null || true
+  $ wait "$CLIENT_PID" 2>/dev/null || true
+  $ if kill -0 "$BATCH_PID" 2>/dev/null; then
+  >   kill "$BATCH_PID"
+  >   wait "$BATCH_PID" 2>/dev/null || true
+  > fi


### PR DESCRIPTION
Install the RPC client-count status-line section for every RPC lifecycle run instead of tying it to registry publication. Batch builds use a temporary RPC server without writing a registry entry, but they should still refresh the [rpc n] section while clients are connected.

Extend the status-line cram test to cover a batch build with a held RPC client.