### PR TITLE
Attach Rocq output tests to the right directory

### DIFF
--- a/src/dune_rules/rocq/rocq_rules.ml
+++ b/src/dune_rules/rocq/rocq_rules.ml
@@ -820,7 +820,8 @@ let setup_output_diff_rule ~loc ~dir ~sctx ~rocq_lang_version ~rocq_sources rocq
       ; directory_diffs = true
       }
     in
-    let alias = Alias.make ~dir Alias0.runtest in
+    let alias_dir = Path.Build.parent_exn expected in
+    let alias = Alias.make ~dir:alias_dir Alias0.runtest in
     Simple_rules.Alias_rules.add
       sctx
       ~loc

--- a/test/blackbox-tests/test-cases/rocq/rocq-expected-alias.t
+++ b/test/blackbox-tests/test-cases/rocq/rocq-expected-alias.t
@@ -1,0 +1,40 @@
+Testing that the diff rules are attached to the @runtest alias of the right
+directory. This used to not be the case, and these rules would be attached
+to the @runtest alias of the directory defining the rocq.theory stanza, even
+for files living in its sub-directories.
+
+  $ make_rocq_project 3.22 0.12
+
+  $ cat > dune <<EOF
+  > (include_subdirs qualified)
+  > (rocq.theory
+  >  (name a))
+  > EOF
+
+  $ mkdir sub
+  $ cat > sub/foo.v <<EOF
+  > Locate bool.
+  > EOF
+  $ touch sub/foo.expected
+
+This has always worked:
+
+  $ dune runtest
+  File "sub/foo.expected", line 1, characters 0-0:
+  --- sub/foo.expected
+  +++ sub/foo.output
+  @@ -0,0 +1 @@
+  +Inductive Corelib.Init.Datatypes.bool
+  [1]
+
+But this used to fail:
+
+  $ dune runtest sub
+  File "sub/foo.expected", line 1, characters 0-0:
+  --- sub/foo.expected
+  +++ sub/foo.output
+  @@ -0,0 +1 @@
+  +Inductive Corelib.Init.Datatypes.bool
+  [1]
+
+


### PR DESCRIPTION
Tests used to be attached to the runtest alias of the top-level directory of the rocq.theory stanza, even if they lived in some sub-directory via (include_subdirs qualified).