### PR TITLE
refactor(trace): move file watcher events into a module

### DIFF
--- a/src/dune_scheduler/event.ml
+++ b/src/dune_scheduler/event.ml
@@ -15,29 +15,17 @@ let dyn_of_job { pid; is_process_group_leader; ivar } =
 ;;
 
 module Fs_memo_event = struct
-  type kind =
-    | Created
-    | Deleted
-    | File_changed
-    | Unknown
-
-  let dyn_of_kind kind =
-    Dyn.string
-      (match kind with
-       | Created -> "Created"
-       | Deleted -> "Deleted"
-       | File_changed -> "File_changed"
-       | Unknown -> "Unknown")
-  ;;
-
   type t =
     { path : Path.t
-    ; kind : kind
+    ; kind : Dune_trace.File_watcher_event.kind
     }
 
   let to_dyn { path; kind } =
     let open Dyn in
-    record [ "path", Path.to_dyn path; "kind", dyn_of_kind kind ]
+    record
+      [ "path", Path.to_dyn path
+      ; "kind", Repr.to_dyn Dune_trace.File_watcher_event.kind_repr kind
+      ]
   ;;
 
   let create ~kind ~path = { path; kind }

--- a/src/dune_scheduler/event.mli
+++ b/src/dune_scheduler/event.mli
@@ -9,18 +9,12 @@ type job =
 val dyn_of_job : job -> Dyn.t
 
 module Fs_memo_event : sig
-  type kind =
-    | Created
-    | Deleted
-    | File_changed
-    | Unknown
-
   type t = private
     { path : Path.t
-    ; kind : kind
+    ; kind : Dune_trace.File_watcher_event.kind
     }
 
-  val create : kind:kind -> path:Path.t -> t
+  val create : kind:Dune_trace.File_watcher_event.kind -> path:Path.t -> t
   val to_dyn : t -> Dyn.t
 end
 

--- a/src/dune_scheduler/file_watcher.ml
+++ b/src/dune_scheduler/file_watcher.ml
@@ -369,14 +369,7 @@ let event_to_trace_event = function
   | Sync { id; _ } -> `Sync (Sync.Id.to_int id)
   | Watcher_terminated -> `Watcher_terminated
   | Filesystem_event Queue_overflow -> `Queue_overflow
-  | Filesystem_event (Fs_memo_event { path; kind }) ->
-    `File
-      ( path
-      , match kind with
-        | Created -> `Created
-        | Deleted -> `Deleted
-        | File_changed -> `File_changed
-        | Unknown -> `Unknown )
+  | Filesystem_event (Fs_memo_event { path; kind }) -> `File (path, kind)
 ;;
 
 let trace_event_to_dyn = function
@@ -384,20 +377,15 @@ let trace_event_to_dyn = function
   | `Queue_overflow -> Dyn.variant "Queue_overflow" []
   | `Watcher_terminated -> Dyn.variant "Watcher_terminated" []
   | `File (path, kind) ->
-    let kind =
-      match kind with
-      | `Created -> "Created"
-      | `Deleted -> "Deleted"
-      | `File_changed -> "File_changed"
-      | `Unknown -> "Unknown"
-    in
-    Dyn.variant "File" [ Path.to_dyn path; Dyn.string kind ]
+    Dyn.variant
+      "File"
+      [ Path.to_dyn path; Repr.to_dyn Dune_trace.File_watcher_event.kind_repr kind ]
 ;;
 
 let emit_events events =
   Dune_trace.emit_all ~buffered:true File_watcher (fun () ->
     List.map events ~f:(fun event ->
-      Dune_trace.Event.file_watcher (event_to_trace_event event)))
+      Dune_trace.File_watcher_event.to_event (event_to_trace_event event)))
 ;;
 
 let log_dropped_events events =
@@ -715,7 +703,7 @@ let fsevents_standard_event_impl
          (* FSEvents can report directory-wide or ambiguous changes without
             listing all affected descendants. Until Fs_memo supports subtree
             invalidation, over-invalidate by clearing the filesystem caches. *)
-         Some (Filesystem_event Event.Queue_overflow)
+         Some (Filesystem_event Queue_overflow)
        | Create -> fs_memo_event Created
        | Modify -> fs_memo_event Unknown)
     | File ->
@@ -750,7 +738,7 @@ let%expect_test "fsevents standard event handling" =
   print Create File ~should_exclude:(Fun.const true);
   [%expect
     {|
-    { path = In_source_tree "x"; kind = "File_changed" }
+    { path = In_source_tree "x"; kind = File_changed }
     Queue_overflow
     Queue_overflow
     Queue_overflow
@@ -876,11 +864,11 @@ let fswatch_win_event ~sync_table ~should_exclude event =
       Some
         (let kind =
            match Fswatch_win.Event.action event with
-           | Added | Renamed_new -> Fs_memo_event.Created
+           | Added | Renamed_new -> Dune_trace.File_watcher_event.Created
            | Removed | Renamed_old -> Deleted
            | Modified -> File_changed
          in
-         Filesystem_event (Event.Fs_memo_event (Fs_memo_event.create ~kind ~path)))
+         Filesystem_event (Fs_memo_event (Fs_memo_event.create ~kind ~path)))
 ;;
 
 let create_fswatch_win ~sync_table ~event_channel ~debounce_interval:sleep ~should_exclude

--- a/src/dune_trace/dune_trace.ml
+++ b/src/dune_trace/dune_trace.ml
@@ -1,6 +1,7 @@
 open Stdune
 module Category = Category
 module Event = Event
+module File_watcher_event = File_watcher_event
 module Raw_out = Out
 
 module Out = struct

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -156,14 +156,6 @@ module Event : sig
   val load_dir : Path.t -> t
   val log : Log.Message.t -> t
 
-  val file_watcher
-    :  [ `File of Path.t * [ `Created | `Deleted | `File_changed | `Unknown ]
-       | `Queue_overflow
-       | `Sync of int
-       | `Watcher_terminated
-       ]
-    -> t
-
   val error
     :  Loc.t option
     -> [< `Fatal | `User ]
@@ -278,6 +270,24 @@ module Event : sig
 
   val debug : (string * Dyn.t) list -> t
   val artifact_substitution : file:Path.t -> placeholder:Dyn.t -> value:string -> t
+end
+
+module File_watcher_event : sig
+  type kind =
+    | Created
+    | Deleted
+    | File_changed
+    | Unknown
+
+  type t =
+    [ `File of Path.t * kind
+    | `Queue_overflow
+    | `Sync of int
+    | `Watcher_terminated
+    ]
+
+  val kind_repr : kind Repr.t
+  val to_event : t -> Event.t
 end
 
 module Out : sig

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -703,25 +703,6 @@ let load_dir dir =
   Event.instant ~name:"load-dir" ~args now Debug
 ;;
 
-let file_watcher event =
-  (* CR-soon rgrinberg: this timestamp is wrong *)
-  let now = Time.now () in
-  let name, args =
-    match event with
-    | `Queue_overflow -> "queue_overflow", []
-    | `Sync id -> "sync", [ "id", Arg.int id ]
-    | `Watcher_terminated -> "watcher_terminated", []
-    | `File (path, kind) ->
-      ( (match kind with
-         | `Created -> "create"
-         | `Deleted -> "delete"
-         | `File_changed -> "changed"
-         | `Unknown -> "unknown")
-      , [ "path", Arg.path path ] )
-  in
-  Event.instant ~name ~args now File_watcher
-;;
-
 let error loc kind exn backtrace memo_stack =
   let now = Time.now () in
   let name =

--- a/src/dune_trace/file_watcher_event.ml
+++ b/src/dune_trace/file_watcher_event.ml
@@ -1,0 +1,52 @@
+open Stdune
+
+type kind =
+  | Created
+  | Deleted
+  | File_changed
+  | Unknown
+
+type t =
+  [ `File of Path.t * kind
+  | `Queue_overflow
+  | `Sync of int
+  | `Watcher_terminated
+  ]
+
+let kind_to_trace_name = function
+  | Created -> "create"
+  | Deleted -> "delete"
+  | File_changed -> "changed"
+  | Unknown -> "unknown"
+;;
+
+let kind_repr =
+  Repr.variant
+    "file-watcher-event-kind"
+    [ Repr.case0 "Created" ~test:(function
+        | Created -> true
+        | Deleted | File_changed | Unknown -> false)
+    ; Repr.case0 "Deleted" ~test:(function
+        | Deleted -> true
+        | Created | File_changed | Unknown -> false)
+    ; Repr.case0 "File_changed" ~test:(function
+        | File_changed -> true
+        | Created | Deleted | Unknown -> false)
+    ; Repr.case0 "Unknown" ~test:(function
+        | Unknown -> true
+        | Created | Deleted | File_changed -> false)
+    ]
+;;
+
+let to_event event =
+  (* CR-soon rgrinberg: this timestamp is wrong *)
+  let now = Time.now () in
+  let name, args =
+    match event with
+    | `Queue_overflow -> "queue_overflow", []
+    | `Sync id -> "sync", [ "id", Event.Arg.int id ]
+    | `Watcher_terminated -> "watcher_terminated", []
+    | `File (path, kind) -> kind_to_trace_name kind, [ "path", Event.Arg.path path ]
+  in
+  Event.Event.instant ~name ~args now File_watcher
+;;

--- a/src/dune_trace/file_watcher_event.mli
+++ b/src/dune_trace/file_watcher_event.mli
@@ -1,0 +1,17 @@
+open Stdune
+
+type kind =
+  | Created
+  | Deleted
+  | File_changed
+  | Unknown
+
+type t =
+  [ `File of Path.t * kind
+  | `Queue_overflow
+  | `Sync of int
+  | `Watcher_terminated
+  ]
+
+val kind_repr : kind Repr.t
+val to_event : t -> Event.t

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
@@ -13,17 +13,17 @@ let%expect_test _ =
   print_events 2;
   [%expect
     {|
-{ path = In_source_tree "x"; kind = "Created" }
-{ path = In_source_tree "x"; kind = "File_changed" }
-|}];
+    { path = In_source_tree "x"; kind = Created }
+    { path = In_source_tree "x"; kind = File_changed }
+    |}];
   (* CR-someday aalekseyev: renaming is not detected *)
   Unix.rename "x" "y";
   print_events 2;
   [%expect
     {|
-    { path = In_source_tree "x"; kind = "Deleted" }
-    { path = In_source_tree "y"; kind = "Created" }
-|}];
+    { path = In_source_tree "x"; kind = Deleted }
+    { path = In_source_tree "y"; kind = Created }
+    |}];
   let (_ : _) = Fpath.mkdir_p "d/w" in
   (match Dune_scheduler.File_watcher.add_watch watcher (Path.of_string "d/w") with
    | Error _ -> assert false
@@ -32,15 +32,15 @@ let%expect_test _ =
   print_events 3;
   [%expect
     {|
-    { path = In_source_tree "d"; kind = "Created" }
-    { path = In_source_tree "d/w/x"; kind = "Created" }
-    { path = In_source_tree "d/w/x"; kind = "File_changed" }
-|}];
+    { path = In_source_tree "d"; kind = Created }
+    { path = In_source_tree "d/w/x"; kind = Created }
+    { path = In_source_tree "d/w/x"; kind = File_changed }
+    |}];
   Stdio.Out_channel.write_all "d/w/y" ~data:"y";
   print_events 2;
   [%expect
     {|
-  { path = In_source_tree "d/w/y"; kind = "Created" }
-  { path = In_source_tree "d/w/y"; kind = "File_changed" }
-|}]
+    { path = In_source_tree "d/w/y"; kind = Created }
+    { path = In_source_tree "d/w/y"; kind = File_changed }
+    |}]
 ;;

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_macos.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_macos.ml
@@ -12,23 +12,23 @@ let%expect_test _ =
   print_events 2;
   [%expect
     {|
-    { path = In_source_tree "."; kind = "Created" }
-    { path = In_source_tree "x"; kind = "Unknown" } |}];
+    { path = In_source_tree "."; kind = Created }
+    { path = In_source_tree "x"; kind = Unknown } |}];
   Unix.rename "x" "y";
   print_events 2;
   [%expect
     {|
-    { path = In_source_tree "x"; kind = "Unknown" }
-    { path = In_source_tree "y"; kind = "Unknown" } |}];
+    { path = In_source_tree "x"; kind = Unknown }
+    { path = In_source_tree "y"; kind = Unknown } |}];
   let (_ : _) = Fpath.mkdir_p "d/w" in
   Stdio.Out_channel.write_all "d/w/x" ~data:"x";
   print_events 3;
   [%expect
     {|
-    { path = In_source_tree "d"; kind = "Created" }
-    { path = In_source_tree "d/w"; kind = "Created" }
-    { path = In_source_tree "d/w/x"; kind = "Unknown" } |}];
+    { path = In_source_tree "d"; kind = Created }
+    { path = In_source_tree "d/w"; kind = Created }
+    { path = In_source_tree "d/w/x"; kind = Unknown } |}];
   Stdio.Out_channel.write_all "d/w/y" ~data:"y";
   print_events 1;
-  [%expect {| { path = In_source_tree "d/w/y"; kind = "Unknown" } |}]
+  [%expect {| { path = In_source_tree "d/w/y"; kind = Unknown } |}]
 ;;


### PR DESCRIPTION
Move file-watcher trace event construction out of Dune_trace.Event and into Dune_trace.File_watcher_event. Use the shared file-watcher event kind in the scheduler event type so file-watcher tracing no longer needs kind conversions.