### PR TITLE
refactor(sexp): use stdlib utf-8 decoding

### DIFF
--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -993,12 +993,6 @@ module Libs = struct
       ; special_builtin_support = None
       ; root_module = None
       }
-    ; { path = "vendor/uutf"
-      ; main_module_name = Some "Uutf"
-      ; include_subdirs = No
-      ; special_builtin_support = None
-      ; root_module = None
-      }
     ]
     @ Libs.local_libraries
     |> List.map ~f:make_lib
@@ -2012,7 +2006,7 @@ let resolve_externals external_libraries =
     let convert = function
       | "threads" -> Some ("threads" ^ Config.ocaml_archive_ext, [ "-I"; "+threads" ])
       | "unix" -> Some ("unix" ^ Config.ocaml_archive_ext, Config.unix_library_flags)
-      | "csexp" | "pp" | "re" | "seq" | "spawn" | "uutf" -> None
+      | "csexp" | "pp" | "re" | "seq" | "spawn" -> None
       | s -> fatal "unhandled external library %s" s
     in
     List.filter_map ~f:convert external_libraries |> List.split

--- a/opam/dune.opam
+++ b/opam/dune.opam
@@ -64,7 +64,6 @@ depends: [
   "ctypes" { with-dev-setup & os != "win32" }
   "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
   "melange" { with-dev-setup & >= "5.1.0-51" & < "7.0" & os != "win32" }
-  "uutf" { with-dev-setup }
   # the rev store negotiation test launches a git daemon, needs it to be
   # installed on some distributions
   "conf-git-daemon" { with-test }

--- a/opam/dune.opam.template
+++ b/opam/dune.opam.template
@@ -25,7 +25,6 @@ depends: [
   "ctypes" { with-dev-setup & os != "win32" }
   "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
   "melange" { with-dev-setup & >= "5.1.0-51" & < "7.0" & os != "win32" }
-  "uutf" { with-dev-setup }
   # the rev store negotiation test launches a git daemon, needs it to be
   # installed on some distributions
   "conf-git-daemon" { with-test }

--- a/src/dune_sexp/dune
+++ b/src/dune_sexp/dune
@@ -4,6 +4,6 @@
  (inline_tests)
  (preprocess
   (pps ppx_expect))
- (libraries stdune uutf))
+ (libraries stdune))
 
 (ocamllex lexer versioned_file_first_line)

--- a/src/dune_sexp/escape.ml
+++ b/src/dune_sexp/escape.ml
@@ -1,33 +1,8 @@
 open Import
 
-(** Note: on OCaml >= 4.14, this can be switched to the following (and the
-    dependency to [Uutf] can be removed)
-
-    {[
-      let next_valid_utf8_length s i =
-        let decode = String.get_utf_8_uchar s i in
-        Option.some_if (Uchar.utf_decode_is_valid decode) (Uchar.utf_decode_length decode)
-      ;;
-    ]} *)
 let next_valid_utf8_uchar_len s i =
-  let pos = ref i in
-  let buf = Bytes.create 1 in
-  let decoder = Uutf.decoder ~encoding:`UTF_8 `Manual in
-  let rec go () =
-    match Uutf.decode decoder with
-    | `Await ->
-      if !pos >= String.length s
-      then None
-      else (
-        Bytes.set buf 0 (String.get s !pos);
-        incr pos;
-        Uutf.Manual.src decoder buf 0 1;
-        go ())
-    | `Uchar _ -> Some (!pos - i)
-    | `Malformed _ -> None
-    | `End -> Code_error.raise "next_valid_utf8_uchar: `End" []
-  in
-  go ()
+  let decode = String.get_utf_8_uchar s i in
+  Option.some_if (Uchar.utf_decode_is_valid decode) (Uchar.utf_decode_length decode)
 ;;
 
 let quote_length s =

--- a/src/dune_sexp/import.ml
+++ b/src/dune_sexp/import.ml
@@ -1,2 +1,1 @@
-include Uutf
 include Stdune

--- a/vendor/notty/src/dune
+++ b/vendor/notty/src/dune
@@ -3,7 +3,6 @@
 (library
   (name dune_notty)
   (synopsis "Declaring terminals")
-  (libraries uutf)
   (wrapped false)
   (modules notty notty_grapheme_cluster notty_uucp notty_uucp_data)
   (private_modules notty_grapheme_cluster notty_uucp notty_uucp_data))

--- a/vendor/notty/src/notty.ml
+++ b/vendor/notty/src/notty.ml
@@ -50,6 +50,21 @@ end
 module String = struct
   include String
   let sub0cp s i len = if i > 0 || len < length s then sub s i len else s
+  let fold_utf_8 f acc s =
+    let len = length s in
+    let rec loop acc i =
+      if i >= len then acc else
+        let decode = get_utf_8_uchar s i in
+        let next = i + Uchar.utf_decode_length decode in
+        let acc =
+          if Uchar.utf_decode_is_valid decode then
+            f acc i (`Uchar (Uchar.utf_decode_uchar decode))
+          else
+            f acc i (`Malformed "invalid UTF-8")
+        in
+        loop acc next
+    in
+    loop acc 0
   let of_chars_rev = function
     | []  -> ""
     | [c] -> String.make 1 c
@@ -100,7 +115,7 @@ module Text = struct
       | `Boundary     ->
           let is = match w with 0 -> is | 1 -> i::is | _ -> i::(-1)::is in
           f (is, 0) i `Await in
-    let acc = Uutf.String.fold_utf_8 (fun acc i -> function
+    let acc = String.fold_utf_8 (fun acc i -> function
       | `Malformed err -> err_malformed err str
       | `Uchar _ as u  -> f acc i u
       ) ([0], 0) str in
@@ -842,7 +857,7 @@ module Unescape = struct
   let list_of_utf8 buf i l =
     let f cs _ = function `Uchar c -> c::cs | _ -> cs in
     String.sub0cp (Bytes.unsafe_to_string buf) i l
-    |> Uutf.String.fold_utf_8 f [] |> List.rev
+    |> String.fold_utf_8 f [] |> List.rev
 
   let input t buf i l = t := match !t with
     | (es, false) when l > 0 -> (es @ (list_of_utf8 buf i l |> decode), false)

--- a/vendor/opam/src/core/dune
+++ b/vendor/opam/src/core/dune
@@ -4,5 +4,5 @@
  (foreign_stubs
   (language c)
   (names custom_opamStubs))
- (libraries re unix sha uutf)
+ (libraries re unix sha)
  (wrapped false))


### PR DESCRIPTION
Use String.get_utf_8_uchar for sexp string escaping now that Dune requires OCaml 4.14, and drop the Uutf dependency from dune_sexp and bootstrap inputs.