### PR TITLE
refactor(rpc): share client signature

### DIFF
--- a/otherlibs/dune-rpc/client.ml
+++ b/otherlibs/dune-rpc/client.ml
@@ -2,14 +2,24 @@ open Import
 open Types
 open Exported_types
 
-module type S = sig
+module type Public = sig
   type t
   type 'a fiber
   type chan
 
+  module Handler : sig
+    type t
+
+    val create
+      :  ?log:(Message.t -> unit fiber)
+      -> ?abort:(Message.t -> unit fiber)
+      -> unit
+      -> t
+  end
+
   module Versioned : sig
-    type ('a, 'b) request = ('a, 'b) Versioned_intf.Staged.request
-    type 'a notification = 'a Versioned_intf.Staged.notification
+    type ('a, 'b) request
+    type 'a notification
 
     val prepare_request
       :  t
@@ -58,15 +68,19 @@ module type S = sig
     val submit : t -> unit fiber
   end
 
-  module Handler : sig
-    type t
+  val connect
+    :  ?handler:Handler.t
+    -> chan
+    -> Initialize.Request.t
+    -> f:(t -> 'a fiber)
+    -> 'a fiber
+end
 
-    val create
-      :  ?log:(Message.t -> unit fiber)
-      -> ?abort:(Message.t -> unit fiber)
-      -> unit
-      -> t
-  end
+module type S = sig
+  include
+    Public
+    with type ('a, 'b) Versioned.request = ('a, 'b) Versioned_intf.Staged.request
+     and type 'a Versioned.notification = 'a Versioned_intf.Staged.notification
 
   type proc =
     | Request : ('a, 'b) Decl.request -> proc
@@ -77,13 +91,6 @@ module type S = sig
   val connect_with_menu
     :  ?handler:Handler.t
     -> private_menu:proc list
-    -> chan
-    -> Initialize.Request.t
-    -> f:(t -> 'a fiber)
-    -> 'a fiber
-
-  val connect
-    :  ?handler:Handler.t
     -> chan
     -> Initialize.Request.t
     -> f:(t -> 'a fiber)

--- a/otherlibs/dune-rpc/v1.ml
+++ b/otherlibs/dune-rpc/v1.ml
@@ -14,81 +14,10 @@ module Registry = Registry
 module Ansi_color = Ansi_color
 module User_message = User_message
 include Public
+module Client_impl = Client
 
 module Client = struct
-  module type S = sig
-    type t
-    type 'a fiber
-    type chan
+  module type S = Client_impl.Public
 
-    module Handler : sig
-      type t
-
-      val create
-        :  ?log:(Message.t -> unit fiber)
-        -> ?abort:(Message.t -> unit fiber)
-        -> unit
-        -> t
-    end
-
-    module Versioned : sig
-      type 'a notification
-      type ('a, 'b) request
-
-      val prepare_request
-        :  t
-        -> ('a, 'b) Request.t
-        -> (('a, 'b) request, Version_error.t) result fiber
-
-      val prepare_notification
-        :  t
-        -> 'a Notification.t
-        -> ('a notification, Version_error.t) result fiber
-    end
-
-    val request
-      :  ?id:Id.t
-      -> t
-      -> ('a, 'b) Versioned.request
-      -> 'a
-      -> ('b, Response.Error.t) result fiber
-
-    val notification : t -> 'a Versioned.notification -> 'a -> unit fiber
-    val disconnected : t -> unit fiber
-
-    module Stream : sig
-      type 'a t
-
-      val cancel : _ t -> unit fiber
-      val next : 'a t -> 'a option fiber
-    end
-
-    val poll : ?id:Id.t -> t -> 'a Sub.t -> ('a Stream.t, Version_error.t) result fiber
-
-    module Batch : sig
-      type client := t
-      type t
-
-      val create : client -> t
-
-      val request
-        :  ?id:Id.t
-        -> t
-        -> ('a, 'b) Versioned.request
-        -> 'a
-        -> ('b, Response.Error.t) result fiber
-
-      val notification : t -> 'a Versioned.notification -> 'a -> unit
-      val submit : t -> unit fiber
-    end
-
-    val connect
-      :  ?handler:Handler.t
-      -> chan
-      -> Request.Initialize.t
-      -> f:(t -> 'a fiber)
-      -> 'a fiber
-  end
-
-  module Make = Client.Make
+  module Make = Client_impl.Make
 end


### PR DESCRIPTION
Split the common public client module type out of Client.S and reuse it for the versioned V1 client API, leaving Client.S to add only the private connect_with_menu surface.