### PR TITLE
fix(ppx): share ppx executable key table

### DIFF
--- a/doc/changes/fixed/15361.md
+++ b/doc/changes/fixed/15361.md
@@ -1,0 +1,2 @@
+- Fix the `%{ppx:ppx1+..+ppxn}` form. Previously, it was just broken
+  and pointed at the wrong binary (#15361, @rgrinberg)

--- a/src/dune_rules/pp_spec_rules.ml
+++ b/src/dune_rules/pp_spec_rules.ml
@@ -45,14 +45,14 @@ let pp_corrected_path m ~ml_kind ~suffix =
 let get_rules sctx key =
   let ctx = Super_context.context sctx in
   let build_context = Context.build_context ctx in
-  let exe = Ppx_driver.ppx_exe_path build_context ~key in
+  let exe = Ppx_exe.ppx_exe_path build_context ~key in
   let* pp_names, scope =
     match Digest.from_hex key with
     | None ->
       User_error.raise
         [ Pp.textf "invalid ppx key for %s" (Path.Build.to_string_maybe_quoted exe) ]
     | Some key ->
-      let { Ppx_driver.Key.Decoded.pps; project_root } = Ppx_driver.Key.decode key in
+      let { Ppx_exe.Key.Decoded.pps; project_root } = Ppx_exe.Key.decode key in
       let+ scope =
         let dir =
           match project_root with

--- a/src/dune_rules/ppx_driver.ml
+++ b/src/dune_rules/ppx_driver.ml
@@ -1,99 +1,6 @@
 open Import
 open Memo.O
 
-(* Encoded representation of a set of library names + scope *)
-module Key : sig
-  (* This module implements a bi-directional function between [encoded] and
-     [decoded] *)
-  type encoded = Digest.t
-
-  module Decoded : sig
-    type t = private
-      { pps : Lib_name.t list
-      ; project_root : Path.Source.t option
-      }
-
-    val of_libs : Lib.t list -> t
-  end
-
-  (* [decode y] fails if there hasn't been a previous call to [encode] such that
-     [encode x = y]. *)
-  val encode : Decoded.t -> encoded
-  val decode : encoded -> Decoded.t
-end = struct
-  type encoded = Digest.t
-
-  module Decoded = struct
-    (* Values of type type are preserved in a global table between builds, so
-       they must not embed values that are not safe to keep between builds, such
-       as [Dune_project.t] values *)
-    type t =
-      { pps : Lib_name.t list
-      ; project_root : Path.Source.t option
-      }
-
-    let equal x y =
-      List.equal Lib_name.equal x.pps y.pps
-      && Option.equal Path.Source.equal x.project_root y.project_root
-    ;;
-
-    let to_string { pps; project_root } =
-      let s = String.enumerate_and (List.map pps ~f:Lib_name.to_string) in
-      match project_root with
-      | None -> s
-      | Some dir ->
-        sprintf "%s (in project: %s)" s (Path.Source.to_string_maybe_quoted dir)
-    ;;
-
-    let of_libs libs =
-      let pps =
-        (let compare a b = Lib_name.compare (Lib.name a) (Lib.name b) in
-         List.sort libs ~compare)
-        |> List.map ~f:Lib.name
-      in
-      let project_root = Lib.L.project_root libs in
-      { pps; project_root }
-    ;;
-  end
-
-  (* This mutable table is safe. Even though it can have stale entries remaining
-     from previous runs, the entries themselves are correct, so this seems
-     harmless apart from the lack of error in [decode] in this situation. *)
-  let reverse_table : (Digest.t, Decoded.t) Table.t = Table.create (module Digest) 128
-
-  let encode ({ Decoded.pps; project_root } as x) =
-    let y =
-      Digest.repr
-        Repr.(pair (list Lib_name.repr) (option Path.Source.repr))
-        (pps, project_root)
-    in
-    match Table.find reverse_table y with
-    | None ->
-      Table.set reverse_table y x;
-      y
-    | Some x' ->
-      if Decoded.equal x x'
-      then y
-      else
-        User_error.raise
-          [ Pp.textf "Hash collision between set of ppx drivers:"
-          ; Pp.textf "- cache : %s" (Decoded.to_string x')
-          ; Pp.textf "- fetch : %s" (Decoded.to_string x)
-          ]
-  ;;
-
-  let decode y =
-    match Table.find reverse_table y with
-    | Some x -> x
-    | None ->
-      User_error.raise
-        [ Pp.textf
-            "I don't know what ppx rewriters set %s correspond to."
-            (Digest.to_string y)
-        ]
-  ;;
-end
-
 module Driver = struct
   module M = struct
     module Info = struct
@@ -345,17 +252,6 @@ let build_ppx_driver =
     ()
 ;;
 
-let ppx_exe_path (ctx : Build_context.t) ~key =
-  Path.Build.relative ctx.build_dir (".ppx/" ^ key ^ "/ppx.exe")
-;;
-
-let ppx_driver_exe (ctx : Context.t) libs =
-  let key = Digest.to_string (Key.Decoded.of_libs libs |> Key.encode) in
-  (* Make sure to compile ppx.exe for the compiling host. See: #2252, #2286 and
-     #3698 *)
-  Context.host ctx >>| Context.build_context >>| ppx_exe_path ~key
-;;
-
 let get_cookies ~loc ~expander ~lib_name libs =
   let expander, library_name_cookie =
     match lib_name with
@@ -427,7 +323,7 @@ let ppx_driver_and_flags_internal
   and+ cookies =
     let* libs = Resolve.Memo.read (Lib.closure libs ~linking:true ~for_) in
     Action_builder.of_memo (get_cookies ~loc ~lib_name ~expander libs)
-  and+ ppx_driver_exe = Action_builder.of_memo @@ ppx_driver_exe context libs in
+  and+ ppx_driver_exe = Action_builder.of_memo @@ Ppx_exe.ppx_driver_exe context libs in
   ppx_driver_exe, flags @ cookies
 ;;
 
@@ -452,8 +348,4 @@ let get_ppx_driver ctx ~loc ~expander ~scope ~lib_name ~flags pps =
   ppx_driver_and_flags_internal ctx ~loc ~expander ~dune_version ~lib_name ~flags libs
 ;;
 
-let ppx_exe ctx ~scope pp =
-  let open Resolve.Memo.O in
-  let* libs = Lib.DB.resolve_pps (Scope.libs scope) [ Loc.none, pp ] in
-  ppx_driver_exe ctx libs |> Resolve.Memo.lift_memo
-;;
+let ppx_exe ctx ~scope pp = Ppx_exe.get_ppx_exe ctx ~scope [ Loc.none, pp ]

--- a/src/dune_rules/ppx_driver.mli
+++ b/src/dune_rules/ppx_driver.mli
@@ -1,25 +1,5 @@
 open Import
 
-module Key : sig
-  (* This module implements a bi-directional function between [encoded] and
-     [decoded] *)
-  type encoded = Digest.t
-
-  module Decoded : sig
-    type t = private
-      { pps : Lib_name.t list
-      ; project_root : Path.Source.t option
-      }
-
-    val of_libs : Lib.t list -> t
-  end
-
-  (* [decode y] fails if there hasn't been a previous call to [encode] such that
-     [encode x = y]. *)
-  val encode : Decoded.t -> encoded
-  val decode : encoded -> Decoded.t
-end
-
 module Driver : sig
   type t
 
@@ -51,7 +31,6 @@ val ppx_driver_and_flags
   -> (Loc.t * Lib_name.t) list
   -> (Path.Build.t * Driver.t * string list) Action_builder.t
 
-val ppx_exe_path : Build_context.t -> key:string -> Path.Build.t
 val ppx_exe : Context.t -> scope:Scope.t -> Lib_name.t -> Path.Build.t Resolve.Memo.t
 
 (** Get a path to a cached ppx driver with some extra flags for cookies. *)

--- a/src/dune_rules/ppx_exe.ml
+++ b/src/dune_rules/ppx_exe.ml
@@ -15,6 +15,7 @@ module Key : sig
   end
 
   val encode : Decoded.t -> encoded
+  val decode : encoded -> Decoded.t
 end = struct
   type encoded = Digest.t
 
@@ -82,6 +83,17 @@ end = struct
           ; Pp.textf "- fetch : %s" (Decoded.to_string x)
           ]
   ;;
+
+  let decode y =
+    match Table.find reverse_table y with
+    | Some x -> x
+    | None ->
+      User_error.raise
+        [ Pp.textf
+            "I don't know what ppx rewriters set %s correspond to."
+            (Digest.to_string y)
+        ]
+  ;;
 end
 
 let ppx_exe_path (ctx : Build_context.t) ~key =
@@ -90,6 +102,8 @@ let ppx_exe_path (ctx : Build_context.t) ~key =
 
 let ppx_driver_exe (ctx : Context.t) libs =
   let key = Digest.to_string (Key.Decoded.of_libs libs |> Key.encode) in
+  (* Make sure to compile ppx.exe for the compiling host. See: #2252, #2286 and
+     #3698 *)
   Context.host ctx >>| Context.build_context >>| ppx_exe_path ~key
 ;;
 

--- a/src/dune_rules/ppx_exe.mli
+++ b/src/dune_rules/ppx_exe.mli
@@ -4,6 +4,20 @@ open Import
     This module provides the core ppx executable resolution logic without depending
     on the Expander module. *)
 
+module Key : sig
+  module Decoded : sig
+    type t = private
+      { pps : Lib_name.t list
+      ; project_root : Path.Source.t option
+      }
+  end
+
+  val decode : Digest.t -> Decoded.t
+end
+
+val ppx_exe_path : Build_context.t -> key:string -> Path.Build.t
+val ppx_driver_exe : Context.t -> Lib.t list -> Path.Build.t Memo.t
+
 (** Get the path to the ppx driver executable for a list of ppx libraries.
     The libraries must be provided with their locations for error reporting. *)
 val get_ppx_exe

--- a/test/blackbox-tests/test-cases/ppx/ppx-pform.t
+++ b/test/blackbox-tests/test-cases/ppx/ppx-pform.t
@@ -52,10 +52,11 @@ Force the generated ppx executable to be built:
   > EOF
 
   $ dune build @test-ppx-run 2>&1 | censor
-  Error: I don't know what ppx rewriters set $DIGEST
-  correspond to.
-  -> required by _build/default/ppx-help
-  -> required by alias test-ppx-run in dune:1
+  File "_build/default/.ppx/$DIGEST/ppx.exe", line 1, characters 0-0:
+  Error: Failed to create on-demand ppx rewriter for ppx1 and ppx2; no ppx
+  driver were found. It seems that ppx1 and ppx2 are not compatible with Dune.
+  Examples of ppx rewriters that are compatible with Dune are ones using
+  ocaml-migrate-parsetree, ppxlib or ppx_driver.
   [1]
 
 Test that the order of libraries doesn't matter


### PR DESCRIPTION
Use Ppx_exe.Key as the single encoder and decoder for generated .ppx executables, and make Ppx_driver delegate ppx executable path resolution to Ppx_exe. This lets .ppx rules decode keys produced by %{ppx:...} instead of failing with an unknown ppx rewriters set.

Update the ppx pform cram test to expect the build to reach ppx driver selection.