### PR TITLE
test(trace): wait for trace init before following nested traces

### DIFF
--- a/test/blackbox-tests/test-cases/trace/trace-cat-follow-nested.t
+++ b/test/blackbox-tests/test-cases/trace/trace-cat-follow-nested.t
@@ -26,9 +26,7 @@ Set up a nested dune project:
 
   $ checkStart() {
   >   dune trace cat \
-  >     | jq 'select(.name == "init" and .cat == "config")' \
-  >     | head -n 1 \
-  >     || true
+  >     | jq -e 'select(.name == "init" and .cat == "config")'
   > } 1> /dev/null 2>&1
 
   $ dune build ./x &


### PR DESCRIPTION
The trace-cat-follow-nested test intended to wait until the outer dune process had emitted its config init event before starting dune trace cat --follow. The helper always succeeded because the pipeline ended in head, and || true forced success on errors.

Use jq -e so the polling loop actually waits for the init event. Without this synchronization, follow mode can observe only the outer init/exit pair and miss the nested events the test expects.