### PR TITLE
refactor(rpc): track long-poll pollers with an Active_set

### DIFF
--- a/src/rpc/long_poll.ml
+++ b/src/rpc/long_poll.ml
@@ -59,13 +59,70 @@ end
 module Poll_comparable = Comparable.Make (Poller)
 module Map = Poll_comparable.Map
 
+type 'a initial =
+  { source : 'a Source.t
+  ; on_cancel : 'a -> unit Fiber.t
+  }
+
+type 'a active =
+  { value : 'a
+  ; initial : 'a initial
+  }
+
 module Status = struct
   type 'a t =
-    | Idle of 'a
-    | Waiting
+    | Initialized of 'a initial
+    | Active of 'a active
+    | Cancelled
 end
 
-let make_on_poll map source ~equal ~diff _session poller =
+(* The set of pollers belonging to a single long-poll implementation, tracking each
+   poller's lifecycle. Cancelled pollers are kept around so that an in-flight poll can
+   observe the cancellation; they are reclaimed by [find_and_remove_cancelled]. *)
+module Active_set = struct
+  type 'a t = 'a Status.t Map.t ref
+
+  let create () = ref Map.empty
+
+  let initialize (t : _ t) poller initial =
+    match Map.find !t poller with
+    | None | Some Cancelled -> t := Map.set !t poller (Status.Initialized initial)
+    | Some (Active _ | Initialized _) -> Code_error.raise "poller already initialized" []
+  ;;
+
+  let cancel (t : _ t) poller =
+    match Map.find !t poller with
+    | None | Some Cancelled -> Fiber.return ()
+    | Some (Initialized a) ->
+      t := Map.set !t poller Status.Cancelled;
+      a.on_cancel (Source.read a.source)
+    | Some (Active a) ->
+      t := Map.set !t poller Status.Cancelled;
+      a.initial.on_cancel (Source.read a.initial.source)
+  ;;
+
+  let update (t : _ t) poller value =
+    match Map.find !t poller with
+    | Some (Active active) ->
+      t := Map.set !t poller (Status.Active { active with value });
+      `Updated
+    | Some (Initialized initial) ->
+      t := Map.set !t poller (Status.Active { initial; value });
+      `Updated
+    | Some Cancelled -> `Poller_was_cancelled
+    | None -> Code_error.raise "Active_set.update on a non-existent poller" []
+  ;;
+
+  let find_and_remove_cancelled (t : _ t) poller =
+    let res = Map.find !t poller in
+    (match res with
+     | Some Cancelled -> t := Map.remove !t poller
+     | None | Some (Active _) | Some (Initialized _) -> ());
+    res
+  ;;
+end
+
+let make_on_poll active_set source ~equal ~diff _session poller =
   let cancel = Poller.cancel poller in
   let wait_for_change last =
     let wait () =
@@ -81,24 +138,23 @@ let make_on_poll map source ~equal ~diff _session poller =
     ()
   in
   let send last =
-    map := Map.set !map poller Status.Waiting;
     let* () = wait_for_change last in
     if Poller.cancelled poller
-    then (
-      map := Map.remove !map poller;
-      raise Poll_cancelled)
+    then raise Poll_cancelled
     else (
-      match Map.find !map poller with
-      | Some Waiting ->
-        let now = Source.read source in
-        map := Map.set !map poller (Status.Idle now);
+      let now = Source.read source in
+      match Active_set.update active_set poller now with
+      | `Poller_was_cancelled -> raise Poll_cancelled
+      | `Updated ->
         let to_send = diff ~last ~now in
-        Fiber.return (Some to_send)
-      | None | Some (Idle _) ->
-        Code_error.raise "poller changed state while a poll was in flight" [])
+        Fiber.return (Some to_send))
   in
-  match Map.find !map poller with
-  | None -> send None
-  | Some (Idle last) -> send (Some last)
-  | Some Waiting -> Code_error.raise "poller already has an in-flight request" []
+  match Active_set.find_and_remove_cancelled active_set poller with
+  | None ->
+    let initial = { source; on_cancel = (fun _ -> Fiber.return ()) } in
+    Active_set.initialize active_set poller initial;
+    send None
+  | Some (Initialized _) -> send None
+  | Some (Active a) -> send (Some a.value)
+  | Some Cancelled -> raise Poll_cancelled
 ;;

--- a/src/rpc/long_poll.mli
+++ b/src/rpc/long_poll.mli
@@ -27,20 +27,24 @@ module Source : sig
   val wait : 'a t -> until:('a -> bool) -> unit Fiber.t
 end
 
-module Status : sig
-  type 'a t =
-    | Idle of 'a
-    | Waiting
+(** The set of pollers belonging to a single long-poll implementation. Each poller
+    progresses [Initialized] -> [Active] and may become [Cancelled]. *)
+module Active_set : sig
+  type 'a t
+
+  val create : unit -> 'a t
+
+  (** [cancel t poller] marks [poller] as cancelled, running its [on_cancel] hook with the
+      source's current value. *)
+  val cancel : 'a t -> Poller.t -> unit Fiber.t
 end
 
-module Map : Map.S with type key = Poller.t
-
-(** [make_on_poll map source ~equal ~diff session poller] computes the response for one
-    poll request: it waits (respecting [poller]'s cancellation) until [source]'s value
-    satisfies [equal]-difference from the last one served, then records the new value in
-    [map] and returns [diff ~last ~now]. *)
+(** [make_on_poll set source ~equal ~diff session poller] computes the response for one
+    poll request against [set]: it waits (respecting [poller]'s cancellation) until
+    [source]'s value differs (per [equal]) from the last one served, records it, and
+    returns [diff ~last ~now]. *)
 val make_on_poll
-  :  'a Status.t Map.t ref
+  :  'a Active_set.t
   -> 'a Source.t
   -> equal:('a -> 'a -> bool)
   -> diff:(last:'a option -> now:'a -> 'b)

--- a/src/rpc/server.ml
+++ b/src/rpc/server.ml
@@ -726,14 +726,12 @@ module H = struct
     ;;
 
     let implement_long_poll (rpc : _ t) proc source ~equal ~diff =
-      let map = ref Long_poll.Map.empty in
+      let active_set = Long_poll.Active_set.create () in
       implement_poll
         rpc
         proc
-        ~on_cancel:(fun _session poller ->
-          map := Long_poll.Map.remove !map poller;
-          Fiber.return ())
-        ~on_poll:(Long_poll.make_on_poll map source ~equal ~diff)
+        ~on_cancel:(fun _session poller -> Long_poll.Active_set.cancel active_set poller)
+        ~on_poll:(Long_poll.make_on_poll active_set source ~equal ~diff)
     ;;
 
     module For_tests = struct


### PR DESCRIPTION
## Summary

Replace the ad-hoc `Idle | Waiting` poller map in `Long_poll` with an `Active_set`
that gives each poller a proper lifecycle and a value-carrying cancellation hook,
moving public dune's long-poll bookkeeping closer to the internal Jane Street
implementation.

This is the first of two alignment steps (a follow-up will introduce the
per-session `Univ_map` registry / `implement`/`find`).

## Details

- `Long_poll` now has:
  - `type 'a initial = { source; on_cancel : 'a -> unit Fiber.t }` and
    `type 'a active = { value; initial }`,
  - `Status = Initialized | Active | Cancelled` (was `Idle | Waiting`),
  - `module Active_set` with `create`/`initialize`/`cancel`/`update`/
    `find_and_remove_cancelled`.
- `Active_set.cancel` now *records* the cancellation (so an in-flight poll
  observes it via `update`) and runs the poller's `on_cancel` hook with the
  source's current value, rather than just dropping the poller from the map.
- `make_on_poll` drives this lifecycle.
- `long_poll.mli` now exposes an abstract `Active_set` instead of the raw
  `Map`/`Status` internals.

For public dune the per-poller `on_cancel` is a no-op (there are no termination
hooks yet), matching internal's regular long-poll path.

## Tests

Behaviour is unchanged — the existing `test/expect-tests/dune_rpc/long_polling.ml`
expect tests pass as-is (no promotion).
