### PR TITLE
fix(scheduler): reap subreaper children on an isolated loop on shutdown

### DIFF
--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -139,7 +139,7 @@ let signal_processes pids signal =
              ])))
 ;;
 
-let rec await_no_child_processes t ~deadline ~signal ~signaled =
+let rec await_no_child_processes t ~async_io ~deadline ~signal ~signaled =
   match child_process_cleanup_candidates_after_reap t with
   | Error error -> Fiber.return (`Failed [ Proc.Linux.Process_tree.pp_error error ])
   | Ok pids when Pid.Set.is_empty pids -> Fiber.return `Exited
@@ -149,11 +149,11 @@ let rec await_no_child_processes t ~deadline ~signal ~signaled =
     (match signal_processes unsignaled signal with
      | Error paragraphs -> Fiber.return (`Failed paragraphs)
      | Ok () ->
-       Async_io.Task.await (Async_io.sleep t.async_io child_process_poll_interval)
+       Async_io.Task.await (Async_io.sleep async_io child_process_poll_interval)
        >>= (function
         | Ok () ->
           let signaled = Pid.Set.union signaled unsignaled in
-          await_no_child_processes t ~deadline ~signal ~signaled
+          await_no_child_processes t ~async_io ~deadline ~signal ~signaled
         | Error (`Exn _) -> assert false
         | Error `Cancelled ->
           (match child_process_cleanup_candidates_after_reap t with
@@ -162,7 +162,7 @@ let rec await_no_child_processes t ~deadline ~signal ~signaled =
              Fiber.return (`Failed [ Proc.Linux.Process_tree.pp_error error ]))))
 ;;
 
-let cleanup_subreaper_child_processes_impl t =
+let cleanup_subreaper_child_processes_impl t ~async_io =
   match child_process_cleanup_candidates_after_reap t with
   | Error error ->
     warn_child_process_cleanup_failed
@@ -173,7 +173,7 @@ let cleanup_subreaper_child_processes_impl t =
   | Ok pids ->
     trace_child_process_cleanup pids `Started;
     let deadline = Time.add (Time.now ()) sigterm_grace_period in
-    await_no_child_processes t ~deadline ~signal:Term ~signaled:Pid.Set.empty
+    await_no_child_processes t ~async_io ~deadline ~signal:Term ~signaled:Pid.Set.empty
     >>= (function
      | `Failed paragraphs ->
        warn_child_process_cleanup_failed pids paragraphs;
@@ -183,7 +183,7 @@ let cleanup_subreaper_child_processes_impl t =
        Fiber.return ()
      | `Timed_out _ ->
        let deadline = Time.add (Time.now ()) sigterm_grace_period in
-       await_no_child_processes t ~deadline ~signal:Kill ~signaled:Pid.Set.empty
+       await_no_child_processes t ~async_io ~deadline ~signal:Kill ~signaled:Pid.Set.empty
        >>| (function
         | `Failed paragraphs -> warn_child_process_cleanup_failed pids paragraphs
         | `Exited -> trace_child_process_cleanup pids `Finished
@@ -201,7 +201,9 @@ let cleanup_subreaper_child_processes_impl t =
 
 let cleanup_subreaper_child_processes () =
   if Lazy.force child_subreaper_enabled
-  then cleanup_subreaper_child_processes_impl (t ())
+  then (
+    let t = t () in
+    cleanup_subreaper_child_processes_impl t ~async_io:t.async_io)
   else Fiber.return ()
 ;;
 
@@ -308,9 +310,24 @@ let kill_and_wait_for_all_processes t =
     ignore (cleanup_iter t saw_shutdown : Fiber.fill list)
   done;
   if Lazy.force child_subreaper_enabled
-  then
-    Fiber.run (cleanup_subreaper_child_processes_impl t) ~iter:(fun () ->
-      cleanup_iter t saw_shutdown);
+  then (
+    (* Reap escaped subreaper children on an isolated event queue / async-io loop.
+       The main run has finished and cleared [current], so reusing the scheduler's
+       queue here would make this [Fiber.run] resume the finished run's fibers
+       (a different fiber scheduler) and observe stale fills. A fresh queue only
+       ever receives this cleanup's own async-io completions. *)
+    let events = Event.Queue.create () in
+    let async_io = Async_io.create events in
+    Exn.protect
+      ~finally:(fun () -> Async_io.shutdown async_io)
+      ~f:(fun () ->
+        Fiber.run (cleanup_subreaper_child_processes_impl t ~async_io) ~iter:(fun () ->
+          let rec next () =
+            match Event.Queue.next events with
+            | Fiber_fill_ivar fill -> [ fill ]
+            | Job_complete_ready | Shutdown _ -> next ()
+          in
+          next ())));
   (* This silliness is needed because we have tests that run the scheduler
      more than once per process. Such tests require the signal watcher to be
      reset with the correct event queue. *)


### PR DESCRIPTION
## Summary

Fix internal errors during scheduler shutdown when the subreaper child-process
cleanup runs.

On shutdown, `kill_and_wait_for_all_processes` reaps any "escaped" subreaper
children in a second `Fiber.run`. By that point the main run has finished and its
`current` binding has been cleared, yet that second run **reused the scheduler's
own event queue**. As a result it could:

- resume fibers belonging to the finished run — a *different* fiber scheduler —
  giving `advance: it's illegal to call advance with a fiber created in a
  different scheduler`, and
- run code (e.g. the build loop's end-of-build `cleanup_subreaper_child_processes`
  and the file-watcher's `shutdown`) with no current scheduler, giving
  `Option.value_exn` from `t ()`.

This surfaced as a flaky failure in `test/blackbox-tests/test-cases/watching/shutdown.t`:
watch mode + an RPC server keeps fibers parked on `Async_io` timers/ivars, so on
shutdown there are stale fills and in-flight fibers for the cleanup run to trip
over (a plain build has none).

## Fix

Run the subreaper cleanup on a **fresh, isolated `Event.Queue` + `Async_io`
loop** instead of the scheduler's shared queue, so it only ever observes its own
async-io completions — never the finished run's leftover fills or fibers. The
reap logic is unchanged; it is just parameterized over the async-io loop it uses.

The public `cleanup_subreaper_child_processes` (used by the build loop within the
main run) keeps using the scheduler's own loop and is unaffected.
