### PR TITLE
fix(watch): show build duration in status line

### DIFF
--- a/bin/build.ml
+++ b/bin/build.ml
@@ -12,13 +12,11 @@ let run_build_system ~action_runner ~run_id ~request =
       ~run_id
       ~cancellation:(Fiber.Cancel.create ())
   in
-  let request =
-    action_builder_of_request request
-    |> Dune_engine.Build_system.Request.Goal.create
-    |> List.singleton
-    |> Dune_engine.Build_system.Request.create
-  in
-  Dune_engine.Build_system.run_build_requests ~build request
+  action_builder_of_request request
+  |> Dune_engine.Build_system.Request.Goal.create
+  |> List.singleton
+  |> Dune_engine.Build_system.Request.create
+  |> Dune_engine.Build_system.run_build_requests ~build_started_at:(Time.now ()) ~build
 ;;
 
 let run_build_command_poll ~(common : Common.t) ~config ~sticky_goal : unit =

--- a/doc/changes/added/15384.md
+++ b/doc/changes/added/15384.md
@@ -1,0 +1,1 @@
+- Add build time information to watch mode (#15384, @rgrinberg)

--- a/src/dune_engine/build_loop.ml
+++ b/src/dune_engine/build_loop.ml
@@ -48,6 +48,7 @@ type t =
   ; mutable pending_reset : Memo.Invalidation.t option
   ; mutable watch_restart_started_at : Time.t option
   ; mutable status_overlay : Console.Status_line.overlay option
+  ; mutable build_duration_section : Console.Status_line.section option
   ; file_event_debouncer : Debouncer.t
   ; mutable wakeup : Trigger.t
   ; mutable wakeup_generation : int
@@ -68,6 +69,22 @@ let clear_status_overlay t =
 let set_status_overlay t message =
   clear_status_overlay t;
   t.status_overlay <- Some (Console.Status_line.add_overlay message)
+;;
+
+let clear_build_duration_section t =
+  Option.iter t.build_duration_section ~f:Console.Status_line.remove_section;
+  t.build_duration_section <- None
+;;
+
+let set_build_duration_section t message =
+  clear_build_duration_section t;
+  t.build_duration_section <- Some (Console.Status_line.add_section message)
+;;
+
+let format_duration duration = sprintf "%.1fs" (Time.Span.to_secs duration)
+
+let format_elapsed_since started_at =
+  sprintf "[%s]" (format_duration (Time.diff (Time.now ()) started_at))
 ;;
 
 let build_finish t (build_result : Build_outcome.t) =
@@ -154,8 +171,7 @@ let request_restart t invalidation =
           t
           (Live
              (fun () ->
-               let elapsed = Time.diff (Time.now ()) now |> Time.Span.to_secs in
-               Pp.textf "Restarting current build... (%.1fs)" elapsed));
+               Pp.textf "Restarting current build... %s" (format_elapsed_since now)));
         t.status <- Restarting_build run_id;
         let+ () = Process.Build.cancel_current () in
         Dune_trace.emit Build (fun () ->
@@ -183,8 +199,9 @@ let wait_for_file_event_debounce t =
     t
     (Live
        (fun () ->
-         let elapsed = Time.diff (Time.now ()) started_at |> Time.Span.to_secs in
-         Pp.textf "Waiting for filesystem changes to settle... (%.1fs)" elapsed));
+         Pp.textf
+           "Waiting for filesystem changes to settle... %s"
+           (format_elapsed_since started_at)));
   let rec loop () =
     match Debouncer.latest t.file_event_debouncer with
     | None -> Fiber.return ()
@@ -237,6 +254,7 @@ let create () =
   ; pending_reset = None
   ; watch_restart_started_at = None
   ; status_overlay = None
+  ; build_duration_section = None
   ; file_event_debouncer = Debouncer.create ()
   ; wakeup = Trigger.create ()
   ; wakeup_generation = 0
@@ -258,6 +276,7 @@ let run t f =
     ignore (Fs_memo.init ~dune_file_watcher:None : Memo.Invalidation.t);
     Fiber.finalize f ~finally:(fun () ->
       clear_status_overlay t;
+      clear_build_duration_section t;
       Fiber.return ())
   | Some file_watcher ->
     Fs_memo.init ~dune_file_watcher:(Some file_watcher) |> Memo.reset;
@@ -266,6 +285,7 @@ let run t f =
       (fun () ->
          Fiber.finalize f ~finally:(fun () ->
            clear_status_overlay t;
+           clear_build_duration_section t;
            File_watcher.close file_watcher;
            Fiber.return ()))
 ;;
@@ -299,7 +319,11 @@ let run_current_build
    | Building _ -> assert false
    | Standing_by | Restarting_build _ -> ());
   t.status <- Building run_id;
+  let build_started_at = Time.now () in
   clear_status_overlay t;
+  set_build_duration_section
+    t
+    (Live (fun () -> Pp.text (format_elapsed_since build_started_at)));
   t.current_request <- Some request;
   let* outcome =
     Fiber.finalize
@@ -310,12 +334,17 @@ let run_current_build
              ~run_id
              ~cancellation:(Fiber.Cancel.create ())
          in
-         Build_system.run_build_requests ?restart_started_at ~build:build_ctx request)
+         Build_system.run_build_requests
+           ?restart_started_at
+           ~build_started_at
+           ~build:build_ctx
+           request)
       ~finally:(fun () ->
         t.current_request <- None;
         Fiber.return ())
   in
   let+ () = Scheduler.cleanup_subreaper_child_processes () in
+  let duration = Time.diff (Time.now ()) build_started_at in
   let next =
     match t.status with
     | Restarting_build _
@@ -329,6 +358,10 @@ let run_current_build
       t.watch_restart_started_at <- None;
       `Done
   in
+  (match next with
+   | `Restart -> ()
+   | `Done ->
+     set_build_duration_section t (Constant (Pp.textf "[%s]" (format_duration duration))));
   outcome, next, build_start_input_change_generation, build_start_wakeup_generation
 ;;
 

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1139,7 +1139,7 @@ let handle_final_exns exns =
        List.iter exns ~f:Dune_util.Report_error.report)
 ;;
 
-let run_with_error_collection ?restart_started_at ~build collect_errors =
+let run_with_error_collection ?restart_started_at ~build_started_at ~build collect_errors =
   let build =
     match build with
     | Some build -> build
@@ -1155,12 +1155,11 @@ let run_with_error_collection ?restart_started_at ~build collect_errors =
   let run_id = Process.Build.run_id build in
   let open Fiber.O in
   let f () =
-    let start = Time.now () in
     Dune_trace.emit ~buffered:false Build (fun () ->
       Dune_trace.Event.watch_build_start
         ~run_id:(Run_id.to_int run_id)
         ~restart:(Option.is_some restart_started_at)
-        ~start);
+        ~start:build_started_at);
     Dune_trace.reset_alloc_profile ();
     (* CR-someday amokhov: Currently we invalidate cached timestamps on every
        incremental rebuild. This conservative approach helps us to work around
@@ -1210,7 +1209,7 @@ let run_with_error_collection ?restart_started_at ~build collect_errors =
           (match outcome with
            | Ok _ -> `Success
            | Error `Already_reported -> `Failure)
-        ~start
+        ~start:build_started_at
         ~stop
         ~restart_duration);
     Dune_trace.capture_alloc_profile (`Build (Run_id.to_int run_id))
@@ -1274,7 +1273,7 @@ let complete_action_runner_build = function
          ~cancellation:(Process.Build.cancellation build))
 ;;
 
-let run_build_requests ?restart_started_at ?build (request : Request.t) =
+let run_build_requests ?restart_started_at ~build_started_at ?build (request : Request.t) =
   let open Fiber.O in
   let finish_request goal outcome =
     let* pending =
@@ -1309,7 +1308,7 @@ let run_build_requests ?restart_started_at ?build (request : Request.t) =
   Fiber.finalize
     ~finally:(fun () -> complete_action_runner_build build)
     (fun () ->
-       run_with_error_collection ?restart_started_at ~build (fun () ->
+       run_with_error_collection ?restart_started_at ~build_started_at ~build (fun () ->
          Request.goals request
          |> Fiber.parallel_map ~f:run_request
          >>| List.concat_map ~f:(function
@@ -1330,7 +1329,7 @@ let run ?restart_started_at ?build f =
   in
   let request = Request.create [ Request.Goal.create goal ] in
   let open Fiber.O in
-  run_build_requests ?restart_started_at ?build request
+  run_build_requests ?restart_started_at ~build_started_at:(Time.now ()) ?build request
   >>| function
   | Error `Already_reported -> Error `Already_reported
   | Ok () ->

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -81,6 +81,7 @@ end
 
 val run_build_requests
   :  ?restart_started_at:Time.t
+  -> build_started_at:Time.t
   -> ?build:Process.Build.t
   -> Request.t
   -> (unit, [ `Already_reported ]) result Fiber.t


### PR DESCRIPTION
Display elapsed time while a watch build is running and keep the completed build duration in the watch status line. Pass the build start timestamp explicitly into the build system so the status line and build trace use the same start time.