### PR TITLE
Allow `dune tools exec utop`

### DIFF
--- a/bin/tools/group.ml
+++ b/bin/tools/group.ml
@@ -1,32 +1,31 @@
 open Import
 
-module Exec = struct
-  let doc = "Command group for running wrapped tools."
-  let info = Cmd.info ~doc "exec"
-  let group = Cmd.group info (List.map Dune_pkg.Dev_tool.all ~f:Tools_common.exec_command)
-end
+let subcommand ~prefix ~doc f =
+  let info = Cmd.info ~doc prefix in
+  Cmd.group info (List.map Dune_pkg.Dev_tool.all ~f)
+;;
 
-module Install = struct
-  let doc = "Command group for installing wrapped tools."
-  let info = Cmd.info ~doc "install"
+let exec =
+  subcommand
+    ~prefix:"exec"
+    ~doc:"Command group for running wrapped tools."
+    Tools_common.exec_command
+;;
 
-  let group =
-    Cmd.group info (List.map Dune_pkg.Dev_tool.all ~f:Tools_common.install_command)
-  ;;
-end
+let install =
+  subcommand
+    ~prefix:"install"
+    ~doc:"Command group for installing wrapped tools."
+    Tools_common.install_command
+;;
 
-module Which = struct
-  let doc = "Command group for printing the path to wrapped tools."
-  let info = Cmd.info ~doc "which"
-
-  let group =
-    Cmd.group info (List.map Dune_pkg.Dev_tool.all ~f:Tools_common.which_command)
-  ;;
-end
+let which =
+  subcommand
+    ~prefix:"which"
+    ~doc:"Command group for printing the path to wrapped tools."
+    Tools_common.which_command
+;;
 
 let doc = "Command group for wrapped tools."
 let info = Cmd.info ~doc "tools"
-
-let group =
-  Cmd.group info [ Exec.group; Install.group; Which.group; Tools_common.env_command ]
-;;
+let group = Cmd.group info [ exec; install; which; Tools_common.env_command ]

--- a/bin/tools/group.ml
+++ b/bin/tools/group.ml
@@ -3,23 +3,7 @@ open Import
 module Exec = struct
   let doc = "Command group for running wrapped tools."
   let info = Cmd.info ~doc "exec"
-
-  let group =
-    Cmd.group
-      info
-      (List.map
-         [ Ocamlformat
-         ; Ocamllsp
-         ; Ocamlearlybird
-         ; Odig
-         ; Opam_publish
-         ; Dune_release
-         ; Ocaml_index
-         ; Merlin
-         ; Utop
-         ]
-         ~f:Tools_common.exec_command)
-  ;;
+  let group = Cmd.group info (List.map Dune_pkg.Dev_tool.all ~f:Tools_common.exec_command)
 end
 
 module Install = struct

--- a/bin/tools/group.ml
+++ b/bin/tools/group.ml
@@ -16,6 +16,7 @@ module Exec = struct
          ; Dune_release
          ; Ocaml_index
          ; Merlin
+         ; Utop
          ]
          ~f:Tools_common.exec_command)
   ;;

--- a/doc/changes/added/15388.md
+++ b/doc/changes/added/15388.md
@@ -1,0 +1,2 @@
+- Added the missing `dune tools exec utop` and `dune tools exec odoc` options.
+  (#15388, @Leonidas-from-XIV)

--- a/test/blackbox-tests/test-cases/pkg/dev-tools-help-message.t
+++ b/test/blackbox-tests/test-cases/pkg/dev-tools-help-message.t
@@ -60,6 +60,12 @@ Output the help text:
              executable (pass flags to odig after the '--' argument, such as
              'dune tools exec odig -- --help').
   
+         odoc [OPTION]… [ARGS]…
+             Wrapper for running odoc intended to be run automatically by a
+             text editor. All positional arguments will be passed to the odoc
+             executable (pass flags to odoc after the '--' argument, such as
+             'dune tools exec odoc -- --help').
+  
          opam-publish [OPTION]… [ARGS]…
              Wrapper for running opam-publish intended to be run automatically
              by a text editor. All positional arguments will be passed to the

--- a/test/blackbox-tests/test-cases/pkg/dev-tools-help-message.t
+++ b/test/blackbox-tests/test-cases/pkg/dev-tools-help-message.t
@@ -66,6 +66,12 @@ Output the help text:
              opam-publish executable (pass flags to opam-publish after the '--'
              argument, such as 'dune tools exec opam-publish -- --help').
   
+         utop [OPTION]… [ARGS]…
+             Wrapper for running utop intended to be run automatically by a
+             text editor. All positional arguments will be passed to the utop
+             executable (pass flags to utop after the '--' argument, such as
+             'dune tools exec utop -- --help').
+  
   COMMON OPTIONS
          --help[=FMT] (default=auto)
              Show this help in format FMT. The value FMT must be one of auto,


### PR DESCRIPTION
Make `dune tools exec` more consistent by also allowing `utop` to be launched.