### PR TITLE
refactor(stdune): add labelled Option.value_exn'

### DIFF
--- a/otherlibs/stdune/src/option.ml
+++ b/otherlibs/stdune/src/option.ml
@@ -45,6 +45,12 @@ let value_exn = function
   | None -> Code_error.raise "Option.value_exn" []
 ;;
 
+let value_exn' t ~message =
+  match t with
+  | Some x -> x
+  | None -> Code_error.raise "Option.value_exn'" [ "message", Dyn.string message ]
+;;
+
 let some x = Some x
 let some_if cond x = if cond then Some x else None
 

--- a/otherlibs/stdune/src/option.mli
+++ b/otherlibs/stdune/src/option.mli
@@ -17,6 +17,7 @@ val iter : 'a t -> f:('a -> unit) -> unit
 val forall : 'a t -> f:('a -> bool) -> bool
 val value : 'a t -> default:'a -> 'a
 val value_exn : 'a t -> 'a
+val value_exn' : 'a t -> message:string -> 'a
 val some : 'a -> 'a t
 val some_if : bool -> 'a -> 'a t
 val is_some : _ t -> bool

--- a/src/dune_scheduler/file_watcher.ml
+++ b/src/dune_scheduler/file_watcher.ml
@@ -827,7 +827,9 @@ let create_fsevents
         while Option.is_none !dispatch_queue_ref do
           Condition.wait cv mutex
         done;
-        Option.value_exn !dispatch_queue_ref)
+        Option.value_exn'
+          !dispatch_queue_ref
+          ~message:"FSEvents dispatch queue initialization did not signal")
     with
     | Ok dispatch_queue -> dispatch_queue
     | Error exn -> Exn_with_backtrace.reraise exn

--- a/src/dune_scheduler/process_watcher.ml
+++ b/src/dune_scheduler/process_watcher.ml
@@ -163,7 +163,11 @@ let wait_unix t = List.rev (wait_unix t [])
 
 let run_win32 t =
   let mutex = Lazy.force t.mutex in
-  let something_is_running = Option.value_exn t.something_is_running in
+  let something_is_running =
+    Option.value_exn'
+      t.something_is_running
+      ~message:"process watcher condition must exist on Windows"
+  in
   Mutex.lock mutex;
   while true do
     while Process_table.running_count t = 0 do

--- a/src/dune_scheduler/types.ml
+++ b/src/dune_scheduler/types.ml
@@ -72,5 +72,8 @@ module Scheduler = struct
 
   let current : t option ref = ref None
   let t_opt () = !current
-  let t () = Option.value_exn !current
+
+  let t () =
+    Option.value_exn' !current ~message:"scheduler accessed before initialization"
+  ;;
 end


### PR DESCRIPTION
Add Option.value_exn' with a required constant message field for Code_error diagnostics, and use it for scheduler option unwraps that previously raised the generic Option.value_exn error.