### PR TITLE
trace: record build process timing totals

### DIFF
--- a/doc/changes/added/15401.md
+++ b/doc/changes/added/15401.md
@@ -1,0 +1,2 @@
+- Add process counts, system cpu, user cpu, and wall clock cpu times to trace
+  events (#15401, @rgrinberg)

--- a/otherlibs/stdune/src/metrics.ml
+++ b/otherlibs/stdune/src/metrics.ml
@@ -1,19 +1,30 @@
 module Build = struct
   let count = Counter.create ()
-  let process_time_counter = Counter.Timer.create ()
+  let process_wall_clock = Counter.Timer.create ()
+  let user = Counter.Timer.create ()
+  let system = Counter.Timer.create ()
 
-  let add_process_time process_time =
+  let add_process_times ~elapsed_time ~user_cpu_time ~system_cpu_time =
     Counter.incr count;
-    Counter.Timer.add process_time_counter process_time
+    Counter.Timer.add process_wall_clock elapsed_time;
+    (match user_cpu_time with
+     | None -> ()
+     | Some user_cpu_time -> Counter.Timer.add user user_cpu_time);
+    match system_cpu_time with
+    | None -> ()
+    | Some system_cpu_time -> Counter.Timer.add system system_cpu_time
   ;;
 
-  let process_time () =
-    Option.some_if (Counter.read count > 0) (Counter.Timer.read process_time_counter)
-  ;;
+  let process_count () = Counter.read count
+  let process_time () = Counter.Timer.read process_wall_clock
+  let process_user_cpu_time () = Counter.Timer.read user
+  let process_system_cpu_time () = Counter.Timer.read system
 
   let reset () =
     Counter.reset count;
-    Counter.Timer.reset process_time_counter
+    Counter.Timer.reset process_wall_clock;
+    Counter.Timer.reset user;
+    Counter.Timer.reset system
   ;;
 end
 

--- a/otherlibs/stdune/src/metrics.mli
+++ b/otherlibs/stdune/src/metrics.mli
@@ -4,8 +4,16 @@
 val reset : unit -> unit
 
 module Build : sig
-  val add_process_time : Time.Span.t -> unit
-  val process_time : unit -> Time.Span.t option
+  val add_process_times
+    :  elapsed_time:Time.Span.t
+    -> user_cpu_time:Time.Span.t option
+    -> system_cpu_time:Time.Span.t option
+    -> unit
+
+  val process_count : unit -> int
+  val process_time : unit -> Time.Span.t
+  val process_user_cpu_time : unit -> Time.Span.t
+  val process_system_cpu_time : unit -> Time.Span.t
   val reset : unit -> unit
 end
 

--- a/src/dune_engine/build_loop.ml
+++ b/src/dune_engine/build_loop.ml
@@ -86,8 +86,8 @@ let parallelism ~build_duration ~process_time =
     match Time.Span.compare build_duration Time.Span.zero with
     | Eq | Lt -> None
     | Gt ->
-      Option.map process_time ~f:(fun process_time ->
-        Time.Span.to_secs process_time /. Time.Span.to_secs build_duration)
+      (try Some (Time.Span.to_secs process_time /. Time.Span.to_secs build_duration) with
+       | _ -> None)
   with
   | None -> ""
   | Some s -> sprintf "%.1fx" s

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -1368,7 +1368,17 @@ let run_internal
          | None -> local ())
       | None -> local ()
     in
-    Option.iter build ~f:(fun _ -> Metrics.Build.add_process_time times.elapsed_time);
+    Option.iter build ~f:(fun (_ : Build.t) ->
+      let user_cpu_time, system_cpu_time =
+        match times.resource_usage with
+        | None -> None, None
+        | Some { Proc.Resource_usage.user_cpu_time; system_cpu_time; _ } ->
+          Some user_cpu_time, Some system_cpu_time
+      in
+      Metrics.Build.add_process_times
+        ~elapsed_time:times.elapsed_time
+        ~user_cpu_time
+        ~system_cpu_time);
     let result = Result.make t process_info fail_mode in
     (match remote_started_at with
      | None ->

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -196,6 +196,17 @@ let make_rusage_args resource_usage =
     ]
 ;;
 
+let make_process_times_args () =
+  let args =
+    [ "count", Arg.int (Metrics.Build.process_count ())
+    ; "elapsed_time", Arg.span (Metrics.Build.process_time ())
+    ; "user_cpu_time", Arg.span (Metrics.Build.process_user_cpu_time ())
+    ; "system_cpu_time", Arg.span (Metrics.Build.process_system_cpu_time ())
+    ]
+  in
+  [ "process_times", Arg.record args |> Arg.list ]
+;;
+
 let exit () =
   let now = Time.now () in
   let args =
@@ -300,6 +311,7 @@ let watch_build_finish ~run_id ~outcome ~start ~stop ~restart_duration =
     @ (match restart_duration with
        | None -> []
        | Some restart_duration -> [ "restart_duration", Arg.span restart_duration ])
+    @ make_process_times_args ()
     @ make_rusage_args (Proc.Resource_usage.get_self ())
   in
   Event.complete ~name:"build-finish" ~args ~start ~dur Build

--- a/test/blackbox-tests/dune.jq
+++ b/test/blackbox-tests/dune.jq
@@ -251,6 +251,10 @@ def buildEvents:
     then .args.restart_duration |= type
     else .
     end
+  | if .args.process_times? != null
+    then .args.process_times |= keys
+    else .
+    end
   | if .args.rusage? != null
     then .args.rusage |= keys
     else .

--- a/test/blackbox-tests/test-cases/trace/interrupted-watch-build-events.t
+++ b/test/blackbox-tests/test-cases/trace/interrupted-watch-build-events.t
@@ -45,7 +45,7 @@ own source invalidation.
   $ stop_dune > /dev/null
 
   $ dune trace cat | jq_dune -s '
-  > [ .[] | buildEvents | del(.args.rusage) ] | .[-5:]'
+  > [ .[] | buildEvents | del(.args.process_times, .args.rusage) ] | .[-5:]'
   [
     {
       "args": {

--- a/test/blackbox-tests/test-cases/trace/watch-build-events.t
+++ b/test/blackbox-tests/test-cases/trace/watch-build-events.t
@@ -1,5 +1,5 @@
-Batch and watch-mode builds emit run ids and dune's own rusage snapshots on
-build trace events.
+Batch and watch-mode builds emit run ids, process-time totals, and dune's own
+rusage snapshots on build trace events.
 
   $ make_dune_project 3.22
 
@@ -43,6 +43,12 @@ build trace events.
     "args": {
       "run_id": 0,
       "outcome": "success",
+      "process_times": [
+        "count",
+        "elapsed_time",
+        "system_cpu_time",
+        "user_cpu_time"
+      ],
       "rusage": [
         "inblock",
         "majflt",
@@ -99,6 +105,12 @@ active build is interrupted.
     "args": {
       "run_id": 1,
       "outcome": "success",
+      "process_times": [
+        "count",
+        "elapsed_time",
+        "system_cpu_time",
+        "user_cpu_time"
+      ],
       "rusage": [
         "inblock",
         "majflt",
@@ -136,6 +148,12 @@ active build is interrupted.
       "run_id": 2,
       "outcome": "success",
       "restart_duration": "number",
+      "process_times": [
+        "count",
+        "elapsed_time",
+        "system_cpu_time",
+        "user_cpu_time"
+      ],
       "rusage": [
         "inblock",
         "majflt",


### PR DESCRIPTION
Track the number of processes run during a build along with accumulated elapsed, user CPU, and system CPU process times. Include these totals in the existing build-finish trace event.