### PR TITLE
Use Aarch64 toolchain for the `dune-static` build

### DIFF
--- a/nix/dune-package.nix
+++ b/nix/dune-package.nix
@@ -78,5 +78,9 @@ in
         "LIBDIR=$(OCAMLFIND_DESTDIR)"
       ];
     };
-  dune-static = pkgs-static.pkgsCross.musl64.ocamlPackages.dune;
+  dune-static =
+    if pkgs.stdenv.hostPlatform.isAarch64 then
+      pkgs-static.pkgsCross.aarch64-multiplatform-musl.ocamlPackages.dune
+    else
+      pkgs-static.pkgsCross.musl64.ocamlPackages.dune;
 }


### PR DESCRIPTION
It currently always uses `musl64` which unfortunately despite its confusing name is explicitly for amd64.

Thanks to @Alizter for the insights and helping me debug this issue.

Fixes #15411