### PR TITLE
Use same compiler settings for `.#dune` and `.#dune-static`

### DIFF
--- a/nix/dune-package.nix
+++ b/nix/dune-package.nix
@@ -41,6 +41,10 @@ let
   dune-static-overlay = self: super: {
     ocamlPackages = super.ocaml-ng.ocamlPackages_5_4.overrideScope (
       oself: osuper: {
+        ocaml = osuper.ocaml.override {
+          flambdaSupport = false;
+          framePointerSupport = true;
+        };
         dune_3 = osuper.dune_3.overrideAttrs (a: {
           src = dune-source;
           preBuild = "ocaml boot/bootstrap.ml --static";


### PR DESCRIPTION
The nix-overlay enables `flambda` automatically and in the flake we disable it for `dune`, instead enabling frame pointers. However, this is not the case for `dune-static`, where we use the regular `ocaml` package (from the overlay) which uses `flambda` but no frame pointers.

This applies the same compiler configuration to `dune-static` as to `dune`.