### PR TITLE
Fix typo 'Disabed' -> 'Disabled' in `dune_config_file.ml`

### DIFF
--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -208,7 +208,7 @@ module Dune_config = struct
       let repr =
         Repr.variant
           "cache-toggle"
-          [ Repr.case0 "Disabed" ~test:(function
+          [ Repr.case0 "Disabled" ~test:(function
               | Disabled -> true
               | Enabled_except_user_rules | Enabled -> false)
           ; Repr.case0 "Enabled_except_user_rules" ~test:(function


### PR DESCRIPTION
Fixing in passing a typo from 'Disabed' to 'Disabled' in `dune_config_file.ml`
