### PR TITLE
test(watch): cover cached failed actions

### DIFF
--- a/test/blackbox-tests/test-cases/watching/batch-mode.t
+++ b/test/blackbox-tests/test-cases/watching/batch-mode.t
@@ -1,0 +1,36 @@
+Failed actions are memoized as reproducible errors. Use an action that increments
+a counter before failing to distinguish rerunning the external process from
+reraising the cached failure.
+
+In a non-watch build, requesting the same failing action through two aliases in a
+single build executes the failed action only once.
+
+  $ make_dune_project 3.22
+  $ setup_failing_action_script
+
+  $ counter="$TMPDIR/cached-failed-actions-counter"
+  $ rm -f "$counter"
+  $ cat > dune <<EOF
+  > (rule
+  >  (alias fail)
+  >  (deps fail.sh)
+  >  (action (run sh %{dep:fail.sh} $counter)))
+  > (alias
+  >  (name a)
+  >  (deps (alias fail)))
+  > (alias
+  >  (name b)
+  >  (deps (alias fail)))
+  > EOF
+
+  $ dune build @a @b > build.out 2>&1
+  [1]
+  $ cat "$counter"
+  1
+  $ print_build_finish_process_counts
+  [
+    {
+      "outcome": "failure",
+      "process_count": 2
+    }
+  ]

--- a/test/blackbox-tests/test-cases/watching/cached-failed-actions-helpers.sh
+++ b/test/blackbox-tests/test-cases/watching/cached-failed-actions-helpers.sh
@@ -1,0 +1,18 @@
+setup_failing_action_script () {
+    cat > fail.sh <<'EOF'
+counter="$1"
+count=0
+if [ -e "$counter" ]; then count=$(cat "$counter"); fi
+count=$((count + 1))
+echo "$count" > "$counter"
+echo failed action >&2
+exit 1
+EOF
+}
+
+print_build_finish_process_counts () {
+    dune trace cat | jq -s '
+[ .[]
+| select(.cat == "build" and .name == "build-finish")
+| { outcome: .args.outcome, process_count: .args.process_times.count } ]'
+}

--- a/test/blackbox-tests/test-cases/watching/dune
+++ b/test/blackbox-tests/test-cases/watching/dune
@@ -24,6 +24,10 @@
   (<> %{ocaml-config:system} win)))
 
 (cram
+ (applies_to batch-mode watch-mode)
+ (setup_scripts cached-failed-actions-helpers.sh))
+
+(cram
  (applies_to rpc-flush-file-watcher rpc-registry)
  (deps
   %{bin:action_plugin_helper}

--- a/test/blackbox-tests/test-cases/watching/watch-mode.t
+++ b/test/blackbox-tests/test-cases/watching/watch-mode.t
@@ -1,0 +1,46 @@
+Failed actions are memoized as reproducible errors. Use an action that increments
+a counter before failing to distinguish rerunning the external process from
+reraising the cached failure.
+
+In watch mode, a repeated build request for the same failing action reraises the
+cached failure without rerunning the action.
+
+  $ make_dune_project 3.22
+  $ setup_failing_action_script
+
+  $ counter="$TMPDIR/cached-failed-actions-counter"
+  $ rm -f "$counter"
+  $ cat > dune <<EOF
+  > (alias
+  >  (name idle))
+  > (rule
+  >  (alias fail)
+  >  (deps fail.sh)
+  >  (action (run sh %{dep:fail.sh} $counter)))
+  > EOF
+
+  $ start_dune @idle
+  $ build "(alias fail)" > first.out 2>&1
+  [1]
+  $ count_after_first_build=$(cat "$counter")
+  $ build "(alias fail)" > second.out 2>&1
+  [1]
+  $ test "$(cat "$counter")" = "$count_after_first_build"
+  $ stop_dune_quiet
+
+The final build request reused the cached failure, so it executed fewer
+processes than the preceding request and did not increment the action counter.
+
+  $ print_build_finish_process_counts
+  [
+    {
+      "outcome": "failure",
+      "process_count": 2
+    },
+    {
+      "outcome": "failure",
+      "process_count": 1
+    }
+  ]
+  $ test "$(cat "$counter")" = "$count_after_first_build" && echo "counter unchanged"
+  counter unchanged


### PR DESCRIPTION
Add a blackbox test showing that failed actions are memoized as reproducible errors. The test covers both a batch build with two aliases reaching the same failing action, and watch mode where a repeated build request reraises the cached failure without rerunning the action.