### PR TITLE
test(changes): lint changelog fragments

### DIFF
--- a/doc/changes/changed/14954.md
+++ b/doc/changes/changed/14954.md
@@ -1,3 +1,3 @@
 - `$ dune rpc build` invocations no longer queue. All build requests are built
   in parallel. Watch servers started by `$ dune exec --watch` can now also
-  handle forwarded build and runtest requests (#14964, @rgrinberg)
+  handle forwarded build and runtest requests (#14954, @rgrinberg)

--- a/doc/changes/dune
+++ b/doc/changes/dune
@@ -9,7 +9,23 @@
 
 (rule
  (alias runtest)
+ (deps
+  ./lint-change-fragments.sh
+  (source_tree added)
+  (source_tree changed)
+  (source_tree fixed))
+ (action
+  (run %{bin:bash} ./lint-change-fragments.sh)))
+
+(rule
+ (alias runtest)
  (deps forbid-files.sh)
+ (action
+  (run %{bin:bash} -n %{deps})))
+
+(rule
+ (alias runtest)
+ (deps lint-change-fragments.sh)
  (action
   (run %{bin:bash} -n %{deps})))
 
@@ -17,5 +33,12 @@
  (alias runtest)
  (enabled_if %{bin-available:shellcheck})
  (deps forbid-files.sh)
+ (action
+  (run %{bin:shellcheck} -s bash %{deps})))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:shellcheck})
+ (deps lint-change-fragments.sh)
  (action
   (run %{bin:shellcheck} -s bash %{deps})))

--- a/doc/changes/fixed/15070.md
+++ b/doc/changes/fixed/15070.md
@@ -1,3 +1,3 @@
 - Improve the error message for private libraries that cannot be dependencies of
   public libraries by mentioning the `(package ...)` field as an alternative to
-  giving the private library a public name (#10230, @rgrinberg).
+  giving the private library a public name (#15070, fixes #10230, @rgrinberg).

--- a/doc/changes/fixed/15072.md
+++ b/doc/changes/fixed/15072.md
@@ -1,3 +1,3 @@
 - Clarify the module conflict error shown when a module is used in multiple
   stanzas. The message now explains implicit module ownership and lists all
-  relevant stanza kinds (#6598, @rgrinberg).
+  relevant stanza kinds (#15072, fixes #6598, @rgrinberg).

--- a/doc/changes/lint-change-fragments.sh
+++ b/doc/changes/lint-change-fragments.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+errors=0
+
+report_error() {
+  echo "$1" >&2
+  errors=$((errors + 1))
+}
+
+check_entry() {
+  local entry="$1"
+  local name="${entry##*/}"
+
+  if [[ ! "$name" =~ ^[[:digit:]]+\.md$ ]]; then
+    report_error \
+      "$entry: expected filename to be a PR number followed by .md"
+    return
+  fi
+
+  if [[ ! -f "$entry" ]]; then
+    report_error "$entry: expected a regular file"
+    return
+  fi
+
+  local pr="${name%.md}"
+  local first_line
+  first_line="$(head -n 1 "$entry")"
+
+  if [[ "$first_line" != -* ]]; then
+    report_error "$entry: first line must start with '-'"
+  fi
+
+  local contents
+  contents="$(< "$entry")"
+  local pr_then_user="\\([^)]*#${pr}([^[:digit:]][^)]*@|@)[^)]*\\)"
+  local user_then_pr="\\([^)]*@[^)]*#${pr}([^[:digit:]][^)]*)?\\)"
+
+  if [[ ! $contents =~ $pr_then_user && ! $contents =~ $user_then_pr ]]; then
+    report_error \
+      "$entry: expected parenthesized reference with #$pr and @username"
+  fi
+}
+
+check_dir() {
+  local dir="$1"
+
+  if [[ ! -d "$dir" ]]; then
+    report_error "$dir: directory does not exist"
+    return
+  fi
+
+  local entry
+  while IFS= read -r -d '' entry; do
+    check_entry "$entry"
+  done < <(find "$dir" -mindepth 1 -maxdepth 1 ! -name '.*' -print0 | sort -z)
+}
+
+if [[ $# -eq 0 ]]; then
+  cd "$(dirname "$0")"
+  set -- added changed fixed
+fi
+
+for dir in "$@"; do
+  check_dir "$dir"
+done
+
+if ((errors > 0)); then
+  exit 1
+fi


### PR DESCRIPTION
Add a doc/changes runtest check for added/changed/fixed fragments. The
check verifies PR-number filenames, bullet-prefixed first lines, and
parenthesized references containing the fragment PR and an @username.

Update existing fragments so they satisfy the new format.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>