### PR TITLE
fix(jsoo): keep archive dirs for libraries without implementations

### DIFF
--- a/doc/changes/fixed/15427.md
+++ b/doc/changes/fixed/15427.md
@@ -1,0 +1,2 @@
+- Avoid rebuilding `js_of_ocaml` library archives on every invocation for
+  interface-only and empty libraries. (#15427, @anmonteiro)

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -734,6 +734,21 @@ let rules (lib : Library.t) ~sctx ~dir_contents ~expander ~scope =
         ~for_
     in
     let* () =
+      let { Mode.Dict.byte; _ } = Lib_info.archives lib_info in
+      let has_impl = Compilation_context.modules cctx |> Modules.With_vlib.has_impl in
+      match for_, byte, has_impl with
+      | Ocaml, _ :: _, false ->
+        let dir = Compilation_context.obj_dir cctx |> Obj_dir.jsoo_dir in
+        (* JSOO archive rules are generated lazily below [dir]. Without
+           implementation modules, no eagerly generated rule mentions it. The
+           standard alias records [dir] in the rule map so stale-artifact cleanup
+           keeps it. *)
+        Rules.Produce.Alias.add_deps
+          (Alias.make Alias0.all ~dir)
+          (Action_builder.return ())
+      | _ -> Memo.return ()
+    in
+    let* () =
       match buildable.ctypes with
       | None -> Memo.return ()
       | Some _ ->

--- a/test/blackbox-tests/test-cases/jsoo/without_implem.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/without_implem.t/run.t
@@ -69,10 +69,8 @@ JSOO archive rules for interface-only libraries are not spuriously invalidated
 main.bc.js should not rebuild
 
   $ dune build --display=short main.bc.js
-   js_of_ocaml .interface.objs/jsoo/effects=disabled/interface.cma.js
 
   $ dune build --display=short main.bc.js
-   js_of_ocaml .interface.objs/jsoo/effects=disabled/interface.cma.js
 
 JSOO archive rules for libraries without modules are not spuriously invalidated
 
@@ -98,7 +96,6 @@ main.bc.js should not rebuild
   > | .target_files[]?
   > | select(endswith(".cma.js"))
   > '
-  _build/default/.empty.objs/jsoo/effects=disabled/empty.cma.js
 
   $ dune build main.bc.js
   $ dune trace cat | jq_dune -r '
@@ -106,7 +103,6 @@ main.bc.js should not rebuild
   > | .target_files[]?
   > | select(endswith(".cma.js"))
   > '
-  _build/default/.empty.objs/jsoo/effects=disabled/empty.cma.js
 
 JSOO archives in directory groups are not spuriously invalidated
 
@@ -134,7 +130,6 @@ main.bc.js should not rebuild
   > | .target_files[]?
   > | select(endswith(".cma.js"))
   > '
-  _build/default/.grouped.objs/jsoo/effects=disabled/grouped.cma.js
 
   $ dune build main.bc.js
   $ dune trace cat | jq_dune -r '
@@ -142,4 +137,3 @@ main.bc.js should not rebuild
   > | .target_files[]?
   > | select(endswith(".cma.js"))
   > '
-  _build/default/.grouped.objs/jsoo/effects=disabled/grouped.cma.js

--- a/test/blackbox-tests/test-cases/jsoo/without_implem.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/without_implem.t/run.t
@@ -19,6 +19,32 @@ Tests JSOO rules for modules without implementations.
 
   $ dune build
 
+JSOO rules for executables are not spuriously invalidated
+
+  $ dune build
+  $ dune trace cat | jq_dune -r '
+  > progMatching("js_of_ocaml")
+  > | .target_files[]?
+  > | select(endswith("main.bc.js"))
+  > '
+
+Source directories that resemble library object directories are not reserved
+for JSOO rules.
+
+  $ mkdir .foo.objs
+  $ cat > dune <<EOF
+  > (dirs :standard .foo.objs)
+  > EOF
+  $ cat > .foo.objs/dune <<EOF
+  > (rule
+  >  (target jsoo)
+  >  (action (with-stdout-to %{target} (echo source))))
+  > EOF
+
+  $ dune build .foo.objs/jsoo
+  $ cat _build/default/.foo.objs/jsoo
+  source
+
 JSOO archive rules for interface-only libraries are not spuriously invalidated
 
   $ cat > dune <<EOF


### PR DESCRIPTION
Keep the generated JSOO archive directory when the library has no implementation modules.

Fixes repeated rebuilds for interface-only libraries.

fixes the test added in https://github.com/ocaml/dune/pull/15422