### PR TITLE
promote: unify dune promote and dune promotion apply

### DIFF
--- a/bin/promotion.ml
+++ b/bin/promotion.ml
@@ -82,9 +82,7 @@ module Apply = struct
     run ~builder ~exact ~files
   ;;
 
-  let term = term_with_builder Common.Builder.term
-
-  let promote_term =
+  let term =
     term_with_builder
       (let+ no_build = Common.No_build.term in
        Common.Builder.set_no_build Common.Builder.default no_build)
@@ -204,9 +202,5 @@ let info =
 let group = Cmd.group info [ Files.command; Apply.command; Diff.command; Show.command ]
 
 let promote =
-  Common.command_alias
-    ~orig_name:"promotion apply"
-    Apply.command
-    Apply.promote_term
-    "promote"
+  Common.command_alias ~orig_name:"promotion apply" Apply.command Apply.term "promote"
 ;;


### PR DESCRIPTION
## Description

The `dune promote` alias used `Common.No_build.term` (via a separate `Apply.promote_term`) while `dune promotion apply` used `Common.Builder.term`. Nothing about `promotion apply` requires the wider builder, and having the alias and the underlying command accept different flag sets is surprising.

Fold `Apply.promote_term` into `Apply.term` so both surfaces expose the same narrow set of flags (`--file`, `--debug-backtraces`, `--build-info`), matching the workspace-independent nature of the operation.

