### PR TITLE
ci: bump aarch64-darwin runner to macos-15

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -26,7 +26,7 @@ jobs:
           - os: macos-15-intel
             name: x86_64-apple-darwin
             installable: .#dune
-          - os: macos-14
+          - os: macos-15
             name: aarch64-apple-darwin
             installable: .#dune
           - os: ubuntu-22.04


### PR DESCRIPTION
Matches the macos-15-intel generation already in use for x86_64-darwin.
