### PR TITLE
ci: bump ubuntu runners to 24.04

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -29,10 +29,10 @@ jobs:
           - os: macos-14
             name: aarch64-apple-darwin
             installable: .#dune
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             name: x86_64-unknown-linux-musl
             installable: .#dune-static
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             name: x86_64-pc-windows-gnu
             installable: .#windows-static
             binary: dune.exe


### PR DESCRIPTION
22.04 is approaching end-of-mainstream-support; 24.04 is the current LTS.
