### PR TITLE
fix(completion): fall back to shell path completion

### DIFF
--- a/bin/completion.ml
+++ b/bin/completion.ml
@@ -30,7 +30,7 @@ module Bash : Shell = struct
 if ! declare -F %s > /dev/null; then
   _completion_loader %s
 fi
-complete -F %s %s
+complete -o bashdefault -o default -F %s %s
 |}
       fun_def
       fun_name
@@ -57,14 +57,26 @@ module Zsh : Shell = struct
   ;;
 
   let completion_script ~fun_name =
-    let fun_def = Cmdliner_data.zsh_generic_completion fun_name in
+    let inner_fun_name = fun_name ^ "_cmdliner" in
+    let fun_def = Cmdliner_data.zsh_generic_completion inner_fun_name in
     sprintf
       {|#compdef %s
 %s
+function %s {
+  local nmatches="${compstate[nmatches]:-0}"
+  %s
+  local ret=$?
+  if [[ "${compstate[nmatches]:-0}" == "$nmatches" ]]; then
+    _default
+  fi
+  return $ret
+}
 %s
 |}
       "dune"
       fun_def
+      fun_name
+      inner_fun_name
       fun_name
   ;;
 end
@@ -86,14 +98,35 @@ module Powershell : Shell = struct
   ;;
 
   let completion_script ~fun_name =
-    let fun_def = Cmdliner_data.pwsh_generic_completion fun_name in
+    let inner_fun_name = fun_name ^ "_cmdliner" in
+    let fun_def = Cmdliner_data.pwsh_generic_completion inner_fun_name in
     sprintf
       {|
 %s
 
+$Global:%s = {
+  param(
+    $wordToComplete,
+    $commandAst,
+    $cursorPosition
+  )
+
+  $CompletionResults = & $%s $wordToComplete $commandAst $cursorPosition
+  if ($null -ne $CompletionResults -and @($CompletionResults).Count -gt 0) {
+    return $CompletionResults
+  }
+  else {
+    return [Management.Automation.CompletionCompleters]::CompleteFilename(
+      $wordToComplete
+    )
+  }
+}
+
 Register-ArgumentCompleter -Native -CommandName %s -ScriptBlock $%s
 |}
       fun_def
+      fun_name
+      inner_fun_name
       "dune"
       fun_name
   ;;

--- a/flake.nix
+++ b/flake.nix
@@ -162,6 +162,7 @@
               mercurial
               unzip
               coreutils
+              bashInteractive
               curl
               git
               binaryen

--- a/test/blackbox-tests/test-cases/completion/bash.t
+++ b/test/blackbox-tests/test-cases/completion/bash.t
@@ -1,0 +1,27 @@
+Bash completion scripts fall back to filename completion when Dune has no
+semantic completions to offer.
+
+This test sources the generated bash completion script, asks bash which
+completion it registered for dune, and exercises that completion registration.
+
+  $ mkdir completions
+  $ touch completions/bash.t completions/other-file
+  $ bash <<'EOF'
+  > enable complete compgen
+  > source <(dune completion bash)
+  > _get_comp_words_by_ref() {
+  >   local words_var="${@: -2:1}"
+  >   local cword_var="${@: -1}"
+  >   eval "$words_var=(\"\${COMP_WORDS[@]}\")"
+  >   printf -v "$cword_var" "%s" "$COMP_CWORD"
+  > }
+  > cd completions
+  > COMP_WORDS=(dune runtest bas)
+  > COMP_CWORD=2
+  > completion=( $(complete -p dune) )
+  > completion[0]=compgen
+  > unset "completion[${#completion[@]}-1]"
+  > "${completion[@]}" -- bas 2>stderr
+  > sed '/compgen: warning: -F option may not work as you expect/d' stderr
+  > EOF
+  bash.t

--- a/test/blackbox-tests/test-cases/completion/commands.t
+++ b/test/blackbox-tests/test-cases/completion/commands.t
@@ -1,0 +1,30 @@
+Completion scripts fall back to the shell's default filename completion when
+Dune has no semantic completions to offer.
+
+Bash registers the cmdliner completion function with the shell's fallback
+completion options.
+
+  $ dune completion bash | grep '^complete '
+  complete -o bashdefault -o default -F _dune_cmdliner dune
+
+CR-someday Alizter: test the zsh and PowerShell scripts by running their
+completion functions too. For now, check that they contain the fallback
+wrappers.
+
+  $ dune completion zsh | grep '^function _dune_cmdliner'
+  function _dune_cmdliner_cmdliner {
+  function _dune_cmdliner {
+
+  $ dune completion zsh | grep -E 'compstate\[nmatches\]|_default'
+    local nmatches="${compstate[nmatches]:-0}"
+    if [[ "${compstate[nmatches]:-0}" == "$nmatches" ]]; then
+      _default
+
+  $ dune completion powershell | grep '^\$Global:_dune_cmdliner'
+  $Global:_dune_cmdliner_cmdliner = {
+  $Global:_dune_cmdliner = {
+
+  $ dune completion powershell | grep -A2 'CompletionCompleters.*CompleteFilename(' | tail -n3
+      return [Management.Automation.CompletionCompleters]::CompleteFilename(
+        $wordToComplete
+      )

--- a/test/blackbox-tests/test-cases/completion/dune
+++ b/test/blackbox-tests/test-cases/completion/dune
@@ -1,0 +1,5 @@
+(cram
+ (applies_to bash)
+ (enabled_if
+  (= %{system} linux))
+ (deps %{bin:bash}))


### PR DESCRIPTION
## Description

Allow generated shell completion scripts to fall back to the shell's normal filename completion when cmdliner has no semantic completions to offer.

For bash, Dune now registers completion with `-o default`. For zsh and PowerShell, Dune keeps the cmdliner-generated completers unchanged under internal names and exposes small Dune-owned wrappers that fall back to the shell filename completer only when cmdliner returns no matches.

## Related Issue and Motivation

Since #14779 moved completion script handling to cmdliner, commands such as `dune runtest ...` no longer fell through to normal path completion when Dune had no completions to return. This restores the expected shell fallback behavior.

Fixes #15431

## Shell fallback references

- Bash: the GNU Bash manual documents `complete -o default` as using Readline default filename completion when the compspec generates no matches: https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html
- zsh: the zsh completion system documents `_default` for the `-default-` completion context, and `compstate[nmatches]` as the number of matches added so far: https://zsh.sourceforge.io/Doc/Release/Completion-System.html and https://zsh.sourceforge.io/Doc/Release/Completion-Widgets.html
- PowerShell: `Register-ArgumentCompleter -Native` scriptblocks return completion values, and PowerShell's own completion code falls back to `CompletionCompleters.CompleteFilename(...)` when no argument completions are found: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/register-argumentcompleter and https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs

## Checklist

- [x] Tests added, if applicable.
- [ ] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [ ] Documentation added for any user-facing changes.