### PR TITLE
fix: treat all compilers >= 5.5 as relocatable

### DIFF
--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1408,29 +1408,12 @@ module DB = struct
     { id : Id.t
     ; pkg_digest_table : Pkg_table.t
     ; system_provided : Package.Name.Set.t
-    ; is_relocatable_compiler_context : bool
     }
 
   let equal x y = Id.equal x.id y.id
 
-  let create =
-    (* A compiler is relocatable if the solution contains the
-       "relocatable-compiler" meta-package (from dra27's overlay repo) or
-       the "relocatable" virtual package (from upstream opam-repository). *)
-    let is_relocatable_meta_package name =
-      Package.Name.equal name (Package.Name.of_string "relocatable-compiler")
-      || Package.Name.equal name (Package.Name.of_string "relocatable")
-    in
-    fun ~pkg_digest_table ~system_provided ->
-      { id = Id.gen ()
-      ; pkg_digest_table
-      ; system_provided
-      ; is_relocatable_compiler_context =
-          Pkg_digest.Map.existsi
-            pkg_digest_table
-            ~f:(fun _ { Pkg_table.pkg = { info = { name; _ }; _ }; _ } ->
-              is_relocatable_meta_package name)
-      }
+  let create ~pkg_digest_table ~system_provided =
+    { id = Id.gen (); pkg_digest_table; system_provided }
   ;;
 
   let pkg_digest_of_name lock_dir platform pkg_name ~system_provided =
@@ -1559,6 +1542,27 @@ end = struct
     | Action a -> Build_command.Action (relocate a)
   ;;
 
+  let is_relocatable_compiler_marker name =
+    let relocatable_compiler = Package.Name.of_string "relocatable-compiler" in
+    let relocatable = Package.Name.of_string "relocatable" in
+    Package.Name.equal name relocatable_compiler || Package.Name.equal name relocatable
+  ;;
+
+  let has_relocatable_compiler_marker (info : Pkg_info.t) depends =
+    is_relocatable_compiler_marker info.name
+    || Pkg.top_closure depends
+       |> List.exists ~f:(fun (pkg : Pkg.t) ->
+         is_relocatable_compiler_marker pkg.info.name)
+  ;;
+
+  let is_compiler_version_relocatable (info : Pkg_info.t) =
+    Pkg_toolchain.is_compiler_package_with_toolchains_enabled info.name
+    &&
+    match Package_version.compare info.version (Package_version.of_string "5.5.0") with
+    | Lt -> false
+    | Eq | Gt -> true
+  ;;
+
   let resolve_impl { Input.db; pkg_digest; universe = package_universe } =
     match Pkg_digest.Map.find db.pkg_digest_table pkg_digest with
     | None -> Memo.return None
@@ -1616,8 +1620,9 @@ end = struct
       let paths =
         let paths = Paths.map_path write_paths ~f:Path.build in
         if
-          db.is_relocatable_compiler_context
-          || not (Pkg_toolchain.is_compiler_package_with_toolchains_enabled info.name)
+          (not (Pkg_toolchain.is_compiler_package_with_toolchains_enabled info.name))
+          || is_compiler_version_relocatable info
+          || has_relocatable_compiler_marker info depends
         then paths
         else (
           (* Modify the environment as well as build and install commands for

--- a/test/blackbox-tests/test-cases/pkg/relocatable-compiler.t
+++ b/test/blackbox-tests/test-cases/pkg/relocatable-compiler.t
@@ -114,7 +114,8 @@ workspace-local target from the first build.
   $ rm -rf _build dune-cache
   $ export DUNE_CACHE=disabled
   $ build_pkg relocatable-compiler
-  $ build_pkg relocatable-compiler 2>&1 | grep "Building relocatable-compiler" || true
+  $ build_pkg relocatable-compiler 2>&1 | grep "Building relocatable-compiler"
+  [1]
   $ dune trace cat | jq -r '
   >   select(.cat == "cache" and .name == "workspace_local_miss")
   >   | select(.args.head | test("relocatable-compiler.*target$"))

--- a/test/blackbox-tests/test-cases/pkg/relocatable-compiler.t
+++ b/test/blackbox-tests/test-cases/pkg/relocatable-compiler.t
@@ -1,7 +1,6 @@
 Test that relocatable compilers bypass toolchain cache. A compiler is
-considered relocatable if the solution contains either:
-- The "relocatable-compiler" meta-package (from dra27's overlay repo)
-- The "relocatable" virtual package (from upstream opam-repository)
+considered relocatable if it's OCaml 5.5.0 or newer, or if the compiler
+package's dependency closure contains an older relocatable compiler marker.
 
   $ mkrepo
   $ mkdir -p relocatable-repo/packages
@@ -109,37 +108,40 @@ package):
   $ dune_cmd stat hardlinks $(get_build_pkg_dir ocaml-base-compiler)/target/bin/ocamlc.opt
   3
 
-Test the upstream opam-repository approach: the "relocatable" virtual package.
-Non-relocatable compilers conflict with it, so if it's in the solution the
-compiler must be relocatable. See https://github.com/ocaml/opam-repository/pull/29451
+With the shared cache disabled, building the compiler twice should reuse the
+workspace-local target from the first build.
+
+  $ rm -rf _build dune-cache
+  $ export DUNE_CACHE=disabled
+  $ build_pkg relocatable-compiler
+  $ build_pkg relocatable-compiler 2>&1 | grep "Building relocatable-compiler" || true
+  $ dune trace cat | jq -r '
+  >   select(.cat == "cache" and .name == "workspace_local_miss")
+  >   | select(.args.head | test("relocatable-compiler.*target$"))
+  >   | .args.reason
+  > '
+
+Test that OCaml 5.5 and newer compilers are treated as relocatable based on
+their version.
 
 We clean up the previous build state first:
 
   $ rm -rf _build dune.lock dune-cache mock-opam-repository
+  $ export DUNE_CACHE=enabled
   $ mkrepo
 
-  $ mkpkg relocatable packages << 'EOF'
-  > EOF
-
-The non-relocatable compiler in the mock repo conflicts with relocatable:
-
-  $ mkpkg ocaml-base-compiler 5.3.0 << 'EOF'
-  > conflicts: [ "relocatable" ]
+  $ mkpkg ocaml-compiler 5.5.0 << 'EOF'
   > EOF
   $ append_fake_compiler_commands \
-  >   "$mock_packages/ocaml-base-compiler/ocaml-base-compiler.5.3.0/opam" \
-  >   "ocamlc binary"
-
-A relocatable compiler does not conflict with relocatable:
-
-  $ mkpkg ocaml-base-compiler 5.3.0+relocatable << 'EOF'
-  > EOF
-  $ append_fake_compiler_commands \
-  >   "$mock_packages/ocaml-base-compiler/ocaml-base-compiler.5.3.0+relocatable/opam" \
+  >   "$mock_packages/ocaml-compiler/ocaml-compiler.5.5.0/opam" \
   >   "relocatable ocamlc"
 
-  $ mkpkg ocaml 5.3.0 << 'EOF'
-  > depends: [ "ocaml-base-compiler" {>= "5.3.0"} ]
+  $ mkpkg ocaml-base-compiler 5.5.0 << 'EOF'
+  > depends: [ "ocaml-compiler" {= "5.5.0"} ]
+  > EOF
+
+  $ mkpkg ocaml 5.5.0 << 'EOF'
+  > depends: [ "ocaml-base-compiler" {= "5.5.0"} ]
   > EOF
 
   $ cat > dune-project << 'EOF'
@@ -147,7 +149,7 @@ A relocatable compiler does not conflict with relocatable:
   > (package
   >  (name test)
   >  (allow_empty)
-  >  (depends ocaml relocatable))
+  >  (depends ocaml))
   > EOF
 
   $ cat > dune-workspace << EOF
@@ -159,15 +161,15 @@ A relocatable compiler does not conflict with relocatable:
   >  (url "file://$PWD/mock-opam-repository"))
   > EOF
 
-Requiring relocatable should exclude the non-relocatable compiler:
+Solving for OCaml 5.5 should pick the split compiler packages:
 
   $ dune_pkg_lock_normalized
   Solution for dune.lock:
-  - ocaml.5.3.0
-  - ocaml-base-compiler.5.3.0+relocatable
-  - relocatable.packages
+  - ocaml.5.5.0
+  - ocaml-base-compiler.5.5.0
+  - ocaml-compiler.5.5.0
 
-  $ build_pkg ocaml-base-compiler
+  $ build_pkg ocaml-compiler
 
 Toolchain cache should be empty:
 
@@ -177,6 +179,5 @@ Toolchain cache should be empty:
 Check the installed files from the compiler are hardlinked (cached as regular
 package):
 
-  $ dune_cmd stat hardlinks $(get_build_pkg_dir ocaml-base-compiler)/target/bin/ocamlc.opt
+  $ dune_cmd stat hardlinks $(get_build_pkg_dir ocaml-compiler)/target/bin/ocamlc.opt
   3
-


### PR DESCRIPTION
## Description
Treat compiler packages with version >= 5.5.0 as relocatable package installs, so Dune does not route them through the toolchain cache. Keep the existing legacy marker handling for older relocatable compiler packages.

## Related Issue and Motivation
OCaml 5.5 and newer compiler packages are relocatable by version, and the previous solution-wide marker heuristic misses that shape.

Fixes #15443

## Checklist

- [x] Tests added, if applicable.
- [ ] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [ ] Documentation added for any user-facing changes.