### PR TITLE
chore: update CI to OCaml 5.5

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -22,7 +22,7 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-compiler:
-          - 5.4.x
+          - 5.5.x
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/bench.yml.in
+++ b/.github/workflows/bench.yml.in
@@ -21,7 +21,7 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-compiler:
-          - 5.4.x
+          - 5.5.x
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -23,7 +23,7 @@ jobs:
 #
 
   nix-build:
-    name: Bootstrap with OCaml 5.4
+    name: Bootstrap with OCaml 5.5
     strategy:
       fail-fast: false
       matrix:
@@ -162,28 +162,28 @@ jobs:
             os: ubuntu-latest
           # OCaml 5:
           ## ubuntu (x86)
-          - ocaml-compiler: 5.4.x
-            cache-prefix: 5.4.x
+          - ocaml-compiler: 5.5.x
+            cache-prefix: 5.5.x
             os: ubuntu-latest
             run_tests: true
           ## macos (Apple Silicon)
-          - ocaml-compiler: 5.4.x
-            cache-prefix: 5.4.x
+          - ocaml-compiler: 5.5.x
+            cache-prefix: 5.5.x
             os: macos-latest
             run_tests: true
           ## macos (x86)
-          - ocaml-compiler: 5.4.x
-            cache-prefix: 5.4.x
+          - ocaml-compiler: 5.5.x
+            cache-prefix: 5.5.x
             os: macos-15-intel
           ## MSVC
-          - ocaml-compiler: ocaml-compiler.5.4.0,system-msvc
+          - ocaml-compiler: ocaml-compiler.5.5.0,system-msvc
             os: windows-latest
-            cache-prefix: ocaml-compiler.5.4.0-system-msvc
+            cache-prefix: ocaml-compiler.5.5.0-system-msvc
             run_tests: true
           ## mingw
-          - ocaml-compiler: ocaml-base-compiler.5.4.0,system-mingw
+          - ocaml-compiler: ocaml-base-compiler.5.5.0,system-mingw
             os: windows-latest
-            cache-prefix: ocaml-compiler.5.4.0-system-mingw
+            cache-prefix: ocaml-compiler.5.5.0-system-mingw
             run_tests: true
           # OCaml 4:
           ## ubuntu (x86)

--- a/.github/workflows/workflow.yml.in
+++ b/.github/workflows/workflow.yml.in
@@ -22,7 +22,7 @@ jobs:
 #
 
   nix-build:
-    name: Bootstrap with OCaml 5.4
+    name: Bootstrap with OCaml 5.5
     strategy:
       fail-fast: false
       matrix:
@@ -161,28 +161,28 @@ jobs:
             os: ubuntu-latest
           # OCaml 5:
           ## ubuntu (x86)
-          - ocaml-compiler: 5.4.x
-            cache-prefix: 5.4.x
+          - ocaml-compiler: 5.5.x
+            cache-prefix: 5.5.x
             os: ubuntu-latest
             run_tests: true
           ## macos (Apple Silicon)
-          - ocaml-compiler: 5.4.x
-            cache-prefix: 5.4.x
+          - ocaml-compiler: 5.5.x
+            cache-prefix: 5.5.x
             os: macos-latest
             run_tests: true
           ## macos (x86)
-          - ocaml-compiler: 5.4.x
-            cache-prefix: 5.4.x
+          - ocaml-compiler: 5.5.x
+            cache-prefix: 5.5.x
             os: macos-15-intel
           ## MSVC
-          - ocaml-compiler: ocaml-compiler.5.4.0,system-msvc
+          - ocaml-compiler: ocaml-compiler.5.5.0,system-msvc
             os: windows-latest
-            cache-prefix: ocaml-compiler.5.4.0-system-msvc
+            cache-prefix: ocaml-compiler.5.5.0-system-msvc
             run_tests: true
           ## mingw
-          - ocaml-compiler: ocaml-base-compiler.5.4.0,system-mingw
+          - ocaml-compiler: ocaml-base-compiler.5.5.0,system-mingw
             os: windows-latest
-            cache-prefix: ocaml-compiler.5.4.0-system-mingw
+            cache-prefix: ocaml-compiler.5.5.0-system-mingw
             run_tests: true
           # OCaml 4:
           ## ubuntu (x86)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ DEV_DEPS := \
 core_bench \
 patdiff
 
-TEST_OCAMLVERSION := 5.4.0
+TEST_OCAMLVERSION := 5.5.0
 # When updating this version, don't forget to also bump the number in the docs.
 
 -include Makefile.dev

--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam:debian-13-ocaml-5.4
+FROM ocaml/opam:debian-13-ocaml-5.5
 RUN opam install csexp pp re spawn uutf ppx_expect lwt
 COPY --chown=opam:opam . bench-dir
 WORKDIR bench-dir

--- a/doc/tutorials/developing-with-dune/introduction.md
+++ b/doc/tutorials/developing-with-dune/introduction.md
@@ -44,7 +44,7 @@ Let's create a local switch: `cd` to this directory and run the following comman
 This can take a few minutes.
 
 ```sh
-opam switch create ./ 5.4.0
+opam switch create ./ 5.5.0
 ```
 
 This command has created a directory named `_opam` in the current directory.

--- a/flake.lock
+++ b/flake.lock
@@ -8,16 +8,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1783845564,
-        "narHash": "sha256-TJMxOC8ICF7Nlb9lW6giSsYvUnZkk6XYU3IRD/5ITGM=",
+        "lastModified": 1783843147,
+        "narHash": "sha256-lT+PtjJ6l6eQGhd/2szsj9alpV5tn/0uouC3OkeTeX0=",
         "owner": "melange-re",
         "repo": "melange",
-        "rev": "dfa8f1f7597f667b9d57e37142c1f52ce613b509",
+        "rev": "08cd3ca8fcc9ec2a75ebacb5f86f336467cd2e6c",
         "type": "github"
       },
       "original": {
         "owner": "melange-re",
-        "ref": "v7-54",
+        "ref": "v7-55",
         "repo": "melange",
         "type": "github"
       }
@@ -30,16 +30,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1783283171,
-        "narHash": "sha256-EjxyCRfVmvYikLTu4XQtSI/pnXUfcN9mS2RApOyNr6M=",
+        "lastModified": 1783838866,
+        "narHash": "sha256-6WDLbI7JSXTCFCj3oVqREtU8/c0D+92ULZUR0OrjLxE=",
         "owner": "melange-re",
         "repo": "melange-compiler-libs",
-        "rev": "016addf9f5586b2e3fdf4cfb394c65f748df01a3",
+        "rev": "1a75cd25bb0816c047941be084bf5f9527cbbf05",
         "type": "github"
       },
       "original": {
         "owner": "melange-re",
-        "ref": "5.4",
+        "ref": "5.5",
         "repo": "melange-compiler-libs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     melange = {
-      url = "github:melange-re/melange/v7-54";
+      url = "github:melange-re/melange/v7-55";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     ocaml-overlays = {
@@ -42,13 +42,11 @@
         nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (
           system:
           let
-            # Vanilla nixpkgs scope used to source packages we want to take
-            # ahead of what `ocaml-overlays` ships (e.g. odoc 3.2.1).
-            nixpkgsOcaml = nixpkgs.legacyPackages.${system}.ocaml-ng.ocamlPackages_5_4;
+            nixpkgsOcaml = nixpkgs.legacyPackages.${system}.ocaml-ng.ocamlPackages_5_5;
             pkgs = nixpkgs.legacyPackages.${system}.appendOverlays [
               ocaml-overlays.overlays.default
               (self: super: {
-                ocamlPackages = super.ocaml-ng.ocamlPackages_5_4.overrideScope (
+                ocamlPackages = super.ocaml-ng.ocamlPackages_5_5.overrideScope (
                   oself: osuper: {
                     ocaml = osuper.ocaml.override {
                       flambdaSupport = false;
@@ -58,13 +56,18 @@
                       dontGzipMan = true;
                     };
                     odoc-parser = osuper.odoc-parser.overrideAttrs (old: {
-                      inherit (nixpkgsOcaml.odoc-parser) version src;
                       doCheck = false;
                     });
                     odoc = osuper.odoc.overrideAttrs (old: {
-                      inherit (nixpkgsOcaml.odoc) version src;
                       doCheck = false;
                     });
+                    # nix-overlays uses a post-0.38.0 ppxlib commit that no
+                    # longer depends on stdlib-shims. Use nixpkgs' 0.38.0
+                    # release source to match opam and keep `dune describe`
+                    # output independent of the package manager.
+                    ppxlib = osuper.ppxlib.overrideAttrs {
+                      inherit (nixpkgsOcaml.ppxlib) version src;
+                    };
                     # Templates the cross-compiled dune binary used by
                     # `windows-static`. Lives at the top-level scope so
                     # `nix-overlays`' cross-overlay sees it during scope
@@ -74,16 +77,16 @@
                     dune_target = oself.callPackage ./nix/dune-target.nix { };
                   }
                 );
-                # Keep `ocaml-ng.ocamlPackages_5_4` in sync with the override
+                # Keep `ocaml-ng.ocamlPackages_5_5` in sync with the override
                 # above. nix-overlays' `cross/ocaml.nix:46` looks up the native
-                # OCaml via `buildPackages.ocaml-ng."ocamlPackages_5_4"`, so
+                # OCaml via `buildPackages.ocaml-ng."ocamlPackages_5_5"`, so
                 # without this the cross-target side uses our overridden ocaml
                 # while the native side (used to build findlib's `nativeBuild-
                 # Inputs` etc.) uses the unoverridden ocaml+flambda — the
                 # mismatch shows up as cross `ocamlopt` rejecting native
                 # `topdirs.cmx` ("not a compilation unit description").
                 ocaml-ng = super.ocaml-ng // {
-                  ocamlPackages_5_4 = self.ocamlPackages;
+                  ocamlPackages_5_5 = self.ocamlPackages;
                 };
               })
               melange.overlays.default

--- a/nix/dune-package.nix
+++ b/nix/dune-package.nix
@@ -50,7 +50,7 @@ let
   # `nix-overlays` applies its cross-overlay to `pkgsCross.musl64` (it
   # currently only applies the static-overlay) we can move this over too.
   dune-static-overlay = self: super: {
-    ocamlPackages = super.ocaml-ng.ocamlPackages_5_4.overrideScope (
+    ocamlPackages = super.ocaml-ng.ocamlPackages_5_5.overrideScope (
       oself: osuper: {
         ocaml = osuper.ocaml.override {
           flambdaSupport = false;
@@ -85,20 +85,25 @@ let
               # ocaml itself excludes mingw via `meta.platforms`. Widen it
               # so cross builds against this scope evaluate.
               ocaml = osuper.ocaml.overrideAttrs (o: {
-                meta = (o.meta or { }) // { platforms = lib.platforms.all; };
+                meta = (o.meta or { }) // {
+                  platforms = lib.platforms.all;
+                };
               });
               buildDunePackage =
                 arg:
                 let
-                  widen = a: a // {
-                    meta = (a.meta or { }) // { platforms = lib.platforms.all; };
-                  };
+                  widen =
+                    a:
+                    a
+                    // {
+                      meta = (a.meta or { }) // {
+                        platforms = lib.platforms.all;
+                      };
+                    };
                 in
                 # nix-overlays' `buildDunePackage` accepts either an attrset
                 # or a `final: attrset` function (see `cross/ocaml.nix`).
-                osuper.buildDunePackage (
-                  if builtins.isFunction arg then final: widen (arg final) else widen arg
-                );
+                osuper.buildDunePackage (if builtins.isFunction arg then final: widen (arg final) else widen arg);
             }
           );
         })

--- a/nix/revdeps.nix
+++ b/nix/revdeps.nix
@@ -15,7 +15,7 @@ let
     });
     dune = final.dune_3;
 
-    ocamlPackages = prev.ocaml-ng.ocamlPackages_5_4.overrideScope (
+    ocamlPackages = prev.ocaml-ng.ocamlPackages_5_5.overrideScope (
       oself: osuper:
       let
         # Helper to build dune subpackages from revdeps-dune source
@@ -159,7 +159,7 @@ let
   # Get filtered candidates using nix-overlays' logic
   candidates = filter.ocamlCandidates {
     pkgs = pkgsPermissive;
-    ocamlVersion = "5_4";
+    ocamlVersion = "5_5";
   };
 
   # Filter to only packages available on current platform

--- a/test/blackbox-tests/test-cases/expand-make.t
+++ b/test/blackbox-tests/test-cases/expand-make.t
@@ -6,6 +6,7 @@ This needs special setup to have a PATH which does not contain a gmake binary,
 in case the system PATH has one. Instead of prepending to PATH we create a bin/
 subdirectory with links to all the executables dune needs.
 
+  $ export OCAMLLIB=$(ocamlc -where)
   $ mkdir make gmake bin
 
   $ for prog in dune ocamlc sh; do

--- a/test/blackbox-tests/test-cases/melange/missing-melc-install.t
+++ b/test/blackbox-tests/test-cases/melange/missing-melc-install.t
@@ -2,9 +2,10 @@ Test multi-mode single context installed packages when melc is not available
 
 Set up an environment that deliberately hides melc.
 
+  $ export OCAMLLIB=$(ocamlc -where)
   $ mkdir _path
   $ for bin in dune ocamlc ocamldep ocamlopt ocamlobjinfo git gcc ar as ranlib \
-  >   clang cc ld; do
+  >   clang cc ld sh; do
   >   if command -v "$bin" > /dev/null; then
   >     ln -s "$(command -v "$bin")" _path/
   >   fi

--- a/test/blackbox-tests/test-cases/melange/missing-melc.t
+++ b/test/blackbox-tests/test-cases/melange/missing-melc.t
@@ -9,8 +9,9 @@ Test cases when melc is not available
 
 Set up some fake environment without melc
 
+  $ export OCAMLLIB=$(ocamlc -where)
   $ mkdir _path
-  $ for bin in dune ocamlc ocamldep ocamlopt ocamlobjinfo; do
+  $ for bin in dune ocamlc ocamldep ocamlopt ocamlobjinfo sh; do
   >   if command -v "$bin" > /dev/null; then
   >     ln -s "$(command -v "$bin")" _path/
   >   fi
@@ -26,7 +27,7 @@ For melange.emit stanzas, an error is shown
   >  (alias mel))
   > EOF
 
-  $ (unset INSIDE_DUNE; PATH=_path dune build --always-show-command-line --root . @mel 2>&1 | grep Program)
+  $ (unset INSIDE_DUNE; PATH=$PWD/_path dune build --always-show-command-line --root . @mel 2>&1 | grep Program)
   Error: Program melc not found in the tree or in PATH
   [1]
 
@@ -53,7 +54,7 @@ For libraries, if no melange.emit stanza is found, build does not fail
   > let t = "hello from native"
   > EOF
 
-  $ (unset INSIDE_DUNE; PATH=_path dune build --display progress --always-show-command-line --root . main_native.bc)
+  $ (unset INSIDE_DUNE; PATH=$PWD/_path dune build --display progress --always-show-command-line --root . main_native.bc)
   $ dune exec ./main_native.bc
   hello from native
 
@@ -76,13 +77,13 @@ If melange.emit stanza is found, but no rules are executed, build does not fail
   >  (libraries lib1))
   > EOF
 
-  $ (unset INSIDE_DUNE; PATH=_path dune build --display progress --always-show-command-line --root . main_native.bc)
+  $ (unset INSIDE_DUNE; PATH=$PWD/_path dune build --display progress --always-show-command-line --root . main_native.bc)
   $ dune exec ./main_native.bc
   hello from native
 
 But trying to build any melange artifacts will fail
 
-  $ (unset INSIDE_DUNE; PATH=_path dune build --display progress  --always-show-command-line --root . output/main_melange.js)
+  $ (unset INSIDE_DUNE; PATH=$PWD/_path dune build --display progress  --always-show-command-line --root . output/main_melange.js)
   File "dune", lines 10-14, characters 0-94:
   10 | (melange.emit
   11 |  (target output)

--- a/test/blackbox-tests/test-cases/odoc/odoc-no-sherlodoc.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/odoc-no-sherlodoc.t/run.t
@@ -3,6 +3,7 @@ sherlodoc installation to test what happens when sherlodoc is not installed.
 
 Set up some fake environment without sherlodoc
 
+  $ export OCAMLLIB=$(ocamlc -where)
   $ mkdir _path
   $ ln -s $(command -v dune) _path/
   $ ln -s $(command -v ocamlc) _path/
@@ -61,4 +62,3 @@ This test if `.odocl` files are generated
   {1 Library bar}
   The entry point of this library is the module:
   {!module-Bar}.
-

--- a/test/blackbox-tests/test-cases/package-dep.t
+++ b/test/blackbox-tests/test-cases/package-dep.t
@@ -1,5 +1,6 @@
 Tests package-scoped library dependencies.
 
+  $ export OCAMLFIND_LDCONF=ignore
   $ make_dune_project 1.0
 
   $ cat >foo.opam

--- a/test/blackbox-tests/test-cases/ppx/ppx-rewriter.t/run.t
+++ b/test/blackbox-tests/test-cases/ppx/ppx-rewriter.t/run.t
@@ -1,3 +1,4 @@
+  $ export OCAMLFIND_LDCONF=ignore
   $ dune build ./w_omp_driver.exe
   -arg: omp
 

--- a/test/blackbox-tests/test-cases/print-diff.t
+++ b/test/blackbox-tests/test-cases/print-diff.t
@@ -76,6 +76,7 @@ addition to unsetting INSIDE_DUNE, we also need to pass
   > false
   > EOF
   $ chmod +x _tools/fail
+  $ export OCAMLLIB=$(ocamlc -where)
   $ mkdir _path
   $ ln -s $(command -v dune) _path/
   $ ln -s $(command -v ocamlc) _path/

--- a/test/blackbox-tests/test-cases/use-meta.t/run.t
+++ b/test/blackbox-tests/test-cases/use-meta.t/run.t
@@ -1,4 +1,5 @@
 Tests use_meta with installed libraries.
 
+  $ export OCAMLFIND_LDCONF=ignore
   $ dune build @install && dune exec -- ocamlfind opt -package foobarlib -linkpkg main.ml -o main.exe && ./main.exe
   foobarlib


### PR DESCRIPTION
## Description

Update the OCaml version used by CI and development tooling from 5.4 to 5.5.

This updates the opam CI matrix, benchmark workflow, local development switch,
tutorial, and Nix development shell. The flake inputs are refreshed for the
matching Melange 5.5 stack and include the MinGW OCaml 5.5 fixes needed by the
static Windows package set.

### Package-set consistency

`nix-overlays` selects a post-0.38.0 ppxlib commit that no longer depends on
`stdlib-shims`, while opam installs the official ppxlib 0.38.0 release that
still declares this dependency. This made `dune describe` report different
dependency graphs in the two CI environments.

The Nix package set now uses nixpkgs ppxlib 0.38.0 release source, matching
opam and keeping the `stdlib-shims` dependency graph consistent across package
managers.

### OCaml 5.5 test compatibility

OCaml 5.5 relocatable compiler lookup fails in tests that construct a restricted
`PATH` from symlinked compiler tools. Those tests now capture the real standard
library directory in `OCAMLLIB` before replacing `PATH`.

Findlib 1.9.8 also warns about the relative stub-library entries in OCaml 5.5
`ld.conf`. Tests that invoke findlib without exercising stub lookup set
`OCAMLFIND_LDCONF=ignore`, preventing those unrelated warnings from changing
cram output.

## Related Issue and Motivation

The OCaml 5 release tested by CI and used by local development should track the
current release.

Fixes #15445

## Validation

- `./dune.exe build @check @fmt @runtest`
- Affected cram tests under the OCaml 5.5 Nix shell
- Nix ppxlib and its reverse-dependency closure
- `git diff --check`

## Checklist

- [x] Existing tests cover the affected behavior.
- [x] No changelog entry is required for CI and test-environment changes.
- [x] The development tutorial uses OCaml 5.5.