### PR TITLE
Add a dependency graph and a describe pkg tree command

### DIFF
--- a/bin/describe/describe_pkg.ml
+++ b/bin/describe/describe_pkg.ml
@@ -199,10 +199,61 @@ module List_locked_dependencies = struct
   let command = Cmd.v info term
 end
 
+module Tree = struct
+  module Package_universe = Dune_pkg.Package_universe
+  module Dependency_graph = Dune_pkg.Dependency_graph
+
+  let info =
+    let doc = "Display the dependency tree of the packages in a lockdir" in
+    let man = [ `S "DESCRIPTION"; `P doc ] in
+    Cmd.info "tree" ~doc ~man
+  ;;
+
+  let print_tree context_name () =
+    let open Fiber.O in
+    let* lock_dir_with_path, local_packages =
+      Build.build_memo_exn (fun () ->
+        Memo.both
+          (Dune_rules.Lock_dir.get_with_path context_name)
+          Pkg.Pkg_common.find_local_packages)
+    in
+    let lock_dir_path, lock_dir = User_error.ok_exn lock_dir_with_path in
+    let+ platform = Pkg.Pkg_common.solver_env_from_system_and_context ~lock_dir_path in
+    let package_universe =
+      Package_universe.create ~platform local_packages lock_dir |> User_error.ok_exn
+    in
+    let pp =
+      Pp.vbox
+        (Pp.concat
+           ~sep:Pp.cut
+           [ Pp.hbox
+               (Pp.textf
+                  "Dependency tree of local packages locked in %s"
+                  (Path.to_string_maybe_quoted lock_dir_path))
+           ; Dependency_graph.create package_universe |> Dependency_graph.pp_deps_tree
+           ])
+    in
+    Console.print [ pp ]
+  ;;
+
+  let term =
+    let+ builder = Common.Builder.term
+    and+ context_name = Common.context_arg ~doc:(Some "Build context to use.") in
+    let common, config = Common.init builder in
+    Scheduler_setup.go_with_rpc_server ~common ~config @@ print_tree context_name
+  ;;
+
+  let command = Cmd.v info term
+end
+
 let command =
   let doc = "Subcommands related to package management" in
   let info = Cmd.info ~doc "pkg" in
   Cmd.group
     info
-    [ Show_lock.command; List_locked_dependencies.command; Dependency_hash.command ]
+    [ Show_lock.command
+    ; List_locked_dependencies.command
+    ; Tree.command
+    ; Dependency_hash.command
+    ]
 ;;

--- a/doc/changes/added/15445.md
+++ b/doc/changes/added/15445.md
@@ -1,0 +1,4 @@
+- Add `dune describe pkg tree` to display the dependency tree of the local
+  packages in a lockdir. Each package's subtree is expanded once, and packages
+  occurring more than once are annotated with an occurrence count.
+  (#15445, @Sudha247)

--- a/src/dune_pkg/dependency_graph.ml
+++ b/src/dune_pkg/dependency_graph.ml
@@ -1,0 +1,203 @@
+open Import
+
+type t =
+  { roots : Package_name.t list
+  ; forward : Package_name.t list Package_name.Map.t
+  ; reverse : Package_name.t list Package_name.Map.t
+  ; opam_packages : OpamPackage.t Package_name.Map.t
+  }
+
+let roots t = t.roots
+
+let dependencies t package_name =
+  Package_name.Map.find t.forward package_name |> Option.value ~default:[]
+;;
+
+let dependents t package_name =
+  Package_name.Map.find t.reverse package_name |> Option.value ~default:[]
+;;
+
+let opam_package t package_name = Package_name.Map.find_exn t.opam_packages package_name
+let name_repr = Repr.abstract Package_name.to_dyn
+
+let name_map_repr value_repr =
+  Repr.view (Repr.list (Repr.pair name_repr value_repr)) ~to_:Package_name.Map.to_list
+;;
+
+let repr =
+  Repr.record
+    "dependency-graph"
+    [ Repr.field "roots" (Repr.list name_repr) ~get:(fun t -> t.roots)
+    ; Repr.field "forward" (name_map_repr (Repr.list name_repr)) ~get:(fun t -> t.forward)
+    ; Repr.field "reverse" (name_map_repr (Repr.list name_repr)) ~get:(fun t -> t.reverse)
+    ; Repr.field
+        "packages"
+        (name_map_repr (Repr.abstract Opam_dyn.package))
+        ~get:(fun t -> t.opam_packages)
+    ]
+;;
+
+let to_dyn = Repr.to_dyn repr
+
+(* Local packages are not present in the lockdir, so their dependencies must be
+   resolved through the package universe. Locked package dependencies can be read
+   directly from the lockdir because they have already been solved for this
+   platform. *)
+let immediate_dependencies
+      package_universe
+      ~local_packages
+      ~platform_pkgs
+      ~platform
+      package_name
+  =
+  let deps =
+    if Package_name.Map.mem local_packages package_name
+    then
+      Package_universe.opam_package_dependencies_of_package
+        package_universe
+        package_name
+        ~which:`All
+        ~traverse:`Immediate
+      |> List.map ~f:(fun opam_package ->
+        Package_name.of_opam_package_name (OpamPackage.name opam_package))
+    else (
+      match Package_name.Map.find platform_pkgs package_name with
+      | None -> []
+      | Some (pkg : Lock_dir.Pkg.t) ->
+        Lock_dir.Conditional_choice.choose_for_platform pkg.depends ~platform
+        |> Option.value ~default:[]
+        |> List.filter_map ~f:(fun (dep : Lock_dir.Dependency.t) ->
+          Option.some_if
+            (Package_name.Map.mem platform_pkgs dep.name
+             || Package_name.Map.mem local_packages dep.name)
+            dep.name))
+  in
+  List.sort deps ~compare:Package_name.compare
+;;
+
+let create package_universe =
+  let local_packages = Package_universe.local_packages package_universe in
+  let platform = Package_universe.platform package_universe in
+  let lock_dir = Package_universe.lock_dir package_universe in
+  let platform_pkgs =
+    Lock_dir.Packages.pkgs_on_platform_by_name lock_dir.packages ~platform
+  in
+  let roots = Package_name.Map.keys local_packages in
+  (* Expand each reachable package once so graph construction shares work across
+     repeated dependencies and terminates on local dependency cycles. *)
+  let rec collect (forward, reverse, opam_packages, seen) package_name =
+    if Package_name.Set.mem seen package_name
+    then forward, reverse, opam_packages, seen
+    else (
+      let seen = Package_name.Set.add seen package_name in
+      let deps =
+        immediate_dependencies
+          package_universe
+          ~local_packages
+          ~platform_pkgs
+          ~platform
+          package_name
+      in
+      let forward = Package_name.Map.set forward package_name deps in
+      let opam_packages =
+        Package_name.Map.set
+          opam_packages
+          package_name
+          (Package_universe.opam_package_of_package package_universe package_name)
+      in
+      let reverse =
+        List.fold_left deps ~init:reverse ~f:(fun reverse dep ->
+          Package_name.Map.add_multi reverse dep package_name)
+      in
+      List.fold_left deps ~init:(forward, reverse, opam_packages, seen) ~f:collect)
+  in
+  let forward, reverse, opam_packages, _seen =
+    List.fold_left
+      roots
+      ~init:
+        ( Package_name.Map.empty
+        , Package_name.Map.empty
+        , Package_name.Map.empty
+        , Package_name.Set.empty )
+      ~f:collect
+  in
+  { roots; forward; reverse; opam_packages }
+;;
+
+(* A cycle makes the fully-expanded dependency tree infinite, so occurrence
+   counts are intentionally omitted for packages reached through a cycle. *)
+let occurrences t =
+  let root_set = Package_name.Set.of_list t.roots in
+  let cache = ref Package_name.Map.empty in
+  let rec occurrences ~visiting package_name =
+    match Package_name.Map.find !cache package_name with
+    | Some n -> Some n
+    | None ->
+      if Package_name.Set.mem visiting package_name
+      then None
+      else (
+        let visiting = Package_name.Set.add visiting package_name in
+        let from_roots = if Package_name.Set.mem root_set package_name then 1 else 0 in
+        let n =
+          dependents t package_name
+          |> List.fold_left ~init:(Some from_roots) ~f:(fun acc parent ->
+            let open Option.O in
+            let* acc = acc in
+            let+ n = occurrences ~visiting parent in
+            acc + n)
+        in
+        Option.iter n ~f:(fun n -> cache := Package_name.Map.set !cache package_name n);
+        n)
+  in
+  fun package_name -> occurrences ~visiting:Package_name.Set.empty package_name
+;;
+
+(* [visited] is shared across roots so repeated packages collapse to a leaf.
+   [visiting] is path-local so only edges closing a real cycle are marked. *)
+let pp_tree t ~adjacency start =
+  let occurrences = occurrences t in
+  let label ~cyclic package_name =
+    let name = OpamPackage.to_string (opam_package t package_name) in
+    if cyclic
+    then sprintf "%s (cycle)" name
+    else (
+      match occurrences package_name with
+      | Some n when n > 1 -> sprintf "%s (*%d)" name n
+      | Some _ | None -> name)
+  in
+  let rec node ~visiting visited package_name =
+    if Package_name.Set.mem visiting package_name
+    then visited, Pp.text (label ~cyclic:true package_name)
+    else if Package_name.Set.mem visited package_name
+    then visited, Pp.text (label ~cyclic:false package_name)
+    else (
+      let visited = Package_name.Set.add visited package_name in
+      let visiting = Package_name.Set.add visiting package_name in
+      let children =
+        Package_name.Map.find adjacency package_name |> Option.value ~default:[]
+      in
+      match children with
+      | [] -> visited, Pp.text (label ~cyclic:false package_name)
+      | _ :: _ ->
+        let visited, children =
+          List.fold_map children ~init:visited ~f:(node ~visiting)
+        in
+        ( visited
+        , Pp.vbox
+            (Pp.concat
+               ~sep:Pp.cut
+               [ Pp.hbox (Pp.text (label ~cyclic:false package_name))
+               ; Pp.enumerate children ~f:Fun.id |> Pp.box
+               ]) ))
+  in
+  List.fold_map
+    start
+    ~init:Package_name.Set.empty
+    ~f:(node ~visiting:Package_name.Set.empty)
+  |> snd
+  |> Pp.enumerate ~f:Fun.id
+  |> Pp.box
+;;
+
+let pp_deps_tree t = pp_tree t ~adjacency:t.forward t.roots
+let pp_why t package_name = pp_tree t ~adjacency:t.reverse [ package_name ]

--- a/src/dune_pkg/dependency_graph.mli
+++ b/src/dune_pkg/dependency_graph.mli
@@ -1,0 +1,36 @@
+(** The dependency graph of the local packages of a lockdir together with all
+    their transitive dependencies. Nodes are packages; edges are the "depends
+    on" relation. The graph may contain cycles (only between local packages; the
+    lockdir itself is acyclic). *)
+type t
+
+val create : Package_universe.t -> t
+
+(** The local packages, i.e. the roots of the forward dependency graph. *)
+val roots : t -> Package_name.t list
+
+(** Immediate dependencies of a package (forward edges). *)
+val dependencies : t -> Package_name.t -> Package_name.t list
+
+(** Immediate dependents of a package: the packages that directly depend on it
+    (reverse edges). Empty for a package that nothing depends on. *)
+val dependents : t -> Package_name.t -> Package_name.t list
+
+(** The [name.version] of a package in the graph. *)
+val opam_package : t -> Package_name.t -> OpamPackage.t
+
+val to_dyn : t -> Dyn.t
+
+(** Render the forward dependency tree: one entry per local package (root). A
+    package's subtree is expanded only the first time it is encountered; later
+    encounters show just the package with its occurrence count as "(*N)", and
+    an edge closing a dependency cycle is marked "(cycle)". No count is shown
+    for packages involved in a cycle, where the count is not well-defined. This
+    is the view rendered by [dune describe pkg tree]. *)
+val pp_deps_tree : t -> _ Pp.t
+
+(** Render the reverse ("why is this package installed?") tree rooted at
+    [package]: its children are the packages that directly depend on it,
+    recursively up to the local roots. Deduplicated and cycle-closing entries
+    are marked as in [pp_deps_tree]. [package] must be present in the graph. *)
+val pp_why : t -> Package_name.t -> _ Pp.t

--- a/src/dune_pkg/dune_pkg.ml
+++ b/src/dune_pkg/dune_pkg.ml
@@ -19,6 +19,7 @@ module Package_version = Package_version
 module Pkg_workspace = Workspace
 module Local_package = Local_package
 module Package_universe = Package_universe
+module Dependency_graph = Dependency_graph
 module Variable_value = Variable_value
 module Resolved_package = Resolved_package
 module Pin = Pin

--- a/src/dune_pkg/package_universe.ml
+++ b/src/dune_pkg/package_universe.ml
@@ -7,6 +7,10 @@ type t =
   ; version_by_package_name : Package_version.t Package_name.Map.t
   }
 
+let local_packages t = t.local_packages
+let lock_dir t = t.lock_dir
+let platform t = t.platform
+
 let lockdir_regenerate_hints =
   [ Pp.concat
       ~sep:Pp.space

--- a/src/dune_pkg/package_universe.mli
+++ b/src/dune_pkg/package_universe.mli
@@ -14,6 +14,15 @@ val create
   -> Lock_dir.t
   -> (t, User_message.t) result
 
+(** The local packages this universe was created from. *)
+val local_packages : t -> Local_package.t Package_name.Map.t
+
+(** The lock directory this universe was created from. *)
+val lock_dir : t -> Lock_dir.t
+
+(** The platform this universe was created for. *)
+val platform : t -> Solver_env.t
+
 val dependency_digest
   :  Local_package.t Package_name.Map.t
   -> Local_package.Dependency_hash.t option

--- a/test/blackbox-tests/test-cases/pkg/describe-pkg-tree.t
+++ b/test/blackbox-tests/test-cases/pkg/describe-pkg-tree.t
@@ -1,0 +1,273 @@
+Test that "dune describe pkg tree" recursively displays the dependency tree of
+each local package.
+
+  $ mkrepo
+
+  $ mkpkg a 0.0.1 <<EOF
+  > EOF
+  $ mkpkg b <<EOF
+  > EOF
+  $ mkpkg c <<EOF
+  > EOF
+  $ mkpkg bar <<EOF
+  > depends: [ "b" "c"]
+  > EOF
+  $ mkpkg baz <<EOF
+  > depends: [ "bar" ]
+  > EOF
+  $ mkpkg qux <<EOF
+  > depends: [ "a" "b" "c" ]
+  > EOF
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name local_1)
+  >  (depends
+  >   local_2))
+  > (package
+  >  (name local_2)
+  >  (depends
+  >   baz
+  >   (qux :with-test)))
+  > EOF
+  Solution for dune.lock:
+  - a.0.0.1
+  - b.0.0.1
+  - bar.0.0.1
+  - baz.0.0.1
+  - c.0.0.1
+  - qux.0.0.1
+
+The tree is printed recursively. Each package's subtree is expanded only the
+first time it is encountered; later occurrences print just the package, and the
+number of times a package occurs in the full tree is shown as "(*N)". For
+example "b" and "c" occur 4 times each, and "local_2" is both a local package
+and a dependency of "local_1" so it occurs twice.
+
+  $ dune describe pkg tree
+  Dependency tree of local packages locked in _build/_private/default/.lock/dune.lock
+  - local_1.dev
+    - local_2.dev (*2)
+      - baz.0.0.1 (*2)
+        - bar.0.0.1 (*2)
+          - b.0.0.1 (*4)
+          - c.0.0.1 (*4)
+      - qux.0.0.1 (*2)
+        - a.0.0.1 (*2)
+        - b.0.0.1 (*4)
+        - c.0.0.1 (*4)
+  - local_2.dev (*2)
+
+Two local packages that are both roots, where "proj_a" depends on "proj_b". The
+subtree of "proj_b" is expanded under "proj_a"; its second, top-level occurrence
+is collapsed to a leaf. This confirms top-level roots are collapsed like any
+other repeated package.
+
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > (package (name proj_a) (depends proj_b))
+  > (package (name proj_b) (depends c))
+  > EOF
+  Solution for dune.lock:
+  - c.0.0.1
+  $ dune describe pkg tree
+  Dependency tree of local packages locked in _build/_private/default/.lock/dune.lock
+  - proj_a.dev
+    - proj_b.dev (*2)
+      - c.0.0.1 (*2)
+  - proj_b.dev (*2)
+
+A local package ("alpha") depending on a locked package ("beta") that in turn
+depends back on a local package ("gamma") is not a supported workspace: dune
+rejects a package outside the workspace depending on one inside it, so this
+topology never reaches the dependency tree.
+
+  $ mkpkg beta <<EOF
+  > depends: [ "gamma" ]
+  > EOF
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > (package (name alpha) (depends beta))
+  > (package (name gamma))
+  > EOF
+  Error: Dune does not support packages outside the workspace depending on
+  packages in the workspace. The package "beta" is not in the workspace but it
+  depends on the package "gamma" which is in the workspace.
+  [1]
+
+A dependency cycle between two local packages. The graph tolerates cycles: each
+package is expanded once and the edge that closes the cycle is marked "(cycle)"
+instead of looping. Occurrence counts are not shown for packages involved in a
+cycle, where they are not well-defined.
+
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > (package (name left) (depends right))
+  > (package (name right) (depends left))
+  > EOF
+  Solution for dune.lock:
+  (no dependencies to lock)
+  $ dune describe pkg tree
+  Dependency tree of local packages locked in _build/_private/default/.lock/dune.lock
+  - left.dev
+    - right.dev
+      - left.dev (cycle)
+  - right.dev
+
+A local package "app" with ten dependencies that all share a common dependency
+"x". "x" is expanded once and its occurrence count reflects that it is reached
+through all ten dependencies.
+
+  $ mkpkg x <<EOF
+  > EOF
+  $ for i in 0 1 2 3 4 5 6 7 8 9; do
+  >   echo 'depends: [ "x" ]' | mkpkg dep$i
+  > done
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name app)
+  >  (depends dep0 dep1 dep2 dep3 dep4 dep5 dep6 dep7 dep8 dep9))
+  > EOF
+  Solution for dune.lock:
+  - dep0.0.0.1
+  - dep1.0.0.1
+  - dep2.0.0.1
+  - dep3.0.0.1
+  - dep4.0.0.1
+  - dep5.0.0.1
+  - dep6.0.0.1
+  - dep7.0.0.1
+  - dep8.0.0.1
+  - dep9.0.0.1
+  - x.0.0.1
+  $ dune describe pkg tree
+  Dependency tree of local packages locked in _build/_private/default/.lock/dune.lock
+  - app.dev
+    - dep0.0.0.1
+      - x.0.0.1 (*10)
+    - dep1.0.0.1
+      - x.0.0.1 (*10)
+    - dep2.0.0.1
+      - x.0.0.1 (*10)
+    - dep3.0.0.1
+      - x.0.0.1 (*10)
+    - dep4.0.0.1
+      - x.0.0.1 (*10)
+    - dep5.0.0.1
+      - x.0.0.1 (*10)
+    - dep6.0.0.1
+      - x.0.0.1 (*10)
+    - dep7.0.0.1
+      - x.0.0.1 (*10)
+    - dep8.0.0.1
+      - x.0.0.1 (*10)
+    - dep9.0.0.1
+      - x.0.0.1 (*10)
+
+A workspace with a single local package and no dependencies at all: the tree is
+just the header and one leaf line.
+
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > (package (name solo))
+  > EOF
+  Solution for dune.lock:
+  (no dependencies to lock)
+  $ dune describe pkg tree
+  Dependency tree of local packages locked in _build/_private/default/.lock/dune.lock
+  - solo.dev
+
+A cycle deeper in the tree: "a_top" depends on "b_mid", "b_mid" on "c_bot", and
+"c_bot" both closes the cycle back to "b_mid" and depends on the locked package
+"x" below the cycle. The cycle edge is marked at depth 3 and "x" is still
+printed; occurrence counts are suppressed for every package affected by the
+cycle ("a_top" is unaffected).
+
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > (package (name a_top) (depends b_mid))
+  > (package (name b_mid) (depends c_bot))
+  > (package (name c_bot) (depends b_mid x))
+  > EOF
+  Solution for dune.lock:
+  - x.0.0.1
+  $ dune describe pkg tree
+  Dependency tree of local packages locked in _build/_private/default/.lock/dune.lock
+  - a_top.dev
+    - b_mid.dev
+      - c_bot.dev
+        - b_mid.dev (cycle)
+        - x.0.0.1
+  - b_mid.dev
+  - c_bot.dev
+
+A package that depends on itself: the tightest possible cycle, a self-loop
+edge.
+
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > (package (name selfy) (depends selfy))
+  > EOF
+  Solution for dune.lock:
+  (no dependencies to lock)
+  $ dune describe pkg tree
+  Dependency tree of local packages locked in _build/_private/default/.lock/dune.lock
+  - selfy.dev
+    - selfy.dev (cycle)
+
+A cycle of three packages: "ring_a" depends on "ring_b", which depends on
+"ring_c", which closes the cycle back to "ring_a".
+
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > (package (name ring_a) (depends ring_b))
+  > (package (name ring_b) (depends ring_c))
+  > (package (name ring_c) (depends ring_a))
+  > EOF
+  Solution for dune.lock:
+  (no dependencies to lock)
+  $ dune describe pkg tree
+  Dependency tree of local packages locked in _build/_private/default/.lock/dune.lock
+  - ring_a.dev
+    - ring_b.dev
+      - ring_c.dev
+        - ring_a.dev (cycle)
+  - ring_b.dev
+  - ring_c.dev
+
+A workspace with no local packages at all: the tree below the header is empty.
+
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > EOF
+  Solution for dune.lock:
+  (no dependencies to lock)
+  $ dune describe pkg tree
+  Dependency tree of local packages locked in _build/_private/default/.lock/dune.lock
+  
+
+With package management enabled and no committed lockdir, "dune describe pkg
+tree" autolocks on demand and displays the generated lockdir's dependency tree.
+
+  $ mkdir autolock
+  $ cd autolock
+  $ mkrepo
+  $ mkpkg shared <<EOF
+  > EOF
+  $ mkpkg dep <<EOF
+  > depends: [ "shared" ]
+  > EOF
+  $ add_mock_repo_if_needed
+  $ cat > dune-project <<EOF
+  > (lang dune 3.20)
+  > (package
+  >  (name app)
+  >  (depends dep))
+  > EOF
+  $ enable_pkg
+  $ dune describe pkg tree
+  Dependency tree of local packages locked in _build/_private/default/.lock/dune.lock
+  - app.dev
+    - dep.0.0.1
+      - shared.0.0.1


### PR DESCRIPTION
<!-- Thank you for contributing to dune!

 For general guidelines on contributing to dune, see
 https://github.com/ocaml/dune/blob/main/CONTRIBUTING.md#developing-dune -->

## Description
<!-- Briefly describe your changes -->

This adds a command to display the dependency tree of the lockdir dependencies. This is inspired by `dune pkg tree` described in @samoht's [RFC](https://gist.github.com/samoht/41d8c37936297109e0d1263041ee66b6), and a similar command in OPAM, `opam tree`. It gives users a direct way to inspect why packages appear in a lockdir and how local packages depend on the  locked package graph.

### Summary of changes
  - Add `dune describe pkg tree` to print the dependency tree of local packages in a lockdir.
  - Add `Dune_pkg.Dependency_graph`, which records forward and reverse package dependency edges for local packages and their transitive locked dependencies. The reverse edges are recorded for a potential future `dune describe pkg why` command that shows the chain of why a package is installed.
  - Repeated packages are collapsed after their first expansion and annotate them with occurrence counts.
  - Detect local package dependency cycles and mark cycle-closing edges without recursing indefinitely.
  - Add cram coverage for shared dependencies, repeated local roots, empty projects, and local dependency cycles.
  
## Related Issue and Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it closes an open issue, link to the issue here. -->
<!-- Non-trivial contributions are expected to be preceded by an issue, as
     per CONTRIBUTING.md. -->

Fixes #15382 

## Checklist

- [x] Tests added, if applicable.
- [x] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [ ] Documentation added for any user-facing changes.
