### PR TITLE
doc: clarify dune runtest context selection

### DIFF
--- a/doc/explanation/mental-model.rst
+++ b/doc/explanation/mental-model.rst
@@ -128,9 +128,11 @@ Dune can build *files* and *aliases*. These can be found on the command line:
 - ``dune build @example`` will build the ``example`` alias.
 - ``dune build tool.exe @example`` will build both the file ``tool.exe`` and
   the ``example`` alias.
-- ``dune runtest`` is a shortcut for ``dune build @runtest``: it will build the
-  ``runtest`` alias. Passing a directory will build all tests in that directory.
-  Passing the path to a cram test will run that test individually.
+- ``dune runtest`` will build the ``runtest`` alias using the test command's
+  path handling. Passing a directory will build all tests in that directory.
+  Passing the path to a cram test will run that test individually. See
+  :ref:`writing-and-running-tests-running-tests` for the differences from
+  ``dune build @runtest``.
 - ``dune build`` is a shortcut for ``dune build @@default``: it will build the
   default alias in the current directory (by default the ``all`` alias).
 

--- a/doc/explanation/opam-integration.rst
+++ b/doc/explanation/opam-integration.rst
@@ -101,8 +101,10 @@ The meaning of these :term:`aliases <alias>` is the following:
   executables with a public name and files that are manually installed through
   ``(install)`` stanzas).
 - :doc:`/reference/aliases/runtest` is the alias to which all tests are
-  attached, including ``(test)`` stanzas. ``dune build @runtest`` is equivalent
-  to ``dune runtest``.
+  attached, including ``(test)`` stanzas. Building ``@runtest`` directly uses
+  normal alias target semantics. See
+  :ref:`writing-and-running-tests-running-tests` for the command-line behavior
+  of ``dune runtest``.
 - :doc:`/reference/aliases/doc` executes ``odoc`` to create HTML docs under
   ``_build``.
 

--- a/doc/reference/aliases/runtest.rst
+++ b/doc/reference/aliases/runtest.rst
@@ -4,7 +4,13 @@
 Actions that run tests are attached to this alias. For example this convention
 is used by the ``(test)`` stanza.
 
-``dune runtest`` is a shortcut for ``dune build @runtest`` but is also able to
-run individual tests.
+Building ``@runtest`` directly uses normal :doc:`alias </reference/aliases>`
+target semantics. In a workspace with multiple contexts, an unqualified alias
+target is built in every configured context.
+
+The ``dune runtest`` command, also available as ``dune test``, has different
+command-line behavior: it accepts test path arguments and selects a build
+context for source paths. See :ref:`writing-and-running-tests-running-tests`
+for details.
 
 .. seealso:: :doc:`/tests`

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -34,17 +34,33 @@ We distinguish three kinds of tests:
 * Cram tests - expect tests written in Cram_ style.
 
 
+.. _writing-and-running-tests-running-tests:
+
 Running Tests
 =============
 
 Whatever the tests of a project are, the usual way to run tests with Dune is to
-call ``dune runtest`` from the shell (or the command alias ``dune test``). This
-will run all the tests defined in the current directory and any subdirectory
-recursively.
+call ``dune runtest`` from the shell. ``dune test`` is an alias for the same
+command. Without arguments, this runs the tests defined in the current
+directory and any subdirectory recursively.
 
-Note that in any case, ``dune runtest`` is simply shorthand for building the
-``runtest`` alias, so you can always ask Dune to run the tests in conjunction
-with other targets by passing ``@runtest`` to ``dune build``. For instance:
+``dune runtest`` and ``dune test`` are not exactly the same as
+``dune build @runtest``. The ``runtest`` command treats its arguments as test
+paths, defaulting to ``.`` when none are supplied, so it can run all tests in a
+directory, one individual test, or several selected tests.
+
+Most projects use Dune's implicit ``default`` :term:`build context` and do not
+need to think about contexts when running tests. If a workspace defines
+non-default :doc:`workspace contexts </reference/dune-workspace/context>`,
+``dune runtest`` chooses the context named ``default``, or the only available
+context when there is just one. If a workspace defines multiple contexts and
+none of them is named ``default``, pass ``--context`` or a path under a
+:term:`build context root`, such as ``_build/<context>``.
+
+By contrast, ``dune build @runtest`` builds the ``runtest`` alias as a normal
+build target. In a workspace with multiple contexts, an unqualified alias target
+is built in every configured context. This form is useful when you want to run
+tests in conjunction with other targets. For instance:
 
 .. code:: console
 
@@ -507,11 +523,11 @@ The :ref:`tests-stanza` stanza is the multi-test form of ``test``:
 
    (tests (names test1 test2))
 
-More generally, we said in `Running tests`_ that to run tests, Dune simply
-builds the ``runtest`` alias. As a result, you can also add an action to this
-alias in any directory in order to define custom tests. For instance, if you
-have a binary ``tests.exe`` that you want to run as part of running your test
-suite, simply add this to a ``dune`` file:
+More generally, test actions are attached to the ``runtest`` alias. As a
+result, you can also add an action to this alias in any directory in order to
+define custom tests. For instance, if you have a binary ``tests.exe`` that you
+want to run as part of running your test suite, simply add this to a ``dune``
+file:
 
 .. code:: dune
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -270,9 +270,15 @@ There are two ways to run tests:
 -  ``dune build @runtest``
 -  ``dune test`` (or its alias ``dune runtest``)
 
-The two commands are equivalent, and they will run all the tests defined in the
-current directory and its children directories recursively. You can also run the tests in a
-specific sub-directory and its children by using:
+For projects with only the default build context, both commands run all the
+tests defined in the current directory and its children directories
+recursively. They differ when a workspace defines multiple build contexts:
+``dune build @runtest`` builds the alias as a normal build target, while
+``dune test`` selects one context for source paths. See
+:ref:`writing-and-running-tests-running-tests` for details.
+
+You can also run the tests in a specific sub-directory and its children by
+using:
 
 -  ``dune build @foo/bar/runtest``
 -  ``dune test foo/bar`` (or ``dune runtest foo/bar``)


### PR DESCRIPTION
## Description
Clarify that `dune runtest` and `dune test` are not exact shorthands for `dune build @runtest`.

The tests guide now explains that `dune runtest` accepts test path arguments, defaults to `.` when none are supplied, and chooses a single build context for source paths. The multi-context details are kept in a separate paragraph and cross-link to the build context and dune-workspace context reference docs. The `@runtest` alias reference keeps the alias-specific behavior concise and links back to the tests guide for command behavior. The usage page now avoids the old unconditional equivalence claim too.

## Related Issue and Motivation
Fixes #15405

## Checklist

- [x] Tests added, if applicable. Existing blackbox coverage already exercises the documented multi-context behavior.
- [ ] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes. Not applicable: documentation clarification only.
- [x] Documentation added for any user-facing changes.

Validated with:

- `sphinx-build -W doc doc/_build`
- `./dune.exe build @doc`
- `./dune.exe runtest test/blackbox-tests/test-cases/runtest/runtest-cmd.t`
- `./dune.exe build @fmt`