### PR TITLE
fix version sorting in `release-init.sh`

### DIFF
--- a/doc/dev/releases/release-init.sh
+++ b/doc/dev/releases/release-init.sh
@@ -111,7 +111,7 @@ issue_body=
 rc_branch=
 
 function patch_release () {
-    local last_version=$(git tag --list '*.*.*' --sort=-version:refname | head -n 1 )
+    local last_version=$(git -c versionsort.suffix="_alpha" tag --list '*.*.*' --sort=-version:refname | head -n 1 )
     next_version=$(echo "${last_version}" | awk -F. -v OFS=. '{print $1, $2, $3+1 }')
     rc_branch="${next_version}-rc"
 
@@ -145,7 +145,7 @@ ${POST_RELEASE_STEPS}
 }
 
 function minor_release () {
-    next_version=$(git tag --list '*.*.0' --sort=-version:refname | \
+    next_version=$(git -c versionsort.suffix="_alpha" tag --list '*.*.0' --sort=-version:refname | \
         head -n 1 | \
         awk -F. -v OFS=. '{print $1, $2+1, 0 }')
     rc_branch="${next_version}-rc"
@@ -158,7 +158,7 @@ function minor_release () {
 }
 
 function major_release () {
-    next_version=$(git tag --list '*.0.0' --sort=-version:refname | \
+    next_version=$(git -c versionsort.suffix="_alpha" tag --list '*.0.0' --sort=-version:refname | \
         head -n 1 | \
         awk -F. -v OFS=. '{print $1+1, 0, 0 }')
     rc_branch="${next_version}-rc"


### PR DESCRIPTION
<!-- Thank you for contributing to dune!

 For general guidelines on contributing to dune, see
 https://github.com/ocaml/dune/blob/main/CONTRIBUTING.md#developing-dune -->

## Description
<!-- Briefly describe your changes -->

Without setting the `versionsort.suffix`, alpha-suffixed versions are sorted as later than full releases. This will lead to preparing releases from the wrong (outdated) tag.

With this fix, we should get the expected sorting results.

## Related Issue and Motivation

Contributes to #13771

## Checklist

- [x] Tests added, if applicable -- tested by a test run targeting my fork (producing https://github.com/shonfeder/dune/issues/26 and the PR https://github.com/shonfeder/dune/pull/27, which is properly branched off the 3.34.0 tag).
- [x] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [x] Documentation added for any user-facing changes.
