### PR TITLE
Protect shared cache using landlock

### DIFF
--- a/bin/action_runner.ml
+++ b/bin/action_runner.ml
@@ -84,14 +84,13 @@ module Backends = struct
                @ Backend.unavailable_reason b));
         canonicalise bs
       | [] ->
-        (* With the current cache-only policy, bwrap is the least surprising
-           default when it works: it preserves the incumbent namespace isolation
-           without Landlock's ancestor-directory write denial. If a later
-           per-action policy needs Landlock's stronger semantics, revisit this
-           ordering. *)
+        (* The cache policy is implemented by both backends, but Landlock is
+           the backend that will support the per-action policy later in this
+           stack. Prefer it when available so the default moves toward the
+           policy backend; bwrap remains the fallback and an explicit option. *)
         (match Backend.available Landlock, Backend.available Bwrap with
-         | _, true -> [ Bwrap ]
-         | true, false -> [ Landlock ]
+         | true, _ -> [ Landlock ]
+         | false, true -> [ Bwrap ]
          | false, false ->
            User_error.raise
              [ Pp.text
@@ -101,9 +100,18 @@ module Backends = struct
              ]))
   ;;
 
-  let landlock_wrap ~dune_prog argv =
+  let landlock_wrap ~dune_prog ~cache_dir argv =
+    Path.mkdir_p cache_dir;
     let dune = Path.to_string dune_prog in
-    let argv = dune :: "internal" :: "with-landlock" :: "--" :: argv in
+    let argv =
+      dune
+      :: "internal"
+      :: "with-landlock"
+      :: "--deny-write"
+      :: Path.to_absolute_filename cache_dir
+      :: "--"
+      :: argv
+    in
     dune, argv
   ;;
 
@@ -115,6 +123,7 @@ module Backends = struct
   ;;
 
   let compose t ~dune_prog ~worker_argv =
+    let cache_dir = lazy (Lazy.force Dune_cache.Layout.build_cache_dir) in
     (* Fold from innermost to outermost: reverse the chain, then wrap step by
        step so the first element of [t] ends up as the outermost. Each wrapper
        must preserve [argv.(0)] as the program that it execs. *)
@@ -123,7 +132,8 @@ module Backends = struct
       ~init:(Path.to_string dune_prog, worker_argv)
       ~f:(fun b (_, argv) ->
         match b with
-        | Backend.Landlock -> landlock_wrap ~dune_prog argv
+        | Backend.Landlock ->
+          landlock_wrap ~dune_prog ~cache_dir:(Lazy.force cache_dir) argv
         | Backend.Bwrap -> bwrap_wrap argv)
   ;;
 end

--- a/bin/action_runner.ml
+++ b/bin/action_runner.ml
@@ -1,27 +1,135 @@
 open Import
 
 let name = Action_runner_name.of_string "action-runner"
+let dune_prog () = Util.resolve_program_path Sys.executable_name
 
-let find_in_path_exn prog =
-  match Bin.which ~path:(Env_path.path Env.initial) prog with
-  | Some path -> path
-  | None -> User_error.raise [ Pp.textf "unable to find %s in PATH" prog ]
-;;
+module Backend = struct
+  type t =
+    | Bwrap
+    | Landlock
 
-let has_directory_component prog =
-  String.exists prog ~f:(function
-    | '/' | '\\' -> true
-    | _ -> false)
-;;
+  let equal a b =
+    match a, b with
+    | Bwrap, Bwrap | Landlock, Landlock -> true
+    | Bwrap, Landlock | Landlock, Bwrap -> false
+  ;;
 
-let dune_prog () =
-  let prog = Sys.executable_name in
-  if Filename.is_relative prog && not (has_directory_component prog)
-  then find_in_path_exn prog
-  else Path.of_filename_relative_to_initial_cwd prog
-;;
+  let all = [ Bwrap; Landlock ]
 
-let create ~where ~config ~sandbox_actions =
+  let to_string = function
+    | Bwrap -> "bwrap"
+    | Landlock -> "landlock"
+  ;;
+
+  let parse = function
+    | "bwrap" -> Some Bwrap
+    | "landlock" -> Some Landlock
+    | _ -> None
+  ;;
+
+  let conv =
+    let parser s =
+      match parse s with
+      | Some b -> Ok b
+      | None -> Error (`Msg (Printf.sprintf "unknown sandbox backend %S" s))
+    in
+    let printer fmt b = Format.pp_print_string fmt (to_string b) in
+    Arg.conv (parser, printer)
+  ;;
+
+  let available = function
+    | Bwrap -> Bwrap.available ()
+    | Landlock -> Landlock.available ()
+  ;;
+
+  let unavailable_reason = function
+    | Bwrap -> Bwrap.unavailable_reason ()
+    | Landlock ->
+      [ Pp.text
+          "Landlock is unavailable to this Dune binary: requires Dune to be built with \
+           Landlock headers and run on a Linux kernel with the Landlock LSM enabled and \
+           a sufficient ABI version"
+      ]
+  ;;
+end
+
+module Backends = struct
+  (* Canonicalise into chain order (outermost first), deduplicated. The chosen
+     layering is bwrap outer / landlock inner regardless of CLI order. *)
+  let canonicalise bs =
+    List.filter Backend.all ~f:(fun b -> List.mem ~equal:Backend.equal bs b)
+  ;;
+
+  let resolve ~sandbox_actions ~requested =
+    if not sandbox_actions
+    then (
+      match requested with
+      | [] -> []
+      | _ :: _ ->
+        Code_error.raise
+          "sandbox backends were requested without sandbox_actions"
+          [ "requested", Dyn.list (fun b -> Dyn.string (Backend.to_string b)) requested ])
+    else (
+      match requested with
+      | _ :: _ as bs ->
+        List.iter bs ~f:(fun b ->
+          if not (Backend.available b)
+          then
+            User_error.raise
+              ([ Pp.textf
+                   "Sandbox backend %s requested via --sandbox-actions-backend but \
+                    unavailable."
+                   (Backend.to_string b)
+               ]
+               @ Backend.unavailable_reason b));
+        canonicalise bs
+      | [] ->
+        (* With the current cache-only policy, bwrap is the least surprising
+           default when it works: it preserves the incumbent namespace isolation
+           without Landlock's ancestor-directory write denial. If a later
+           per-action policy needs Landlock's stronger semantics, revisit this
+           ordering. *)
+        (match Backend.available Landlock, Backend.available Bwrap with
+         | _, true -> [ Bwrap ]
+         | true, false -> [ Landlock ]
+         | false, false ->
+           User_error.raise
+             [ Pp.text
+                 "--sandbox-actions was requested but no sandbox backend is available on \
+                  this system. Use --sandbox-actions-backend to request a specific \
+                  backend and see the diagnostic, or omit --sandbox-actions."
+             ]))
+  ;;
+
+  let landlock_wrap ~dune_prog argv =
+    let dune = Path.to_string dune_prog in
+    let argv = dune :: "internal" :: "with-landlock" :: "--" :: argv in
+    dune, argv
+  ;;
+
+  let bwrap_wrap argv =
+    let { Bwrap.prog; argv } =
+      Bwrap.wrap ~cwd:(Path.to_absolute_filename Path.root) argv
+    in
+    prog, argv
+  ;;
+
+  let compose t ~dune_prog ~worker_argv =
+    (* Fold from innermost to outermost: reverse the chain, then wrap step by
+       step so the first element of [t] ends up as the outermost. Each wrapper
+       must preserve [argv.(0)] as the program that it execs. *)
+    List.fold_right
+      t
+      ~init:(Path.to_string dune_prog, worker_argv)
+      ~f:(fun b (_, argv) ->
+        match b with
+        | Backend.Landlock -> landlock_wrap ~dune_prog argv
+        | Backend.Bwrap -> bwrap_wrap argv)
+  ;;
+end
+
+let create ~where ~config ~sandbox_actions ~sandbox_actions_backends =
+  let backends = Backends.resolve ~sandbox_actions ~requested:sandbox_actions_backends in
   let pid =
     let env =
       let jobs =
@@ -36,24 +144,16 @@ let create ~where ~config ~sandbox_actions =
       |> Spawn.Env.of_list
     in
     let trace_fd = Dune_trace.duplicate_global_fd () in
-    let prog, argv =
-      let dune_prog = dune_prog () in
-      let worker_argv =
-        [ Path.to_string dune_prog
-        ; "internal"
-        ; "action-runner"
-        ; "start"
-        ; Action_runner_name.to_string name
-        ]
-      in
-      if sandbox_actions
-      then (
-        let { Bwrap.prog; argv } =
-          Bwrap.wrap ~cwd:(Path.to_absolute_filename Path.root) worker_argv
-        in
-        prog, argv)
-      else Path.to_string dune_prog, worker_argv
+    let dune_prog = dune_prog () in
+    let worker_argv =
+      [ Path.to_string dune_prog
+      ; "internal"
+      ; "action-runner"
+      ; "start"
+      ; Action_runner_name.to_string name
+      ]
     in
+    let prog, argv = Backends.compose backends ~dune_prog ~worker_argv in
     let argv =
       let where = Dune_rpc.Where.to_string where in
       argv

--- a/bin/action_runner.mli
+++ b/bin/action_runner.mli
@@ -1,9 +1,20 @@
 open Import
 
+module Backend : sig
+  type t =
+    | Bwrap
+    | Landlock
+
+  val equal : t -> t -> bool
+  val to_string : t -> string
+  val conv : t Arg.conv
+end
+
 val create
   :  where:Dune_rpc.Where.t
   -> config:Dune_config.t
   -> sandbox_actions:bool
+  -> sandbox_actions_backends:Backend.t list
   -> Dune_engine.Action_runner.t
 
 val start_worker : name:string -> where:string -> trace_fd:string option -> unit Fiber.t

--- a/bin/bwrap.ml
+++ b/bin/bwrap.ml
@@ -5,15 +5,9 @@ type command =
   ; argv : string list
   }
 
-let find_in_path_exn prog =
-  match Bin.which ~path:(Env_path.path Env.initial) prog with
-  | Some path -> path
-  | None -> User_error.raise [ Pp.textf "unable to find %s in PATH" prog ]
-;;
-
 let prog () =
   match Platform.OS.value with
-  | Linux -> find_in_path_exn "bwrap"
+  | Linux -> Util.find_in_path_exn "bwrap"
   | _ ->
     User_error.raise [ Pp.text "--sandbox-actions is currently only supported on Linux" ]
 ;;

--- a/bin/bwrap.ml
+++ b/bin/bwrap.ml
@@ -5,6 +5,72 @@ type command =
   ; argv : string list
   }
 
+type availability =
+  | Available
+  | Not_found
+  | Probe_failed of string
+
+let process_status_to_string = function
+  | Unix.WEXITED n -> Printf.sprintf "exit code %d" n
+  | WSIGNALED n -> Printf.sprintf "signal %d" n
+  | WSTOPPED n -> Printf.sprintf "stopped by signal %d" n
+;;
+
+let probe prog =
+  let prog = Path.to_string prog in
+  let argv = [| prog; "--bind"; "/"; "/"; "--"; "true" |] in
+  let env = Env.to_unix Env.initial |> Array.of_list in
+  let dev_null = Unix.openfile "/dev/null" [ O_RDWR ] 0 in
+  Exn.protect
+    ~f:(fun () ->
+      match Unix.create_process_env prog argv env dev_null dev_null dev_null with
+      | exception Unix.Unix_error (err, _, _) -> Probe_failed (Unix.error_message err)
+      | pid ->
+        (match snd (Unix.waitpid [] pid) with
+         | WEXITED 0 -> Available
+         | status -> Probe_failed (process_status_to_string status)))
+    ~finally:(fun () -> Unix.close dev_null)
+;;
+
+let availability =
+  lazy
+    (match Platform.OS.value with
+     | Linux ->
+       (match Bin.which ~path:(Env_path.path Env.initial) "bwrap" with
+        | Some prog -> probe prog
+        | None -> Not_found)
+     | _ -> Not_found)
+;;
+
+let available () =
+  match Lazy.force availability with
+  | Available -> true
+  | Not_found | Probe_failed _ -> false
+;;
+
+let unavailable_reason () =
+  match Platform.OS.value with
+  | Linux ->
+    (match Lazy.force availability with
+     | Available -> []
+     | Not_found ->
+       [ Pp.text
+           "bwrap is unavailable: install the bubblewrap package and ensure the binary \
+            is on PATH (Linux only)"
+       ]
+     | Probe_failed reason ->
+       [ Pp.textf
+           "bwrap is unavailable: the binary was found but failed to create a sandbox \
+            (%s). User namespaces may be disabled."
+           reason
+       ])
+  | _ ->
+    [ Pp.text
+        "bwrap is unavailable: install the bubblewrap package and ensure the binary is \
+         on PATH (Linux only)"
+    ]
+;;
+
 let prog () =
   match Platform.OS.value with
   | Linux -> Util.find_in_path_exn "bwrap"

--- a/bin/bwrap.mli
+++ b/bin/bwrap.mli
@@ -5,6 +5,8 @@ type command =
   ; argv : string list
   }
 
+val available : unit -> bool
+val unavailable_reason : unit -> User_message.Style.t Pp.t list
 val wrap : cwd:string -> string list -> command
 
 module With_bwrap : sig

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -627,6 +627,7 @@ module Builder = struct
     ; target_exec : string option
     ; action_runner : bool
     ; sandbox_actions : bool
+    ; sandbox_actions_backends : Action_runner.Backend.t list
     }
 
   let set_no_build t no_build = { t with no_build }
@@ -963,8 +964,23 @@ module Builder = struct
             ~docs
             ~doc:
               (Some
-                 "Run spawned build processes in an external dune action runner wrapped \
-                  with bubblewrap."))
+                 "Run spawned build processes in an external dune action runner under a \
+                  sandbox. The sandbox layering is selected automatically; pass \
+                  --sandbox-actions-backend to override."))
+    and+ sandbox_actions_backends =
+      Arg.(
+        value
+        & opt_all Action_runner.Backend.conv []
+        & info
+            [ "sandbox-actions-backend" ]
+            ~docs
+            ~docv:"BACKEND"
+            ~doc:
+              (Some
+                 "Use this sandbox backend for --sandbox-actions. Repeatable; when \
+                  passed more than once the backends are stacked (currently bwrap \
+                  outermost, landlock inside). If unset, bwrap is selected when \
+                  available, otherwise Landlock is selected when available."))
     and+ action_runner =
       Arg.(
         value
@@ -973,6 +989,15 @@ module Builder = struct
             [ "action-runner" ]
             ~docs
             ~doc:(Some "Run spawned build processes in an external dune action runner."))
+    in
+    let () =
+      if (not sandbox_actions) && not (List.is_empty sandbox_actions_backends)
+      then
+        User_error.raise
+          [ Pp.text
+              "--sandbox-actions-backend requires --sandbox-actions. Either pass \
+               --sandbox-actions or remove --sandbox-actions-backend."
+          ]
     in
     { no_build
     ; debug_dep_path
@@ -1019,6 +1044,7 @@ module Builder = struct
     ; target_exec
     ; action_runner
     ; sandbox_actions
+    ; sandbox_actions_backends
     }
   ;;
 
@@ -1060,6 +1086,7 @@ module Builder = struct
         ; target_exec
         ; action_runner
         ; sandbox_actions
+        ; sandbox_actions_backends
         }
     =
     No_build.equal t.no_build no_build
@@ -1101,6 +1128,10 @@ module Builder = struct
     && Option.equal String.equal t.target_exec target_exec
     && Bool.equal t.action_runner action_runner
     && Bool.equal t.sandbox_actions sandbox_actions
+    && List.equal
+         Action_runner.Backend.equal
+         t.sandbox_actions_backends
+         sandbox_actions_backends
   ;;
 end
 
@@ -1393,7 +1424,8 @@ let init_with_root_and_rpc ~(root : Workspace_root.t) ~rpc_build (builder : Buil
            (Action_runner.create
               ~where:(Lazy.force where)
               ~config
-              ~sandbox_actions:c.builder.sandbox_actions)
+              ~sandbox_actions:c.builder.sandbox_actions
+              ~sandbox_actions_backends:c.builder.sandbox_actions_backends)
        else None)
   in
   let rpc =

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -966,7 +966,11 @@ module Builder = struct
               (Some
                  "Run spawned build processes in an external dune action runner under a \
                   sandbox. The sandbox layering is selected automatically; pass \
-                  --sandbox-actions-backend to override."))
+                  --sandbox-actions-backend to override. Shared-cache protection is \
+                  path-based and does not cover writes through hardlinks or other \
+                  aliases outside the protected cache subtree. When enforced by \
+                  Landlock, it also denies creating or removing entries directly in \
+                  ancestor directories of the protected cache path."))
     and+ sandbox_actions_backends =
       Arg.(
         value
@@ -979,8 +983,8 @@ module Builder = struct
               (Some
                  "Use this sandbox backend for --sandbox-actions. Repeatable; when \
                   passed more than once the backends are stacked (currently bwrap \
-                  outermost, landlock inside). If unset, bwrap is selected when \
-                  available, otherwise Landlock is selected when available."))
+                  outermost, landlock inside). If unset, Landlock is selected when \
+                  available, otherwise bwrap is selected when available."))
     and+ action_runner =
       Arg.(
         value

--- a/bin/dune
+++ b/bin/dune
@@ -7,6 +7,9 @@
  (enabled_if
   (<> %{profile} dune-bootstrap))
  (root_module root)
+ (foreign_stubs
+  (language c)
+  (names landlock_stubs))
  (libraries
   memo
   ocaml

--- a/bin/internal.ml
+++ b/bin/internal.ml
@@ -230,6 +230,7 @@ let group =
     ; Internal_digest_db.command
     ; Internal_action_runner.group
     ; Bwrap.With_bwrap.command
+    ; Landlock.With_landlock.command
     ; latest_lang_version
     ; bootstrap_info
     ; Sexp_pp.command

--- a/bin/landlock.ml
+++ b/bin/landlock.ml
@@ -1,0 +1,312 @@
+open Import
+
+module Raw = struct
+  external abi_version : unit -> int = "dune_landlock_abi_version"
+  external write_access_rights : int -> int64 = "dune_landlock_write_access_rights"
+
+  external file_write_access_rights
+    :  int
+    -> int64
+    = "dune_landlock_file_write_access_rights"
+
+  external create_ruleset : int64 -> int = "dune_landlock_create_ruleset"
+  external add_rule : int -> string -> int64 -> unit = "dune_landlock_add_rule"
+  external restrict_self : int -> unit = "dune_landlock_restrict_self"
+end
+
+let abi_version () = Raw.abi_version ()
+
+(* ABI 2 adds LANDLOCK_ACCESS_FS_REFER, which is needed to prevent moving files
+   out of a denied tree. ABI 3 adds LANDLOCK_ACCESS_FS_TRUNCATE, which is needed
+   to prevent emptying denied files through truncate. *)
+let minimum_abi = 3
+
+let available () =
+  match abi_version () with
+  | n -> n >= minimum_abi && not (Int64.equal (Raw.write_access_rights n) 0L)
+  | exception Unix.Unix_error _ -> false
+;;
+
+let normalize_absolute_filename path =
+  let path =
+    if Filename.is_relative path then Filename.concat (Sys.getcwd ()) path else path
+  in
+  match Unix.realpath path with
+  | path -> path
+  | exception Unix.Unix_error _ -> path
+;;
+
+let split_absolute path =
+  let rec loop path acc =
+    let dir = Filename.dirname path in
+    let base = Filename.basename path in
+    if String.equal path dir then acc else loop dir (base :: acc)
+  in
+  loop path []
+;;
+
+let concat_dir dir name =
+  if String.equal dir Filename.dir_sep
+  then Filename.concat Filename.dir_sep name
+  else Filename.concat dir name
+;;
+
+let add_rule ruleset_fd path access =
+  if not (Int64.equal access 0L)
+  then (
+    match Raw.add_rule ruleset_fd path access with
+    | () -> ()
+    | exception Unix.Unix_error ((ENOENT | EACCES | EPERM | ENOTDIR | ELOOP), _, _) -> ())
+;;
+
+let add_rule_exn ruleset_fd path access =
+  if not (Int64.equal access 0L)
+  then (
+    match Raw.add_rule ruleset_fd path access with
+    | () -> ()
+    | exception Unix.Unix_error (err, _, _) ->
+      User_error.raise
+        [ Pp.textf
+            "failed to allow writes to %s: %s"
+            (String.maybe_quoted path)
+            (Unix.error_message err)
+        ])
+;;
+
+let stat_key path =
+  match Unix.stat path with
+  | { Unix.st_dev; st_ino; _ } -> Some (st_dev, st_ino)
+  | exception Unix.Unix_error _ -> None
+;;
+
+let write_access_for_path ~write_access ~file_write_access path =
+  match Unix.stat path with
+  | { Unix.st_kind = S_DIR; _ } -> write_access
+  | _ -> file_write_access
+;;
+
+let add_write_rule ruleset_fd ~write_access ~file_write_access path =
+  let access =
+    match write_access_for_path ~write_access ~file_write_access path with
+    | access -> access
+    | exception Unix.Unix_error _ -> 0L
+  in
+  add_rule ruleset_fd path access
+;;
+
+let add_allow_write_rule ruleset_fd ~write_access ~file_write_access path =
+  let access =
+    match write_access_for_path ~write_access ~file_write_access path with
+    | access -> access
+    | exception Unix.Unix_error (err, _, _) ->
+      User_error.raise
+        [ Pp.textf
+            "failed to allow writes to %s: %s"
+            (String.maybe_quoted path)
+            (Unix.error_message err)
+        ]
+  in
+  add_rule_exn ruleset_fd path access
+;;
+
+let is_descendant path ~of_ =
+  String.equal path of_
+  || String.equal of_ Filename.dir_sep
+  || ((not (String.equal of_ Filename.dir_sep))
+      && Option.is_some (String.drop_prefix path ~prefix:(of_ ^ Filename.dir_sep)))
+;;
+
+let is_strict_descendant path ~of_ =
+  (not (String.equal path of_)) && is_descendant path ~of_
+;;
+
+let is_protected_alias path ~protected_ancestors =
+  match stat_key path with
+  | None -> false
+  | Some key ->
+    List.exists protected_ancestors ~f:(Tuple.T2.equal Int.equal Int.equal key)
+;;
+
+let path_and_ancestors path =
+  let rec loop dir acc = function
+    | [] -> List.rev (dir :: acc)
+    | next :: rest -> loop (concat_dir dir next) (dir :: acc) rest
+  in
+  loop Filename.dir_sep [] (split_absolute path)
+;;
+
+(* Landlock rules are allow-lists. To keep a set of subtrees write-protected,
+   allow writes to siblings of every ancestor of every protected path. Skip
+   lexical descendants of protected paths, paths whose realpath is at or above
+   any protected path (symlink aliases), and bind-mount aliases of
+   protected-path ancestors. Then apply explicit allow paths as punch-holes on
+   top. Ancestor directories of denied paths are intentionally not granted
+   directory write rights, so creating/removing entries directly in those
+   ancestors is also denied. *)
+let add_rules ruleset_fd ~write_access ~file_write_access ~deny_paths ~allow_paths =
+  (match deny_paths with
+   | [] -> ()
+   | _ ->
+     let skeleton =
+       List.concat_map deny_paths ~f:path_and_ancestors |> String.Set.of_list
+     in
+     let protected_ancestors =
+       String.Set.to_list skeleton |> List.filter_map ~f:stat_key
+     in
+     let in_or_above_protected realpath =
+       List.exists deny_paths ~f:(fun p ->
+         is_descendant realpath ~of_:p || is_descendant p ~of_:realpath)
+     in
+     String.Set.iter skeleton ~f:(fun dir ->
+       match Sys.readdir dir with
+       | exception Sys_error _ -> ()
+       | entries ->
+         Array.iter entries ~f:(fun entry ->
+           let path = concat_dir dir entry in
+           if not (String.Set.mem skeleton path)
+           then (
+             let realpath = normalize_absolute_filename path in
+             if
+               not
+                 (in_or_above_protected realpath
+                  || is_protected_alias path ~protected_ancestors)
+             then add_write_rule ruleset_fd ~write_access ~file_write_access path))));
+  List.iter
+    allow_paths
+    ~f:(add_allow_write_rule ruleset_fd ~write_access ~file_write_access)
+;;
+
+let with_ruleset ~handled_access ~f =
+  let fd = Raw.create_ruleset handled_access in
+  Exn.protect ~f:(fun () -> f fd) ~finally:(fun () -> Fd.close (Fd.unsafe_of_int fd))
+;;
+
+let validate_allow_paths ~deny_write ~allow_write =
+  List.iter allow_write ~f:(fun allow ->
+    if not (List.exists deny_write ~f:(fun deny -> is_strict_descendant allow ~of_:deny))
+    then
+      User_error.raise
+        [ Pp.textf
+            "--allow-write path %s must be strictly inside a --deny-write path"
+            (String.maybe_quoted allow)
+        ];
+    match List.find deny_write ~f:(fun deny -> is_descendant deny ~of_:allow) with
+    | None -> ()
+    | Some deny ->
+      User_error.raise
+        [ Pp.textf
+            "--allow-write path %s must not cover --deny-write path %s"
+            (String.maybe_quoted allow)
+            (String.maybe_quoted deny)
+        ])
+;;
+
+(* Contract for [restrict_write_policy]:
+
+   - Paths are normalized before restriction. Relative paths are interpreted
+     relative to the wrapper's current working directory. Existing paths are
+     resolved with [realpath], so a symlink argument protects its target.
+     Nonexistent paths fall back to lexical normalization.
+   - With no [deny_write] paths, the policy is a no-op, including any
+     [allow_write] paths.
+   - With [deny_write = ["/"]], the policy is a pure allow-list: only explicit
+     allow paths are writable.
+   - Otherwise, writes are denied in each denied subtree and directly in each
+     ancestor directory of a denied path. Existing siblings of protected
+     ancestors keep write-in-place rights, but creating/removing entries in
+     those ancestor directories is denied.
+   - Allow paths are punch-holes and must be strictly inside a denied path. An
+     allow path that covers a deny path is rejected instead of silently
+     nullifying the deny.
+   - Allow paths must exist when the Landlock rules are installed. Missing or
+     inaccessible allow paths are rejected.
+   - A file allow path grants write/truncate of that file, not unlink/rename of
+     the file. Those operations are controlled by the parent directory's rights.
+     A directory allow path grants write operations within that directory, not
+     unlink/rename of the directory itself.
+   - "Write" here means the Landlock file-system rights handled by
+     [write_access_rights]: open-for-write, truncate, create/remove, and
+     rename/link. Landlock ABI 3 does not cover chmod/chown/utimes/xattrs,
+     writes through already-open file descriptors, writes through hardlinks
+     outside the denied tree, or device ioctls. *)
+let restrict_write_policy ~deny_write ~allow_write =
+  match deny_write with
+  | [] -> ()
+  | _ ->
+    let normalize = List.map ~f:normalize_absolute_filename in
+    let deny_write = normalize deny_write in
+    let allow_write = normalize allow_write in
+    validate_allow_paths ~deny_write ~allow_write;
+    let abi =
+      match abi_version () with
+      | abi -> abi
+      | exception Unix.Unix_error _ ->
+        User_error.raise [ Pp.text "Landlock is not available on this system" ]
+    in
+    if abi < minimum_abi
+    then User_error.raise [ Pp.text "Landlock is not available on this system" ];
+    let write_access = Raw.write_access_rights abi in
+    if Int64.equal write_access 0L
+    then User_error.raise [ Pp.text "Landlock write restrictions are not available" ];
+    let file_write_access = Raw.file_write_access_rights abi in
+    with_ruleset ~handled_access:write_access ~f:(fun ruleset_fd ->
+      add_rules
+        ruleset_fd
+        ~write_access
+        ~file_write_access
+        ~deny_paths:deny_write
+        ~allow_paths:allow_write;
+      Raw.restrict_self ruleset_fd)
+;;
+
+module With_landlock = struct
+  external sys_exit : int -> 'a = "caml_sys_exit"
+
+  let execve prog args ~env =
+    let argv = Array.of_list (prog :: args) in
+    let env = Env.to_unix env |> Array.of_list in
+    Stdlib.do_at_exit ();
+    if Sys.win32 || Platform.OS.value = Platform.OS.Haiku
+    then (
+      let pid =
+        Unix.create_process_env prog argv env Unix.stdin Unix.stdout Unix.stderr
+      in
+      match snd (Unix.waitpid [] pid) with
+      | WEXITED n -> sys_exit n
+      | WSIGNALED _ -> sys_exit 255
+      | WSTOPPED _ -> assert false)
+    else (
+      ignore (Unix.sigprocmask SIG_SETMASK [] : int list);
+      Unix.execve prog argv env)
+  ;;
+
+  let command =
+    let doc = "Run a command under Dune's Landlock wrapper." in
+    let info = Cmd.info "with-landlock" ~doc in
+    let path_list_flag ~name ~doc =
+      Arg.(value & opt_all string [] & info [ name ] ~docv:"PATH" ~doc:(Some doc))
+    in
+    let term =
+      let+ deny_write =
+        path_list_flag
+          ~name:"deny-write"
+          ~doc:
+            "Forbid writes within this subtree and directly in its ancestor directories. \
+             With PATH=/, switch to a pure allow-list. Repeatable."
+      and+ allow_write =
+        path_list_flag
+          ~name:"allow-write"
+          ~doc:
+            "Allow writes to a path strictly inside a --deny-write subtree. Has no \
+             effect unless --deny-write is also passed. The path must exist when the \
+             policy is installed. Repeatable."
+      and+ argv = Arg.(value & pos_all string [] (info [] ~docv:"COMMAND" ~doc:None)) in
+      match argv with
+      | [] -> User_error.raise [ Pp.text "missing command after --" ]
+      | prog :: args ->
+        restrict_write_policy ~deny_write ~allow_write;
+        execve (Util.resolve_prog prog) args ~env:Env.initial
+    in
+    Cmd.v info term
+  ;;
+end

--- a/bin/landlock.mli
+++ b/bin/landlock.mli
@@ -1,0 +1,7 @@
+open Import
+
+val available : unit -> bool
+
+module With_landlock : sig
+  val command : unit Cmd.t
+end

--- a/bin/landlock_stubs.c
+++ b/bin/landlock_stubs.c
@@ -1,0 +1,180 @@
+#define _GNU_SOURCE
+
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <caml/unixsupport.h>
+
+#include <errno.h>
+#include <stdint.h>
+
+#ifndef ENOSYS
+#define ENOSYS EINVAL
+#endif
+
+#if defined(__linux__)
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#if defined(__has_include)
+#if __has_include(<linux/landlock.h>)
+#define DUNE_HAS_LINUX_LANDLOCK_H 1
+#include <linux/landlock.h>
+#endif
+#endif
+#endif
+
+#if defined(__linux__) && defined(DUNE_HAS_LINUX_LANDLOCK_H) &&                 \
+    defined(SYS_landlock_create_ruleset) && defined(SYS_landlock_add_rule) &&  \
+    defined(SYS_landlock_restrict_self) &&                                     \
+    defined(LANDLOCK_CREATE_RULESET_VERSION) &&                                \
+    defined(LANDLOCK_ACCESS_FS_WRITE_FILE) &&                                  \
+    defined(LANDLOCK_ACCESS_FS_REMOVE_DIR) &&                                  \
+    defined(LANDLOCK_ACCESS_FS_REMOVE_FILE) &&                                 \
+    defined(LANDLOCK_ACCESS_FS_MAKE_CHAR) &&                                   \
+    defined(LANDLOCK_ACCESS_FS_MAKE_DIR) &&                                    \
+    defined(LANDLOCK_ACCESS_FS_MAKE_REG) &&                                    \
+    defined(LANDLOCK_ACCESS_FS_MAKE_SOCK) &&                                   \
+    defined(LANDLOCK_ACCESS_FS_MAKE_FIFO) &&                                   \
+    defined(LANDLOCK_ACCESS_FS_MAKE_BLOCK) &&                                  \
+    defined(LANDLOCK_ACCESS_FS_MAKE_SYM) &&                                    \
+    defined(LANDLOCK_ACCESS_FS_REFER) &&                                       \
+    defined(LANDLOCK_ACCESS_FS_TRUNCATE)
+#define DUNE_HAS_LANDLOCK 1
+#else
+#define DUNE_HAS_LANDLOCK 0
+#endif
+
+#if DUNE_HAS_LANDLOCK
+static uint64_t landlock_file_write_access_rights(int abi) {
+  uint64_t access = LANDLOCK_ACCESS_FS_WRITE_FILE;
+  if (abi >= 3) {
+    access |= LANDLOCK_ACCESS_FS_TRUNCATE;
+  }
+  return access;
+}
+
+static uint64_t landlock_write_access_rights(int abi) {
+  uint64_t access = landlock_file_write_access_rights(abi) |
+                    LANDLOCK_ACCESS_FS_REMOVE_DIR |
+                    LANDLOCK_ACCESS_FS_REMOVE_FILE |
+                    LANDLOCK_ACCESS_FS_MAKE_CHAR |
+                    LANDLOCK_ACCESS_FS_MAKE_DIR |
+                    LANDLOCK_ACCESS_FS_MAKE_REG |
+                    LANDLOCK_ACCESS_FS_MAKE_SOCK |
+                    LANDLOCK_ACCESS_FS_MAKE_FIFO |
+                    LANDLOCK_ACCESS_FS_MAKE_BLOCK |
+                    LANDLOCK_ACCESS_FS_MAKE_SYM;
+  if (abi >= 2) {
+    access |= LANDLOCK_ACCESS_FS_REFER;
+  }
+  return access;
+}
+#endif
+
+CAMLprim value dune_landlock_abi_version(value unit) {
+  (void)unit;
+#if DUNE_HAS_LANDLOCK
+  int abi = syscall(SYS_landlock_create_ruleset, NULL, 0,
+                    LANDLOCK_CREATE_RULESET_VERSION);
+  if (abi < 0) {
+    switch (errno) {
+    case ENOSYS:
+    case EOPNOTSUPP:
+    case EINVAL:
+      return Val_int(0);
+    default:
+      uerror("landlock_create_ruleset", Nothing);
+    }
+  }
+  return Val_int(abi);
+#else
+  return Val_int(0);
+#endif
+}
+
+CAMLprim value dune_landlock_write_access_rights(value v_abi) {
+  CAMLparam1(v_abi);
+#if DUNE_HAS_LANDLOCK
+  CAMLreturn(caml_copy_int64(landlock_write_access_rights(Int_val(v_abi))));
+#else
+  CAMLreturn(caml_copy_int64(0));
+#endif
+}
+
+CAMLprim value dune_landlock_file_write_access_rights(value v_abi) {
+  CAMLparam1(v_abi);
+#if DUNE_HAS_LANDLOCK
+  CAMLreturn(
+      caml_copy_int64(landlock_file_write_access_rights(Int_val(v_abi))));
+#else
+  CAMLreturn(caml_copy_int64(0));
+#endif
+}
+
+CAMLprim value dune_landlock_create_ruleset(value v_handled_access) {
+  CAMLparam1(v_handled_access);
+#if DUNE_HAS_LANDLOCK
+  struct landlock_ruleset_attr ruleset_attr = {
+      .handled_access_fs = Int64_val(v_handled_access),
+  };
+  int ruleset_fd = syscall(SYS_landlock_create_ruleset, &ruleset_attr,
+                           sizeof(ruleset_attr), 0);
+  if (ruleset_fd < 0) {
+    uerror("landlock_create_ruleset", Nothing);
+  }
+  CAMLreturn(Val_int(ruleset_fd));
+#else
+  (void)v_handled_access;
+  errno = ENOSYS;
+  uerror("landlock_create_ruleset", Nothing);
+#endif
+}
+
+CAMLprim value dune_landlock_add_rule(value v_ruleset_fd, value v_path,
+                                      value v_allowed_access) {
+  CAMLparam3(v_ruleset_fd, v_path, v_allowed_access);
+#if DUNE_HAS_LANDLOCK
+  int path_fd = open(String_val(v_path), O_PATH | O_CLOEXEC);
+  if (path_fd < 0) {
+    uerror("open", v_path);
+  }
+
+  struct landlock_path_beneath_attr path_beneath = {
+      .allowed_access = Int64_val(v_allowed_access),
+      .parent_fd = path_fd,
+  };
+  int ret = syscall(SYS_landlock_add_rule, Int_val(v_ruleset_fd),
+                    LANDLOCK_RULE_PATH_BENEATH, &path_beneath, 0);
+  int saved_errno = errno;
+  close(path_fd);
+  if (ret < 0) {
+    errno = saved_errno;
+    uerror("landlock_add_rule", v_path);
+  }
+  CAMLreturn(Val_unit);
+#else
+  (void)v_ruleset_fd;
+  (void)v_allowed_access;
+  errno = ENOSYS;
+  uerror("landlock_add_rule", v_path);
+#endif
+}
+
+CAMLprim value dune_landlock_restrict_self(value v_ruleset_fd) {
+  CAMLparam1(v_ruleset_fd);
+#if DUNE_HAS_LANDLOCK
+  if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) {
+    uerror("prctl", Nothing);
+  }
+  if (syscall(SYS_landlock_restrict_self, Int_val(v_ruleset_fd), 0) != 0) {
+    uerror("landlock_restrict_self", Nothing);
+  }
+  CAMLreturn(Val_unit);
+#else
+  (void)v_ruleset_fd;
+  errno = ENOSYS;
+  uerror("landlock_restrict_self", Nothing);
+#endif
+}

--- a/bin/util.ml
+++ b/bin/util.ml
@@ -1,5 +1,27 @@
 open Import
 
+let find_in_path_exn prog =
+  match Bin.which ~path:(Env_path.path Env.initial) prog with
+  | Some path -> path
+  | None -> User_error.raise [ Pp.textf "unable to find %s in PATH" prog ]
+;;
+
+let has_directory_component prog =
+  String.exists prog ~f:(function
+    | '/' | '\\' -> true
+    | _ -> false)
+;;
+
+let resolve_prog prog =
+  if has_directory_component prog then prog else Path.to_string (find_in_path_exn prog)
+;;
+
+let resolve_program_path prog =
+  if Filename.is_relative prog && not (has_directory_component prog)
+  then find_in_path_exn prog
+  else Path.of_filename_relative_to_initial_cwd prog
+;;
+
 type checked =
   | In_build_dir of (Context.t * Path.Source.t)
   | In_private_context of Path.Build.t

--- a/bin/util.mli
+++ b/bin/util.mli
@@ -1,5 +1,9 @@
 open Import
 
+val find_in_path_exn : string -> Path.t
+val resolve_prog : string -> string
+val resolve_program_path : string -> Path.t
+
 type checked =
   | In_build_dir of (Context.t * Path.Source.t)
   | In_private_context of Path.Build.t

--- a/test/blackbox-tests/test-cases/sandbox-actions/backends-bwrap.t
+++ b/test/blackbox-tests/test-cases/sandbox-actions/backends-bwrap.t
@@ -14,9 +14,8 @@ outside Landlock.
   >    "if touch \"$DUNE_CACHE_ROOT/db/runner-marker\" 2>/dev/null; then echo wrote > %{target}; else echo blocked > %{target}; fi")))
   > EOF
 
-By default, bwrap remains in the stack when it is available. At this point
-bwrap still provides the existing shared-cache read-only bind, so cache writes
-are blocked.
+By default, Landlock is selected when available, even if bwrap is also
+available. The cache protection policy blocks writes to the shared cache.
 
   $ rm -f "$DUNE_CACHE_ROOT/db/runner-marker"
   $ rm -rf _build
@@ -27,8 +26,7 @@ are blocked.
   missing
 
 Explicit `--sandbox-actions-backend=bwrap` runs the action through bwrap.
-At this point bwrap still provides the existing shared-cache read-only bind,
-so cache writes are blocked.
+The cache protection policy blocks writes to the shared cache.
 
   $ rm -f "$DUNE_CACHE_ROOT/db/runner-marker"
   $ rm -rf _build
@@ -38,7 +36,7 @@ so cache writes are blocked.
   $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present || echo missing
   missing
 
-Both backends stacked also include bwrap's shared-cache read-only bind.
+Both backends stacked also block cache writes.
 
   $ rm -f "$DUNE_CACHE_ROOT/db/runner-marker"
   $ rm -rf _build

--- a/test/blackbox-tests/test-cases/sandbox-actions/backends-bwrap.t
+++ b/test/blackbox-tests/test-cases/sandbox-actions/backends-bwrap.t
@@ -1,0 +1,51 @@
+The --sandbox-actions-backend flag can select bwrap explicitly or stack bwrap
+outside Landlock.
+
+  $ make_dune_project 3.23
+  $ export DUNE_CACHE_ROOT=$PWD/cache-root
+  $ echo "$DUNE_CACHE_ROOT" > cache-root-name
+  $ mkdir -p "$DUNE_CACHE_ROOT/db"
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (target result)
+  >  (deps cache-root-name)
+  >  (action
+  >   (bash
+  >    "if touch \"$DUNE_CACHE_ROOT/db/runner-marker\" 2>/dev/null; then echo wrote > %{target}; else echo blocked > %{target}; fi")))
+  > EOF
+
+By default, bwrap remains in the stack when it is available. At this point
+bwrap still provides the existing shared-cache read-only bind, so cache writes
+are blocked.
+
+  $ rm -f "$DUNE_CACHE_ROOT/db/runner-marker"
+  $ rm -rf _build
+  $ dune build --sandbox-actions result \
+  >   && cat _build/default/result
+  blocked
+  $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present || echo missing
+  missing
+
+Explicit `--sandbox-actions-backend=bwrap` runs the action through bwrap.
+At this point bwrap still provides the existing shared-cache read-only bind,
+so cache writes are blocked.
+
+  $ rm -f "$DUNE_CACHE_ROOT/db/runner-marker"
+  $ rm -rf _build
+  $ dune build --sandbox-actions --sandbox-actions-backend=bwrap result \
+  >   && cat _build/default/result
+  blocked
+  $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present || echo missing
+  missing
+
+Both backends stacked also include bwrap's shared-cache read-only bind.
+
+  $ rm -f "$DUNE_CACHE_ROOT/db/runner-marker"
+  $ rm -rf _build
+  $ dune build --sandbox-actions \
+  >   --sandbox-actions-backend=bwrap \
+  >   --sandbox-actions-backend=landlock \
+  >   result && cat _build/default/result
+  blocked
+  $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present || echo missing
+  missing

--- a/test/blackbox-tests/test-cases/sandbox-actions/backends.t
+++ b/test/blackbox-tests/test-cases/sandbox-actions/backends.t
@@ -48,37 +48,36 @@ Requesting an installed but unusable backend reports the probe failure.
   (exit code 42). User namespaces may be disabled.
   [1]
 
-When bwrap is unavailable, automatic backend selection falls back to Landlock.
-The cache protection policy is added later, so cache writes still succeed.
+When bwrap is unavailable, automatic backend selection uses Landlock.
+The cache protection policy blocks writes to the shared cache.
 
   $ rm -f "$DUNE_CACHE_ROOT/db/runner-marker"
   $ bwrap_dir=$(dirname "$(command -v bwrap 2>/dev/null || echo /nonexistent/bwrap)")
   $ without_bwrap_path=$(printf '%s' "$PATH" | tr ':' '\n' | grep -vx "$bwrap_dir" | paste -sd: -)
   $ PATH=$without_bwrap_path dune build --sandbox-actions result \
   >   && cat _build/default/result
-  wrote
+  blocked
   $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present || echo missing
-  present
+  missing
 
-Automatic backend selection also falls back to Landlock when bwrap is on PATH
-but cannot create a sandbox.
+Automatic backend selection also uses Landlock when bwrap is on PATH but cannot
+create a sandbox.
 
   $ rm -f "$DUNE_CACHE_ROOT/db/runner-marker"
   $ rm -rf _build
   $ PATH=$PWD/fake-bwrap-bin:$PATH dune build --sandbox-actions result \
   >   && cat _build/default/result
-  wrote
+  blocked
   $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present || echo missing
-  present
+  missing
 
 Explicit `--sandbox-actions-backend=landlock` runs the action through
-Landlock. The cache protection policy is added later, so cache writes still
-succeed.
+Landlock. The cache protection policy blocks writes to the shared cache.
 
   $ rm -f "$DUNE_CACHE_ROOT/db/runner-marker"
   $ rm -rf _build
   $ dune build --sandbox-actions --sandbox-actions-backend=landlock result \
   >   && cat _build/default/result
-  wrote
+  blocked
   $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present || echo missing
-  present
+  missing

--- a/test/blackbox-tests/test-cases/sandbox-actions/backends.t
+++ b/test/blackbox-tests/test-cases/sandbox-actions/backends.t
@@ -1,0 +1,84 @@
+The --sandbox-actions-backend flag selects specific sandbox backends.
+
+  $ make_dune_project 3.23
+  $ export DUNE_CACHE_ROOT=$PWD/cache-root
+  $ echo "$DUNE_CACHE_ROOT" > cache-root-name
+  $ mkdir -p "$DUNE_CACHE_ROOT/db"
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (target result)
+  >  (deps cache-root-name)
+  >  (action
+  >   (bash
+  >    "if touch \"$DUNE_CACHE_ROOT/db/runner-marker\" 2>/dev/null; then echo wrote > %{target}; else echo blocked > %{target}; fi")))
+  > EOF
+
+Requesting a backend without enabling sandbox-actions is rejected.
+
+  $ dune build --sandbox-actions-backend=landlock result
+  Error: --sandbox-actions-backend requires --sandbox-actions. Either pass
+  --sandbox-actions or remove --sandbox-actions-backend.
+  [1]
+
+Requesting an unavailable backend reports that backend's diagnostic.
+
+  $ rm -rf _build/fake-bin
+  $ mkdir -p _build/fake-bin
+  $ ln -s "$(command -v dune)" _build/fake-bin/dune
+  $ PATH=$PWD/_build/fake-bin dune build --sandbox-actions --sandbox-actions-backend=bwrap result
+  Error: Sandbox backend bwrap requested via --sandbox-actions-backend but
+  unavailable.
+  bwrap is unavailable: install the bubblewrap package and ensure the binary is
+  on PATH (Linux only)
+  [1]
+
+Requesting an installed but unusable backend reports the probe failure.
+
+  $ rm -rf fake-bwrap-bin
+  $ mkdir -p fake-bwrap-bin
+  $ cat > fake-bwrap-bin/bwrap <<'EOF'
+  > #!/bin/sh
+  > exit 42
+  > EOF
+  $ chmod +x fake-bwrap-bin/bwrap
+  $ PATH=$PWD/fake-bwrap-bin:$PATH dune build --sandbox-actions --sandbox-actions-backend=bwrap result
+  Error: Sandbox backend bwrap requested via --sandbox-actions-backend but
+  unavailable.
+  bwrap is unavailable: the binary was found but failed to create a sandbox
+  (exit code 42). User namespaces may be disabled.
+  [1]
+
+When bwrap is unavailable, automatic backend selection falls back to Landlock.
+The cache protection policy is added later, so cache writes still succeed.
+
+  $ rm -f "$DUNE_CACHE_ROOT/db/runner-marker"
+  $ bwrap_dir=$(dirname "$(command -v bwrap 2>/dev/null || echo /nonexistent/bwrap)")
+  $ without_bwrap_path=$(printf '%s' "$PATH" | tr ':' '\n' | grep -vx "$bwrap_dir" | paste -sd: -)
+  $ PATH=$without_bwrap_path dune build --sandbox-actions result \
+  >   && cat _build/default/result
+  wrote
+  $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present || echo missing
+  present
+
+Automatic backend selection also falls back to Landlock when bwrap is on PATH
+but cannot create a sandbox.
+
+  $ rm -f "$DUNE_CACHE_ROOT/db/runner-marker"
+  $ rm -rf _build
+  $ PATH=$PWD/fake-bwrap-bin:$PATH dune build --sandbox-actions result \
+  >   && cat _build/default/result
+  wrote
+  $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present || echo missing
+  present
+
+Explicit `--sandbox-actions-backend=landlock` runs the action through
+Landlock. The cache protection policy is added later, so cache writes still
+succeed.
+
+  $ rm -f "$DUNE_CACHE_ROOT/db/runner-marker"
+  $ rm -rf _build
+  $ dune build --sandbox-actions --sandbox-actions-backend=landlock result \
+  >   && cat _build/default/result
+  wrote
+  $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present || echo missing
+  present

--- a/test/blackbox-tests/test-cases/sandbox-actions/basic.t
+++ b/test/blackbox-tests/test-cases/sandbox-actions/basic.t
@@ -25,11 +25,11 @@ processes.
   $ dune build --sandbox-actions pure probe
   $ dune trace cat | jq -s 'include "dune"; writeFileCountBySuffix("/pure")'
   0
-With the automatic backend, bwrap remains in the stack when it is available, so
-the action runs in a new mount namespace.
+With the automatic backend, Landlock is selected when it is available. Landlock
+does not create a new mount namespace.
 
   $ cmp -s host-ns _build/default/probe && echo same || echo different
-  different
+  same
   $ cat _build/default/pure
   pure
 

--- a/test/blackbox-tests/test-cases/sandbox-actions/basic.t
+++ b/test/blackbox-tests/test-cases/sandbox-actions/basic.t
@@ -25,6 +25,9 @@ processes.
   $ dune build --sandbox-actions pure probe
   $ dune trace cat | jq -s 'include "dune"; writeFileCountBySuffix("/pure")'
   0
+With the automatic backend, bwrap remains in the stack when it is available, so
+the action runs in a new mount namespace.
+
   $ cmp -s host-ns _build/default/probe && echo same || echo different
   different
   $ cat _build/default/pure

--- a/test/blackbox-tests/test-cases/sandbox-actions/cache-hardlink-integrity-bwrap.t
+++ b/test/blackbox-tests/test-cases/sandbox-actions/cache-hardlink-integrity-bwrap.t
@@ -1,0 +1,71 @@
+Cache-integrity attacks through sandbox aliases are not closed by bwrap's
+worker-level cache bind.
+
+  $ export DUNE_CACHE=enabled
+  $ export DUNE_CACHE_STORAGE_MODE=hardlink
+  $ export DUNE_CACHE_ROOT=$PWD/.cache
+  $ make_dune_project 3.23
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (target dep.txt)
+  >  (action (with-stdout-to %{target} (echo "original"))))
+  > (rule
+  >  (target result)
+  >  (deps (sandbox always) dep.txt)
+  >  (action
+  >   (bash
+  >    "chmod 777 dep.txt && echo poisoned > dep.txt && cp dep.txt %{target}")))
+  > EOF
+
+  $ check_cache_contents() {
+  >   rm -rf _build
+  >   dune build dep.txt 2>/dev/null
+  >   cat _build/default/dep.txt
+  > }
+
+`--sandbox-actions-backend=bwrap`: bwrap's `--ro-bind` denies writes through
+paths under `<cache>`, but the action writes through `_build/.sandbox/...`,
+which is on the read-write `/` bind. The hardlinked inode is mutated through
+the writable mount.
+
+  $ rm -rf .cache _build
+  $ dune build dep.txt
+  $ dune build --sandbox=hardlink \
+  >   --sandbox-actions --sandbox-actions-backend=bwrap result
+  $ check_cache_contents
+  poisoned
+
+With both backends stacked under hardlink sandboxing: still corrupted, since
+neither blocks the write path that aliases the cache inode.
+
+  $ rm -rf .cache _build
+  $ dune build dep.txt
+  $ dune build --sandbox=hardlink \
+  >   --sandbox-actions \
+  >   --sandbox-actions-backend=bwrap \
+  >   --sandbox-actions-backend=landlock result
+  $ check_cache_contents
+  poisoned
+
+bwrap + symlink: chmod and write resolve through the symlink to
+`_build/default/dep.txt`, which is on the read-write `/` bind. The cache
+RO bind doesn't cover this path. Cache corrupted.
+
+  $ rm -rf .cache _build
+  $ dune build dep.txt
+  $ dune build --sandbox=symlink \
+  >   --sandbox-actions --sandbox-actions-backend=bwrap result
+  $ check_cache_contents
+  poisoned
+
+bwrap + landlock + symlink: still corrupted, for the same combined reasons as
+the individual backends.
+
+  $ rm -rf .cache _build
+  $ dune build dep.txt
+  $ dune build --sandbox=symlink \
+  >   --sandbox-actions \
+  >   --sandbox-actions-backend=bwrap \
+  >   --sandbox-actions-backend=landlock result
+  $ check_cache_contents
+  poisoned

--- a/test/blackbox-tests/test-cases/sandbox-actions/cache-hardlink-integrity.t
+++ b/test/blackbox-tests/test-cases/sandbox-actions/cache-hardlink-integrity.t
@@ -1,0 +1,92 @@
+Cache-integrity attack: a sandboxed action that chmods and writes a
+hardlinked dependency can corrupt the shared cache entry. The cache stores
+files via hardlinks (default mode). In hardlink sandboxes, the sandbox entry
+shares the cache inode directly. In symlink sandboxes, the sandbox symlink
+resolves to the build-dir file, which also shares the cache inode. In both
+cases, the action writes through paths outside the cache directory, so bwrap's
+`--ro-bind <cache>` and Landlock's `--deny-write <cache>` both miss the write.
+
+  $ export DUNE_CACHE=enabled
+  $ export DUNE_CACHE_STORAGE_MODE=hardlink
+  $ export DUNE_CACHE_ROOT=$PWD/.cache
+  $ make_dune_project 3.23
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (target dep.txt)
+  >  (action (with-stdout-to %{target} (echo "original"))))
+  > (rule
+  >  (target result)
+  >  (deps (sandbox always) dep.txt)
+  >  (action
+  >   (bash
+  >    "chmod 777 dep.txt && echo poisoned > dep.txt && cp dep.txt %{target}")))
+  > EOF
+
+Helper: clear the build dir, restore dep.txt from cache, and print its
+contents. If the cache entry was corrupted in a prior step, the restored
+contents will not match the original.
+
+  $ check_cache_contents() {
+  >   rm -rf _build
+  >   dune build dep.txt 2>/dev/null
+  >   cat _build/default/dep.txt
+  > }
+
+Baseline: no sandbox-actions. The sandboxed action's chmod+write succeeds
+because the action's `dep.txt` shares an inode with the cache entry. After
+clearing the build dir, the cache returns the corrupted contents.
+
+  $ rm -rf .cache _build
+  $ dune build dep.txt
+  $ dune build --sandbox=hardlink result
+  $ check_cache_contents
+  poisoned
+
+`--sandbox-actions-backend=landlock`: same outcome. The worker-level Landlock
+policy denies writes under the cache subtree by path. The write goes through
+the hardlink inside the sandbox, which is allowed, so the inode is mutated.
+
+  $ rm -rf .cache _build
+  $ dune build dep.txt
+  $ dune build --sandbox=hardlink \
+  >   --sandbox-actions --sandbox-actions-backend=landlock result
+  $ check_cache_contents
+  poisoned
+
+Now repeat the four sandbox-actions configurations with `--sandbox=symlink`.
+The mechanism is different from hardlink mode: chmod and write both follow the
+symlink to the build-dir hardlink, which shares the cache inode. The empirical
+outcome with the current worker-level policies is the same. Recorded here so
+the limit of each backend is visible.
+
+Baseline symlink: cache corrupted.
+
+  $ rm -rf .cache _build
+  $ dune build dep.txt
+  $ dune build --sandbox=symlink result
+  $ check_cache_contents
+  poisoned
+
+landlock + symlink: Landlock evaluates rules on the resolved path. The
+symlink resolves to `_build/default/dep.txt`, which is *not* in the
+denied cache subtree. Open allowed, cache corrupted. Unlike hardlink
+mode, this case is in principle fixable: extending the policy to also
+deny writes to the build directory would catch the resolved-path open.
+The current `--sandbox-actions-backend=landlock` does not enable that.
+
+  $ rm -rf .cache _build
+  $ dune build dep.txt
+  $ dune build --sandbox=symlink \
+  >   --sandbox-actions --sandbox-actions-backend=landlock result
+  $ check_cache_contents
+  poisoned
+
+The actual protection: `--sandbox=copy`. The sandbox dep is an independent
+inode, so the action's chmod+write does not touch the cache entry's inode.
+The action corrupts its own sandbox copy, but the cache is intact.
+
+  $ rm -rf .cache _build
+  $ dune build dep.txt
+  $ dune build --sandbox=copy result
+  $ check_cache_contents
+  original

--- a/test/blackbox-tests/test-cases/sandbox-actions/dune
+++ b/test/blackbox-tests/test-cases/sandbox-actions/dune
@@ -1,5 +1,5 @@
 (cram
- (applies_to :whole_subtree)
+ (applies_to basic shared-cache with-bwrap)
  (alias runtest-bwrap)
  (runtest_alias
   (<> %{env:CI=false} true))

--- a/test/blackbox-tests/test-cases/sandbox-actions/dune
+++ b/test/blackbox-tests/test-cases/sandbox-actions/dune
@@ -1,5 +1,10 @@
 (cram
- (applies_to basic shared-cache with-bwrap backends-bwrap)
+ (applies_to
+  basic
+  shared-cache
+  with-bwrap
+  backends-bwrap
+  cache-hardlink-integrity-bwrap)
  (alias runtest-bwrap)
  (runtest_alias
   (<> %{env:CI=false} true))
@@ -7,6 +12,6 @@
  (enabled_if %{bin-available:bwrap}))
 
 (cram
- (applies_to backends)
+ (applies_to backends cache-hardlink-integrity)
  (enabled_if
   (= %{system} linux)))

--- a/test/blackbox-tests/test-cases/sandbox-actions/dune
+++ b/test/blackbox-tests/test-cases/sandbox-actions/dune
@@ -1,7 +1,12 @@
 (cram
- (applies_to basic shared-cache with-bwrap)
+ (applies_to basic shared-cache with-bwrap backends-bwrap)
  (alias runtest-bwrap)
  (runtest_alias
   (<> %{env:CI=false} true))
  (deps %{bin:bwrap})
  (enabled_if %{bin-available:bwrap}))
+
+(cram
+ (applies_to backends)
+ (enabled_if
+  (= %{system} linux)))

--- a/test/blackbox-tests/test-cases/sandbox-actions/landlock/cache-ancestor-writes.t
+++ b/test/blackbox-tests/test-cases/sandbox-actions/landlock/cache-ancestor-writes.t
@@ -1,0 +1,32 @@
+When Landlock protects the shared cache, the worker cannot create new entries
+directly in ancestors of the protected cache directory.
+
+  $ make_dune_project 3.23
+  $ export DUNE_CACHE_ROOT=$PWD/cache-root
+  $ mkdir -p "$DUNE_CACHE_ROOT/db"
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (target result)
+  >  (action
+  >   (bash
+  >    "if touch \"$DUNE_CACHE_ROOT/ancestor-marker\" 2>/dev/null; then echo wrote > %{target}; else echo blocked > %{target}; fi")))
+  > EOF
+
+Normal actions can create entries directly in the cache root.
+
+  $ dune build result
+  $ cat _build/default/result
+  wrote
+  $ test -e "$DUNE_CACHE_ROOT/ancestor-marker" && echo present || echo missing
+  present
+
+The Landlock backend protects `$DUNE_CACHE_ROOT/db`, and the deny algorithm
+does not grant directory write rights on `$DUNE_CACHE_ROOT` itself.
+
+  $ rm -f "$DUNE_CACHE_ROOT/ancestor-marker"
+  $ rm -rf _build
+  $ dune build --sandbox-actions --sandbox-actions-backend=landlock result
+  $ cat _build/default/result
+  blocked
+  $ test -e "$DUNE_CACHE_ROOT/ancestor-marker" && echo present || echo missing
+  missing

--- a/test/blackbox-tests/test-cases/sandbox-actions/landlock/dune
+++ b/test/blackbox-tests/test-cases/sandbox-actions/landlock/dune
@@ -1,0 +1,5 @@
+(cram
+ ; TODO detect the Landlock ABI version and enable these tests only when the
+ ; kernel supports the ABI that dune requires.
+ (enabled_if
+  (= %{system} linux)))

--- a/test/blackbox-tests/test-cases/sandbox-actions/landlock/landlock-extended-policy.t
+++ b/test/blackbox-tests/test-cases/sandbox-actions/landlock/landlock-extended-policy.t
@@ -1,0 +1,42 @@
+Verify the claim that `dune internal with-landlock` with an extended
+deny-write policy (cache + build directory) blocks the cache-corruption
+attack for the sandbox=symlink configuration. This is a synthetic test:
+it constructs the inode chain manually rather than going through
+`dune build`, so the policy can be varied without changing dune-side code.
+
+Scenario A: deny writes to the cache only, matching the current worker-level
+Landlock write policy. The attack writes through the sandbox symlink, which
+resolves to `build/dep.txt`. Landlock's check fires on the resolved path, which
+is not in the denied subtree, so the write proceeds and the cache is corrupted.
+
+  $ rm -rf scratch-a
+  $ mkdir -p scratch-a/cache scratch-a/build scratch-a/sandbox
+  $ echo original > scratch-a/cache/dep.txt
+  $ chmod 444 scratch-a/cache/dep.txt
+  $ ln scratch-a/cache/dep.txt scratch-a/build/dep.txt
+  $ ln -s "$PWD/scratch-a/build/dep.txt" scratch-a/sandbox/dep.txt
+  $ dune internal with-landlock --deny-write "$PWD/scratch-a/cache" -- \
+  >   sh -c 'chmod 777 scratch-a/sandbox/dep.txt 2>/dev/null && (echo poisoned > scratch-a/sandbox/dep.txt) 2>/dev/null && echo wrote || echo blocked'
+  wrote
+  $ cat scratch-a/cache/dep.txt
+  poisoned
+
+Scenario B: deny writes to both the cache and the build directory. The
+resolved path of the symlink now falls in the denied build subtree, so the
+destructive write returns EACCES. The chmod still succeeds (landlock does
+not gate chmod) but the write itself is blocked, and the cache content
+survives.
+
+  $ rm -rf scratch-b
+  $ mkdir -p scratch-b/cache scratch-b/build scratch-b/sandbox
+  $ echo original > scratch-b/cache/dep.txt
+  $ chmod 444 scratch-b/cache/dep.txt
+  $ ln scratch-b/cache/dep.txt scratch-b/build/dep.txt
+  $ ln -s "$PWD/scratch-b/build/dep.txt" scratch-b/sandbox/dep.txt
+  $ dune internal with-landlock \
+  >   --deny-write "$PWD/scratch-b/cache" \
+  >   --deny-write "$PWD/scratch-b/build" \
+  >   -- sh -c 'chmod 777 scratch-b/sandbox/dep.txt 2>/dev/null && (echo poisoned > scratch-b/sandbox/dep.txt) 2>/dev/null && echo wrote || echo blocked'
+  blocked
+  $ cat scratch-b/cache/dep.txt
+  original

--- a/test/blackbox-tests/test-cases/sandbox-actions/landlock/with-landlock.t
+++ b/test/blackbox-tests/test-cases/sandbox-actions/landlock/with-landlock.t
@@ -1,0 +1,116 @@
+`dune internal with-landlock --deny-write PATH` blocks writes within that subtree.
+
+  $ export DUNE_CACHE_ROOT=$PWD/cache-root
+  $ mkdir -p "$DUNE_CACHE_ROOT/db" writable
+  $ echo cache > "$DUNE_CACHE_ROOT/db/item"
+  $ dune internal with-landlock --deny-write "$DUNE_CACHE_ROOT/db" -- sh -c 'cat "$DUNE_CACHE_ROOT/db/item"; if touch "$DUNE_CACHE_ROOT/db/new" 2>/dev/null; then echo cache-wrote; else echo cache-blocked; fi; if touch writable/outside 2>/dev/null; then echo outside-wrote; else echo outside-blocked; fi'
+  cache
+  cache-blocked
+  outside-wrote
+  $ test -e "$DUNE_CACHE_ROOT/db/new" && echo present || echo missing
+  missing
+
+Rename/link out of a denied tree and truncation of a denied file are blocked.
+These are the ABI 2/3 rights that keep a protected file from being moved or
+emptied through a non-write operation.
+
+  $ rm -f writable/item writable/item-link
+  $ dune internal with-landlock --deny-write "$DUNE_CACHE_ROOT/db" -- sh -c 'if mv "$DUNE_CACHE_ROOT/db/item" writable/item 2>/dev/null; then echo moved; else echo move-blocked; fi; if ln "$DUNE_CACHE_ROOT/db/item" writable/item-link 2>/dev/null; then echo linked; else echo link-blocked; fi; if truncate -s 0 "$DUNE_CACHE_ROOT/db/item" 2>/dev/null; then echo truncated; else echo truncate-blocked; fi'
+  move-blocked
+  link-blocked
+  truncate-blocked
+  $ test -e "$DUNE_CACHE_ROOT/db/item" && echo present || echo missing
+  present
+  $ test -e writable/item && echo present || echo missing
+  missing
+  $ test -e writable/item-link && echo present || echo missing
+  missing
+  $ cat "$DUNE_CACHE_ROOT/db/item"
+  cache
+
+Symlink aliases of denied paths are not granted write rules while enumerating
+siblings of protected ancestors.
+
+  $ rm -f alias
+  $ ln -s cache-root alias
+  $ dune internal with-landlock --deny-write "$DUNE_CACHE_ROOT/db" -- sh -c 'if touch alias/db/through-alias 2>/dev/null; then echo alias-wrote; else echo alias-blocked; fi'
+  alias-blocked
+  $ test -e "$DUNE_CACHE_ROOT/db/through-alias" && echo present || echo missing
+  missing
+
+The ancestor directories of a denied path are not granted directory write
+rights, so creating new entries directly in those ancestors is denied too.
+
+  $ rm -f ancestor-new
+  $ dune internal with-landlock --deny-write "$DUNE_CACHE_ROOT/db" -- sh -c 'if touch ancestor-new 2>/dev/null; then echo ancestor-wrote; else echo ancestor-blocked; fi'
+  ancestor-blocked
+  $ test -e ancestor-new && echo present || echo missing
+  missing
+
+Without any flags, `dune internal with-landlock` is a no-op.
+
+  $ rm -f "$DUNE_CACHE_ROOT/db/no-flag-write"
+  $ dune internal with-landlock -- sh -c 'touch "$DUNE_CACHE_ROOT/db/no-flag-write" && echo wrote'
+  wrote
+  $ test -e "$DUNE_CACHE_ROOT/db/no-flag-write" && echo present || echo missing
+  present
+
+Allow flags are punch-holes in denied subtrees. Without a corresponding deny
+flag they do not turn the policy into a deny-everything-else allow-list.
+
+  $ mkdir -p "$DUNE_CACHE_ROOT/db/allowed"
+  $ rm -f "$DUNE_CACHE_ROOT/db/allowed/punch-hole" "$DUNE_CACHE_ROOT/db/blocked"
+  $ dune internal with-landlock \
+  >   --deny-write "$DUNE_CACHE_ROOT/db" \
+  >   --allow-write "$DUNE_CACHE_ROOT/db/allowed" \
+  >   -- sh -c 'if touch "$DUNE_CACHE_ROOT/db/allowed/punch-hole" 2>/dev/null; then echo allow-wrote; else echo allow-blocked; fi; if touch "$DUNE_CACHE_ROOT/db/blocked" 2>/dev/null; then echo deny-wrote; else echo deny-blocked; fi'
+  allow-wrote
+  deny-blocked
+  $ test -e "$DUNE_CACHE_ROOT/db/allowed/punch-hole" && echo present || echo missing
+  present
+  $ test -e "$DUNE_CACHE_ROOT/db/blocked" && echo present || echo missing
+  missing
+
+  $ rm -f "$DUNE_CACHE_ROOT/db/allow-only-write"
+  $ dune internal with-landlock --allow-write writable -- sh -c 'touch "$DUNE_CACHE_ROOT/db/allow-only-write" && echo wrote'
+  wrote
+  $ test -e "$DUNE_CACHE_ROOT/db/allow-only-write" && echo present || echo missing
+  present
+
+Allow paths must be strictly inside a denied path. An allow path that covers a
+deny path is rejected instead of silently nullifying the deny.
+
+  $ dune internal with-landlock --deny-write "$DUNE_CACHE_ROOT/db" --allow-write "$DUNE_CACHE_ROOT" -- true 2>&1 | sed "s#$PWD#PWD#g"
+  Error: --allow-write path
+  PWD/cache-root
+  must be strictly inside a --deny-write path
+  [1]
+
+An allow path is also rejected if it covers another denied path.
+
+  $ mkdir -p "$DUNE_CACHE_ROOT/db/secret"
+  $ dune internal with-landlock \
+  >   --deny-write "$DUNE_CACHE_ROOT/db" \
+  >   --deny-write "$DUNE_CACHE_ROOT/db/secret" \
+  >   --allow-write "$DUNE_CACHE_ROOT/db/secret" \
+  >   -- true 2>&1 | sed "s#$PWD#PWD#g"
+  Error: --allow-write path
+  PWD/cache-root/db/secret
+  must not cover --deny-write path
+  PWD/cache-root/db/secret
+  [1]
+
+Allow paths must exist when the policy is installed. Missing allow paths are
+rejected.
+
+  $ rm -rf "$DUNE_CACHE_ROOT/missing"
+  $ dune internal with-landlock \
+  >   --deny-write "$DUNE_CACHE_ROOT" \
+  >   --allow-write "$DUNE_CACHE_ROOT/missing" \
+  >   -- true 2>&1 | sed "s#$PWD#PWD#g"
+  Error: failed to allow writes to
+  PWD/cache-root/missing:
+  No such file or directory
+  [1]
+  $ test -e "$DUNE_CACHE_ROOT/missing" && echo present || echo missing
+  missing

--- a/test/blackbox-tests/test-cases/sandbox-actions/shared-cache.t
+++ b/test/blackbox-tests/test-cases/sandbox-actions/shared-cache.t
@@ -1,6 +1,5 @@
-Before the Landlock cache policy is installed, `--sandbox-actions` still uses
-bwrap when it is available, so the existing bwrap shared-cache bind prevents
-the worker from writing to the launching dune's shared cache.
+`--sandbox-actions` prevents the worker from writing to the launching dune's
+shared cache.
 
   $ make_dune_project 3.23
   $ export DUNE_CACHE_ROOT=$PWD/cache-root
@@ -23,11 +22,26 @@ Normal actions can still write there.
   $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present
   present
 
-Sandboxed actions are blocked from writing there by bwrap.
+Actions run through the external action runner are blocked from writing there.
 
   $ rm -f "$DUNE_CACHE_ROOT/db/runner-marker"
   $ dune build --sandbox-actions result
   $ cat _build/default/result
   blocked
+  $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present || echo missing
+  missing
+
+If the shared cache path does not exist yet, dune creates it and still protects
+it from the worker.
+
+  $ export DUNE_CACHE_ROOT=$PWD/fresh-cache-root
+  $ echo "$DUNE_CACHE_ROOT" > cache-root-name
+  $ test -e "$DUNE_CACHE_ROOT/db" && echo present || echo missing
+  missing
+  $ dune build --sandbox-actions result
+  $ cat _build/default/result
+  blocked
+  $ test -d "$DUNE_CACHE_ROOT/db" && echo present || echo missing
+  present
   $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present || echo missing
   missing

--- a/test/blackbox-tests/test-cases/sandbox-actions/shared-cache.t
+++ b/test/blackbox-tests/test-cases/sandbox-actions/shared-cache.t
@@ -1,5 +1,6 @@
-`--sandbox-actions` prevents the worker from writing to the launching dune's
-shared cache.
+Before the Landlock cache policy is installed, `--sandbox-actions` still uses
+bwrap when it is available, so the existing bwrap shared-cache bind prevents
+the worker from writing to the launching dune's shared cache.
 
   $ make_dune_project 3.23
   $ export DUNE_CACHE_ROOT=$PWD/cache-root
@@ -22,26 +23,11 @@ Normal actions can still write there.
   $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present
   present
 
-Sandboxed actions are blocked from writing there.
+Sandboxed actions are blocked from writing there by bwrap.
 
   $ rm -f "$DUNE_CACHE_ROOT/db/runner-marker"
   $ dune build --sandbox-actions result
   $ cat _build/default/result
   blocked
-  $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present || echo missing
-  missing
-
-If the shared cache path does not exist yet, dune creates it and still protects
-it from the worker.
-
-  $ export DUNE_CACHE_ROOT=$PWD/fresh-cache-root
-  $ echo "$DUNE_CACHE_ROOT" > cache-root-name
-  $ test -e "$DUNE_CACHE_ROOT/db" && echo present || echo missing
-  missing
-  $ dune build --sandbox-actions result
-  $ cat _build/default/result
-  blocked
-  $ test -d "$DUNE_CACHE_ROOT/db" && echo present || echo missing
-  present
   $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present || echo missing
   missing

--- a/test/blackbox-tests/test-cases/sandbox-actions/with-bwrap.t
+++ b/test/blackbox-tests/test-cases/sandbox-actions/with-bwrap.t
@@ -5,3 +5,15 @@
   wrapped
   $ cmp -s host-ns wrapped-ns && echo same || echo different
   different
+
+It also applies Dune's shared-cache policy.
+
+  $ export DUNE_CACHE_ROOT=$PWD/cache-root
+  $ mkdir -p "$DUNE_CACHE_ROOT/db" writable
+  $ echo cache > "$DUNE_CACHE_ROOT/db/item"
+  $ dune internal with-bwrap -- sh -c 'cat "$DUNE_CACHE_ROOT/db/item"; if touch "$DUNE_CACHE_ROOT/db/new" 2>/dev/null; then echo cache-wrote; else echo cache-blocked; fi; if touch writable/outside 2>/dev/null; then echo outside-wrote; else echo outside-blocked; fi'
+  cache
+  cache-blocked
+  outside-wrote
+  $ test -e "$DUNE_CACHE_ROOT/db/new" && echo present || echo missing
+  missing


### PR DESCRIPTION
## Description

This PR adds a Landlock backend for `--sandbox-actions` and uses it to protect the shared cache from writes by the external action-runner worker.

The stack is split into three pieces:

1. Add `dune internal with-landlock`, a Linux Landlock wrapper that supports `--deny-write` subtrees and `--allow-write` punch-holes.
2. Add `--sandbox-actions-backend` so callers can request `bwrap`, `landlock`, or an explicit stack of both backends.
3. Apply worker-level shared-cache protection to sandbox-actions backends.

Final automatic selection in this PR prefers Landlock when it is available and falls back to bwrap otherwise. Explicit backend requests still use exactly what was requested, after availability validation. Stacking remains explicit by passing `--sandbox-actions-backend` more than once.

The shared-cache policy is path-based:

- bwrap protects the cache with the existing read-only bind.
- Landlock protects the cache with `--deny-write` on the shared cache directory.

The policy does not prevent writes through hardlinks or other aliases outside the protected subtree. With Landlock, it also denies creating or removing entries directly in ancestor directories of the protected cache path; this is documented and covered by tests.

## Not in this PR

This PR intentionally does not implement:

- source-tree read prevention;
- source-tree write prevention;
- per-action write confinement to the current action sandbox/output root.

Those policies need more design work and are left for follow-up changes.

## Testing

The PR adds and updates blackbox tests under `test/blackbox-tests/test-cases/sandbox-actions`:

- backend selection, explicit backend requests, functional bwrap availability probing, automatic fallback, and stacked backends;
- direct `with-landlock` wrapper semantics, including allow/deny validation, `REFER`, `TRUNCATE`, and symlink-alias behavior;
- bwrap and Landlock shared-cache protection;
- remaining hardlink/symlink cache-integrity limitations;
- Landlock ancestor-directory write denial at the build level.

Focused local checks run during development:

- `./dune.exe runtest test/blackbox-tests/test-cases/sandbox-actions/`
- `./dune.exe runtest test/blackbox-tests/test-cases/sandbox-actions/landlock/`
- `./dune.exe fmt`