### PR TITLE
refactor(stdune): distinguish failed process signaling

### DIFF
--- a/otherlibs/stdune/src/pid.ml
+++ b/otherlibs/stdune/src/pid.ml
@@ -12,7 +12,7 @@ let of_int_exn t =
 
 let me () = Unix.getpid ()
 
-let kill pid where signal =
+let signal pid where signal =
   let where =
     match where with
     | `Pid -> pid
@@ -20,7 +20,33 @@ let kill pid where signal =
       assert (not Sys.win32);
       -pid
   in
-  Unix.kill where (Signal.to_int signal)
+  match
+    Unix.kill
+      where
+      (match signal with
+       | `Null -> 0
+       | `Signal s -> Signal.to_int s)
+  with
+  | () -> `Delivered
+  | exception Unix.Unix_error (Unix.EPERM, _, _) -> `Not_allowed
+  | exception Unix.Unix_error (Unix.ESRCH, _, _) -> `Dead
+;;
+
+let kill pid where (signal' : Signal.t) =
+  match signal pid where (`Signal signal') with
+  | `Delivered -> `Delivered
+  | `Dead -> `Dead
+  | `Not_allowed ->
+    Code_error.raise
+      "Not allowed to signal"
+      [ "signal", Signal.to_dyn signal'; "pid", to_dyn pid ]
+;;
+
+let kill_exn pid where signal =
+  match kill pid where signal with
+  | `Delivered -> ()
+  | `Dead ->
+    Code_error.raise "Pid is dead" [ "signal", Signal.to_dyn signal; "pid", to_dyn pid ]
 ;;
 
 module Set = Int.Set

--- a/otherlibs/stdune/src/pid.mli
+++ b/otherlibs/stdune/src/pid.mli
@@ -11,6 +11,7 @@ val me : unit -> t
     further *)
 val of_int_exn : int -> t
 
-val kill : t -> [ `Pid | `Group ] -> Signal.t -> unit
+val kill : t -> [ `Pid | `Group ] -> Signal.t -> [ `Delivered | `Dead ]
+val kill_exn : t -> [ `Pid | `Group ] -> Signal.t -> unit
 
 module Set : Set.S with type elt = t

--- a/otherlibs/stdune/test/proc_linux_tests.ml
+++ b/otherlibs/stdune/test/proc_linux_tests.ml
@@ -61,7 +61,7 @@ let fork_child_with_grandchild () =
 ;;
 
 let cleanup_child_tree (child, _grandchild) =
-  Pid.kill child `Pid Kill;
+  Pid.kill_exn child `Pid Kill;
   wait_no_eintr child
 ;;
 

--- a/src/dune_scheduler/file_watcher.ml
+++ b/src/dune_scheduler/file_watcher.ml
@@ -438,7 +438,7 @@ let shutdown t =
   close t;
   match t.kind with
   | Inotify _ -> ()
-  | Fswatch { pid; _ } -> Pid.kill pid `Pid Term
+  | Fswatch { pid; _ } -> Pid.kill_exn pid `Pid Term
   | Fswatch_win { t } -> Fswatch_win.shutdown t
   | Fsevents fsevents ->
     Fsevents.stop fsevents.source;

--- a/src/dune_scheduler/process_watcher.ml
+++ b/src/dune_scheduler/process_watcher.ml
@@ -18,10 +18,7 @@ let kill_process_group pid signal ~is_process_group_leader =
        The downside is that it's more complicated, but also that by sending the
        signal twice we're greatly increasing the existing race condition where
        we call [wait] in parallel with [kill]. *)
-    (try Pid.kill pid `Group signal with
-     (* CR-someday rgrinerg: do we need to catch this error now that we're no
-        longer racing? *)
-     | Unix.Unix_error _ -> ())
+    ignore (Pid.kill pid `Group signal : [ `Delivered | `Dead ])
   | false ->
     (* Process groups are not supported on Windows (or even if they are, [spawn]
        does not know how to use them), so we're only sending the signal to the
@@ -31,8 +28,7 @@ let kill_process_group pid signal ~is_process_group_leader =
       a process group id that we know about. This happens when
       [is_process_group_leader] is [false]. In those cases, it doesn't make
       sense to pretend the pid corresponds to the correct process group. *)
-    (try Pid.kill pid `Pid signal with
-     | Unix.Unix_error _ -> ())
+    ignore (Pid.kill pid `Pid signal : [ `Delivered | `Dead ])
 ;;
 
 (* This mutable table is safe: it does not interact with the state we track in

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -127,8 +127,7 @@ let signal_processes pids signal =
       | Error _ -> acc
       | Ok () ->
         (match Pid.kill pid `Pid signal with
-         | () -> Ok ()
-         | exception Unix.Unix_error (Unix.ESRCH, _, _) -> Ok ()
+         | `Delivered | `Dead -> Ok ()
          | exception exn ->
            Error
              [ Pp.textf
@@ -324,7 +323,7 @@ let kill_and_wait_for_all_processes t =
      reset with the correct event queue. *)
   if not Sys.win32
   then (
-    Pid.kill (Pid.me ()) `Pid Thread0.signal_watcher_interrupt;
+    Pid.kill_exn (Pid.me ()) `Pid Thread0.signal_watcher_interrupt;
     Thread.join t.signal_watcher);
   !saw_shutdown
 ;;

--- a/src/dune_tui/dune_tui.ml
+++ b/src/dune_tui/dune_tui.ml
@@ -26,7 +26,7 @@ let term =
                    match Lazy.force old with
                    | Sys.Signal_handle f -> f i
                    | _ ->
-                     Pid.kill (Pid.me ()) `Pid Stop;
+                     Pid.kill_exn (Pid.me ()) `Pid Stop;
                      Dune_trace.emit Process (fun () ->
                        Dune_trace.Event.signal_sent Stop `Ui)))
        in
@@ -270,7 +270,7 @@ let document =
   let keyboard_handler = function
     (* When we encounter q we make sure to quit by signaling termination. *)
     | `ASCII 'q', _ ->
-      Pid.kill (Pid.me ()) `Pid Term;
+      Pid.kill_exn (Pid.me ()) `Pid Term;
       Dune_trace.emit Process (fun () -> Dune_trace.Event.signal_sent Term `Ui);
       `Handled
     (* Toggle help screen *)


### PR DESCRIPTION

Return `Dead from Pid.kill when the target disappears before signaling, and add Pid.kill_exn for call sites where a missing target should remain a code error.

Update existing callers to use the non-raising result where they previously caught signaling races and Pid.kill_exn elsewhere.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>