### PR TITLE
Disable `flambda` in Nix

### DIFF
--- a/nix/dune-package.nix
+++ b/nix/dune-package.nix
@@ -52,6 +52,9 @@ let
   dune-static-overlay = self: super: {
     ocamlPackages = super.ocaml-ng.ocamlPackages_5_4.overrideScope (
       oself: osuper: {
+        ocaml = osuper.ocaml.override {
+          flambdaSupport = false;
+        };
         dune_3 = osuper.dune_3.overrideAttrs (a: {
           src = dune-source;
           preBuild = "ocaml boot/bootstrap.ml --static";


### PR DESCRIPTION
The nix-overlay enables `flambda` automatically and in the flake we disable it for `dune`. However, this is
not the case for `dune-static`, where we use the regular `ocaml` package (from the overlay) continues to use `flambda`.

This disables flambda in both `dune-static` as well as `dune`, according to the decision from the Dune developer meeting on 2026-07-08.
