### PR TITLE
jsoo: honor build_runtime_flags when the shared standalone runtime is used

### DIFF
--- a/doc/changes/unreleased/15455.md
+++ b/doc/changes/unreleased/15455.md
@@ -1,0 +1,5 @@
+- Fix `build_runtime_flags` given in a `js_of_ocaml`/`wasm_of_ocaml` field of
+  an executable being silently ignored in separate compilation mode: such
+  executables were given the workspace-shared standalone runtime, which is
+  built with the default flags. Executables customizing `build_runtime_flags`
+  now get their own standalone runtime again. (#15455, @hhugo)

--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -1120,7 +1120,14 @@ let build_standalone_runtime cc ~loc ~in_context ~jsoo_mode:mode =
     assert (Js_of_ocaml.Mode.select ~mode ~js:(wasm_files = []) ~wasm:true);
     let runtime_files = javascript_files @ wasm_files in
     let* eligible =
-      if List.is_empty runtime_files
+      if
+        List.is_empty runtime_files
+        (* The shared runtime is built with the default flags, so an
+           executable customizing [build_runtime_flags] needs its own
+           runtime. *)
+        && Ordered_set_lang.Unexpanded.equal
+             (Js_of_ocaml.Flags.build_runtime flags)
+             Ordered_set_lang.Unexpanded.standard
       then
         Resolve.Memo.peek (Compilation_context.requires_link cc)
         >>| function

--- a/test/blackbox-tests/test-cases/jsoo/shared-runtime-build-runtime-flags.t
+++ b/test/blackbox-tests/test-cases/jsoo/shared-runtime-build-runtime-flags.t
@@ -1,0 +1,47 @@
+Regression test for per-executable build_runtime_flags in separate
+compilation.
+
+Since the introduction of the shared standalone runtime, an executable
+with no javascript_files of its own was always given the shared runtime,
+which is built with the default flags: its build_runtime_flags were
+silently dropped. Here --file must embed data.txt into the
+pseudo-filesystem of main.bc.js.
+
+  $ make_dune_project 3.19
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (modes js)
+  >  (js_of_ocaml
+  >   (compilation_mode separate)
+  >   (build_runtime_flags (:standard --file %{dep:data.txt}))))
+  > EOF
+  $ cat > main.ml <<EOF
+  > let () = print_endline "hi"
+  > EOF
+  $ echo EMBEDDED_PAYLOAD > data.txt
+
+  $ dune build ./main.bc.js
+  $ grep -c EMBEDDED_PAYLOAD _build/default/main.bc.js
+  0
+  [1]
+
+An executable with default build_runtime_flags still uses the shared
+runtime:
+
+  $ mkdir other
+  $ cat > other/dune <<EOF
+  > (executable
+  >  (name other)
+  >  (modes js)
+  >  (js_of_ocaml
+  >   (compilation_mode separate)))
+  > EOF
+  $ cat > other/other.ml <<EOF
+  > let () = print_endline "hi"
+  > EOF
+
+  $ dune build ./other/other.bc.js
+  $ find _build/default/.js -name 'runtime.bc.runtime.js' | wc -l | xargs
+  1

--- a/test/blackbox-tests/test-cases/jsoo/shared-runtime-build-runtime-flags.t
+++ b/test/blackbox-tests/test-cases/jsoo/shared-runtime-build-runtime-flags.t
@@ -24,8 +24,7 @@ pseudo-filesystem of main.bc.js.
 
   $ dune build ./main.bc.js
   $ grep -c EMBEDDED_PAYLOAD _build/default/main.bc.js
-  0
-  [1]
+  1
 
 An executable with default build_runtime_flags still uses the shared
 runtime:


### PR DESCRIPTION
Since #13621 (workspace-shared standalone runtimes, released in 3.23.0), an executable in separate compilation mode that has no `javascript_files`/`wasm_files` of its own is always given the shared runtime — and the shared runtime is built by `setup_shared_runtime_rule` with `In_context.default.flags`. The stanza's `(js_of_ocaml (build_runtime_flags ...))` are silently dropped: nothing is emitted at build time, and e.g. a `--file %{dep:data.txt}` pseudo-filesystem embed simply doesn't happen, breaking `Sys_js.read_file` at run time.

Minimal reproduction (first commit adds it as a cram test, recording the buggy output):

```
$ cat dune
(executable
 (name main)
 (modes js)
 (js_of_ocaml
  (compilation_mode separate)
  (build_runtime_flags (:standard --file %{dep:data.txt}))))
$ dune build ./main.bc.js && grep -c EMBEDDED_PAYLOAD _build/default/main.bc.js
0        # expected 1; the build-runtime command contains no --file
```

Adding a dummy `(javascript_files extra.js)` to the very same stanza — which disqualifies it from sharing — makes the flags take effect again, isolating the sharing path as the cause.

The fix (second commit) makes sharing eligibility also require that the stanza's `build_runtime_flags` spec is the default `(:standard)`; otherwise the executable falls back to the per-stanza standalone runtime, where its flags apply as before 3.23. Executables with default flags keep sharing (the test's second half checks a single shared runtime is still produced).

Known limitation, unchanged by this PR: `build_runtime_flags` customized through an `(env ...)` stanza are still not reflected in the shared runtime, which is built with the flags of the workspace root. Fixing that would require either including expanded flags in the runtime key or comparing env nodes; both seemed better discussed separately.

Found in the wild: js_of_ocaml's own examples embed data files via `--file` and silently broke (blank canvas); see ocsigen/js_of_ocaml#2388 which now also ships the files over http as a workaround.
