### PR TITLE
feature(trace): emit OCaml runtime events

### DIFF
--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -952,7 +952,17 @@ module Process = Fiber.Process
 (** {2 OCaml tools} *)
 
 module Libs = struct
-  let external_libraries = [ "unix"; "threads" ]
+  let ocaml_version = Scanf.sscanf Sys.ocaml_version "%d.%d" (fun a b -> a, b)
+
+  let is_oxcaml =
+    let check suffix = String.ends_with Sys.ocaml_version ~suffix in
+    check "+ox" || check "+jst"
+  ;;
+
+  let external_libraries =
+    let base = [ "unix"; "threads" ] in
+    if ocaml_version >= (5, 0) && not is_oxcaml then base @ [ "runtime_events" ] else base
+  ;;
 
   let make_lib lib =
     let root_module =
@@ -2000,6 +2010,8 @@ let resolve_externals external_libraries =
     let convert = function
       | "threads" -> Some ("threads" ^ Config.ocaml_archive_ext, [ "-I"; "+threads" ])
       | "unix" -> Some ("unix" ^ Config.ocaml_archive_ext, Config.unix_library_flags)
+      | "runtime_events" ->
+        Some ("runtime_events" ^ Config.ocaml_archive_ext, [ "-I"; "+runtime_events" ])
       | "csexp" | "pp" | "re" | "seq" -> None
       | s -> fatal "unhandled external library %s" s
     in

--- a/boot/pps.mll
+++ b/boot/pps.mll
@@ -34,6 +34,17 @@
     Scanf.sscanf Sys.ocaml_version "%d.%d.%d" (fun a b c -> a, b, c)
   ;;
 
+  let is_oxcaml =
+    let version = Sys.ocaml_version in
+    let ends_with suffix =
+      let version_len = String.length version in
+      let suffix_len = String.length suffix in
+      version_len >= suffix_len
+      && String.sub version (version_len - suffix_len) suffix_len = suffix
+    in
+    ends_with "+ox" || ends_with "+jst"
+  ;;
+
   let eval_relop relop rhs =
     match relop with
     | "<" -> ocaml_version < rhs
@@ -73,6 +84,9 @@ let char_escape =
   | 'o' ['0'-'3'] octal_digit octal_digit)
 let char_literal = '\'' (char_simple | char_escape) '\''
 let lower_ident = ['a'-'z' '_']['A'-'Z' 'a'-'z' '_' '0'-'9' '\'']*
+let oxcaml_guard =
+  "&&" blank "not_defined_permissive" blank
+  ("oxcaml" | '(' blank "oxcaml" blank ')')
 
 rule copy dst mode = parse
  | "let%expect_test" { skip_expect_test (copy dst mode) 0 lexbuf }
@@ -180,6 +194,29 @@ and skip_test_module k depth = parse
  | eof { failwith "unterminated let%test_module" }
 
 and copy_conditional dst mode = parse
+ | blank "ocaml_version" blank
+   (("<=" | ">=" | "<>" | "<" | ">" | "=") as relop)
+   blank '(' blank
+   (integer as major)
+   blank ',' blank
+   (integer as minor)
+   blank ',' blank
+   (integer as patch)
+   blank ')' blank
+   oxcaml_guard blank ']'
+   {
+     let keep_then =
+       eval_relop
+         relop
+         (int_of_string major, int_of_string minor, int_of_string patch)
+       && not is_oxcaml
+     in
+     copy
+       (branch_dst dst keep_then false)
+       (Conditional { root_dst = dst; keep_then; seen_else = false })
+       lexbuf;
+     copy dst mode lexbuf
+   }
  | blank "ocaml_version" blank
    (("<=" | ">=" | "<>" | "<" | ">" | "=") as relop)
    blank '(' blank

--- a/src/dune_engine/build_loop.ml
+++ b/src/dune_engine/build_loop.ml
@@ -554,6 +554,7 @@ let poll t ~action_runner ~sticky_goal =
     (* Work we're allowed to do between successive polling iterations. this work
    should be fast and never fail (within reason) *)
     Dune_trace.emit ~buffered:true Scheduler Dune_trace.Event.scheduler_idle;
+    Dune_trace.emit_runtime ();
     Dune_trace.flush ();
     let sticky_built_at = Option.first_some built sticky_built_at in
     let* () = wait_for_wakeup_after t wakeup_generation in

--- a/src/dune_trace/alloc.ml
+++ b/src/dune_trace/alloc.ml
@@ -35,7 +35,7 @@ module Memprof = struct
   let start ~sampling_rate:_ ?callstack_size:_ (_ : (_, _) tracker) = ()
 end
 
-[%%if ocaml_version >= (5, 4, 0)]
+[%%if ocaml_version >= (5, 4, 0) && not_defined_permissive oxcaml]
 
 open Gc
 
@@ -192,7 +192,7 @@ let start () =
   t
 ;;
 
-[%%if ocaml_version >= (5, 4, 0)]
+[%%if ocaml_version >= (5, 4, 0) && not_defined_permissive oxcaml]
 
 let stop t =
   Option.iter t.profile ~f:(fun profile ->

--- a/src/dune_trace/category.ml
+++ b/src/dune_trace/category.ml
@@ -24,6 +24,7 @@ type t =
   | Digest
   | Artifact_substitution
   | Thread
+  | Runtime
 
 let all =
   [ Rpc
@@ -49,6 +50,7 @@ let all =
   ; Digest
   ; Artifact_substitution
   ; Thread
+  ; Runtime
   ]
 ;;
 
@@ -76,6 +78,7 @@ let to_string = function
   | Digest -> "digest"
   | Artifact_substitution -> "artifact_subtitution"
   | Thread -> "thread"
+  | Runtime -> "runtime"
 ;;
 
 let of_string =
@@ -115,6 +118,7 @@ module Set = Bit_set.Make (struct
       | Digest -> 20
       | Artifact_substitution -> 21
       | Thread -> 22
+      | Runtime -> 23
     ;;
   end)
 

--- a/src/dune_trace/category.mli
+++ b/src/dune_trace/category.mli
@@ -22,6 +22,7 @@ type t =
   | Digest
   | Artifact_substitution
   | Thread
+  | Runtime
 
 val to_string : t -> string
 val of_string : string -> t option

--- a/src/dune_trace/dune
+++ b/src/dune_trace/dune
@@ -1,8 +1,42 @@
+(rule
+ (write-file runtime_events_support.enabled ""))
+
+(rule
+ (write-file runtime_events_support.disabled ""))
+
+;; ppx_optcomp doesn't know about OxCaml, but Dune does.
+
+(rule
+ (enabled_if %{ocaml-config:ox})
+ (action
+  (write-file
+   ppx-optcomp-flags
+   "-cookie\nppx_optcomp.env=env ~ocaml_version:(Defined(4,14,0)) ~oxcaml:(Defined())")))
+
+(rule
+ (enabled_if
+  (not %{ocaml-config:ox}))
+ (action
+  (write-file ppx-optcomp-flags "")))
+
 (library
  (name dune_trace)
  (preprocess
-  (pps ppx_optcomp))
+  (pps ppx_optcomp -- %{read-lines:ppx-optcomp-flags}))
  (foreign_stubs
   (language c)
   (names dune_trace_stubs))
- (libraries stdune dune_action_trace re csexp bigstringaf threads.posix unix))
+ (libraries
+  stdune
+  dune_action_trace
+  re
+  csexp
+  bigstringaf
+  (select
+   runtime_events_support
+   from
+   ;; CR-someday rgrinberg: remove once ox gains support for this
+   (runtime_events -> runtime_events_support.enabled)
+   (!runtime_events -> runtime_events_support.disabled))
+  threads.posix
+  unix))

--- a/src/dune_trace/dune_trace.ml
+++ b/src/dune_trace/dune_trace.ml
@@ -41,11 +41,13 @@ let at_exit =
     match !global with
     | None -> ()
     | Some { out; ownership = Borrowed } ->
+      Out.emit_runtime out;
       let alloc_summary = capture_alloc_profile `Exit in
       Option.iter (Out.alloc out) ~f:Alloc.stop;
       Option.iter alloc_summary ~f:(Out.emit out);
       Out.close out
     | Some { out; ownership = Owned path } ->
+      Out.emit_runtime out;
       let alloc_summary = capture_alloc_profile `Exit in
       Option.iter (Out.alloc out) ~f:Alloc.stop;
       Option.iter alloc_summary ~f:(Out.emit out);
@@ -109,6 +111,8 @@ let flush () =
   | None -> ()
   | Some out -> Out.flush out
 ;;
+
+let emit_runtime () = Option.iter (global ()) ~f:Out.emit_runtime
 
 let emit_all ?buffered cat f =
   match global () with

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -25,6 +25,7 @@ module Category : sig
     | Digest
     | Artifact_substitution
     | Thread
+    | Runtime
 end
 
 module Event : sig
@@ -317,6 +318,7 @@ val always_emit : Event.t -> unit
 val enabled : Category.t -> bool
 val emit : ?buffered:bool -> Category.t -> (unit -> Event.t) -> unit
 val emit_all : ?buffered:bool -> Category.t -> (unit -> Event.t list) -> unit
+val emit_runtime : unit -> unit
 val flush : unit -> unit
 val reset_alloc_profile : unit -> unit
 val capture_alloc_profile : [ `Build of int | `Exit ] -> Event.t option

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -152,7 +152,7 @@ let init ~version =
     let args =
       [ "build_dir", Arg.build_path Path.Build.root
       ; "argv", Arg.list (Array.to_list Sys.argv |> List.map ~f:Arg.string)
-      ; "env", Arg.list (Unix.environment () |> Array.to_list |> List.map ~f:Arg.string)
+      ; "env", Arg.list (Env.initial |> Env.to_unix |> List.map ~f:Arg.string)
       ; "root", Arg.string Path.(to_absolute_filename root)
       ; "pid", Arg.int (Unix.getpid ())
       ; "initial_cwd", Arg.string Fpath.initial_cwd
@@ -981,4 +981,24 @@ let sandbox name ~start ~stop ~queued loc ~dir =
     | `Corrected -> "corrected"
   in
   Event.complete ~args ~name ~start ~dur Sandbox
+;;
+
+let runtime time what phase =
+  let args =
+    [ "phase", Arg.string (Runtime.runtime_phase_name phase)
+    ; ( "what"
+      , Arg.string
+          (match what with
+           | `Begin -> "begin"
+           | `End -> "end") )
+    ]
+  in
+  Event.instant ~args ~name:"event" time Runtime
+;;
+
+let runtime_counter time name value =
+  let args =
+    [ "name", Arg.string (Runtime.runtime_counter_name name); "value", Arg.int value ]
+  in
+  Event.instant ~args ~name:"counter" time Runtime
 ;;

--- a/src/dune_trace/out.ml
+++ b/src/dune_trace/out.ml
@@ -1,11 +1,22 @@
 open Stdune
 
+type runtime_clock =
+  { dune : Time.t
+  ; runtime : int64
+  }
+
+type runtime =
+  { callbacks : Runtime.Callbacks.t
+  ; cursor : Runtime.cursor
+  }
+
 type t =
   { fd : Fd.t
   ; buf : Buffer.t
   ; cats : Category.Set.t
   ; mutex : Mutex.t
   ; alloc : Alloc.t option
+  ; runtime : runtime option
   }
 
 let fd t = t.fd
@@ -57,27 +68,6 @@ let close t =
       Fd.close t.fd))
 ;;
 
-let create how =
-  let buf = Buffer.create (1 lsl 16) in
-  let cats = Category.enabled () in
-  let fd =
-    match how with
-    | `Fd fd -> fd
-    | `Path path ->
-      Unix.openfile
-        (Path.to_string path)
-        [ O_TRUNC; O_APPEND; O_CLOEXEC; O_WRONLY; O_CREAT ]
-        0o644
-      |> Fd.unsafe_of_unix_file_descr
-  in
-  { fd
-  ; cats
-  ; buf
-  ; mutex = Mutex.create ()
-  ; alloc = (if Category.Set.mem cats Alloc then Some (Alloc.start ()) else None)
-  }
-;;
-
 let to_buffer t sexp =
   let rec loop = function
     | Csexp.Atom str ->
@@ -113,6 +103,15 @@ let flush t =
   Mutex.protect t.mutex (fun () -> if not (Fd.is_closed t.fd) then flush_unlocked t)
 ;;
 
+let emit_runtime t =
+  Option.iter t.runtime ~f:(fun { callbacks; cursor } ->
+    (* Avoid recording allocations done while consuming runtime events. *)
+    Runtime.pause ();
+    Exn.protect ~finally:Runtime.resume ~f:(fun () ->
+      ignore (Runtime.read_poll cursor callbacks None);
+      flush t))
+;;
+
 let start t k : Event.Async.t option =
   match t with
   | None -> None
@@ -132,4 +131,87 @@ let finish t event =
     in
     let event = Event.Event.complete ?args ~start ~dur cat ~name in
     emit t event
+;;
+
+let setup_runtime ~events_dir =
+  Option.iter events_dir ~f:(fun path ->
+    let dir = Path.relative (Path.parent_exn path) ".runtime-events" in
+    Path.mkdir_p dir;
+    Unix.putenv "OCAML_RUNTIME_EVENTS_DIR" (Path.to_absolute_filename dir));
+  Runtime.start ();
+  Runtime.pause ()
+;;
+
+let runtime_callbacks =
+  (* Runtime event timestamps use the runtime's clock rather than the wall-clock
+    timestamps used by dune trace. Keep one sample from both clocks to translate
+    runtime timestamps into the trace clock. *)
+  let runtime_clock_base clock timestamp =
+    match !clock with
+    | Some base -> base
+    | None ->
+      let runtime =
+        match Runtime.current_timestamp () with
+        | None -> timestamp
+        | Some now -> Runtime.Timestamp.to_int64 now
+      in
+      let base = { dune = Time.now (); runtime } in
+      clock := Some base;
+      base
+  in
+  let time_of_runtime_timestamp clock timestamp =
+    let timestamp = Runtime.Timestamp.to_int64 timestamp in
+    let { dune; runtime } = runtime_clock_base clock timestamp in
+    let delta = Int64.sub timestamp runtime |> Int64.to_int |> Time.Span.of_ns in
+    Time.add dune delta
+  in
+  fun t ->
+    let clock = ref None in
+    let emit event = emit (Lazy.force t) ~buffered:true event in
+    let time timestamp = time_of_runtime_timestamp clock timestamp in
+    Runtime.Callbacks.create
+      ~runtime_begin:(fun _ timestamp phase ->
+        emit (Event.runtime (time timestamp) `Begin phase))
+      ~runtime_end:(fun _ timestamp phase ->
+        emit (Event.runtime (time timestamp) `End phase))
+      ~runtime_counter:(fun _ timestamp name value ->
+        emit (Event.runtime_counter (time timestamp) name value))
+      ()
+;;
+
+let create how =
+  let cats = Category.enabled () in
+  let runtime_enabled = Category.Set.mem cats Runtime in
+  if runtime_enabled
+  then
+    setup_runtime
+      ~events_dir:
+        (match how with
+         | `Fd _ -> None
+         | `Path path -> Some path);
+  let fd =
+    match how with
+    | `Fd fd -> fd
+    | `Path path ->
+      Unix.openfile
+        (Path.to_string path)
+        [ O_TRUNC; O_APPEND; O_CLOEXEC; O_WRONLY; O_CREAT ]
+        0o644
+      |> Fd.unsafe_of_unix_file_descr
+  in
+  let buf = Buffer.create (1 lsl 16) in
+  let alloc = if Category.Set.mem cats Alloc then Some (Alloc.start ()) else None in
+  let rec t =
+    lazy { fd; cats; buf; mutex = Mutex.create (); alloc; runtime = Lazy.force runtime }
+  and runtime =
+    lazy
+      (match runtime_enabled with
+       | false -> None
+       | true ->
+         let callbacks = runtime_callbacks t in
+         Some { callbacks; cursor = Runtime.create_cursor None })
+  in
+  let t = Lazy.force t in
+  if runtime_enabled then Runtime.resume ();
+  t
 ;;

--- a/src/dune_trace/out.mli
+++ b/src/dune_trace/out.mli
@@ -9,5 +9,6 @@ val emit : ?buffered:bool -> t -> Event.t -> unit
 val flush : t -> unit
 val close : t -> unit
 val create : [ `Path of Stdune.Path.t | `Fd of Fd.t ] -> t
+val emit_runtime : t -> unit
 val start : t option -> (unit -> Event.Async.data) -> Event.Async.t option
 val finish : t -> Event.Async.t option -> unit

--- a/src/dune_trace/runtime.ml
+++ b/src/dune_trace/runtime.ml
@@ -1,0 +1,49 @@
+[%%if ocaml_version >= (5, 0, 0) && not_defined_permissive oxcaml]
+
+include Runtime_events
+
+[%%if ocaml_version >= (5, 4, 0)]
+
+let current_timestamp () = Some (Timestamp.get_current ())
+
+[%%else]
+
+let current_timestamp () = None
+
+[%%endif]
+[%%else]
+
+include struct
+  [@@@ocaml.warning "-32-34"]
+
+  type runtime_counter = unit
+  type runtime_phase = unit
+  type cursor = unit
+
+  module Timestamp = struct
+    type t = unit
+
+    let to_int64 () = 0L
+  end
+
+  module Callbacks = struct
+    type t = unit
+
+    let create ?runtime_begin ?runtime_end ?runtime_counter () =
+      ignore runtime_begin;
+      ignore runtime_end;
+      ignore runtime_counter
+    ;;
+  end
+
+  let runtime_counter_name () = ""
+  let runtime_phase_name () = ""
+  let start () = ()
+  let pause () = ()
+  let resume () = ()
+  let create_cursor _ = ()
+  let read_poll () () _ = 0
+  let current_timestamp () = None
+end
+
+[%%endif]

--- a/test/blackbox-tests/test-cases/boot/ppx-optcomp.t
+++ b/test/blackbox-tests/test-cases/boot/ppx-optcomp.t
@@ -146,6 +146,36 @@ and drops false branches with no [%%else].
   $ sed '/^$/d' expected-all-operators.ml > expected.normalized
   $ diff -u expected.normalized actual.normalized
 
+It also accepts the [not_defined_permissive(oxcaml)] guard used to select
+runtime event support during bootstrap.
+
+  $ cat > oxcaml-condition.ml <<EOF
+  > [%%if ocaml_version >= (0, 0, 0) && not_defined_permissive oxcaml]
+  > let runtime_events = "available"
+  > [%%else]
+  > let runtime_events = "disabled"
+  > [%%endif]
+  > EOF
+  $ cat > expected-oxcaml-condition.ml <<'EOF'
+  > let is_oxcaml =
+  >   let version = Sys.ocaml_version in
+  >   let ends_with suffix =
+  >     let version_len = String.length version in
+  >     let suffix_len = String.length suffix in
+  >     version_len >= suffix_len
+  >     && String.sub version (version_len - suffix_len) suffix_len = suffix
+  >   in
+  >   ends_with "+ox" || ends_with "+jst"
+  > ;;
+  > let selected = if is_oxcaml then "disabled" else "available"
+  > let () = Printf.printf "let runtime_events = %S\n" selected
+  > EOF
+  $ ./dump_pps.exe oxcaml-condition.ml > actual
+  $ ocaml expected-oxcaml-condition.ml > expected
+  $ sed '/^$/d' actual > actual.normalized
+  $ sed '/^$/d' expected > expected.normalized
+  $ diff -u expected.normalized actual.normalized
+
 Literal marker text inside strings and comments is preserved.
 
   $ cat > literal-markers.ml <<EOF

--- a/test/blackbox-tests/test-cases/trace/dune
+++ b/test/blackbox-tests/test-cases/trace/dune
@@ -7,3 +7,8 @@
  (applies_to file-watcher-events)
  (enabled_if
   (<> %{system} macosx)))
+
+(cram
+ (applies_to runtime-events)
+ (enabled_if
+  (>= %{ocaml_version} 5.0.0)))

--- a/test/blackbox-tests/test-cases/trace/runtime-events.t
+++ b/test/blackbox-tests/test-cases/trace/runtime-events.t
@@ -1,0 +1,55 @@
+Runtime trace events
+====================
+
+Runtime events are timing- and allocation-dependent, so only assert the stable
+shape of emitted events.
+
+  $ make_dune_project 3.22
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (alias runtest)
+  >  (targets output.txt)
+  >  (action (write-file output.txt ok)))
+  > EOF
+
+Use a small minor heap to make runtime GC events reproducible without asserting
+exact event counts or counter values.
+
+  $ unset OCAML_RUNTIME_EVENTS_DIR
+  $ export OCAMLRUNPARAM=s=32k
+  $ export DUNE_TRACE=runtime
+  $ dune build @runtest
+
+  $ dune trace cat | jq -s '
+  >   [ .[] | select(.cat == "runtime") ]
+  > | { has_runtime_events: (length > 0)
+  >   , timestamps_in_trace_clock:
+  >       all(.[].ts; type == "number" and . > 1000000000)
+  >   , valid_shape:
+  >       all(.[];
+  >         if .name == "event" then
+  >           ((.args.phase | type) == "string"
+  >            and (.args.what == "begin" or .args.what == "end"))
+  >         elif .name == "counter" then
+  >           ((.args.name | type) == "string"
+  >            and (.args.value | type) == "number")
+  >         else
+  >           false
+  >         end)
+  >   }
+  > '
+  {
+    "has_runtime_events": true,
+    "timestamps_in_trace_clock": true,
+    "valid_shape": true
+  }
+
+The runtime events directory is an implementation detail, not part of the
+process environment Dune reports in its init event.
+
+  $ dune trace cat | jq -s '
+  >   [ .[] | select(.cat == "config" and .name == "init") ][0].args.env
+  > | any(startswith("OCAML_RUNTIME_EVENTS_DIR="))
+  > '
+  false


### PR DESCRIPTION
Add a runtime trace category backed by runtime_events. When runtime tracing is
enabled, initialize runtime event collection, poll it during scheduler idle
points and trace shutdown, and translate runtime phases/counters into trace
events.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>