### PR TITLE
test: reproduce user config ENOTDIR crash

### DIFF
--- a/test/blackbox-tests/test-cases/config/user-config-file-parent-gh15406.t
+++ b/test/blackbox-tests/test-cases/config/user-config-file-parent-gh15406.t
@@ -1,0 +1,25 @@
+A regular file where the user config directory should be must not make Dune
+crash while probing the default user config file.
+
+  $ echo '(lang dune 3.0)' > dune-project
+  $ touch dune
+
+  $ mkdir .config
+  $ touch .config/dune
+  $ (
+  >   unset INSIDE_DUNE
+  >   output=dune.out
+  >   XDG_CONFIG_HOME=$(dune_cmd native-path "$PWD/.config") dune build > "$output" 2>&1
+  >   status=$?
+  >   if [ $status -ne 0 ]; then
+  >     if grep -q 'Unix.Unix_error(Unix.ENOTDIR' "$output"; then
+  >       echo "dune crashed with ENOTDIR"
+  >     else
+  >       cat "$output"
+  >     fi
+  >     exit $status
+  >   fi
+  >   cat "$output"
+  > )
+  dune crashed with ENOTDIR
+  [2]


### PR DESCRIPTION
Add a cram test for gh-15406 that runs Dune outside an existing Dune invocation
with XDG_CONFIG_HOME pointing at a tree where the default user config parent is
a regular file.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>