### PR TITLE
refactor(spawn): make [spawn] return [Pid.t]

### DIFF
--- a/bin/action_runner.ml
+++ b/bin/action_runner.ml
@@ -66,7 +66,6 @@ let create ~where ~config ~sandbox_actions =
     Exn.protect
       ~f:(fun () -> Spawn.spawn ~env ~prog ~argv ())
       ~finally:(fun () -> Option.iter trace_fd ~f:Fd.close)
-    |> Pid.of_int_exn
   in
   Dune_engine.Action_runner.create name pid
 ;;

--- a/otherlibs/stdune/src/spawn.ml
+++ b/otherlibs/stdune/src/spawn.ml
@@ -102,6 +102,22 @@ external spawn_unix
   -> int
   = "spawn_unix_byte" "spawn_unix"
 
+let spawn_unix
+      ~env
+      ~cwd
+      ~prog
+      ~argv
+      ~stdin
+      ~stdout
+      ~stderr
+      ~use_vfork
+      ~setpgid
+      ~sigprocmask
+  =
+  spawn_unix ~env ~cwd ~prog ~argv ~stdin ~stdout ~stderr ~use_vfork ~setpgid ~sigprocmask
+  |> Pid.of_int_exn
+;;
+
 external spawn_windows
   :  env:Env.t option
   -> cwd:string option
@@ -143,7 +159,7 @@ let spawn_windows
     | true, Some p -> Filename.concat p prog
     | _ -> prog
   in
-  spawn_windows ~env ~cwd ~prog ~cmdline ~stdin ~stdout ~stderr
+  spawn_windows ~env ~cwd ~prog ~cmdline ~stdin ~stdout ~stderr |> Pid.of_int_exn
 ;;
 
 let no_null s =

--- a/otherlibs/stdune/src/spawn.mli
+++ b/otherlibs/stdune/src/spawn.mli
@@ -123,7 +123,7 @@ val spawn
   -> ?sigprocmask:Unix.sigprocmask_command * int list
        (** default: unblock all signals in child *)
   -> unit
-  -> int
+  -> Pid.t
 
 (**/**)
 

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -745,7 +745,7 @@ module Dune_config = struct
                      | exception End_of_file -> None
                    in
                    close_in ic;
-                   (match n, snd (Unix.waitpid [] pid) with
+                   (match n, snd (Unix.waitpid [] (Stdune.Pid.to_int pid)) with
                     | Some n, WEXITED 0 -> n
                     | _ -> loop rest)))
          in

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -1003,7 +1003,6 @@ let spawn
         (match dir with
          | None -> Inherit
          | Some dir -> Path (Path.to_string dir))
-    |> Pid.of_int_exn
   in
   if emit_trace
   then

--- a/src/dune_scheduler/file_watcher.ml
+++ b/src/dune_scheduler/file_watcher.ml
@@ -546,7 +546,7 @@ let spawn_external_watcher ~backend ~watch_exclusions =
     let prog = Path.to_absolute_filename prog in
     let argv = prog :: args in
     (* CR-someday rgrinberg: we sohuldn't let this program write anything to our stderr *)
-    Spawn.spawn () ~prog ~argv ~stdout:w_stdout |> Pid.of_int_exn
+    Spawn.spawn () ~prog ~argv ~stdout:w_stdout
   in
   Unix.close w_stdout;
   Unix.in_channel_of_descr r_stdout, pid

--- a/src/dune_trace/fd_count.ml
+++ b/src/dune_trace/fd_count.ml
@@ -23,7 +23,7 @@ let lsof =
         let argv =
           [ prog; "-l"; "-O"; "-P"; "-n"; "-w"; "-p"; string_of_int (Unix.getpid ()) ]
         in
-        Spawn.spawn ~prog ~argv ~stdout:lsof_w () |> Pid.of_int_exn
+        Spawn.spawn ~prog ~argv ~stdout:lsof_w ()
       in
       Unix.close lsof_w;
       (match

--- a/test/expect-tests/dune_pkg/rev_store_fetch_depth/rev_store_fetch_depth_test.ml
+++ b/test/expect-tests/dune_pkg/rev_store_fetch_depth/rev_store_fetch_depth_test.ml
@@ -37,7 +37,6 @@ let with_git_daemon ~parent_dir ~port ~repo_dir ~unrelated_repo_dir ~f =
       ~stdout:(Fd.unsafe_to_unix_file_descr (Lazy.force Dev_null.out))
       ~stderr:(Fd.unsafe_to_unix_file_descr (Lazy.force Dev_null.out))
       ()
-    |> Pid.of_int_exn
   in
   let stop_daemon () =
     (* The scheduler's process watcher can reap an unregistered child that exits

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -103,7 +103,6 @@ let run ?env ~prog ~argv () =
       ~stdin:(Fd.unsafe_to_unix_file_descr (Lazy.force Dev_null.in_))
       ?env
       ()
-    |> Pid.of_int_exn
   in
   Unix.close stdout_w;
   Unix.close stderr_w;

--- a/test/expect-tests/foreign_stubs/archive_creation_behavior.ml
+++ b/test/expect-tests/foreign_stubs/archive_creation_behavior.ml
@@ -60,7 +60,8 @@ let spawn_and_capture ?env ~prog ~argv ~cwd () =
               ?env
               ())
       in
-      let waited_pid, status = Unix.waitpid [] pid in
+      let waited_pid, status = Unix.waitpid [] (Pid.to_int pid) in
+      let waited_pid = Pid.of_int_exn waited_pid in
       if waited_pid <> pid then Code_error.raise "waitpid returned another process" [];
       { status; stdout = Io.read_file stdout_path; stderr = Io.read_file stderr_path }))
 ;;

--- a/test/expect-tests/timer_tests.ml
+++ b/test/expect-tests/timer_tests.ml
@@ -57,7 +57,7 @@ let%expect_test "run process with timeout" =
         let path = Env.get Env.initial "PATH" |> Option.value_exn |> Bin.parse_path in
         Bin.which ~path "sleep" |> Option.value_exn |> Path.to_string
       in
-      Spawn.spawn ~prog ~argv:[ prog; "100000" ] () |> Pid.of_int_exn
+      Spawn.spawn ~prog ~argv:[ prog; "100000" ] ()
     in
     let+ (_ : Proc.Process_info.t) =
       Scheduler.wait_for_process


### PR DESCRIPTION
removes a bunch of repetetive conversions everywhere

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>