### PR TITLE
fix(stdune): treat ENOTDIR as a missing path

### DIFF
--- a/doc/changes/fixed/15475.md
+++ b/doc/changes/fixed/15475.md
@@ -1,0 +1,2 @@
+- Do not crash when `~/.config/dune` is a file instead of a directory. Just
+  pretend it doesn't exist (#15475, fixes #15406, @rgrinberg)

--- a/otherlibs/stdune/src/fpath.ml
+++ b/otherlibs/stdune/src/fpath.ml
@@ -374,7 +374,7 @@ let is_broken_symlink path =
 
 let is_directory x =
   try (Unix.stat x).st_kind = S_DIR with
-  | Unix.Unix_error (ENOENT, _, _) -> false
+  | Unix.Unix_error ((ENOENT | ENOTDIR), _, _) -> false
 ;;
 
 let exists x =
@@ -382,5 +382,5 @@ let exists x =
     ignore (Unix.stat x);
     true
   with
-  | Unix.Unix_error (ENOENT, _, _) -> false
+  | Unix.Unix_error ((ENOENT | ENOTDIR), _, _) -> false
 ;;

--- a/otherlibs/stdune/test/fpath_tests.ml
+++ b/otherlibs/stdune/test/fpath_tests.ml
@@ -24,6 +24,19 @@ let%expect_test "is_root" =
     Fpath.is_root "/foo" = false |}]
 ;;
 
+let%expect_test "path with non-directory parent does not exist" =
+  let dir = Temp.create Dir ~prefix:"fpath" ~suffix:"test" in
+  let file = Path.relative dir "file" in
+  let child = Path.relative file "child" in
+  Io.write_file file "";
+  printfn "exists: %b" (Fpath.exists (Path.to_string child));
+  printfn "is_directory: %b" (Fpath.is_directory (Path.to_string child));
+  [%expect
+    {|
+    exists: false
+    is_directory: false |}]
+;;
+
 let%expect_test "mkdir_p" =
   let test path =
     match Fpath.mkdir_p path with

--- a/test/blackbox-tests/test-cases/config/user-config-file-parent-gh15406.t
+++ b/test/blackbox-tests/test-cases/config/user-config-file-parent-gh15406.t
@@ -8,8 +8,10 @@ crash while probing the default user config file.
   $ touch .config/dune
   $ (
   >   unset INSIDE_DUNE
+  >   setup_xdg_runtime_dir
   >   output=dune.out
-  >   XDG_CONFIG_HOME=$(dune_cmd native-path "$PWD/.config") dune build > "$output" 2>&1
+  >   XDG_CONFIG_HOME=$(dune_cmd native-path "$PWD/.config") \
+  >     dune build --root . > "$output" 2>&1
   >   status=$?
   >   if [ $status -ne 0 ]; then
   >     if grep -q 'Unix.Unix_error(Unix.ENOTDIR' "$output"; then
@@ -21,5 +23,3 @@ crash while probing the default user config file.
   >   fi
   >   cat "$output"
   > )
-  dune crashed with ENOTDIR
-  [2]


### PR DESCRIPTION
Have Fpath.exists and Fpath.is_directory return false when an intermediate path
component is not a directory. This prevents default user config probing from
crashing when XDG_CONFIG_HOME/dune is a regular file.

Add stdune coverage and update the gh-15406 cram regression to expect success.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>