### PR TITLE
fix: remove support for lsof for counting fd's

### DIFF
--- a/doc/changes/changed/15477.md
+++ b/doc/changes/changed/15477.md
@@ -1,0 +1,4 @@
+- Never use `$ lsof` for counting file descriptors, as it is not allowed
+  to reap processes outside of the scheduler. We have better mechanisms
+  on MacOS and Linux for counting file descriptors. So this is only an
+  issue on other Unices. (#15477, @rgrinberg)

--- a/src/dune_trace/fd_count.ml
+++ b/src/dune_trace/fd_count.ml
@@ -9,54 +9,6 @@ module Mac = struct
   external available : unit -> bool = "dune_trace_available"
 end
 
-let lsof =
-  let prog = lazy (Bin.which ~path:(Env_path.path Env.initial) "lsof") in
-  (* note: we do not use the Process module here, because it would create a
-     circular dependency *)
-  fun () ->
-    match Lazy.force prog with
-    | None -> Unknown
-    | Some prog ->
-      let lsof_r, lsof_w = Unix.pipe ~cloexec:true () in
-      let prog = Path.to_string prog in
-      let pid =
-        let argv =
-          [ prog; "-l"; "-O"; "-P"; "-n"; "-w"; "-p"; string_of_int (Unix.getpid ()) ]
-        in
-        Spawn.spawn ~prog ~argv ~stdout:lsof_w ()
-      in
-      Unix.close lsof_w;
-      (match
-         (* CR-someday rgrinberg: we can't reap anything here withhout
-            co-operation from the scheduler *)
-         let _, status = Unix.waitpid [] (Pid.to_int pid) in
-         status
-       with
-       | Unix.WEXITED 0 ->
-         let count =
-           let chan = Unix.in_channel_of_descr lsof_r in
-           let rec loop acc =
-             match input_line chan with
-             | exception End_of_file -> acc
-             | _ -> loop (acc + 1)
-           in
-           (* the output contains a header line *)
-           let res = loop (-1) in
-           Io.close_in chan;
-           res
-         in
-         This count
-       | (exception Unix.Unix_error (_, _, _))
-       (* The final [waitpid] call fails with:
-
-            {[
-              Error: waitpid(): No child processes
-            ]} *)
-       | _ ->
-         Unix.close lsof_r;
-         Unknown)
-;;
-
 let proc_fs () =
   match Sys.readdir "/proc/self/fd" with
   | files -> This (Array.length files - 1 (* -1 for the dirfd *))
@@ -68,7 +20,6 @@ let how = ref `Unknown
 let get () =
   match !how with
   | `Disable -> Unknown
-  | `Lsof -> lsof ()
   | `Proc_fs -> proc_fs ()
   | `Mac -> This (Mac.open_fds ~pid:(Pid.me () |> Pid.to_int))
   | `Unknown ->
@@ -78,14 +29,8 @@ let get () =
       This (Mac.open_fds ~pid:(Pid.me () |> Pid.to_int)))
     else (
       match proc_fs () with
+      | Unknown -> Unknown
       | This _ as n ->
         how := `Proc_fs;
-        n
-      | Unknown ->
-        let res = lsof () in
-        (how
-         := match res with
-            | This _ -> `Lsof
-            | Unknown -> `Disable);
-        res)
+        n)
 ;;


### PR DESCRIPTION
Running a process without co-operation from the dune scheduler is buggy,
so let's not do that. Moreoever, we already have good proper fd counts
on MacOS and Linux. It's not worth it to keep this footgun around.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>