### PR TITLE
test(install): update file-as-directory error output

### DIFF
--- a/test/blackbox-tests/test-cases/install/cmxs_exec.t
+++ b/test/blackbox-tests/test-cases/install/cmxs_exec.t
@@ -64,5 +64,6 @@ Test the error message if a destination is a file instead of a directory.
   $ rm -rf prefix
   $ mkdir -p prefix/lib; touch prefix/lib/foo
   $ dune install --prefix prefix --display short
-  Error: stat(prefix/lib/foo/META): Not a directory
+  Installing prefix/lib/foo/META
+  Error: Please delete file prefix/lib/foo manually.
   [1]


### PR DESCRIPTION
nnwsrxss made Fpath.exists and Fpath.is_directory treat ENOTDIR like a missing
path. During install, that lets the check for prefix/lib/foo/META proceed until
mkdir_p sees that prefix/lib/foo is a file, so the error is now the installer’s
friendly “Please delete file ...” diagnostic.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>