### PR TITLE
install: validate destination directories before logging

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -167,6 +167,19 @@ module type File_operations = sig
   val remove_dir_if_exists : if_non_empty:rmdir_mode -> Path.t -> unit
 end
 
+let raise_file_should_be_deleted p =
+  User_error.raise
+    [ Pp.textf "Please delete file %s manually." (Path.to_string_maybe_quoted p) ]
+;;
+
+let rec validate_dir_can_be_created dir =
+  match Unix.stat (Path.to_string dir) with
+  | { st_kind = S_DIR; _ } -> ()
+  | _ -> raise_file_should_be_deleted dir
+  | exception Unix.Unix_error ((ENOENT | ENOTDIR), _, _) ->
+    Option.iter (Path.parent dir) ~f:validate_dir_can_be_created
+;;
+
 module File_ops_dry_run (Verbosity : sig
     val verbosity : Display.t
   end) : File_operations = struct
@@ -183,7 +196,10 @@ module File_ops_dry_run (Verbosity : sig
     Fiber.return ()
   ;;
 
-  let mkdir_p path = print_line "Creating directory %s" (Path.to_string_maybe_quoted path)
+  let mkdir_p path =
+    validate_dir_can_be_created path;
+    print_line "Creating directory %s" (Path.to_string_maybe_quoted path)
+  ;;
 
   let remove_file_if_exists path =
     print_line "Removing (if it exists) %s" (Path.to_string_maybe_quoted path)
@@ -374,9 +390,7 @@ module File_ops_real (W : sig
   let mkdir_p p =
     match Fpath.mkdir_p_strict (Path.to_string p) with
     | `Created | `Already_exists -> ()
-    | `Not_a_dir ->
-      User_error.raise
-        [ Pp.textf "Please delete file %s manually." (Path.to_string_maybe_quoted p) ]
+    | `Not_a_dir -> raise_file_should_be_deleted p
   ;;
 end
 
@@ -467,6 +481,7 @@ let install_entry
   | false -> Fiber.return entry
   | true ->
     let+ () =
+      Ops.mkdir_p dir;
       (match Fpath.is_directory (Path.to_string dst) with
        | true -> Ops.remove_dir_if_exists ~if_non_empty:Fail dst
        | false -> Ops.remove_file_if_exists dst);
@@ -475,7 +490,6 @@ let install_entry
         "%s %s"
         (if create_install_files then "Copying to" else "Installing")
         (Path.to_string_maybe_quoted dst);
-      Ops.mkdir_p dir;
       let executable = Section.should_set_executable_bit entry.section in
       let kind =
         match special_file with

--- a/test/blackbox-tests/test-cases/install-dir/install-bindir.t
+++ b/test/blackbox-tests/test-cases/install-dir/install-bindir.t
@@ -16,11 +16,11 @@ Honors `--bindir` and `--sbindir` during installation.
   $ dune build @install
   $ mkdir install bindir sbindir
   $ dune install --dry-run --prefix ./install --bindir $PWD/bindir --sbindir $PWD/sbindir --display short 2>&1 | grep bindir
+  Creating directory $TESTCASE_ROOT/bindir
   Removing (if it exists) $TESTCASE_ROOT/bindir/user
   Installing $TESTCASE_ROOT/bindir/user
-  Creating directory $TESTCASE_ROOT/bindir
   Copying _build/install/default/bin/user to $TESTCASE_ROOT/bindir/user (executable: true)
+  Creating directory $TESTCASE_ROOT/sbindir
   Removing (if it exists) $TESTCASE_ROOT/sbindir/admin.exe
   Installing $TESTCASE_ROOT/sbindir/admin.exe
-  Creating directory $TESTCASE_ROOT/sbindir
   Copying _build/install/default/sbin/admin.exe to $TESTCASE_ROOT/sbindir/admin.exe (executable: true)

--- a/test/blackbox-tests/test-cases/install-dir/install-datadir.t
+++ b/test/blackbox-tests/test-cases/install-dir/install-datadir.t
@@ -10,7 +10,7 @@ Honors `--datadir` for installed shared files.
   $ dune build @install
   $ mkdir install datadir
   $ dune install --dry-run --prefix ./install --datadir $PWD/datadir --display short 2>&1 | grep datadir
+  Creating directory $TESTCASE_ROOT/datadir/foo
   Removing (if it exists) $TESTCASE_ROOT/datadir/foo/datafile
   Installing $TESTCASE_ROOT/datadir/foo/datafile
-  Creating directory $TESTCASE_ROOT/datadir/foo
   Copying _build/install/default/share/foo/datafile to $TESTCASE_ROOT/datadir/foo/datafile (executable: false)

--- a/test/blackbox-tests/test-cases/install-dir/install-docdir.t
+++ b/test/blackbox-tests/test-cases/install-dir/install-docdir.t
@@ -10,7 +10,7 @@ Honors `--docdir` for installed documentation files.
   $ dune build @install
   $ mkdir install docdir
   $ dune install --dry-run --prefix ./install --docdir $PWD/docdir --display short 2>&1 | grep docdir
+  Creating directory $TESTCASE_ROOT/docdir/foo
   Removing (if it exists) $TESTCASE_ROOT/docdir/foo/docfile
   Installing $TESTCASE_ROOT/docdir/foo/docfile
-  Creating directory $TESTCASE_ROOT/docdir/foo
   Copying _build/install/default/doc/foo/docfile to $TESTCASE_ROOT/docdir/foo/docfile (executable: false)

--- a/test/blackbox-tests/test-cases/install-dir/install-etcdir.t
+++ b/test/blackbox-tests/test-cases/install-dir/install-etcdir.t
@@ -10,7 +10,7 @@ Honors `--etcdir` for installed configuration files.
   $ dune build @install
   $ mkdir install etcdir
   $ dune install --dry-run --prefix ./install --etcdir $PWD/etcdir --display short 2>&1 | grep etcdir
+  Creating directory $TESTCASE_ROOT/etcdir/foo
   Removing (if it exists) $TESTCASE_ROOT/etcdir/foo/configfile
   Installing $TESTCASE_ROOT/etcdir/foo/configfile
-  Creating directory $TESTCASE_ROOT/etcdir/foo
   Copying _build/install/default/etc/foo/configfile to $TESTCASE_ROOT/etcdir/foo/configfile (executable: false)

--- a/test/blackbox-tests/test-cases/install-dir/install-libdir.t/run.t
+++ b/test/blackbox-tests/test-cases/install-dir/install-libdir.t/run.t
@@ -41,65 +41,65 @@ Even if it is possible to ask for different libexecdir than libdir, the installe
 If prefix is passed, the default for libdir is `$prefix/lib`:
 
   $ dune install --prefix install --dry-run --display short 2>&1 | dune_cmd sanitize
+  Creating directory install/lib/foo
   Removing (if it exists) install/lib/foo/META
   Installing install/lib/foo/META
-  Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/META to install/lib/foo/META (executable: false)
+  Creating directory install/lib/foo
   Removing (if it exists) install/lib/foo/dune-package
   Installing install/lib/foo/dune-package
-  Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/dune-package to install/lib/foo/dune-package (executable: false)
+  Creating directory install/lib/foo
   Removing (if it exists) install/lib/foo/foo$ext_lib
   Installing install/lib/foo/foo$ext_lib
-  Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/foo$ext_lib to install/lib/foo/foo$ext_lib (executable: false)
+  Creating directory install/lib/foo
   Removing (if it exists) install/lib/foo/foo.cma
   Installing install/lib/foo/foo.cma
-  Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/foo.cma to install/lib/foo/foo.cma (executable: false)
+  Creating directory install/lib/foo
   Removing (if it exists) install/lib/foo/foo.cmi
   Installing install/lib/foo/foo.cmi
-  Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/foo.cmi to install/lib/foo/foo.cmi (executable: false)
+  Creating directory install/lib/foo
   Removing (if it exists) install/lib/foo/foo.cmt
   Installing install/lib/foo/foo.cmt
-  Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/foo.cmt to install/lib/foo/foo.cmt (executable: false)
+  Creating directory install/lib/foo
   Removing (if it exists) install/lib/foo/foo.cmx
   Installing install/lib/foo/foo.cmx
-  Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/foo.cmx to install/lib/foo/foo.cmx (executable: false)
+  Creating directory install/lib/foo
   Removing (if it exists) install/lib/foo/foo.cmxa
   Installing install/lib/foo/foo.cmxa
-  Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/foo.cmxa to install/lib/foo/foo.cmxa (executable: false)
+  Creating directory install/lib/foo
   Removing (if it exists) install/lib/foo/foo.ml
   Installing install/lib/foo/foo.ml
-  Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/foo.ml to install/lib/foo/foo.ml (executable: false)
+  Creating directory install/lib/foo
   Removing (if it exists) install/lib/foo/opam
   Installing install/lib/foo/opam
-  Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/opam to install/lib/foo/opam (executable: false)
+  Creating directory install/lib/foo
   Removing (if it exists) install/lib/foo/foo.cmxs
   Installing install/lib/foo/foo.cmxs
-  Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/foo.cmxs to install/lib/foo/foo.cmxs (executable: true)
+  Creating directory install/bin
   Removing (if it exists) install/bin/exec
   Installing install/bin/exec
-  Creating directory install/bin
   Copying _build/install/default/bin/exec to install/bin/exec (executable: true)
+  Creating directory install/man
   Removing (if it exists) install/man/a-man-page-with-no-ext
   Installing install/man/a-man-page-with-no-ext
-  Creating directory install/man
   Copying _build/install/default/man/a-man-page-with-no-ext to install/man/a-man-page-with-no-ext (executable: false)
+  Creating directory install/man/man1
   Removing (if it exists) install/man/man1/a-man-page.1
   Installing install/man/man1/a-man-page.1
-  Creating directory install/man/man1
   Copying _build/install/default/man/man1/a-man-page.1 to install/man/man1/a-man-page.1 (executable: false)
+  Creating directory install/man/man3
   Removing (if it exists) install/man/man3/another-man-page.3
   Installing install/man/man3/another-man-page.3
-  Creating directory install/man/man3
   Copying _build/install/default/man/man3/another-man-page.3 to install/man/man3/another-man-page.3 (executable: false)
 
 If prefix is not passed, libdir defaults to the opam-prefix/lib directory:
@@ -107,65 +107,65 @@ If prefix is not passed, libdir defaults to the opam-prefix/lib directory:
   $ (export OCAMLFIND_DESTDIR=/OCAMLFIND_DESTDIR
   >  dune install --dry-run --display short 2>&1 | dune_cmd sanitize
   >  dune uninstall --dry-run --display short 2>&1 | dune_cmd sanitize)
+  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) $TESTCASE_ROOT/switch/lib/foo/META
   Installing $TESTCASE_ROOT/switch/lib/foo/META
-  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/META to $TESTCASE_ROOT/switch/lib/foo/META (executable: false)
+  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) $TESTCASE_ROOT/switch/lib/foo/dune-package
   Installing $TESTCASE_ROOT/switch/lib/foo/dune-package
-  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/dune-package to $TESTCASE_ROOT/switch/lib/foo/dune-package (executable: false)
+  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) $TESTCASE_ROOT/switch/lib/foo/foo$ext_lib
   Installing $TESTCASE_ROOT/switch/lib/foo/foo$ext_lib
-  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/foo$ext_lib to $TESTCASE_ROOT/switch/lib/foo/foo$ext_lib (executable: false)
+  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) $TESTCASE_ROOT/switch/lib/foo/foo.cma
   Installing $TESTCASE_ROOT/switch/lib/foo/foo.cma
-  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/foo.cma to $TESTCASE_ROOT/switch/lib/foo/foo.cma (executable: false)
+  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) $TESTCASE_ROOT/switch/lib/foo/foo.cmi
   Installing $TESTCASE_ROOT/switch/lib/foo/foo.cmi
-  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/foo.cmi to $TESTCASE_ROOT/switch/lib/foo/foo.cmi (executable: false)
+  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) $TESTCASE_ROOT/switch/lib/foo/foo.cmt
   Installing $TESTCASE_ROOT/switch/lib/foo/foo.cmt
-  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/foo.cmt to $TESTCASE_ROOT/switch/lib/foo/foo.cmt (executable: false)
+  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) $TESTCASE_ROOT/switch/lib/foo/foo.cmx
   Installing $TESTCASE_ROOT/switch/lib/foo/foo.cmx
-  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/foo.cmx to $TESTCASE_ROOT/switch/lib/foo/foo.cmx (executable: false)
+  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) $TESTCASE_ROOT/switch/lib/foo/foo.cmxa
   Installing $TESTCASE_ROOT/switch/lib/foo/foo.cmxa
-  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/foo.cmxa to $TESTCASE_ROOT/switch/lib/foo/foo.cmxa (executable: false)
+  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) $TESTCASE_ROOT/switch/lib/foo/foo.ml
   Installing $TESTCASE_ROOT/switch/lib/foo/foo.ml
-  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/foo.ml to $TESTCASE_ROOT/switch/lib/foo/foo.ml (executable: false)
+  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) $TESTCASE_ROOT/switch/lib/foo/opam
   Installing $TESTCASE_ROOT/switch/lib/foo/opam
-  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/opam to $TESTCASE_ROOT/switch/lib/foo/opam (executable: false)
+  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) $TESTCASE_ROOT/switch/lib/foo/foo.cmxs
   Installing $TESTCASE_ROOT/switch/lib/foo/foo.cmxs
-  Creating directory $TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/foo.cmxs to $TESTCASE_ROOT/switch/lib/foo/foo.cmxs (executable: true)
+  Creating directory $TESTCASE_ROOT/switch/bin
   Removing (if it exists) $TESTCASE_ROOT/switch/bin/exec
   Installing $TESTCASE_ROOT/switch/bin/exec
-  Creating directory $TESTCASE_ROOT/switch/bin
   Copying _build/install/default/bin/exec to $TESTCASE_ROOT/switch/bin/exec (executable: true)
+  Creating directory $TESTCASE_ROOT/switch/man
   Removing (if it exists) $TESTCASE_ROOT/switch/man/a-man-page-with-no-ext
   Installing $TESTCASE_ROOT/switch/man/a-man-page-with-no-ext
-  Creating directory $TESTCASE_ROOT/switch/man
   Copying _build/install/default/man/a-man-page-with-no-ext to $TESTCASE_ROOT/switch/man/a-man-page-with-no-ext (executable: false)
+  Creating directory $TESTCASE_ROOT/switch/man/man1
   Removing (if it exists) $TESTCASE_ROOT/switch/man/man1/a-man-page.1
   Installing $TESTCASE_ROOT/switch/man/man1/a-man-page.1
-  Creating directory $TESTCASE_ROOT/switch/man/man1
   Copying _build/install/default/man/man1/a-man-page.1 to $TESTCASE_ROOT/switch/man/man1/a-man-page.1 (executable: false)
+  Creating directory $TESTCASE_ROOT/switch/man/man3
   Removing (if it exists) $TESTCASE_ROOT/switch/man/man3/another-man-page.3
   Installing $TESTCASE_ROOT/switch/man/man3/another-man-page.3
-  Creating directory $TESTCASE_ROOT/switch/man/man3
   Copying _build/install/default/man/man3/another-man-page.3 to $TESTCASE_ROOT/switch/man/man3/another-man-page.3 (executable: false)
   Removing (if it exists) $TESTCASE_ROOT/switch/lib/foo/META
   Removing (if it exists) $TESTCASE_ROOT/switch/lib/foo/dune-package
@@ -193,65 +193,65 @@ in libdir:
 
   $ dune install --libdir /LIBDIR --dry-run --display short 2>&1 | dune_cmd sanitize
   > dune uninstall --libdir /LIBDIR --dry-run --display short
+  Creating directory /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/META
   Installing /LIBDIR/foo/META
-  Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/META to /LIBDIR/foo/META (executable: false)
+  Creating directory /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/dune-package
   Installing /LIBDIR/foo/dune-package
-  Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/dune-package to /LIBDIR/foo/dune-package (executable: false)
+  Creating directory /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/foo$ext_lib
   Installing /LIBDIR/foo/foo$ext_lib
-  Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/foo$ext_lib to /LIBDIR/foo/foo$ext_lib (executable: false)
+  Creating directory /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/foo.cma
   Installing /LIBDIR/foo/foo.cma
-  Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/foo.cma to /LIBDIR/foo/foo.cma (executable: false)
+  Creating directory /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/foo.cmi
   Installing /LIBDIR/foo/foo.cmi
-  Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/foo.cmi to /LIBDIR/foo/foo.cmi (executable: false)
+  Creating directory /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/foo.cmt
   Installing /LIBDIR/foo/foo.cmt
-  Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/foo.cmt to /LIBDIR/foo/foo.cmt (executable: false)
+  Creating directory /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/foo.cmx
   Installing /LIBDIR/foo/foo.cmx
-  Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/foo.cmx to /LIBDIR/foo/foo.cmx (executable: false)
+  Creating directory /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/foo.cmxa
   Installing /LIBDIR/foo/foo.cmxa
-  Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/foo.cmxa to /LIBDIR/foo/foo.cmxa (executable: false)
+  Creating directory /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/foo.ml
   Installing /LIBDIR/foo/foo.ml
-  Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/foo.ml to /LIBDIR/foo/foo.ml (executable: false)
+  Creating directory /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/opam
   Installing /LIBDIR/foo/opam
-  Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/opam to /LIBDIR/foo/opam (executable: false)
+  Creating directory /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/foo.cmxs
   Installing /LIBDIR/foo/foo.cmxs
-  Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/foo.cmxs to /LIBDIR/foo/foo.cmxs (executable: true)
+  Creating directory $TESTCASE_ROOT/switch/bin
   Removing (if it exists) $TESTCASE_ROOT/switch/bin/exec
   Installing $TESTCASE_ROOT/switch/bin/exec
-  Creating directory $TESTCASE_ROOT/switch/bin
   Copying _build/install/default/bin/exec to $TESTCASE_ROOT/switch/bin/exec (executable: true)
+  Creating directory $TESTCASE_ROOT/switch/man
   Removing (if it exists) $TESTCASE_ROOT/switch/man/a-man-page-with-no-ext
   Installing $TESTCASE_ROOT/switch/man/a-man-page-with-no-ext
-  Creating directory $TESTCASE_ROOT/switch/man
   Copying _build/install/default/man/a-man-page-with-no-ext to $TESTCASE_ROOT/switch/man/a-man-page-with-no-ext (executable: false)
+  Creating directory $TESTCASE_ROOT/switch/man/man1
   Removing (if it exists) $TESTCASE_ROOT/switch/man/man1/a-man-page.1
   Installing $TESTCASE_ROOT/switch/man/man1/a-man-page.1
-  Creating directory $TESTCASE_ROOT/switch/man/man1
   Copying _build/install/default/man/man1/a-man-page.1 to $TESTCASE_ROOT/switch/man/man1/a-man-page.1 (executable: false)
+  Creating directory $TESTCASE_ROOT/switch/man/man3
   Removing (if it exists) $TESTCASE_ROOT/switch/man/man3/another-man-page.3
   Installing $TESTCASE_ROOT/switch/man/man3/another-man-page.3
-  Creating directory $TESTCASE_ROOT/switch/man/man3
   Copying _build/install/default/man/man3/another-man-page.3 to $TESTCASE_ROOT/switch/man/man3/another-man-page.3 (executable: false)
   Removing (if it exists) /LIBDIR/foo/META
   Removing (if it exists) /LIBDIR/foo/dune-package
@@ -278,191 +278,191 @@ The DESTDIR var is supported. When set, it is prepended to the prefix.
 This is the case when the prefix is implicit:
 
   $ DESTDIR=DESTDIR dune install --dry-run --display short 2>&1 | dune_cmd sanitize
+  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) DESTDIR$TESTCASE_ROOT/switch/lib/foo/META
   Installing DESTDIR$TESTCASE_ROOT/switch/lib/foo/META
-  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/META to DESTDIR$TESTCASE_ROOT/switch/lib/foo/META (executable: false)
+  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) DESTDIR$TESTCASE_ROOT/switch/lib/foo/dune-package
   Installing DESTDIR$TESTCASE_ROOT/switch/lib/foo/dune-package
-  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/dune-package to DESTDIR$TESTCASE_ROOT/switch/lib/foo/dune-package (executable: false)
+  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo$ext_lib
   Installing DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo$ext_lib
-  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/foo$ext_lib to DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo$ext_lib (executable: false)
+  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.cma
   Installing DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.cma
-  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/foo.cma to DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.cma (executable: false)
+  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.cmi
   Installing DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.cmi
-  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/foo.cmi to DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.cmi (executable: false)
+  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.cmt
   Installing DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.cmt
-  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/foo.cmt to DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.cmt (executable: false)
+  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.cmx
   Installing DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.cmx
-  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/foo.cmx to DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.cmx (executable: false)
+  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.cmxa
   Installing DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.cmxa
-  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/foo.cmxa to DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.cmxa (executable: false)
+  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.ml
   Installing DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.ml
-  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/foo.ml to DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.ml (executable: false)
+  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) DESTDIR$TESTCASE_ROOT/switch/lib/foo/opam
   Installing DESTDIR$TESTCASE_ROOT/switch/lib/foo/opam
-  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/opam to DESTDIR$TESTCASE_ROOT/switch/lib/foo/opam (executable: false)
+  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Removing (if it exists) DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.cmxs
   Installing DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.cmxs
-  Creating directory DESTDIR$TESTCASE_ROOT/switch/lib/foo
   Copying _build/install/default/lib/foo/foo.cmxs to DESTDIR$TESTCASE_ROOT/switch/lib/foo/foo.cmxs (executable: true)
+  Creating directory DESTDIR$TESTCASE_ROOT/switch/bin
   Removing (if it exists) DESTDIR$TESTCASE_ROOT/switch/bin/exec
   Installing DESTDIR$TESTCASE_ROOT/switch/bin/exec
-  Creating directory DESTDIR$TESTCASE_ROOT/switch/bin
   Copying _build/install/default/bin/exec to DESTDIR$TESTCASE_ROOT/switch/bin/exec (executable: true)
+  Creating directory DESTDIR$TESTCASE_ROOT/switch/man
   Removing (if it exists) DESTDIR$TESTCASE_ROOT/switch/man/a-man-page-with-no-ext
   Installing DESTDIR$TESTCASE_ROOT/switch/man/a-man-page-with-no-ext
-  Creating directory DESTDIR$TESTCASE_ROOT/switch/man
   Copying _build/install/default/man/a-man-page-with-no-ext to DESTDIR$TESTCASE_ROOT/switch/man/a-man-page-with-no-ext (executable: false)
+  Creating directory DESTDIR$TESTCASE_ROOT/switch/man/man1
   Removing (if it exists) DESTDIR$TESTCASE_ROOT/switch/man/man1/a-man-page.1
   Installing DESTDIR$TESTCASE_ROOT/switch/man/man1/a-man-page.1
-  Creating directory DESTDIR$TESTCASE_ROOT/switch/man/man1
   Copying _build/install/default/man/man1/a-man-page.1 to DESTDIR$TESTCASE_ROOT/switch/man/man1/a-man-page.1 (executable: false)
+  Creating directory DESTDIR$TESTCASE_ROOT/switch/man/man3
   Removing (if it exists) DESTDIR$TESTCASE_ROOT/switch/man/man3/another-man-page.3
   Installing DESTDIR$TESTCASE_ROOT/switch/man/man3/another-man-page.3
-  Creating directory DESTDIR$TESTCASE_ROOT/switch/man/man3
   Copying _build/install/default/man/man3/another-man-page.3 to DESTDIR$TESTCASE_ROOT/switch/man/man3/another-man-page.3 (executable: false)
 
 But also when the prefix is explicit:
 
   $ DESTDIR=DESTDIR dune install --prefix prefix --dry-run --display short 2>&1 | dune_cmd sanitize
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/META
   Installing DESTDIR/prefix/lib/foo/META
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/META to DESTDIR/prefix/lib/foo/META (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/dune-package
   Installing DESTDIR/prefix/lib/foo/dune-package
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/dune-package to DESTDIR/prefix/lib/foo/dune-package (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/foo$ext_lib
   Installing DESTDIR/prefix/lib/foo/foo$ext_lib
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo$ext_lib to DESTDIR/prefix/lib/foo/foo$ext_lib (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cma
   Installing DESTDIR/prefix/lib/foo/foo.cma
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cma to DESTDIR/prefix/lib/foo/foo.cma (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmi
   Installing DESTDIR/prefix/lib/foo/foo.cmi
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmi to DESTDIR/prefix/lib/foo/foo.cmi (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmt
   Installing DESTDIR/prefix/lib/foo/foo.cmt
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmt to DESTDIR/prefix/lib/foo/foo.cmt (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmx
   Installing DESTDIR/prefix/lib/foo/foo.cmx
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmx to DESTDIR/prefix/lib/foo/foo.cmx (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmxa
   Installing DESTDIR/prefix/lib/foo/foo.cmxa
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmxa to DESTDIR/prefix/lib/foo/foo.cmxa (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/foo.ml
   Installing DESTDIR/prefix/lib/foo/foo.ml
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.ml to DESTDIR/prefix/lib/foo/foo.ml (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/opam
   Installing DESTDIR/prefix/lib/foo/opam
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/opam to DESTDIR/prefix/lib/foo/opam (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmxs
   Installing DESTDIR/prefix/lib/foo/foo.cmxs
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmxs to DESTDIR/prefix/lib/foo/foo.cmxs (executable: true)
+  Creating directory DESTDIR/prefix/bin
   Removing (if it exists) DESTDIR/prefix/bin/exec
   Installing DESTDIR/prefix/bin/exec
-  Creating directory DESTDIR/prefix/bin
   Copying _build/install/default/bin/exec to DESTDIR/prefix/bin/exec (executable: true)
+  Creating directory DESTDIR/prefix/man
   Removing (if it exists) DESTDIR/prefix/man/a-man-page-with-no-ext
   Installing DESTDIR/prefix/man/a-man-page-with-no-ext
-  Creating directory DESTDIR/prefix/man
   Copying _build/install/default/man/a-man-page-with-no-ext to DESTDIR/prefix/man/a-man-page-with-no-ext (executable: false)
+  Creating directory DESTDIR/prefix/man/man1
   Removing (if it exists) DESTDIR/prefix/man/man1/a-man-page.1
   Installing DESTDIR/prefix/man/man1/a-man-page.1
-  Creating directory DESTDIR/prefix/man/man1
   Copying _build/install/default/man/man1/a-man-page.1 to DESTDIR/prefix/man/man1/a-man-page.1 (executable: false)
+  Creating directory DESTDIR/prefix/man/man3
   Removing (if it exists) DESTDIR/prefix/man/man3/another-man-page.3
   Installing DESTDIR/prefix/man/man3/another-man-page.3
-  Creating directory DESTDIR/prefix/man/man3
   Copying _build/install/default/man/man3/another-man-page.3 to DESTDIR/prefix/man/man3/another-man-page.3 (executable: false)
 
 DESTDIR can also be passed as a command line flag.
 
   $ dune install --destdir DESTDIR --prefix prefix --dry-run --display short 2>&1 | dune_cmd sanitize
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/META
   Installing DESTDIR/prefix/lib/foo/META
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/META to DESTDIR/prefix/lib/foo/META (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/dune-package
   Installing DESTDIR/prefix/lib/foo/dune-package
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/dune-package to DESTDIR/prefix/lib/foo/dune-package (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/foo$ext_lib
   Installing DESTDIR/prefix/lib/foo/foo$ext_lib
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo$ext_lib to DESTDIR/prefix/lib/foo/foo$ext_lib (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cma
   Installing DESTDIR/prefix/lib/foo/foo.cma
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cma to DESTDIR/prefix/lib/foo/foo.cma (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmi
   Installing DESTDIR/prefix/lib/foo/foo.cmi
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmi to DESTDIR/prefix/lib/foo/foo.cmi (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmt
   Installing DESTDIR/prefix/lib/foo/foo.cmt
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmt to DESTDIR/prefix/lib/foo/foo.cmt (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmx
   Installing DESTDIR/prefix/lib/foo/foo.cmx
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmx to DESTDIR/prefix/lib/foo/foo.cmx (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmxa
   Installing DESTDIR/prefix/lib/foo/foo.cmxa
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmxa to DESTDIR/prefix/lib/foo/foo.cmxa (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/foo.ml
   Installing DESTDIR/prefix/lib/foo/foo.ml
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.ml to DESTDIR/prefix/lib/foo/foo.ml (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/opam
   Installing DESTDIR/prefix/lib/foo/opam
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/opam to DESTDIR/prefix/lib/foo/opam (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
   Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmxs
   Installing DESTDIR/prefix/lib/foo/foo.cmxs
-  Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmxs to DESTDIR/prefix/lib/foo/foo.cmxs (executable: true)
+  Creating directory DESTDIR/prefix/bin
   Removing (if it exists) DESTDIR/prefix/bin/exec
   Installing DESTDIR/prefix/bin/exec
-  Creating directory DESTDIR/prefix/bin
   Copying _build/install/default/bin/exec to DESTDIR/prefix/bin/exec (executable: true)
+  Creating directory DESTDIR/prefix/man
   Removing (if it exists) DESTDIR/prefix/man/a-man-page-with-no-ext
   Installing DESTDIR/prefix/man/a-man-page-with-no-ext
-  Creating directory DESTDIR/prefix/man
   Copying _build/install/default/man/a-man-page-with-no-ext to DESTDIR/prefix/man/a-man-page-with-no-ext (executable: false)
+  Creating directory DESTDIR/prefix/man/man1
   Removing (if it exists) DESTDIR/prefix/man/man1/a-man-page.1
   Installing DESTDIR/prefix/man/man1/a-man-page.1
-  Creating directory DESTDIR/prefix/man/man1
   Copying _build/install/default/man/man1/a-man-page.1 to DESTDIR/prefix/man/man1/a-man-page.1 (executable: false)
+  Creating directory DESTDIR/prefix/man/man3
   Removing (if it exists) DESTDIR/prefix/man/man3/another-man-page.3
   Installing DESTDIR/prefix/man/man3/another-man-page.3
-  Creating directory DESTDIR/prefix/man/man3
   Copying _build/install/default/man/man3/another-man-page.3 to DESTDIR/prefix/man/man3/another-man-page.3 (executable: false)

--- a/test/blackbox-tests/test-cases/install-dir/install-mandir.t
+++ b/test/blackbox-tests/test-cases/install-dir/install-mandir.t
@@ -10,7 +10,7 @@ Honors `--mandir` for installed manpages.
   $ dune build @install
   $ mkdir install mandir
   $ dune install --dry-run --prefix ./install --mandir $PWD/mandir --display short 2>&1 | grep mandir
+  Creating directory $TESTCASE_ROOT/mandir
   Removing (if it exists) $TESTCASE_ROOT/mandir/manfile
   Installing $TESTCASE_ROOT/mandir/manfile
-  Creating directory $TESTCASE_ROOT/mandir
   Copying _build/install/default/man/manfile to $TESTCASE_ROOT/mandir/manfile (executable: false)

--- a/test/blackbox-tests/test-cases/install-dry-run.t/run.t
+++ b/test/blackbox-tests/test-cases/install-dry-run.t/run.t
@@ -4,49 +4,49 @@ Shows the files that `dune install --dry-run` would copy.
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
   $ dune build @install
   $ dune install --dry-run --display short 2>&1 --prefix _install | dune_cmd sanitize
+  Creating directory _install/lib/mylib
   Removing (if it exists) _install/lib/mylib/META
   Installing _install/lib/mylib/META
-  Creating directory _install/lib/mylib
   Copying _build/install/default/lib/mylib/META to _install/lib/mylib/META (executable: false)
+  Creating directory _install/lib/mylib
   Removing (if it exists) _install/lib/mylib/dune-package
   Installing _install/lib/mylib/dune-package
-  Creating directory _install/lib/mylib
   Copying _build/install/default/lib/mylib/dune-package to _install/lib/mylib/dune-package (executable: false)
+  Creating directory _install/lib/mylib
   Removing (if it exists) _install/lib/mylib/mylib$ext_lib
   Installing _install/lib/mylib/mylib$ext_lib
-  Creating directory _install/lib/mylib
   Copying _build/install/default/lib/mylib/mylib$ext_lib to _install/lib/mylib/mylib$ext_lib (executable: false)
+  Creating directory _install/lib/mylib
   Removing (if it exists) _install/lib/mylib/mylib.cma
   Installing _install/lib/mylib/mylib.cma
-  Creating directory _install/lib/mylib
   Copying _build/install/default/lib/mylib/mylib.cma to _install/lib/mylib/mylib.cma (executable: false)
+  Creating directory _install/lib/mylib
   Removing (if it exists) _install/lib/mylib/mylib.cmi
   Installing _install/lib/mylib/mylib.cmi
-  Creating directory _install/lib/mylib
   Copying _build/install/default/lib/mylib/mylib.cmi to _install/lib/mylib/mylib.cmi (executable: false)
+  Creating directory _install/lib/mylib
   Removing (if it exists) _install/lib/mylib/mylib.cmt
   Installing _install/lib/mylib/mylib.cmt
-  Creating directory _install/lib/mylib
   Copying _build/install/default/lib/mylib/mylib.cmt to _install/lib/mylib/mylib.cmt (executable: false)
+  Creating directory _install/lib/mylib
   Removing (if it exists) _install/lib/mylib/mylib.cmx
   Installing _install/lib/mylib/mylib.cmx
-  Creating directory _install/lib/mylib
   Copying _build/install/default/lib/mylib/mylib.cmx to _install/lib/mylib/mylib.cmx (executable: false)
+  Creating directory _install/lib/mylib
   Removing (if it exists) _install/lib/mylib/mylib.cmxa
   Installing _install/lib/mylib/mylib.cmxa
-  Creating directory _install/lib/mylib
   Copying _build/install/default/lib/mylib/mylib.cmxa to _install/lib/mylib/mylib.cmxa (executable: false)
+  Creating directory _install/lib/mylib
   Removing (if it exists) _install/lib/mylib/mylib.ml
   Installing _install/lib/mylib/mylib.ml
-  Creating directory _install/lib/mylib
   Copying _build/install/default/lib/mylib/mylib.ml to _install/lib/mylib/mylib.ml (executable: false)
+  Creating directory _install/lib/mylib
   Removing (if it exists) _install/lib/mylib/opam
   Installing _install/lib/mylib/opam
-  Creating directory _install/lib/mylib
   Copying _build/install/default/lib/mylib/opam to _install/lib/mylib/opam (executable: false)
+  Creating directory _install/lib/mylib
   Removing (if it exists) _install/lib/mylib/mylib.cmxs
   Installing _install/lib/mylib/mylib.cmxs
-  Creating directory _install/lib/mylib
   Copying _build/install/default/lib/mylib/mylib.cmxs to _install/lib/mylib/mylib.cmxs (executable: true)
 
   $ dune uninstall --dry-run --prefix _install --display short 2>&1 | dune_cmd sanitize

--- a/test/blackbox-tests/test-cases/install-single-section.t/run.t
+++ b/test/blackbox-tests/test-cases/install-single-section.t/run.t
@@ -2,21 +2,21 @@ Dune supports installing a subset of the sections in the .install file. This is
 particularly useful if one wants to install binaries:
   $ dune build @install
   $ dune install --dry-run --prefix ./ --sections bin,man --display short
+  Creating directory bin
   Removing (if it exists) bin/foo
   Installing bin/foo
-  Creating directory bin
   Copying _build/install/default/bin/foo to bin/foo (executable: true)
+  Creating directory man
   Removing (if it exists) man/mp
   Installing man/mp
-  Creating directory man
   Copying _build/install/default/man/mp to man/mp (executable: false)
 
 Now let's install with the above command with one less section:
 
   $ dune install --dry-run --prefix ./ --sections bin --display short
+  Creating directory bin
   Removing (if it exists) bin/foo
   Installing bin/foo
-  Creating directory bin
   Copying _build/install/default/bin/foo to bin/foo (executable: true)
 
 The above command shouldn't include the man page anymore

--- a/test/blackbox-tests/test-cases/install/cmxs_exec.t
+++ b/test/blackbox-tests/test-cases/install/cmxs_exec.t
@@ -64,6 +64,11 @@ Test the error message if a destination is a file instead of a directory.
   $ rm -rf prefix
   $ mkdir -p prefix/lib; touch prefix/lib/foo
   $ dune install --prefix prefix --display short
-  Installing prefix/lib/foo/META
+  Error: Please delete file prefix/lib/foo manually.
+  [1]
+
+Dry runs should validate the same existing directory blockers.
+
+  $ dune install --prefix prefix --display short --dry-run
   Error: Please delete file prefix/lib/foo manually.
   [1]

--- a/test/blackbox-tests/test-cases/rewrite-tests/library-install-paths.t
+++ b/test/blackbox-tests/test-cases/rewrite-tests/library-install-paths.t
@@ -36,59 +36,59 @@ the grep 0.
   $ dune build @all 2>&2 | dune_cmd sanitize
   0
   $ dune install --dry-run --prefix _install --display short
+  Creating directory _install/lib/minlib
   Removing (if it exists) _install/lib/minlib/META
   Installing _install/lib/minlib/META
-  Creating directory _install/lib/minlib
   Copying _build/install/default/lib/minlib/META to _install/lib/minlib/META (executable: false)
+  Creating directory _install/lib/minlib
   Removing (if it exists) _install/lib/minlib/dune-package
   Installing _install/lib/minlib/dune-package
-  Creating directory _install/lib/minlib
   Copying _build/install/default/lib/minlib/dune-package to _install/lib/minlib/dune-package (executable: false)
+  Creating directory _install/lib/minlib
   Removing (if it exists) _install/lib/minlib/minlib.a
   Installing _install/lib/minlib/minlib.a
-  Creating directory _install/lib/minlib
   Copying _build/install/default/lib/minlib/minlib.a to _install/lib/minlib/minlib.a (executable: false)
+  Creating directory _install/lib/minlib
   Removing (if it exists) _install/lib/minlib/minlib.cma
   Installing _install/lib/minlib/minlib.cma
-  Creating directory _install/lib/minlib
   Copying _build/install/default/lib/minlib/minlib.cma to _install/lib/minlib/minlib.cma (executable: false)
+  Creating directory _install/lib/minlib
   Removing (if it exists) _install/lib/minlib/minlib.cmi
   Installing _install/lib/minlib/minlib.cmi
-  Creating directory _install/lib/minlib
   Copying _build/install/default/lib/minlib/minlib.cmi to _install/lib/minlib/minlib.cmi (executable: false)
+  Creating directory _install/lib/minlib
   Removing (if it exists) _install/lib/minlib/minlib.cmt
   Installing _install/lib/minlib/minlib.cmt
-  Creating directory _install/lib/minlib
   Copying _build/install/default/lib/minlib/minlib.cmt to _install/lib/minlib/minlib.cmt (executable: false)
+  Creating directory _install/lib/minlib
   Removing (if it exists) _install/lib/minlib/minlib.cmx
   Installing _install/lib/minlib/minlib.cmx
-  Creating directory _install/lib/minlib
   Copying _build/install/default/lib/minlib/minlib.cmx to _install/lib/minlib/minlib.cmx (executable: false)
+  Creating directory _install/lib/minlib
   Removing (if it exists) _install/lib/minlib/minlib.cmxa
   Installing _install/lib/minlib/minlib.cmxa
-  Creating directory _install/lib/minlib
   Copying _build/install/default/lib/minlib/minlib.cmxa to _install/lib/minlib/minlib.cmxa (executable: false)
+  Creating directory _install/lib/minlib
   Removing (if it exists) _install/lib/minlib/minlib.ml
   Installing _install/lib/minlib/minlib.ml
-  Creating directory _install/lib/minlib
   Copying _build/install/default/lib/minlib/minlib.ml to _install/lib/minlib/minlib.ml (executable: false)
+  Creating directory _install/lib/minlib
   Removing (if it exists) _install/lib/minlib/minlib__Run.cmi
   Installing _install/lib/minlib/minlib__Run.cmi
-  Creating directory _install/lib/minlib
   Copying _build/install/default/lib/minlib/minlib__Run.cmi to _install/lib/minlib/minlib__Run.cmi (executable: false)
+  Creating directory _install/lib/minlib
   Removing (if it exists) _install/lib/minlib/minlib__Run.cmt
   Installing _install/lib/minlib/minlib__Run.cmt
-  Creating directory _install/lib/minlib
   Copying _build/install/default/lib/minlib/minlib__Run.cmt to _install/lib/minlib/minlib__Run.cmt (executable: false)
+  Creating directory _install/lib/minlib
   Removing (if it exists) _install/lib/minlib/minlib__Run.cmx
   Installing _install/lib/minlib/minlib__Run.cmx
-  Creating directory _install/lib/minlib
   Copying _build/install/default/lib/minlib/minlib__Run.cmx to _install/lib/minlib/minlib__Run.cmx (executable: false)
+  Creating directory _install/lib/minlib
   Removing (if it exists) _install/lib/minlib/run.ml
   Installing _install/lib/minlib/run.ml
-  Creating directory _install/lib/minlib
   Copying _build/install/default/lib/minlib/run.ml to _install/lib/minlib/run.ml (executable: false)
+  Creating directory _install/lib/minlib
   Removing (if it exists) _install/lib/minlib/minlib.cmxs
   Installing _install/lib/minlib/minlib.cmxs
-  Creating directory _install/lib/minlib
   Copying _build/install/default/lib/minlib/minlib.cmxs to _install/lib/minlib/minlib.cmxs (executable: true)


### PR DESCRIPTION
For real installs, create or validate the destination directory before printing
the “Installing ...” line. This avoids logging that a file is being installed
when mkdir_p is about to report that an intermediate path is a file.

Keep dry-run output order unchanged and update the install cram expectation.

This change only impacts error messages. They should be improved now