### PR TITLE
fix(describe): Use public names in `executables` where available

### DIFF
--- a/bin/describe/describe_external_lib_deps.ml
+++ b/bin/describe/describe_external_lib_deps.ml
@@ -152,7 +152,7 @@ let libs db (context : Context.t) =
           dir
           exes.buildable.libraries
           exes.buildable.preprocess.config
-          (Nonempty_list.to_list_map exes.names ~f:snd)
+          (Dune_rules.Executables.best_names exes)
           exes.package
           Item.Kind.Executables
           (exes_extensions ocaml.lib_config exes.modes)
@@ -175,7 +175,7 @@ let libs db (context : Context.t) =
           dir
           tests.exes.buildable.libraries
           tests.exes.buildable.preprocess.config
-          (Nonempty_list.to_list_map tests.exes.names ~f:snd)
+          (Executables.best_names tests.exes)
           (if Option.is_none tests.package then tests.exes.package else tests.package)
           Item.Kind.Tests
           (exes_extensions ocaml.lib_config tests.exes.modes)

--- a/bin/describe/describe_tests.ml
+++ b/bin/describe/describe_tests.ml
@@ -63,7 +63,7 @@ module Crawl = struct
     match Stanza.repr stanza with
     | Tests.T (tests : Tests.t) ->
       let* enabled = Expander.eval_blang expander tests.enabled_if in
-      let names = Nonempty_list.to_list_map tests.exes.names ~f:snd in
+      let names = Executables.best_names tests.exes in
       let package =
         Option.map tests.package ~f:(fun p ->
           Dune_lang.Package.name p |> Dune_lang.Package_name.to_string)

--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -465,7 +465,7 @@ module Crawl = struct
        | Ok libs ->
          let include_dirs = Obj_dir.all_cmis obj_dir in
          let exe_descr =
-           { Descr.Exe.names = Nonempty_list.to_list_map exes.names ~f:snd
+           { Descr.Exe.names = Executables.best_names exes
            ; requires = List.map ~f:uid_of_library libs
            ; modules
            ; include_dirs

--- a/doc/changes/changed/15481.md
+++ b/doc/changes/changed/15481.md
@@ -1,3 +1,3 @@
 - `dune describe` now reports the public name of an executable (from
   `public_name`/`public_names`) instead of its private name when one is
-  available, falling back to the private name otherwise. (#99999, @natkarmios)
+  available, falling back to the private name otherwise. (#15481, @natkarmios)

--- a/doc/changes/changed/99999.md
+++ b/doc/changes/changed/99999.md
@@ -1,0 +1,3 @@
+- `dune describe` now reports the public name of an executable (from
+  `public_name`/`public_names`) instead of its private name when one is
+  available, falling back to the private name otherwise. (#99999, @natkarmios)

--- a/src/dune_rules/stanzas/executables.ml
+++ b/src/dune_rules/stanzas/executables.ml
@@ -6,6 +6,7 @@ module Names : sig
   type t
 
   val names : t -> (Loc.t * string) Nonempty_list.t
+  val public_names : t -> (Loc.t * string option) Nonempty_list.t option
   val package : t -> Package.t option
   val has_public_name : t -> bool
 
@@ -33,6 +34,11 @@ end = struct
     }
 
   let names t = t.names
+
+  let public_names t =
+    Option.map t.public ~f:(fun p -> Nonempty_list.of_list_exn p.public_names)
+  ;;
+
   let package t = Option.map t.public ~f:(fun p -> p.package)
   let has_public_name t = Option.is_some t.public
 
@@ -411,6 +417,7 @@ end
 
 type t =
   { names : (Loc.t * string) Nonempty_list.t
+  ; public_names : (Loc.t * string option) Nonempty_list.t option
   ; link_flags : Link_flags.Spec.t
   ; link_deps : Dep_conf.t list
   ; modes : Loc.t Link_mode.Map.t
@@ -504,6 +511,7 @@ let common =
   in
   fun names ~multi ->
     let has_public_name = Names.has_public_name names in
+    let public_names = Names.public_names names in
     let private_names = Names.names names in
     let install_conf =
       match Link_mode.Map.best_install_mode ~dune_version modes with
@@ -546,6 +554,7 @@ let common =
           [ Pp.textf "This field can only be used when linking a plugin." ]
     in
     { names = private_names
+    ; public_names
     ; link_flags
     ; link_deps
     ; modes
@@ -578,4 +587,14 @@ let has_foreign_cxx t = Buildable.has_foreign_cxx t.buildable
 let obj_dir t ~dir =
   let name = snd (Nonempty_list.hd t.names) in
   Obj_dir.make_exe ~dir ~name
+;;
+
+let best_names t =
+  let names = Nonempty_list.to_list_map t.names ~f:snd in
+  match t.public_names with
+  | None -> names
+  | Some public_names ->
+    let public_names = Nonempty_list.to_list_map public_names ~f:snd in
+    List.map2 names public_names ~f:(fun name public_name ->
+      Option.value public_name ~default:name)
 ;;

--- a/src/dune_rules/stanzas/executables.mli
+++ b/src/dune_rules/stanzas/executables.mli
@@ -39,6 +39,7 @@ end
 
 type t =
   { names : (Loc.t * string) Nonempty_list.t
+  ; public_names : (Loc.t * string option) Nonempty_list.t option
   ; link_flags : Dune_lang.Link_flags.Spec.t
   ; link_deps : Dep_conf.t list
   ; modes : Loc.t Link_mode.Map.t
@@ -65,3 +66,6 @@ val has_foreign_cxx : t -> bool
 val obj_dir : t -> dir:Path.Build.t -> Path.Build.t Obj_dir.t
 val single : t Dune_lang.Decoder.t
 val multi : t Dune_lang.Decoder.t
+
+(** Gets [names], with each replaced by its public name if available *)
+val best_names : t -> string list

--- a/src/dune_rules/stanzas/tests.ml
+++ b/src/dune_rules/stanzas/tests.ml
@@ -59,6 +59,7 @@ let gen_parse names =
             ; optional = false
             ; buildable
             ; names = Nonempty_list.of_list_exn names
+            ; public_names = None
             ; package = None
             ; promote = None
             ; install_conf = None

--- a/test/blackbox-tests/test-cases/describe/describe-executable-public-names.t
+++ b/test/blackbox-tests/test-cases/describe/describe-executable-public-names.t
@@ -1,0 +1,42 @@
+`dune describe` reports the public name of an executable when it has one
+========================================================================
+
+  $ make_dune_project_with_package 3.21 mypkg
+
+A single executable with a public name:
+
+  $ cat >dune <<EOF
+  > (executable
+  >  (name main)
+  >  (public_name my-tool)
+  >  (package mypkg))
+  > EOF
+
+  $ touch main.ml
+
+`dune describe` reports the public name rather than the private name:
+
+  $ dune describe | grep -A 2 '(executables'
+   (executables
+    ((names (my-tool))
+     (requires ())
+
+Multiple executables, where only some have a public name (a public name of
+`-` means no public name for that executable):
+
+  $ cat >dune <<EOF
+  > (executables
+  >  (names a b c)
+  >  (public_names x - z)
+  >  (package mypkg))
+  > EOF
+
+  $ touch a.ml b.ml c.ml
+
+The private name is used as a fallback when there is no public name:
+
+  $ dune describe | grep -A 3 '(executables'
+   (executables
+    ((names
+      (x b z))
+     (requires ())


### PR DESCRIPTION
Change `dune describe` to use public names for `executables` where available.