### PR TITLE
test(stdune): run spawn tests on Windows

### DIFF
--- a/otherlibs/stdune/test/dune
+++ b/otherlibs/stdune/test/dune
@@ -66,4 +66,5 @@
 (alias
  (name runtest-windows)
  (deps
-  (alias runtest-stdune_external_build_tests)))
+  (alias runtest-stdune_external_build_tests)
+  (alias spawn/runtest-stdune_spawn_tests)))


### PR DESCRIPTION
Add the stdune spawn test suite to the runtest-windows alias so the Windows
test target exercises the spawn coverage too.