### PR TITLE
spawn: set parent-death signal for subprocesses

### DIFF
--- a/bin/action_runner.ml
+++ b/bin/action_runner.ml
@@ -64,7 +64,10 @@ let create ~where ~config ~sandbox_actions =
       | None -> []
     in
     Exn.protect
-      ~f:(fun () -> Spawn.spawn ~env ~prog ~argv ())
+      ~f:(fun () ->
+        (* Use SIGTERM because the action runner knows how to clean up
+           its children. *)
+        Spawn.spawn ~env ~prog ~argv ~pdeathsig:Term ())
       ~finally:(fun () -> Option.iter trace_fd ~f:Fd.close)
   in
   Dune_engine.Action_runner.create name pid

--- a/doc/changes/fixed/15483.md
+++ b/doc/changes/fixed/15483.md
@@ -1,0 +1,2 @@
+- Dune will now terminate all launched sub-processes even if it received
+  `SIGKILL` itself (#15483, @rgrinberg)

--- a/otherlibs/stdune/src/spawn.ml
+++ b/otherlibs/stdune/src/spawn.ml
@@ -102,6 +102,7 @@ external spawn_unix
   -> use_vfork:bool
   -> setpgid:int option
   -> sigprocmask:(Unix.sigprocmask_command * int list) option
+  -> pdeathsig:int
   -> int
   = "dune_spawn_unix_byte" "dune_spawn_unix"
 
@@ -116,9 +117,22 @@ let spawn_unix
       ~use_vfork
       ~setpgid
       ~sigprocmask
+      ~pdeathsig
   =
   let setpgid = Option.map ~f:Pgid.to_int setpgid in
-  spawn_unix ~env ~cwd ~prog ~argv ~stdin ~stdout ~stderr ~use_vfork ~setpgid ~sigprocmask
+  let pdeathsig = Signal.to_int pdeathsig in
+  spawn_unix
+    ~env
+    ~cwd
+    ~prog
+    ~argv
+    ~stdin
+    ~stdout
+    ~stderr
+    ~use_vfork
+    ~setpgid
+    ~sigprocmask
+    ~pdeathsig
   |> Pid.of_int_exn
 ;;
 
@@ -150,6 +164,7 @@ let spawn_windows
       ~use_vfork:_
       ~setpgid:_
       ~sigprocmask:_
+      ~pdeathsig:_
   =
   let cwd =
     match (cwd : Working_dir.t) with
@@ -185,6 +200,7 @@ let spawn
       ?(stderr = Unix.stderr)
       ?(unix_backend = Unix_backend.default)
       ?setpgid
+      ?(pdeathsig = Signal.Kill)
       ?sigprocmask
       ()
   =
@@ -199,7 +215,18 @@ let spawn
     | Vfork -> true
     | Fork -> false
   in
-  backend ~env ~cwd ~prog ~argv ~stdin ~stdout ~stderr ~use_vfork ~setpgid ~sigprocmask
+  backend
+    ~env
+    ~cwd
+    ~prog
+    ~argv
+    ~stdin
+    ~stdout
+    ~stderr
+    ~use_vfork
+    ~setpgid
+    ~sigprocmask
+    ~pdeathsig
 ;;
 
 external safe_pipe : unit -> Unix.file_descr * Unix.file_descr = "dune_spawn_pipe"

--- a/otherlibs/stdune/src/spawn.mli
+++ b/otherlibs/stdune/src/spawn.mli
@@ -104,6 +104,11 @@ end
     already blocked, or to block a signal that cannot be blocked (e.g., SIGSTOP,
     SIGKILL) are allowed and will be silently ignored.
 
+    On Linux, the sub-process will ask the kernel to send it [pdeathsig] when
+    its parent dies. This defaults to [Signal.Kill]. On other platforms,
+    [pdeathsig] is ignored. The parent is the thread that created the
+    sub-process, not necessarily the whole parent process.
+
     {b Implementation}
 
     [unix_backend] describes what backend to use on Unix. If set to [Default],
@@ -119,6 +124,7 @@ val spawn
   -> ?stderr:Unix.file_descr
   -> ?unix_backend:Unix_backend.t (* default: [Unix_backend.default] *)
   -> ?setpgid:Pgid.t
+  -> ?pdeathsig:Signal.t
   -> ?sigprocmask:Unix.sigprocmask_command * int list
        (** default: unblock all signals in child *)
   -> unit

--- a/otherlibs/stdune/src/spawn_stubs.c
+++ b/otherlibs/stdune/src/spawn_stubs.c
@@ -26,6 +26,10 @@
 
 #include <errno.h>
 
+#if defined(__linux__)
+#include <sys/prctl.h>
+#endif
+
 #if defined(__APPLE__)
 
 # if defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
@@ -290,13 +294,48 @@ struct spawn_info {
   int std_fds[3];
   int set_pgid;
   pid_t pgid;
+  int pdeathsig;
+  pid_t parent_pid;
   sigset_t child_sigmask;
 };
+
+static void reset_signal_to_default(int signal)
+{
+  struct sigaction sa;
+  sa.sa_handler = SIG_DFL;
+  sigemptyset(&sa.sa_mask);
+  sa.sa_flags = 0;
+  /* Ignore errors as there is no interesting way it can fail. */
+  sigaction(signal, &sa, NULL);
+}
+
+static void set_parent_death_signal(int failure_fd, struct spawn_info *info)
+{
+#if defined(__linux__)
+  if (info->pdeathsig == 0) return;
+
+  reset_signal_to_default(info->pdeathsig);
+
+  if (prctl(PR_SET_PDEATHSIG, (long)info->pdeathsig, 0L, 0L, 0L) == -1) {
+    subprocess_failure(failure_fd, "prctl", NOTHING);
+    return;
+  }
+
+  if (getppid() != info->parent_pid) {
+    if (kill(getpid(), info->pdeathsig) == -1)
+      subprocess_failure(failure_fd, "kill", NOTHING);
+  }
+#else
+  (void)failure_fd;
+  (void)info;
+#endif
+}
 
 static void subprocess(int failure_fd, struct spawn_info *info)
 {
   int i, fd, tmp_fds[3];
-  struct sigaction sa;
+
+  set_parent_death_signal(failure_fd, info);
 
   if (info->set_pgid) {
     if (setpgid(0, info->pgid) == -1) {
@@ -308,11 +347,7 @@ static void subprocess(int failure_fd, struct spawn_info *info)
   /* Restore all signals to their default behavior before setting the
      desired signal mask for the subprocess to avoid invoking handlers
      from the parent */
-  sa.sa_handler = SIG_DFL;
-  sigemptyset(&sa.sa_mask);
-  sa.sa_flags = 0;
-  /* Ignore errors as there is no interesting way it can fail. */
-  for (i = 1; i < NSIG; i++) sigaction(i, &sa, NULL);
+  for (i = 1; i < NSIG; i++) reset_signal_to_default(i);
 
   switch (info->cwd_kind) {
     case INHERIT: break;
@@ -451,8 +486,6 @@ enum caml_unix_sigprocmask_command {
   CAML_SIG_UNBLOCK,
 };
 
-/* Initializes all fields of `*info` except for `info->child_sigmask`,
-   which must be initalized by `init_spawn_info_sigmask` (below). */
 static void init_spawn_info(struct spawn_info *info,
                             value v_env,
                             value v_cwd,
@@ -462,7 +495,8 @@ static void init_spawn_info(struct spawn_info *info,
                             value v_stdout,
                             value v_stderr,
                             value v_setpgid,
-                            value v_sigprocmask)
+                            value v_sigprocmask,
+                            value v_pdeathsig)
 {
   extern char ** environ;
 
@@ -501,6 +535,16 @@ static void init_spawn_info(struct spawn_info *info,
   info->pgid =
     Is_block(v_setpgid) ?
     Long_val(Field(v_setpgid, 0)) : 0;
+#if defined(__linux__)
+  int pdeathsig = Int_val(v_pdeathsig);
+  info->pdeathsig =
+    pdeathsig == 0 ? 0 : caml_convert_signal_number(pdeathsig);
+  info->parent_pid = getpid();
+#else
+  (void)v_pdeathsig;
+  info->pdeathsig = 0;
+  info->parent_pid = 0;
+#endif
 
   if (v_sigprocmask == Val_long(0)) {
     sigemptyset(&info->child_sigmask);
@@ -555,7 +599,8 @@ CAMLprim value dune_spawn_unix(value v_env,
                                value v_stderr,
                                value v_use_vfork,
                                value v_setpgid,
-                               value v_sigprocmask)
+                               value v_sigprocmask,
+                               value v_pdeathsig)
 {
   CAMLparam4(v_env, v_cwd, v_prog, v_argv);
   CAMLlocal1(e_arg);
@@ -581,7 +626,8 @@ CAMLprim value dune_spawn_unix(value v_env,
 
   struct spawn_info info;
   init_spawn_info(&info, v_env, v_cwd, v_prog, v_argv,
-                  v_stdin, v_stdout, v_stderr, v_setpgid, v_sigprocmask);
+                  v_stdin, v_stdout, v_stderr, v_setpgid, v_sigprocmask,
+                  v_pdeathsig);
 
   short attr_flags = POSIX_SPAWN_SETSIGMASK;
   if (info.set_pgid) attr_flags |= POSIX_SPAWN_SETPGROUP;
@@ -684,7 +730,8 @@ CAMLprim value dune_spawn_unix(value v_env,
                                value v_stderr,
                                value v_use_vfork,
                                value v_setpgid,
-                               value v_sigprocmask)
+                               value v_sigprocmask,
+                               value v_pdeathsig)
 {
   CAMLparam4(v_env, v_cwd, v_prog, v_argv);
   pid_t ret;
@@ -699,7 +746,8 @@ CAMLprim value dune_spawn_unix(value v_env,
   int status;
 
   init_spawn_info(&info, v_env, v_cwd, v_prog, v_argv,
-                  v_stdin, v_stdout, v_stderr, v_setpgid, v_sigprocmask);
+                  v_stdin, v_stdout, v_stderr, v_setpgid, v_sigprocmask,
+                  v_pdeathsig);
 
   caml_enter_blocking_section();
   enter_safe_pipe_section();
@@ -823,7 +871,8 @@ CAMLprim value dune_spawn_unix(value v_env,
                                value v_stderr,
                                value v_use_vfork,
                                value v_setpgid,
-                               value v_sigprocmask)
+                               value v_sigprocmask,
+                               value v_pdeathsig)
 {
   (void)v_env;
   (void)v_cwd;
@@ -835,6 +884,7 @@ CAMLprim value dune_spawn_unix(value v_env,
   (void)v_use_vfork;
   (void)v_setpgid;
   (void)v_sigprocmask;
+  (void)v_pdeathsig;
   unix_error(ENOSYS, "spawn_unix", Nothing);
 }
 
@@ -937,7 +987,8 @@ CAMLprim value dune_spawn_unix_byte(value * argv)
                     argv[6],
                     argv[7],
                     argv[8],
-                    argv[9]);
+                    argv[9],
+                    argv[10]);
 }
 
 CAMLprim value dune_spawn_windows_byte(value * argv)

--- a/otherlibs/stdune/test/spawn/exe/dune
+++ b/otherlibs/stdune/test/spawn/exe/dune
@@ -1,2 +1,3 @@
 (executables
- (names hello list_files print_env))
+ (names hello list_files print_env)
+ (libraries unix))

--- a/otherlibs/stdune/test/spawn/exe/print_env.ml
+++ b/otherlibs/stdune/test/spawn/exe/print_env.ml
@@ -1,5 +1,40 @@
+let write_file fn s =
+  let oc = open_out fn in
+  output_string oc s;
+  close_out oc
+;;
+
+let pdeathsig_child ready_file marker_file =
+  Sys.set_signal
+    Sys.sigusr1
+    (Sys.Signal_handle
+       (fun _ ->
+         write_file marker_file "got signal\n";
+         exit 0));
+  write_file ready_file "ready\n";
+  while true do
+    ignore (Unix.pause ())
+  done
+;;
+
+let pdeathsig_default_child ready_file marker_file =
+  Sys.set_signal Sys.sigterm Sys.Signal_ignore;
+  let parent = Unix.getppid () in
+  write_file ready_file "ready\n";
+  while Unix.getppid () = parent do
+    Unix.sleepf 0.01
+  done;
+  write_file marker_file "survived\n"
+;;
+
 let () =
-  match Sys.getenv "FOO" with
-  | exception _ -> print_endline "None"
-  | str -> Printf.printf "Some %S\n" str
+  match Array.to_list Sys.argv with
+  | _ :: "pdeathsig-child" :: ready_file :: marker_file :: _ ->
+    pdeathsig_child ready_file marker_file
+  | _ :: "pdeathsig-default-child" :: ready_file :: marker_file :: _ ->
+    pdeathsig_default_child ready_file marker_file
+  | _ ->
+    (match Sys.getenv "FOO" with
+     | exception _ -> print_endline "None"
+     | str -> Printf.printf "Some %S\n" str)
 ;;

--- a/otherlibs/stdune/test/spawn/tests.ml
+++ b/otherlibs/stdune/test/spawn/tests.ml
@@ -1,5 +1,8 @@
+module Int = Stdune.Int
 module Exn = Stdune.Exn
 module Pid = Stdune.Pid
+module Platform = Stdune.Platform
+module Signal = Stdune.Signal
 module Spawn = Stdune.Spawn
 
 let show_raise f =
@@ -45,6 +48,7 @@ let wait pid =
 ;;
 
 let list_files = Filename.concat (Sys.getcwd ()) "exe/list_files.exe"
+let print_env = Filename.concat (Sys.getcwd ()) "exe/print_env.exe"
 
 let () =
   Unix.mkdir "sub" 0o777;
@@ -189,6 +193,105 @@ let%expect_test "pgid tests" =
        ()
        ~prog:"pgid_test/checkpgid.exe"
        ~argv:[]);
+  [%expect {||}]
+;;
+
+let wait_for_file ?(timeout = 5.0) fn =
+  let deadline = Unix.gettimeofday () +. timeout in
+  let rec loop () =
+    if Sys.file_exists fn
+    then ()
+    else if Unix.gettimeofday () >= deadline
+    then Printf.ksprintf failwith "timed out waiting for %s" fn
+    else (
+      ignore (Unix.select [] [] [] 0.05);
+      loop ())
+  in
+  loop ()
+;;
+
+let wait_for_no_file ?(timeout = 1.0) fn =
+  let deadline = Unix.gettimeofday () +. timeout in
+  let rec loop () =
+    if Sys.file_exists fn
+    then Printf.ksprintf failwith "%s unexpectedly exists" fn
+    else if Unix.gettimeofday () >= deadline
+    then ()
+    else (
+      ignore (Unix.select [] [] [] 0.05);
+      loop ())
+  in
+  loop ()
+;;
+
+let kill_child pid_file =
+  if Sys.file_exists pid_file
+  then (
+    let pid_file_contents = Stdune.Io.String_path.read_file pid_file in
+    match Int.of_string (String.trim pid_file_contents) with
+    | None -> ()
+    | Some pid ->
+      let pid = Pid.of_int_exn pid in
+      (match Pid.kill pid `Pid Kill with
+       | `Delivered | `Dead -> ()))
+;;
+
+let with_pdeathsig_child mode ~spawn ~f =
+  let temp_name suffix =
+    Filename.concat
+      (Sys.getcwd ())
+      (Printf.sprintf "stdune-spawn-%d-%s-%s" (Unix.getpid ()) mode suffix)
+  in
+  let ready_file = temp_name "ready" in
+  let marker_file = temp_name "marker" in
+  let pid_file = temp_name "pid" in
+  let cleanup () =
+    kill_child pid_file;
+    List.iter
+      (fun fn -> if Sys.file_exists fn then Unix.unlink fn)
+      [ ready_file; marker_file; pid_file ]
+  in
+  Exn.protect ~finally:cleanup ~f:(fun () ->
+    cleanup ();
+    match Unix.fork () with
+    | 0 ->
+      let exit_code =
+        try
+          let argv = "print_env" :: mode :: [ ready_file; marker_file ] in
+          let child = spawn argv in
+          Stdune.Io.String_path.write_file
+            pid_file
+            (Printf.sprintf "%d\n" (Pid.to_int child));
+          wait_for_file ready_file;
+          0
+        with
+        | _ -> 1
+      in
+      Unix._exit exit_code
+    | intermediate ->
+      wait (Pid.of_int_exn intermediate);
+      f ~marker_file)
+;;
+
+let%expect_test "pdeathsig defaults to kill" =
+  (match Platform.OS.value with
+   | Linux ->
+     with_pdeathsig_child
+       "pdeathsig-default-child"
+       ~f:(fun ~marker_file -> wait_for_no_file marker_file)
+       ~spawn:(fun argv -> Spawn.spawn () ~prog:print_env ~argv)
+   | _ -> ());
+  [%expect {||}]
+;;
+
+let%expect_test "pdeathsig explicit signal" =
+  (match Platform.OS.value with
+   | Linux ->
+     with_pdeathsig_child
+       "pdeathsig-child"
+       ~f:(fun ~marker_file -> wait_for_file marker_file)
+       ~spawn:(fun argv -> Spawn.spawn ~pdeathsig:Usr1 () ~prog:print_env ~argv)
+   | _ -> ());
   [%expect {||}]
 ;;
 


### PR DESCRIPTION
Add Linux PR_SET_PDEATHSIG support to Stdune.Spawn, defaulting spawned
processes to receive SIGKILL when their parent dies. Ignore the setting on
unsupported platforms and handle the parent-exit race by self-signaling if the
parent changed after prctl.

Spawn the action runner with SIGTERM instead so it can clean up its own
children, and add spawn tests for the default and explicit parent-death signals.