### PR TITLE
fix(fs_memo): include ctime in digest cache stats

### DIFF
--- a/doc/changes/fixed/15495.md
+++ b/doc/changes/fixed/15495.md
@@ -1,0 +1,1 @@
+- Account for `ctime` in stat based digest cache (#15495, @rgrinberg)

--- a/otherlibs/stdune/src/stat.ml
+++ b/otherlibs/stdune/src/stat.ml
@@ -1,5 +1,6 @@
 type t =
   { mtime : Time.t
+  ; ctime : Time.t
   ; size : int
   ; perm : Unix.file_perm
   ; kind : Unix.file_kind

--- a/otherlibs/stdune/src/stat.mli
+++ b/otherlibs/stdune/src/stat.mli
@@ -1,5 +1,6 @@
 type t =
   { mtime : Time.t
+  ; ctime : Time.t
   ; size : int
   ; perm : Unix.file_perm
   ; kind : Unix.file_kind

--- a/otherlibs/stdune/src/time_stubs.c
+++ b/otherlibs/stdune/src/time_stubs.c
@@ -37,20 +37,35 @@ typedef struct _stati64 dune_time_stat_buf;
 typedef struct stat dune_time_stat_buf;
 #endif
 
-static int64_t dune_time_stat_mtime_ns(const dune_time_stat_buf *stat)
+static int64_t dune_time_stat_timestamp_ns(int64_t sec, int64_t nsec)
 {
-#ifdef _WIN32
-  return ((int64_t) stat->st_mtime) * 1000000000LL;
+  return (sec * 1000000000LL) + nsec;
+}
+
+#if defined(_WIN32) || defined(__HAIKU__)
+#define DUNE_TIME_STAT_TIMESTAMP_NS(stat, prefix) \
+  dune_time_stat_timestamp_ns((int64_t) (stat)->st_##prefix##time, 0)
 #elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) \
    || defined(__OpenBSD__) || defined(__DragonFly__)
-  return ((int64_t) stat->st_mtimespec.tv_sec * 1000000000LL)
-         + (int64_t) stat->st_mtimespec.tv_nsec;
-#elif defined(__HAIKU__)
-  return ((int64_t) stat->st_mtime) * 1000000000LL;
+#define DUNE_TIME_STAT_TIMESTAMP_NS(stat, prefix) \
+  dune_time_stat_timestamp_ns( \
+    (int64_t) (stat)->st_##prefix##timespec.tv_sec, \
+    (int64_t) (stat)->st_##prefix##timespec.tv_nsec)
 #else
-  return ((int64_t) stat->st_mtim.tv_sec * 1000000000LL)
-         + (int64_t) stat->st_mtim.tv_nsec;
+#define DUNE_TIME_STAT_TIMESTAMP_NS(stat, prefix) \
+  dune_time_stat_timestamp_ns( \
+    (int64_t) (stat)->st_##prefix##tim.tv_sec, \
+    (int64_t) (stat)->st_##prefix##tim.tv_nsec)
 #endif
+
+static int64_t dune_time_stat_mtime_ns(const dune_time_stat_buf *stat)
+{
+  return DUNE_TIME_STAT_TIMESTAMP_NS(stat, m);
+}
+
+static int64_t dune_time_stat_ctime_ns(const dune_time_stat_buf *stat)
+{
+  return DUNE_TIME_STAT_TIMESTAMP_NS(stat, c);
 }
 
 static value dune_time_stat_file_kind(int mode)
@@ -81,13 +96,14 @@ static value dune_time_alloc_stat(const dune_time_stat_buf *stat)
 {
   CAMLparam0();
   CAMLlocal1(v_stat);
-  v_stat = caml_alloc_small(6, 0);
+  v_stat = caml_alloc_small(7, 0);
   Field(v_stat, 0) = Val_long(dune_time_stat_mtime_ns(stat));
-  Field(v_stat, 1) = Val_long(stat->st_size);
-  Field(v_stat, 2) = Val_long(stat->st_mode & 07777);
-  Field(v_stat, 3) = dune_time_stat_file_kind(stat->st_mode);
-  Field(v_stat, 4) = Val_long(stat->st_dev);
-  Field(v_stat, 5) = Val_long(stat->st_ino);
+  Field(v_stat, 1) = Val_long(dune_time_stat_ctime_ns(stat));
+  Field(v_stat, 2) = Val_long(stat->st_size);
+  Field(v_stat, 3) = Val_long(stat->st_mode & 07777);
+  Field(v_stat, 4) = dune_time_stat_file_kind(stat->st_mode);
+  Field(v_stat, 5) = Val_long(stat->st_dev);
+  Field(v_stat, 6) = Val_long(stat->st_ino);
   CAMLreturn(v_stat);
 }
 

--- a/otherlibs/stdune/test/stat_tests.ml
+++ b/otherlibs/stdune/test/stat_tests.ml
@@ -16,12 +16,14 @@ let%expect_test "Stat.stat matches Unix.stat on stable fields" =
   print_bool "perm_matches" (Int.equal stat.perm unix.st_perm);
   print_bool "kind_matches" (File_kind.equal stat.kind unix.st_kind);
   print_bool "mtime_is_positive" (Time.compare stat.mtime (Time.of_ns 0) = Gt);
+  print_bool "ctime_is_positive" (Time.compare stat.ctime (Time.of_ns 0) = Gt);
   [%expect
     {|
     size_matches: true
     perm_matches: true
     kind_matches: true
     mtime_is_positive: true
+    ctime_is_positive: true
   |}]
 ;;
 

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -26,6 +26,7 @@ module Cached_digest = struct
   module Stats = struct
     type t =
       { mtime : Time.t
+      ; ctime : Time.t
       ; size : int
       ; perm : Unix.file_perm
       ; dev : int
@@ -36,6 +37,7 @@ module Cached_digest = struct
       Repr.record
         "fs-memo-cached-digest-reduced-stats"
         [ Repr.field "mtime" Time.repr ~get:(fun t -> t.mtime)
+        ; Repr.field "ctime" Time.repr ~get:(fun t -> t.ctime)
         ; Repr.field "size" Repr.int ~get:(fun t -> t.size)
         ; Repr.field "perm" Repr.int ~get:(fun t -> t.perm)
         ; Repr.field "dev" Repr.int ~get:(fun t -> t.dev)
@@ -47,6 +49,7 @@ module Cached_digest = struct
 
     let of_stat (stat : Stat.t) =
       { mtime = stat.mtime
+      ; ctime = stat.ctime
       ; size = stat.size
       ; perm = stat.perm
       ; dev = stat.dev
@@ -103,7 +106,7 @@ module Cached_digest = struct
       type nonrec t = t
 
       let name = "DIGEST-DB"
-      let version = 11
+      let version = 12
       let sharing = true
       let repr = repr
     end)

--- a/test/blackbox-tests/test-cases/digest-cache/debug-option.t
+++ b/test/blackbox-tests/test-cases/digest-cache/debug-option.t
@@ -13,6 +13,8 @@ Test the tracing of digest events
   > | .args
   > | .old_stats.mtime |= type
   > | .new_stats.mtime |= type
+  > | .old_stats.ctime |= type
+  > | .new_stats.ctime |= type
   > | .new_stats.dev |= type
   > | .new_stats.ino |= type
   > | .old_stats.dev |= type
@@ -24,6 +26,7 @@ Test the tracing of digest events
     "new_digest": "f31e1f1c33564e07cd02ad2c52f4df85",
     "old_stats": {
       "mtime": "number",
+      "ctime": "number",
       "size": 0,
       "perm": 420,
       "dev": "number",
@@ -31,6 +34,7 @@ Test the tracing of digest events
     },
     "new_stats": {
       "mtime": "number",
+      "ctime": "number",
       "size": 2,
       "perm": 420,
       "dev": "number",
@@ -70,6 +74,7 @@ Test the tracing of digest events
     ],
     "old_stats": {
       "mtime": "number",
+      "ctime": "number",
       "size": "number",
       "perm": "number",
       "dev": "number",
@@ -77,6 +82,7 @@ Test the tracing of digest events
     },
     "new_stats": {
       "mtime": "number",
+      "ctime": "number",
       "size": "number",
       "perm": "number",
       "dev": "number",

--- a/test/blackbox-tests/test-cases/digest-cache/stale-source-stats.t
+++ b/test/blackbox-tests/test-cases/digest-cache/stale-source-stats.t
@@ -1,7 +1,6 @@
-A source change can be missed when the persistent digest database believes the
-source file's cached digest is still valid. The rule cache then reuses a target
-built from the old source contents. Removing _build drops the stale digest and
-rule caches, so the same build sees the changed source.
+A source change used to be missed when the persistent digest database believed
+the source file's cached digest was still valid. The rule cache then reused a
+target built from the old source contents until _build was removed.
 
   $ make_dune_project 3.25
   $ cat > dune <<'EOF'
@@ -18,24 +17,17 @@ Populate the persistent digest database and the rule cache.
   $ cat _build/default/copy
   old-source-contents
 
-Now change the source contents, but preserve the file metadata that Dune's
-digest database uses to decide whether the cached digest is still valid.
+Now change the source contents while preserving the metadata that used to be
+checked by Dune's digest database. The ctime still changes, so Dune should no
+longer trust the cached digest.
 
   $ cp -p source source.stamp
   $ printf 'new-source-contents\n' > source
   $ touch -r source.stamp source
 
-The source changed, but Dune incorrectly reuses the stale cached digest and
-keeps the target built from the old contents.
+The source changed, so Dune must recompute the digest and rebuild the target
+without requiring _build to be removed.
 
-  $ dune build copy
-  $ cat _build/default/copy
-  old-source-contents
-
-Removing _build removes the stale digest and rule caches, so the same build now
-sees the changed source file.
-
-  $ rm -rf _build
   $ dune build copy
   $ cat _build/default/copy
   new-source-contents

--- a/test/blackbox-tests/test-cases/internal/digest-db.t
+++ b/test/blackbox-tests/test-cases/internal/digest-db.t
@@ -38,7 +38,7 @@ Only actual digest mismatches are reported, classified as invalid or stale.
 
   $ dune internal digest-db check invalid.txt stale.txt 2>&1 \
   > | sed -n 's/.*status = /status = /p;s/.*path = /path = /p'
-  status = "invalid"
+  status = "stale"
   path = In_source_tree "invalid.txt"
   status = "stale"
   path = In_source_tree "stale.txt"


### PR DESCRIPTION
Record ctime in Stdune.Stat and in the persistent digest database's cached
source-file metadata. This catches same-size edits that restore mtime before
Dune decides whether to trust a cached digest.

Update the stale source digest regression test to expect a rebuild without
removing _build.