### PR TITLE
Allow omitting unit for 0

### DIFF
--- a/doc/changes/changed/15498.md
+++ b/doc/changes/changed/15498.md
@@ -1,0 +1,3 @@
+- Numbers with unit now allow dropping the unit if the number is zero ("0").
+  For example, `dune cache trim --trimmed-size 0` and `dune cache trim
+  --trimmed-size 0TiB` are now both accepted and equivalent. (#15498, @reynir)

--- a/src/dune_sexp/decoder.ml
+++ b/src/dune_sexp/decoder.ml
@@ -794,31 +794,34 @@ let triple a b c = enter (a >>= fun a -> b >>= fun b -> c >>= fun c -> return (a
 
 let unit_number_generic ~of_string ~mul name suffixes =
   let unit_number_of_string ~loc s =
-    let possible_suffixes () =
-      (* We take the first suffix in the list to be the suggestion *)
-      String.concat ~sep:", " (List.map ~f:(fun x -> List.hd @@ fst x) suffixes)
-    in
-    let n, suffix =
-      let f c = not (Char.is_digit c) in
-      match String.findi s ~f with
-      | None ->
-        User_error.raise
-          ~loc
-          [ Pp.textf "missing suffix, use one of %s" (possible_suffixes ()) ]
-      | Some i -> String.split_n s i
-    in
-    let suffixes =
-      List.concat_map suffixes ~f:(fun (xs, y) -> List.map ~f:(fun x -> x, y) xs)
-    in
-    let factor =
-      match List.assoc suffixes suffix with
-      | Some f -> f
-      | None ->
-        User_error.raise
-          ~loc
-          [ Pp.textf "invalid suffix, use one of %s" (possible_suffixes ()) ]
-    in
-    Option.map ~f:(mul factor) (of_string n)
+    match s with
+    | "0" -> of_string s
+    | _ ->
+      let possible_suffixes () =
+        (* We take the first suffix in the list to be the suggestion *)
+        String.concat ~sep:", " (List.map ~f:(fun x -> List.hd @@ fst x) suffixes)
+      in
+      let n, suffix =
+        let f c = not (Char.is_digit c) in
+        match String.findi s ~f with
+        | None ->
+          User_error.raise
+            ~loc
+            [ Pp.textf "missing suffix, use one of %s" (possible_suffixes ()) ]
+        | Some i -> String.split_n s i
+      in
+      let suffixes =
+        List.concat_map suffixes ~f:(fun (xs, y) -> List.map ~f:(fun x -> x, y) xs)
+      in
+      let factor =
+        match List.assoc suffixes suffix with
+        | Some f -> f
+        | None ->
+          User_error.raise
+            ~loc
+            [ Pp.textf "invalid suffix, use one of %s" (possible_suffixes ()) ]
+      in
+      Option.map ~f:(mul factor) (of_string n)
   in
   basic_loc name unit_number_of_string
 ;;

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -34,6 +34,11 @@ Check that trimming does not crash when the cache directory does not exist.
   $ dune cache trim --size 0B
   Freed 0B (0 files removed)
 
+Check that the unit can be omitted for zero
+
+  $ dune cache trim --size 0
+  Freed 0B (0 files removed)
+
 Check that the digest scheme for executable and non-executable digests hasn't
 changed. If it has, make sure to increment the version of the cache. Note that
 the current digests for both files match those computed by Jenga.


### PR DESCRIPTION
## Description
This allows omitting the unit in number units if the number is zero. It checks if the string is `"0"` and then calls `of_string` directly on the string. There is an assumption that `"0"` represents zero. The implementation already uses `Char.is_Digit` to find where the unit starts, and `Char.is_digit` checks for decimals.

## Related Issue and Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it closes an open issue, link to the issue here. -->
<!-- Non-trivial contributions are expected to be preceded by an issue, as
     per CONTRIBUTING.md. -->

Fixes #15496

## Checklist

- [x] Tests added, if applicable.
- [x] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [ ] Documentation added for any user-facing changes.
