### PR TITLE
chore(nix): update OxCaml package set

### DIFF
--- a/nix/opam-overlay.nix
+++ b/nix/opam-overlay.nix
@@ -126,8 +126,19 @@ let
   discovered = builtins.listToAttrs (
     map (name:
       let
-        versions = builtins.attrNames (builtins.readDir "${packagesDir}/${name}");
-        sorted = builtins.sort builtins.lessThan versions;
+        versions = builtins.filter
+          (version: lib.hasPrefix "${name}." version)
+          (builtins.attrNames (builtins.readDir "${packagesDir}/${name}"));
+        preferredVersions = builtins.filter
+          (version:
+            !lib.hasInfix "flags: avoid-version"
+              (builtins.readFile "${packagesDir}/${name}/${version}/opam"))
+          versions;
+        selectableVersions =
+          if preferredVersions == [ ] then versions else preferredVersions;
+        sorted = builtins.sort
+          (a: b: builtins.compareVersions a b < 0)
+          selectableVersions;
       in
       { inherit name; value = lib.last sorted; }
     ) (builtins.attrNames (builtins.readDir packagesDir))

--- a/nix/ox-package-set.nix
+++ b/nix/ox-package-set.nix
@@ -37,6 +37,8 @@ let
       ];
 
       skipPackages = [
+        "angstrom"
+        "faraday"
         "mdx"
         "odoc"
         "odoc-parser"

--- a/nix/oxcaml.nix
+++ b/nix/oxcaml.nix
@@ -24,14 +24,26 @@ let
     type = "github";
     owner = "oxcaml";
     repo = "opam-repository";
-    rev = "231c88c2e564fdca40e15e750aacad5fb0887435";
-    narHash = "sha256-+9ZQF2VH0O0G8RtN0hTf4k+w6yL63g6tblq3uzTKzG8=";
+    rev = "c2662be9bcad3875554acccff7bd1e3fe8cb57bc";
+    narHash = "sha256-2zn4PKRw7vsSh7tp+/nBZFjGE6fWrYm9lgrIWmvfVS8=";
   };
 
   # Parsed for documentation / sanity-check; not used in the getFlake
   # URL (pure mode needs rev, not tag).
   compilerPkgDir = "${oxcaml-opam-repository}/packages/oxcaml-compiler";
-  compilerVersion = lib.last (lib.naturalSort (builtins.attrNames (builtins.readDir compilerPkgDir)));
+  compilerVersions = builtins.attrNames (builtins.readDir compilerPkgDir);
+  preferredCompilerVersions =
+    builtins.filter
+      (version:
+        !lib.hasInfix "flags: avoid-version"
+          (builtins.readFile "${compilerPkgDir}/${version}/opam"))
+      compilerVersions;
+  selectableCompilerVersions =
+    if preferredCompilerVersions == [ ] then
+      compilerVersions
+    else
+      preferredCompilerVersions;
+  compilerVersion = lib.last (lib.naturalSort selectableCompilerVersions);
   compilerOpamFile = builtins.readFile "${compilerPkgDir}/${compilerVersion}/opam";
   oxcamlTag =
     let
@@ -44,13 +56,13 @@ let
 
   # The upstream OxCaml flake at the commit corresponding to oxcamlTag.
   # See the file header for how to resolve rev+narHash.
-  oxcaml = builtins.getFlake "github:oxcaml/oxcaml/7d714cfb3f1c79c9b1e2a9c40ac60ba0c44cafd7?narHash=sha256-JwVNRca8q1WfmuFLPOK3hL1DxmaKRYd%2BgJgV9xTDUhI%3D";
+  oxcaml = builtins.getFlake "github:oxcaml/oxcaml/dd4e8507373d22fb295422eb6dd3d997c76c47cb?narHash=sha256-IXgxNbNS5JlZeR3loZt2SRKrOI7hrOfC%2F%2FmQHGafhxY%3D";
 
   # Sanity: the tag in the opam-repo matches the tag this rev was
   # resolved from. Documentation more than enforcement — the assert
   # fires if a reader bumps one of the three pins above without the
   # others.
-  expectedTag = "5.2.0minus-31";
+  expectedTag = "5.2.0minus-39";
   _tagOk =
     if oxcamlTag == expectedTag then
       null

--- a/test/blackbox-tests/test-cases/oxcaml/parameterised-jsoo.t
+++ b/test/blackbox-tests/test-cases/oxcaml/parameterised-jsoo.t
@@ -132,9 +132,11 @@ Same test for wasm:
 We can check the separate jsoo compilation with the different flags used:
 
   $ ls _build/default/.parameterised/*/lib/lib!impl/.instance.objs/jsoo/*/ | censor
-  _build/default/.parameterised/$DIGEST/lib/lib!impl/.instance.objs/jsoo/default/:
+  _build/default/.parameterised/$DIGEST/lib/lib!impl/.instance.objs/jsoo/effects=disabled+toplevel=false+use-js-string=false/:
   archive.cma.js
-  archive.wasma
   
-  _build/default/.parameterised/$DIGEST/lib/lib!impl/.instance.objs/jsoo/use-js-string+effects=double-translation/:
+  _build/default/.parameterised/$DIGEST/lib/lib!impl/.instance.objs/jsoo/effects=double-translation+toplevel=false+use-js-string=true/:
   archive.cma.js
+  
+  _build/default/.parameterised/$DIGEST/lib/lib!impl/.instance.objs/jsoo/effects=jspi+toplevel=false+use-js-string=false/:
+  archive.wasma


### PR DESCRIPTION
Update to the preferred OxCaml compiler and package versions, and promote the js_of_ocaml 6.3.2 test output.
