### PR TITLE
sandbox-actions: support sandbox-exec on macOS

### DIFF
--- a/bin/bwrap.ml
+++ b/bin/bwrap.ml
@@ -11,22 +11,26 @@ let find_in_path_exn prog =
   | None -> User_error.raise [ Pp.textf "unable to find %s in PATH" prog ]
 ;;
 
-let prog () =
+let bwrap_prog () =
   match Platform.OS.value with
   | Linux -> find_in_path_exn "bwrap"
   | _ ->
-    User_error.raise [ Pp.text "--sandbox-actions is currently only supported on Linux" ]
+    User_error.raise [ Pp.text "Dune's bubblewrap wrapper is only supported on Linux" ]
+;;
+
+let shared_cache_dir () =
+  let build_cache_dir = Lazy.force Dune_cache.Layout.build_cache_dir in
+  Path.mkdir_p build_cache_dir;
+  Path.to_string build_cache_dir
 ;;
 
 let shared_cache_bindings () =
-  let build_cache_dir = Lazy.force Dune_cache.Layout.build_cache_dir in
-  Path.mkdir_p build_cache_dir;
-  let build_cache_dir = Path.to_string build_cache_dir in
+  let build_cache_dir = shared_cache_dir () in
   [ "--ro-bind"; build_cache_dir; build_cache_dir ]
 ;;
 
-let wrap ~cwd argv =
-  let prog = Path.to_string (prog ()) in
+let wrap_with_bwrap ~cwd argv =
+  let prog = Path.to_string (bwrap_prog ()) in
   { prog
   ; argv =
       [ prog; "--die-with-parent"; "--bind"; "/"; "/" ]
@@ -36,20 +40,113 @@ let wrap ~cwd argv =
   }
 ;;
 
+let wrap_with_sandbox_exec =
+  (* Mostly for tests: cram workspaces often live under macOS paths that are
+     reachable through both [/tmp] and [/private/tmp], or through both [/var] and
+     [/private/var]. *)
+  let add_macos_symlink_aliases path =
+    let add_alias ~prefix ~alias paths =
+      match String.drop_prefix path ~prefix with
+      | None -> paths
+      | Some rest -> (alias ^ rest) :: paths
+    in
+    [ path ]
+    |> add_alias ~prefix:"/private/var/" ~alias:"/var/"
+    |> add_alias ~prefix:"/var/" ~alias:"/private/var/"
+    |> add_alias ~prefix:"/private/tmp/" ~alias:"/tmp/"
+    |> add_alias ~prefix:"/tmp/" ~alias:"/private/tmp/"
+  in
+  let sandbox_exec_profile () =
+    let sbpl_string s =
+      let buf = Buffer.create (String.length s + 2) in
+      Buffer.add_char buf '"';
+      String.iter s ~f:(function
+        | '"' -> Buffer.add_string buf "\\\""
+        | '\\' -> Buffer.add_string buf "\\\\"
+        | '\n' -> Buffer.add_string buf "\\n"
+        | '\r' -> Buffer.add_string buf "\\r"
+        | '\t' -> Buffer.add_string buf "\\t"
+        | c -> Buffer.add_char buf c);
+      Buffer.add_char buf '"';
+      Buffer.contents buf
+    in
+    let protected_paths =
+      let build_cache_dir = shared_cache_dir () in
+      [ build_cache_dir; Unix.realpath build_cache_dir ]
+      |> List.concat_map ~f:add_macos_symlink_aliases
+      |> List.sort_uniq ~compare:String.compare
+    in
+    let deny_write path =
+      let path = sbpl_string path in
+      sprintf "(deny file-write* (literal %s) (subpath %s))" path path
+    in
+    String.concat
+      ~sep:"\n"
+      ([ "(version 1)"; "(allow default)" ] @ List.map protected_paths ~f:deny_write)
+  in
+  fun ~cwd argv ->
+    let prog =
+      Path.to_string
+        (match Platform.OS.value with
+         | Darwin -> find_in_path_exn "sandbox-exec"
+         | _ ->
+           User_error.raise
+             [ Pp.text "Dune's sandbox-exec wrapper is only supported on macOS" ])
+    in
+    { prog
+    ; argv =
+        [ prog
+        ; "-p"
+        ; sandbox_exec_profile ()
+        ; "/bin/sh"
+        ; "-c"
+        ; "cd \"$1\" || exit $?; shift; exec \"$@\""
+        ; "dune-sandbox-exec"
+        ; cwd
+        ]
+        @ argv
+    }
+;;
+
+let wrap ~cwd argv =
+  match Platform.OS.value with
+  | Linux -> wrap_with_bwrap ~cwd argv
+  | Darwin -> wrap_with_sandbox_exec ~cwd argv
+  | _ ->
+    User_error.raise [ Pp.text "--sandbox-actions is only supported on Linux and macOS" ]
+;;
+
+let command ~name ~doc ~wrap ~empty_error =
+  let info = Cmd.info name ~doc in
+  let term =
+    let+ argv = Arg.(value & pos_all string [] (info [] ~docv:"COMMAND" ~doc:None)) in
+    match argv with
+    | [] -> User_error.raise [ Pp.text "missing command after --" ]
+    | _ :: _ ->
+      let { prog; argv } = wrap ~cwd:(Sys.getcwd ()) argv in
+      (match argv with
+       | _ :: args -> Proc.restore_cwd_and_execve prog args ~env:Env.initial
+       | [] -> Code_error.raise empty_error [])
+  in
+  Cmd.v info term
+;;
+
 module With_bwrap = struct
   let command =
-    let doc = "Run a command under Dune's bubblewrap wrapper." in
-    let info = Cmd.info "with-bwrap" ~doc in
-    let term =
-      let+ argv = Arg.(value & pos_all string [] (info [] ~docv:"COMMAND" ~doc:None)) in
-      match argv with
-      | [] -> User_error.raise [ Pp.text "missing command after --" ]
-      | _ :: _ ->
-        let { prog; argv } = wrap ~cwd:(Sys.getcwd ()) argv in
-        (match argv with
-         | _ :: args -> Proc.restore_cwd_and_execve prog args ~env:Env.initial
-         | [] -> Code_error.raise "bwrap command is empty" [])
-    in
-    Cmd.v info term
+    command
+      ~name:"with-bwrap"
+      ~doc:"Run a command under Dune's bubblewrap wrapper."
+      ~wrap:wrap_with_bwrap
+      ~empty_error:"bwrap command is empty"
+  ;;
+end
+
+module With_sandbox_exec = struct
+  let command =
+    command
+      ~name:"with-sandbox-exec"
+      ~doc:"Run a command under Dune's sandbox-exec wrapper."
+      ~wrap:wrap_with_sandbox_exec
+      ~empty_error:"sandbox-exec command is empty"
   ;;
 end

--- a/bin/bwrap.mli
+++ b/bin/bwrap.mli
@@ -10,3 +10,7 @@ val wrap : cwd:string -> string list -> command
 module With_bwrap : sig
   val command : unit Cmd.t
 end
+
+module With_sandbox_exec : sig
+  val command : unit Cmd.t
+end

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -962,7 +962,7 @@ module Builder = struct
             ~doc:
               (Some
                  "Run spawned build processes in an external dune action runner wrapped \
-                  with bubblewrap."))
+                  with bubblewrap on Linux or sandbox-exec on macOS."))
     and+ action_runner =
       Arg.(
         value

--- a/bin/internal.ml
+++ b/bin/internal.ml
@@ -230,6 +230,7 @@ let group =
     ; Internal_digest_db.command
     ; Internal_action_runner.group
     ; Bwrap.With_bwrap.command
+    ; Bwrap.With_sandbox_exec.command
     ; latest_lang_version
     ; bootstrap_info
     ; Sexp_pp.command

--- a/doc/changes/added/15500.md
+++ b/doc/changes/added/15500.md
@@ -1,0 +1,2 @@
+- Support `--sandbox-actions` on macOS using sandbox-exec. (#15500,
+  @rgrinberg)

--- a/test/blackbox-tests/test-cases/sandbox-actions/dune
+++ b/test/blackbox-tests/test-cases/sandbox-actions/dune
@@ -1,7 +1,31 @@
 (cram
- (applies_to :whole_subtree)
+ (applies_to basic with-bwrap)
  (alias runtest-bwrap)
  (runtest_alias
   (<> %{env:CI=false} true))
  (deps %{bin:bwrap})
  (enabled_if %{bin-available:bwrap}))
+
+(cram
+ (applies_to shared-cache)
+ (runtest_alias
+  (or
+   (= %{system} macosx)
+   (<> %{env:CI=false} true)))
+ (enabled_if
+  (or
+   (and
+    (= %{system} linux)
+    %{bin-available:bwrap})
+   (and
+    (= %{system} macosx)
+    %{bin-available:sandbox-exec}))))
+
+(cram
+ (applies_to with-sandbox-exec)
+ (alias runtest-sandbox-exec)
+ (deps %{bin:sandbox-exec})
+ (enabled_if
+  (and
+   (= %{system} macosx)
+   %{bin-available:sandbox-exec})))

--- a/test/blackbox-tests/test-cases/sandbox-actions/with-sandbox-exec.t
+++ b/test/blackbox-tests/test-cases/sandbox-actions/with-sandbox-exec.t
@@ -1,0 +1,29 @@
+`dune internal with-sandbox-exec` runs commands in Dune's sandbox-exec wrapper.
+
+  $ export DUNE_CACHE_ROOT=$PWD/cache-root
+  $ mkdir -p "$DUNE_CACHE_ROOT/db"
+  $ cat > probe.sh <<'EOF'
+  > echo wrapped > outside
+  > if touch "$DUNE_CACHE_ROOT/db/runner-marker" 2>/dev/null; then
+  >   echo wrote
+  > else
+  >   echo blocked
+  > fi
+  > EOF
+  $ dune internal with-sandbox-exec -- sh probe.sh
+  blocked
+  $ cat outside
+  wrapped
+  $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present || echo missing
+  missing
+
+The canonical cache path is also protected when the configured cache root is a
+symlink.
+
+  $ mkdir -p real-cache-root/db
+  $ ln -s "$PWD/real-cache-root" cache-root-link
+  $ export DUNE_CACHE_ROOT=$PWD/cache-root-link
+  $ dune internal with-sandbox-exec -- sh probe.sh
+  blocked
+  $ test -e "$PWD/real-cache-root/db/runner-marker" && echo present || echo missing
+  missing


### PR DESCRIPTION
Dispatch the sandbox action runner wrapper by platform, keeping bubblewrap on
Linux and using sandbox-exec on macOS. The sandbox-exec profile denies writes to
the shared cache db while preserving normal filesystem access.

Add an internal with-sandbox-exec wrapper command and macOS-gated cram coverage
for shared cache protection.