### PR TITLE
install: validate dry-run non-empty destination dirs

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -172,6 +172,14 @@ let raise_file_should_be_deleted p =
     [ Pp.textf "Please delete file %s manually." (Path.to_string_maybe_quoted p) ]
 ;;
 
+let raise_non_empty_dir_should_be_deleted dir =
+  User_error.raise
+    [ Pp.textf
+        "Please delete non-empty directory %s manually."
+        (Path.to_string_maybe_quoted dir)
+    ]
+;;
+
 let rec validate_dir_can_be_created dir =
   match Unix.stat (Path.to_string dir) with
   | { st_kind = S_DIR; _ } -> ()
@@ -206,6 +214,9 @@ module File_ops_dry_run (Verbosity : sig
   ;;
 
   let remove_dir_if_exists ~if_non_empty path =
+    (match if_non_empty, Path.readdir_unsorted path with
+     | Fail, Ok (_ :: _) -> raise_non_empty_dir_should_be_deleted path
+     | _, _ -> ());
     print_line
       "Removing directory (%s if not empty) %s"
       (match if_non_empty with
@@ -376,15 +387,13 @@ module File_ops_real (W : sig
     | Error (e, _, _) ->
       User_message.prerr (User_error.make [ Pp.text (Unix.error_message e) ])
     | _ ->
-      let dir = Path.to_string_maybe_quoted dir in
       (match if_non_empty with
+       | Fail -> raise_non_empty_dir_should_be_deleted dir
        | Warn ->
+         let dir = Path.to_string_maybe_quoted dir in
          User_message.prerr
            (User_error.make
-              [ Pp.textf "Directory %s is not empty, cannot delete (ignoring)." dir ])
-       | Fail ->
-         User_error.raise
-           [ Pp.textf "Please delete non-empty directory %s manually." dir ])
+              [ Pp.textf "Directory %s is not empty, cannot delete (ignoring)." dir ]))
   ;;
 
   let mkdir_p p =

--- a/doc/changes/fixed/15501.md
+++ b/doc/changes/fixed/15501.md
@@ -1,0 +1,2 @@
+- `$ dune install --dry-run` now checks for non empty directories as part of its
+  validation (#15501, @rgrinberg)

--- a/test/blackbox-tests/test-cases/install/cmxs_exec.t
+++ b/test/blackbox-tests/test-cases/install/cmxs_exec.t
@@ -71,37 +71,8 @@ Dry runs should validate the same blocker.
   Installing prefix/lib/foo/dune-package
   Copying _build/install/default/lib/foo/dune-package to prefix/lib/foo/dune-package (executable: false)
   Creating directory prefix/lib/foo
-  Removing directory (fail if not empty) prefix/lib/foo/foo.a
-  Installing prefix/lib/foo/foo.a
-  Copying _build/install/default/lib/foo/foo.a to prefix/lib/foo/foo.a (executable: false)
-  Creating directory prefix/lib/foo
-  Removing (if it exists) prefix/lib/foo/foo.cma
-  Installing prefix/lib/foo/foo.cma
-  Copying _build/install/default/lib/foo/foo.cma to prefix/lib/foo/foo.cma (executable: false)
-  Creating directory prefix/lib/foo
-  Removing (if it exists) prefix/lib/foo/foo.cmi
-  Installing prefix/lib/foo/foo.cmi
-  Copying _build/install/default/lib/foo/foo.cmi to prefix/lib/foo/foo.cmi (executable: false)
-  Creating directory prefix/lib/foo
-  Removing (if it exists) prefix/lib/foo/foo.cmt
-  Installing prefix/lib/foo/foo.cmt
-  Copying _build/install/default/lib/foo/foo.cmt to prefix/lib/foo/foo.cmt (executable: false)
-  Creating directory prefix/lib/foo
-  Removing (if it exists) prefix/lib/foo/foo.cmx
-  Installing prefix/lib/foo/foo.cmx
-  Copying _build/install/default/lib/foo/foo.cmx to prefix/lib/foo/foo.cmx (executable: false)
-  Creating directory prefix/lib/foo
-  Removing (if it exists) prefix/lib/foo/foo.cmxa
-  Installing prefix/lib/foo/foo.cmxa
-  Copying _build/install/default/lib/foo/foo.cmxa to prefix/lib/foo/foo.cmxa (executable: false)
-  Creating directory prefix/lib/foo
-  Removing (if it exists) prefix/lib/foo/foo.ml
-  Installing prefix/lib/foo/foo.ml
-  Copying _build/install/default/lib/foo/foo.ml to prefix/lib/foo/foo.ml (executable: false)
-  Creating directory prefix/lib/foo
-  Removing (if it exists) prefix/lib/foo/foo.cmxs
-  Installing prefix/lib/foo/foo.cmxs
-  Copying _build/install/default/lib/foo/foo.cmxs to prefix/lib/foo/foo.cmxs (executable: true)
+  Error: Please delete non-empty directory prefix/lib/foo/foo.a manually.
+  [1]
 
 Test the error message if a destination is a file instead of a directory.
 


### PR DESCRIPTION
Have dry-run inspect destination directories before printing a "Removing directory (fail if not empty)" operation. This makes dry-run report the same non-empty-directory blocker as real install.