### PR TITLE
Add a GitHub Actions workflow for checking changelog entries

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,4 +1,4 @@
-name: Check Changelog
+name: Changelog
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   check-changelog:
-    name: Check changelog entry
+    name: Entry Check
     runs-on: ubuntu-latest
     steps:
       - name: Check for a changelog entry

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,20 @@
+name: Check Changelog
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+jobs:
+  check-changelog:
+    name: Check changelog entry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for a changelog entry
+        uses: tarides/changelog-check-action@v3
+        with:
+          changelog: doc/changes


### PR DESCRIPTION

<!-- Thank you for contributing to dune!

 For general guidelines on contributing to dune, see
 https://github.com/ocaml/dune/blob/main/CONTRIBUTING.md#developing-dune -->

## Description

This uses an existing action from
https://github.com/tarides/changelog-check-action. It checks for changes in the PATH (here: `doc/changes`). I'll add a `no changelog` label if this is okay, as recommended by the action.


## Related Issue and Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it closes an open issue, link to the issue here. -->
<!-- Non-trivial contributions are expected to be preceded by an issue, as
     per CONTRIBUTING.md. -->

Fixes #15460

## Checklist

- [x] Tests added, if applicable. (NA)
- [ ] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [x] Documentation added for any user-facing changes. (NA)
