### PR TITLE
feat(completion): add fish shell completion

### DIFF
--- a/bin/completion.ml
+++ b/bin/completion.ml
@@ -153,7 +153,9 @@ module Fish : Shell = struct
   let completion_script ~fun_name =
     sprintf
       {|function %s
-  set -l tokens (commandline -opc)
+  # fish 4.0 deprecated -o (--tokenize) in favor of -x (--tokens-expanded)
+  set -l tokens (commandline -xpc 2>/dev/null)
+  or set tokens (commandline -opc)
   set -l current (commandline -ct)
   type -q $tokens[1]; or return
   set -l response ($tokens[1] --__complete $tokens[2..-1] --__complete=$current 2>/dev/null)

--- a/bin/completion.ml
+++ b/bin/completion.ml
@@ -132,7 +132,132 @@ Register-ArgumentCompleter -Native -CommandName %s -ScriptBlock $%s
   ;;
 end
 
-let shells : (module Shell) list = [ (module Bash); (module Zsh); (module Powershell) ]
+module Fish : Shell = struct
+  let name = "fish"
+
+  let description =
+    [ `I
+        ( "$(b,fish)"
+        , "Print out a fish completion script. It should then be written to a file named \
+           dune.fish in a directory that fish autoloads completions from, for example \
+           ~/.config/fish/completions:" )
+    ; `Pre
+        {|
+      dune completion fish > ~/.config/fish/completions/dune.fish|}
+    ]
+  ;;
+
+  (* cmdliner does not provide a generic completion script for fish, so it is
+     maintained here. It speaks the same completion protocol as the scripts in
+     [Cmdliner_data]. *)
+  let completion_script ~fun_name =
+    sprintf
+      {|function %s
+  set -l tokens (commandline -opc)
+  set -l current (commandline -ct)
+  type -q $tokens[1]; or return
+  set -l response ($tokens[1] --__complete $tokens[2..-1] --__complete=$current 2>/dev/null)
+  if not set -q response[1]
+    __fish_complete_path $current
+    return
+  end
+  if test "$response[1]" != 1
+    echo "Unsupported cmdliner completion protocol: $response[1]" >&2
+    return 1
+  end
+  set -l found 0
+  set -l group ""
+  set -l n (count $response)
+  set -l i 2
+  while test $i -le $n
+    set -l type $response[$i]
+    set i (math $i + 1)
+    switch $type
+      case group
+        set group $response[$i]
+        set i (math $i + 1)
+      case item
+        set -l item $response[$i]
+        set i (math $i + 1)
+        set -l doc
+        while test $i -le $n; and test "$response[$i]" != item-end
+          set -a doc $response[$i]
+          set i (math $i + 1)
+        end
+        set i (math $i + 1)
+        set -l item_doc
+        if set -q doc[1]
+          set item_doc (string join -- " " $doc | string replace -ra '\e\[[0-9;]*m' '')
+        end
+        # Handle glued forms, the completion item is the full token
+        if test "$group" = Values
+          if string match -q -- '--*' $current
+            set -l opt (string split -m 1 -- = $current)[1]
+            set item $opt=$item
+          else if string match -q -- '-*' $current
+            set item (string sub -l 2 -- $current)$item
+          end
+        end
+        string join -- \t $item $item_doc
+        set found (math $found + 1)
+      case files dirs
+        # trim option prefix in cases like --file=<TAB> or -f<TAB>
+        set -l prefix ""
+        set -l pattern $current
+        if string match -q -- '--*' $current
+          set -l parts (string split -m 1 -- = $current)
+          if set -q parts[2]
+            set prefix $parts[1]=
+            set pattern $parts[2]
+          end
+        else if string match -q -- '-*' $current
+          set prefix (string sub -l 2 -- $current)
+          set pattern (string sub -s 3 -- $current)
+        end
+        set -l paths
+        if test $type = dirs
+          set paths (__fish_complete_directories $pattern)
+        else
+          set paths (__fish_complete_path $pattern)
+        end
+        if set -q paths[1]
+          string replace -r -- '^' $prefix $paths
+          set found (math $found + (count $paths))
+        end
+      case message
+        while test $i -le $n; and test "$response[$i]" != message-end
+          set i (math $i + 1)
+        end
+        set i (math $i + 1)
+      case restart
+        # N.B. only emitted if there is a -- token
+        set -l sep (contains -i -- -- $tokens)
+        if test -n "$sep"
+          set -l subline (string join -- " " (string escape -- $tokens[(math $sep + 1)..-1] $current))
+          set -l results (complete -C"$subline")
+          if set -q results[1]
+            string join -- \n $results
+            set found (math $found + (count $results))
+          end
+        end
+    end
+  end
+  if test $found -eq 0
+    __fish_complete_path $current
+  end
+end
+complete -c %s -f -k -a "(%s)"
+|}
+      fun_name
+      "dune"
+      fun_name
+  ;;
+end
+
+let shells : (module Shell) list =
+  [ (module Bash); (module Zsh); (module Fish); (module Powershell) ]
+;;
+
 let all = shells |> List.map ~f:(fun (module S : Shell) -> S.name, (module S : Shell))
 
 let term =

--- a/doc/changes/added/15515.md
+++ b/doc/changes/added/15515.md
@@ -1,0 +1,3 @@
+- Add `fish` to the shells supported by `dune completion`, enabling
+  command, subcommand, and flag completion in the fish shell (#15515,
+  fixes #15334, @chizy7)

--- a/doc/howto/shell-completion.md
+++ b/doc/howto/shell-completion.md
@@ -5,7 +5,7 @@ Shell command completion refers to a common feature in various shells:
 hitting \<TAB\> after a partially-typed command will print matching suggestions.
 This can apply to command names, flags, arguments...
 
-Dune offers completion for commands, subcommands, and flags, for Bash, Z shell, and PowerShell.
+Dune offers completion for commands, subcommands, and flags, for Bash, Z shell, fish, and PowerShell.
 The various shells and systems require specific configuration setups,
 and this document aims to help users get completion running.
 
@@ -34,6 +34,17 @@ in your `$fpath` (by default it should be `~/.local/share/zsh/site-functions`).
 If you wish to create a dedicated completion directory and add it to your `$fpath`,
 be sure to add the following in your `.zshrc` but **before** any call to `compinit`:
 `fpath+=<your dir>`.
+
+You might need to restart your shell to see the effects.
+
+Fish
+----
+
+Command completion for fish should work out of the box:
+create the fish completion script (by running `dune completion fish`)
+and write it to a directory that fish autoloads completions from,
+for example `~/.config/fish/completions`:
+`dune completion fish > ~/.config/fish/completions/dune.fish`.
 
 You might need to restart your shell to see the effects.
 

--- a/test/blackbox-tests/test-cases/completion/commands.t
+++ b/test/blackbox-tests/test-cases/completion/commands.t
@@ -28,3 +28,13 @@ wrappers.
       return [Management.Automation.CompletionCompleters]::CompleteFilename(
         $wordToComplete
       )
+
+Fish registers the completion function without file completion and falls back
+to it explicitly when there are no semantic completions:
+
+  $ dune completion fish | grep '^complete '
+  complete -c dune -f -k -a "(_dune_cmdliner)"
+
+  $ dune completion fish | grep -A1 'if test $found -eq 0'
+    if test $found -eq 0
+      __fish_complete_path $current

--- a/test/blackbox-tests/test-cases/completion/dune
+++ b/test/blackbox-tests/test-cases/completion/dune
@@ -3,3 +3,8 @@
  (enabled_if
   (= %{system} linux))
  (deps %{bin:bash}))
+
+(cram
+ (applies_to fish)
+ (enabled_if %{bin-available:fish})
+ (deps %{bin:fish}))

--- a/test/blackbox-tests/test-cases/completion/fish.t
+++ b/test/blackbox-tests/test-cases/completion/fish.t
@@ -1,0 +1,21 @@
+Fish completion scripts fall back to filename completion when Dune has no
+semantic completions to offer.
+
+This test sources the generated fish completion script and exercises the
+completion it registered for dune.
+
+  $ mkdir completions
+  $ touch completions/fish.t completions/other-file
+  $ cd completions
+  $ dune completion fish > dune.fish
+
+Subcommand names are completed semantically:
+
+  $ fish --no-config -c 'source dune.fish; complete -C"dune runtes"' | cut -f1
+  runtest
+
+Positional arguments without semantic completions fall back to filename
+completion:
+
+  $ fish --no-config -c 'source dune.fish; complete -C"dune runtest fis"'
+  fish.t


### PR DESCRIPTION
## Description

adds `fish` to the shells supported by `dune completion`, folowing the work in #14779 which added bash, zsh, and powershell but left fish out.

Since cmdliner doesnt provide a generic fish completion script (`dbuenzli/cmdliner#213`), this PR adds one on the Dune side as a new `Fish` module in `bin/completion.ml`. It can't live under `vendor/cmdliner` because that directory is overwritten by `vendor/update-cmdliner.sh`. The implementation is mostly generic apart from the command name, so it could potentially be upstreamed to cmdliner later.

### What's Included

* Subcommand completion with descriptions.
* Flag completion and suggestions.
* Value completion for options like `--root=`.
* Filename fallback when Dune has no semantic completions.
* Support for all completion protocol v1 directives, including `restart` and `message`.

### What's Not Included

* Target completion (`dune build <TAB>` → `@test`, `@install`, etc.), matching the existing shell implementations.
* Displaying `message` directives. Fish has no safe way to show completion messages without interfering with the pager, so they are consumed buut not displayed.

### Notes for Reviewers

* Uses `commandline -opc` for compatibility with both fish 3.x and 4.x.
* Shell order is now: bash, zsh, fish, powershell.
* Tested interactively on fish 4.8.1 on macOS. Testing on other fish versions is welcome.

To try it:

```sh
dune completion fish > ~/.config/fish/completions/dune.fish
```

## Related Issue and Motivation

Fish users currently don't get shell completions from `dune completion` because cmdliner has no fish support. This PR adds a Dune-maintained implementation following the existing completion support, with the possibility of upstreaming it to cmdliner in the future.

Fixes #15334.

## Checklist

* [x] Tests added, if applicable.
* [x] Change log entry added.
* [x] Documentation added.
