### PR TITLE
test(win): bin layouts use incorrect artifact names on win

### DIFF
--- a/test/blackbox-tests/test-cases/bin-pform/dune
+++ b/test/blackbox-tests/test-cases/bin-pform/dune
@@ -1,0 +1,5 @@
+(cram
+ (applies_to windows-install-names)
+ (enabled_if
+  (= %{os_type} Win32))
+ (alias runtest-windows))

--- a/test/blackbox-tests/test-cases/bin-pform/windows-install-names.t
+++ b/test/blackbox-tests/test-cases/bin-pform/windows-install-names.t
@@ -1,0 +1,62 @@
+On Windows, artifact lookup uses extensionless executable names while the
+layout must use the actual installed filenames. Non-executable bin entries
+retain their declared extensions.
+
+  $ make_dune_project_with_package 3.24 mypkg
+  $ mkdir producer
+
+  $ cat >producer/launcher.ml <<'EOF'
+  > let () = print_endline "hello from launcher"
+  > EOF
+
+  $ cat >producer/tool.cmd <<'EOF'
+  > @echo off
+  > echo hello from tool
+  > EOF
+
+  $ cat >producer/dune <<'EOF'
+  > (executable
+  >  (name launcher)
+  >  (public_name launcher)
+  >  (package mypkg))
+  > (install
+  >  (package mypkg)
+  >  (section bin)
+  >  (files tool.cmd))
+  > EOF
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps %{bin:launcher} %{bin:tool.cmd})
+  >  (action
+  >   (progn
+  >    (with-stdout-to launcher.out (system "launcher"))
+  >    (with-stdout-to tool.out (system "tool.cmd")))))
+  > EOF
+
+On native Windows, both entries are callable by their lookup names:
+
+  $ dune build launcher.out tool.out
+  File "dune", lines 1-6, characters 0-168:
+  1 | (rule
+  2 |  (deps %{bin:launcher} %{bin:tool.cmd})
+  3 |  (action
+  4 |   (progn
+  5 |    (with-stdout-to launcher.out (system "launcher"))
+  6 |    (with-stdout-to tool.out (system "tool.cmd")))))
+  'launcher' is not recognized as an internal or external command,
+  operable program or batch file.
+  [1]
+  $ cat _build/default/launcher.out
+  cat: _build/default/launcher.out: No such file or directory
+  [1]
+  $ cat _build/default/tool.out
+  cat: _build/default/tool.out: No such file or directory
+  [1]
+
+The layout uses the installed filenames, including [.exe] only for the
+executable:
+
+  $ ls _build/install/default/.binaries/*
+  launcher
+  tool.cmd


### PR DESCRIPTION
## Description

Add a native Windows cram test covering the artifact names materialized in `%{bin:...}` PATH layouts.

The test records the current behavior: a native executable is placed in the layout as extensionless `launcher`, so Windows command lookup fails, while a declared `tool.cmd` entry retains its filename. This PR intentionally captures the existing failure as expected output so the test-only change remains independently passing. The production fix will follow in a separate PR and update these expectations.

Validated with the `mingw-5.4` opam switch on native Windows 11.

## Related Issue and Motivation

Regression coverage for #15512.

This isolates the Windows regression coverage from its fix so both changes can pass CI independently and be reviewed in order.

## Checklist

- [x] Tests added, if applicable.
- [x] Change log entry not required for this test-only change.
- [x] Documentation not required for this test-only change.
- [x] windows tests pass