### PR TITLE
refactor(rev-store): share LMDB object key codec

### DIFF
--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -234,26 +234,7 @@ module Cache = struct
   ;;
 
   module Files_and_submodules = struct
-    module Key = struct
-      module T = struct
-        type t = Object.t
-
-        let compare = Object.compare
-        let to_dyn = Object.to_dyn
-      end
-
-      include T
-      module C = Comparable.Make (T)
-
-      let conv =
-        Lmdb.Conv.make
-          ~serialise:(fun alloc obj ->
-            Object.to_hex obj |> Lmdb.Conv.(serialise string alloc))
-          ~deserialise:(fun bs ->
-            Lmdb.Conv.(deserialise string bs) |> Object.of_sha1_unsafe)
-          ()
-      ;;
-    end
+    module Key = Key
 
     let map =
       lazy


### PR DESCRIPTION
Reuse the revision store object key module for the files-and-submodules map instead of defining the same comparison and serialization twice.