### PR TITLE
fix(rpc): allow pthread chdir to raise

### DIFF
--- a/src/rpc/csexp_rpc.ml
+++ b/src/rpc/csexp_rpc.ml
@@ -16,7 +16,7 @@ module Socket = struct
   end
 
   module Mac = struct
-    external pthread_chdir : string -> unit = "dune_pthread_chdir" [@@noalloc]
+    external pthread_chdir : string -> unit = "dune_pthread_chdir"
     external set_nosigpipe : Unix.file_descr -> unit = "dune_set_nosigpipe"
 
     let with_chdir fd ~socket ~f =


### PR DESCRIPTION
The macOS pthread chdir stub reports syscall failures with uerror, which allocates and raises an OCaml exception. Marking the external noalloc lets native code omit the bookkeeping required for both operations.

Remove the annotation so failures can safely propagate to OCaml.