### PR TITLE
fix(fsevents): initialize events before allocation

### DIFF
--- a/src/dune_scheduler/fsevents_stubs.c
+++ b/src/dune_scheduler/fsevents_stubs.c
@@ -178,9 +178,9 @@ static void dune_fsevents_callback(const FSEventStreamRef streamRef,
                            0, 0, (UInt8 *)p, byte_len, NULL);
     assert(res == len);
 
-    v_event = caml_alloc(3, 0);
     v_id = caml_copy_int64(eventIds[i]);
     v_flags = caml_copy_int32(flags);
+    v_event = caml_alloc(3, 0);
     Store_field(v_event, 0, v_path);
     Store_field(v_event, 1, v_id);
     Store_field(v_event, 2, v_flags);


### PR DESCRIPTION
The FSEvents callback allocated an event block before boxing its identifier and flags. Either boxing operation can trigger a collection that scans the event block while its fields still contain garbage.

Box and root both values before allocating and initializing the event block.