### PR TITLE
fix(stdune): reject oversized copyfile paths

### DIFF
--- a/otherlibs/stdune/src/copyfile_stubs.c
+++ b/otherlibs/stdune/src/copyfile_stubs.c
@@ -22,8 +22,14 @@ CAMLprim value stdune_copyfile(value v_from, value v_to) {
   char from[PATH_MAX];
   char to[PATH_MAX];
   char real_from[PATH_MAX];
-  int from_len = caml_string_length(v_from);
-  int to_len = caml_string_length(v_to);
+  mlsize_t from_len = caml_string_length(v_from);
+  mlsize_t to_len = caml_string_length(v_to);
+  if (from_len >= sizeof(from)) {
+    unix_error(ENAMETOOLONG, "copyfile", v_from);
+  }
+  if (to_len >= sizeof(to)) {
+    unix_error(ENAMETOOLONG, "copyfile", v_to);
+  }
   memcpy(from, String_val(v_from), from_len);
   memcpy(to, String_val(v_to), to_len);
   from[from_len] = '\0';


### PR DESCRIPTION
The macOS copyfile stub copies OCaml paths into PATH_MAX-sized stack buffers. caml_unix_check_path rejects embedded NUL bytes but does not enforce a length limit, so an oversized path could overflow those buffers.

Keep the lengths as mlsize_t and raise ENAMETOOLONG before copying any path that cannot fit with its terminating NUL.