### PR TITLE
action-runner: connect worker over socketpair

### DIFF
--- a/bin/action_runner.ml
+++ b/bin/action_runner.ml
@@ -21,71 +21,80 @@ let dune_prog () =
   else Path.of_filename_relative_to_initial_cwd prog
 ;;
 
-let create ~where ~config ~sandbox_actions =
-  let pid =
-    let env =
-      let jobs =
-        let scheduler_config =
-          Dune_config.for_scheduler config ~watch_exclusions:[] ~print_ctrl_c_warning:true
-        in
-        Int.to_string scheduler_config.concurrency
-      in
-      Env.add Env.initial ~var:"DUNE_JOBS" ~value:jobs
-      |> Env.add ~var:"DUNE_BUILD_DIR" ~value:(Path.Build.to_string Path.Build.root)
-      |> Env.to_unix
-      |> Spawn.Env.of_list
-    in
-    let trace_fd = Dune_trace.duplicate_global_fd () in
-    let prog, argv =
-      let dune_prog = dune_prog () in
-      let worker_argv =
-        [ Path.to_string dune_prog
-        ; "internal"
-        ; "action-runner"
-        ; "start"
-        ; Action_runner_name.to_string name
-        ]
-      in
-      if sandbox_actions
-      then (
-        let { Bwrap.prog; argv } =
-          Bwrap.wrap ~cwd:(Path.to_absolute_filename Path.root) worker_argv
-        in
-        prog, argv)
-      else Path.to_string dune_prog, worker_argv
-    in
-    let argv =
-      let where = Dune_rpc.Where.to_string where in
-      argv
-      @ [ where ]
-      @
-      match trace_fd with
-      | Some fd -> [ "--trace-fd"; Int.to_string (Fd.unsafe_to_int fd) ]
-      | None -> []
-    in
-    Exn.protect
-      ~f:(fun () ->
-        (* Use SIGTERM because the action runner knows how to clean up
-           its children. *)
-        Spawn.spawn ~env ~prog ~argv ~pdeathsig:Term ())
-      ~finally:(fun () -> Option.iter trace_fd ~f:Fd.close)
-  in
-  Dune_engine.Action_runner.create name pid
+let socketpair () =
+  if Sys.win32
+  then User_error.raise [ Pp.text "action runners are not supported on Windows" ];
+  let parent_fd, worker_fd = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let parent_fd = Fd.unsafe_of_unix_file_descr parent_fd in
+  let worker_fd = Fd.unsafe_of_unix_file_descr worker_fd in
+  Fd.set_close_on_exec parent_fd;
+  Fd.clear_close_on_exec worker_fd;
+  parent_fd, worker_fd
 ;;
 
-let parse_where where =
-  match
-    Dune_rpc.Conv.of_sexp
-      Dune_rpc.Where.sexp
-      ~version:Dune_rpc.Version.latest
-      (Sexp.Atom where)
-  with
-  | Ok where -> where
-  | Error err ->
-    User_error.raise
-      [ Pp.textf "invalid action runner RPC address %S" where
-      ; Pp.text (Dyn.to_string (Dune_rpc.Conv.dyn_of_error err))
-      ]
+let create ~config ~sandbox_actions =
+  let parent_fd, worker_fd = socketpair () in
+  let parent_fd_transferred = ref false in
+  Exn.protect
+    ~finally:(fun () ->
+      Fd.close worker_fd;
+      if not !parent_fd_transferred then Fd.close parent_fd)
+    ~f:(fun () ->
+      let pid =
+        let env =
+          let jobs =
+            let scheduler_config =
+              Dune_config.for_scheduler
+                config
+                ~watch_exclusions:[]
+                ~print_ctrl_c_warning:true
+            in
+            Int.to_string scheduler_config.concurrency
+          in
+          Env.add Env.initial ~var:"DUNE_JOBS" ~value:jobs
+          |> Env.add ~var:"DUNE_BUILD_DIR" ~value:(Path.Build.to_string Path.Build.root)
+          |> Env.to_unix
+          |> Spawn.Env.of_list
+        in
+        let trace_fd = Dune_trace.duplicate_global_fd () in
+        let prog, argv =
+          let dune_prog = dune_prog () in
+          let worker_argv =
+            [ Path.to_string dune_prog
+            ; "internal"
+            ; "action-runner"
+            ; "start"
+            ; Action_runner_name.to_string name
+            ]
+          in
+          if sandbox_actions
+          then (
+            let { Bwrap.prog; argv } =
+              Bwrap.wrap ~cwd:(Path.to_absolute_filename Path.root) worker_argv
+            in
+            prog, argv)
+          else Path.to_string dune_prog, worker_argv
+        in
+        let argv =
+          argv
+          @ [ "--rpc-fd"; Int.to_string (Fd.unsafe_to_int worker_fd) ]
+          @
+          match trace_fd with
+          | Some fd -> [ "--trace-fd"; Int.to_string (Fd.unsafe_to_int fd) ]
+          | None -> []
+        in
+        Exn.protect
+          ~finally:(fun () -> Option.iter trace_fd ~f:Fd.close)
+          ~f:(fun () ->
+            (* Use SIGTERM because the action runner knows how to clean up
+               its children. *)
+            Spawn.spawn ~env ~prog ~argv ~pdeathsig:Term ())
+      in
+      let action_runner =
+        Dune_engine.Action_runner.create name pid ~connection_fd:parent_fd
+      in
+      parent_fd_transferred := true;
+      action_runner)
 ;;
 
 let inherit_trace_fd ~name trace_fd =
@@ -96,9 +105,9 @@ let inherit_trace_fd ~name trace_fd =
       (Fd.unsafe_of_int (Int.of_string_exn fd)))
 ;;
 
-let start_worker ~name ~where ~trace_fd =
+let start_worker ~name ~rpc_fd ~trace_fd =
   let name = Action_runner_name.parse_string_exn (Loc.none, name) in
   inherit_trace_fd ~name trace_fd;
-  let where = parse_where where in
-  Dune_engine.Action_runner_worker.start ~name ~where
+  let rpc_fd = Fd.unsafe_of_int (Int.of_string_exn rpc_fd) in
+  Dune_engine.Action_runner_worker.start ~name ~rpc_fd
 ;;

--- a/bin/action_runner.mli
+++ b/bin/action_runner.mli
@@ -1,9 +1,4 @@
 open Import
 
-val create
-  :  where:Dune_rpc.Where.t
-  -> config:Dune_config.t
-  -> sandbox_actions:bool
-  -> Dune_engine.Action_runner.t
-
-val start_worker : name:string -> where:string -> trace_fd:string option -> unit Fiber.t
+val create : config:Dune_config.t -> sandbox_actions:bool -> Dune_engine.Action_runner.t
+val start_worker : name:string -> rpc_fd:string -> trace_fd:string option -> unit Fiber.t

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1386,12 +1386,7 @@ let init_with_root_and_rpc ~(root : Workspace_root.t) ~rpc_build (builder : Buil
   let action_runner =
     lazy
       (if action_runner_requested c
-       then
-         Some
-           (Action_runner.create
-              ~where:(Lazy.force where)
-              ~config
-              ~sandbox_actions:c.builder.sandbox_actions)
+       then Some (Action_runner.create ~config ~sandbox_actions:c.builder.sandbox_actions)
        else None)
   in
   let rpc =

--- a/bin/internal_action_runner.ml
+++ b/bin/internal_action_runner.ml
@@ -7,15 +7,15 @@ let start =
   let+ builder = Common.Builder.term_no_trace_no_pkg
   and+ name =
     Arg.(required & pos 0 (some string) None (Arg.info [] ~docv:"NAME" ~doc:None))
-  and+ where =
-    Arg.(required & pos 1 (some string) None (Arg.info [] ~docv:"WHERE" ~doc:None))
+  and+ rpc_fd =
+    Arg.(required & opt (some string) None (Arg.info [ "rpc-fd" ] ~docv:"FD" ~doc:None))
   and+ trace_fd =
     Arg.(value & opt (some string) None (Arg.info [ "trace-fd" ] ~docv:"FD" ~doc:None))
   in
   let builder = Common.Builder.forbid_builds builder in
   let common, config = Common.init builder in
   Scheduler_setup.go_without_rpc_server ~common ~config (fun () ->
-    Action_runner.start_worker ~name ~where ~trace_fd)
+    Action_runner.start_worker ~name ~rpc_fd ~trace_fd)
 ;;
 
 let start = Cmd.v (Cmd.info "start") start

--- a/src/dune_engine/action_runner.ml
+++ b/src/dune_engine/action_runner.ml
@@ -18,6 +18,7 @@ type t =
   ; mutable status : status
   ; pid : Pid.t
   ; pool : Fiber.Pool.t
+  ; connection : Root.Rpc.Csexp_rpc.Session.t
   }
 
 let disconnected t =
@@ -37,6 +38,7 @@ let disconnect t =
     t.status <- Closed;
     Dune_trace.emit Action (fun () ->
       Dune_trace.Event.Action.Runner.runner_event ~name:t.name Disconnected);
+    let* () = Fiber.Pool.close t.pool in
     (match ready with
      | None -> Fiber.return ()
      | Some ready -> Fiber.Ivar.fill ready ())
@@ -55,7 +57,7 @@ let await_initialized t =
          [ Pp.textf
              "Action runner %S failed to initialize."
              (Action_runner_name.to_string t.name)
-         ; Pp.text "It exited before connecting back to Dune."
+         ; Pp.text "It exited before connecting to Dune."
          ]
      | Starting _ ->
        Code_error.raise
@@ -137,25 +139,6 @@ let exec_process t ~run_id ~cancellation process =
   | Not_cancelled, Error exns -> Fiber.reraise_all exns
 ;;
 
-let run t =
-  Fiber.fork_and_join_unit
-    (fun () -> Fiber.Pool.run t.pool)
-    (fun () ->
-       let* (_status : Proc.Process_info.t) =
-         Scheduler.wait_for_process t.pid ~is_process_group_leader:false
-       in
-       disconnect t)
-;;
-
-let stop t =
-  let* () =
-    match t.status with
-    | Starting _ | Closed -> Fiber.return ()
-    | Initialized (Session session) -> Server.Session.close session
-  in
-  Fiber.Pool.close t.pool
-;;
-
 let invalid_request message =
   let error = Dune_rpc.Response.Error.create ~kind:Invalid_request ~message () in
   raise (Dune_rpc.Response.Error.E error)
@@ -192,13 +175,43 @@ let implement_handler t (handler : _ Root.Rpc.Server.Handler.t) =
   Server.Handler.implement_request handler Decl.ready (ready t)
 ;;
 
-let create name pid =
+let run t =
+  let serve_session () =
+    let handler =
+      let on_init _ (_ : Dune_rpc.Initialize.Request.t) = Fiber.return () in
+      let rpc = Server.Handler.create ~on_init ~version:Dune_rpc.Version.latest () in
+      implement_handler (Some t) rpc;
+      Server.make rpc
+    in
+    Server.serve (Fiber.Stream.In.of_list [ t.connection ]) handler
+  in
+  Fiber.fork_and_join_unit
+    (fun () -> Fiber.fork_and_join_unit (fun () -> Fiber.Pool.run t.pool) serve_session)
+    (fun () ->
+       let* (_status : Proc.Process_info.t) =
+         Scheduler.wait_for_process t.pid ~is_process_group_leader:false
+       in
+       disconnect t)
+;;
+
+let stop t =
+  let* () =
+    match t.status with
+    | Starting _ | Closed -> Root.Rpc.Csexp_rpc.Session.close t.connection
+    | Initialized (Session session) -> Server.Session.close session
+  in
+  Fiber.Pool.close t.pool
+;;
+
+let create name pid ~connection_fd =
   Dune_trace.emit Action (fun () ->
     Dune_trace.Event.Action.Runner.runner_event ~name (Spawn pid));
   Scheduler.preserve_child_process pid;
+  let connection = Root.Rpc.Csexp_rpc.Session.of_fd connection_fd in
   { name
   ; status = Starting { ready = Fiber.Ivar.create () }
   ; pid
   ; pool = Fiber.Pool.create ()
+  ; connection
   }
 ;;

--- a/src/dune_engine/action_runner.mli
+++ b/src/dune_engine/action_runner.mli
@@ -10,17 +10,13 @@ open Import
 
 type t
 
-(** [implement_handler t handler] wires the action runner requests into an
-      existing RPC handler. *)
-val implement_handler : t option -> 'a Root.Rpc.Server.Handler.t -> unit
-
 (** [run t] is to be run by the RPC server. *)
 val run : t -> unit Fiber.t
 
 (** [stop t] is to be run by the RPC server. *)
 val stop : t -> unit Fiber.t
 
-val create : Action_runner_name.t -> Pid.t -> t
+val create : Action_runner_name.t -> Pid.t -> connection_fd:Fd.t -> t
 val ensure_ready : t -> unit Fiber.t
 
 (** [exec_process t ~run_id ~cancellation process] dispatches [process] to [t]

--- a/src/dune_engine/action_runner_worker.ml
+++ b/src/dune_engine/action_runner_worker.ml
@@ -104,15 +104,11 @@ let finish_build t ({ Request.Finish_build.run_id } : Request.Finish_build.t) =
   Scheduler.cleanup_subreaper_child_processes ()
 ;;
 
-let connect_retry_delay = Time.Span.of_secs 0.1
-
-let start ~name ~where =
+let start ~name ~rpc_fd =
   let t = create () in
   Dune_trace.emit Action (fun () ->
     Dune_trace.Event.Action.Runner.runner_event ~name Connection_start);
-  let* connection =
-    Client.Connection.connect_retrying_exn where ~retry_delay:connect_retry_delay
-  in
+  let connection = Client.Connection.of_fd rpc_fd in
   Dune_trace.emit Action (fun () ->
     Dune_trace.Event.Action.Runner.runner_event ~name Connection_established);
   let private_menu : Client.proc list =
@@ -138,9 +134,8 @@ let start ~name ~where =
         ; Pp.text (Dune_rpc.Version_error.message version_error)
         ]
     | Ok request ->
-      let payload = { Request.Ready.name } in
-      let* response = Client.request client request payload in
-      (match response with
+      Client.request client request { Request.Ready.name }
+      >>= (function
        | Ok () -> Client.disconnected client
        | Error error ->
          User_error.raise

--- a/src/dune_engine/action_runner_worker.mli
+++ b/src/dune_engine/action_runner_worker.mli
@@ -1,5 +1,5 @@
 open Import
 
-(** [start ~name ~where] starts a runner named [name] connected to the main dune
-    RPC server listening at [where]. *)
-val start : name:Action_runner_name.t -> where:Dune_rpc.Where.t -> unit Fiber.t
+(** [start ~name ~rpc_fd] starts a runner named [name] connected to the main
+    dune process through [rpc_fd]. *)
+val start : name:Action_runner_name.t -> rpc_fd:Fd.t -> unit Fiber.t

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -141,7 +141,7 @@ let cancel_all_build_requests t =
   | Enabled { build_loop; _ } -> Build_loop.cancel_all_rpc_requests build_loop
 ;;
 
-let handler (t : t Fdecl.t) action_runner_server : unit Handler.t =
+let handler (t : t Fdecl.t) : unit Handler.t =
   let on_init session (_ : Initialize.Request.t) =
     let t = Fdecl.get t in
     t.server.clients <- Clients.add_session t.server.clients session;
@@ -389,7 +389,6 @@ let handler (t : t Fdecl.t) action_runner_server : unit Handler.t =
     let f _ () = Fiber.return Path.Build.(to_string root) in
     Handler.implement_request rpc Procedures.Public.build_dir f
   in
-  Action_runner.implement_handler action_runner_server rpc;
   Dune_rules_rpc.register rpc;
   rpc
 ;;
@@ -418,7 +417,7 @@ let create ~registry ~root ~build ~where ~action_runner watch_mode =
                  (Path.Build.to_string_maybe_quoted (Where.rpc_socket_file ()))
              ])
     in
-    let handler = Rpc.Server.make (handler t action_runner) in
+    let handler = Rpc.Server.make (handler t) in
     let server = Lazy.force server in
     let lifecycle = Rpc.Server.Lifecycle.create ~handler ~root ~where ~registry ~server in
     action_runner, lifecycle

--- a/src/rpc/client.ml
+++ b/src/rpc/client.ml
@@ -20,6 +20,13 @@ module Connection = struct
 
   let connect_sock sock = Csexp_rpc.Client.create sock |> Csexp_rpc.Client.connect
 
+  let of_fd fd =
+    match Csexp_rpc.Session.of_fd fd with
+    | fd -> fd
+    | exception exn ->
+      User_error.raise [ Pp.text "failed to use RPC file descriptor"; Exn.pp exn ]
+  ;;
+
   let connect where =
     match Where.to_socket where with
     | exception exn ->

--- a/src/rpc/client.mli
+++ b/src/rpc/client.mli
@@ -7,6 +7,7 @@ module Connection : sig
   type t
 
   val connect : Dune_rpc.Where.t -> (t, User_message.t) result Fiber.t
+  val of_fd : Fd.t -> t
 
   (** like [connect] but fails with a nice error message for the user *)
   val connect_exn : Dune_rpc.Where.t -> t Fiber.t

--- a/src/rpc/csexp_rpc.ml
+++ b/src/rpc/csexp_rpc.ml
@@ -151,6 +151,14 @@ module Session = struct
     { id; state }
   ;;
 
+  let of_fd fd =
+    Socket.prepare_fd fd
+    |> Result.map ~f:(fun () ->
+      Fd.set_close_on_exec fd;
+      create fd)
+    |> Result.ok_exn
+  ;;
+
   let close_fd t =
     let* () = Fiber.return () in
     match t.state with

--- a/src/rpc/csexp_rpc.mli
+++ b/src/rpc/csexp_rpc.mli
@@ -21,6 +21,7 @@ module Session : sig
   type t
 
   val close : t -> unit Fiber.t
+  val of_fd : Fd.t -> t
 
   (** [write t xs] writes the s-expressions [xs]. *)
   val write : t -> Sexp.t list -> (unit, [ `Closed ]) result Fiber.t

--- a/test/blackbox-tests/test-cases/action-runner/dune
+++ b/test/blackbox-tests/test-cases/action-runner/dune
@@ -2,6 +2,12 @@
  (alias runtest-action-runner)
  (applies_to basic cancel-disconnect disconnect failure pool runtest trace))
 
+(cram
+ (alias runtest-action-runner)
+ (applies_to fd-leak)
+ (enabled_if
+  (= %{system} linux)))
+
 ;; Disabled until stop-on-first-error cancellation through action runners exits
 ;; promptly instead of relying on the test harness timeout.
 

--- a/test/blackbox-tests/test-cases/action-runner/fd-leak.t
+++ b/test/blackbox-tests/test-cases/action-runner/fd-leak.t
@@ -1,0 +1,18 @@
+`--action-runner` should not leak its control socket to spawned actions.
+
+  $ make_dune_project 3.23
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (target fds)
+  >  (action
+  >   (bash
+  >    "for fd in /proc/self/fd/*; do
+  >       target=$(readlink \"$fd\" 2>/dev/null || true)
+  >       case \"$target\" in
+  >         socket:*) echo \"$fd -> $target\" ;;
+  >       esac
+  >     done > %{target}")))
+  > EOF
+
+  $ dune build --action-runner fds
+  $ cat _build/default/fds


### PR DESCRIPTION
Start action-runner workers with an inherited socketpair fd instead of having
the worker connect back to the main RPC server address. Serve the runner RPC
protocol on that private session and keep the main RPC server focused on public
client connections.

Expose fd-backed RPC session construction for the action-runner transport, and
mark inherited RPC sessions close-on-exec after the worker starts so spawned
actions do not inherit the control socket.

Add a Linux-only cram test covering the leaked control socket.