### PR TITLE
fix(blake3): validate feed ranges

### DIFF
--- a/src/ocaml-blake3-mini/blake3_stubs.c
+++ b/src/ocaml-blake3-mini/blake3_stubs.c
@@ -184,14 +184,22 @@ CAMLprim value blake3_mini_digest(value v_t) {
   CAMLreturn(v_ret);
 }
 
+static void blake3_mini_check_range(intnat pos, intnat len, uintnat size) {
+  if (pos < 0 || len < 0 || (uintnat)pos > size ||
+      (uintnat)len > size - (uintnat)pos) {
+    caml_invalid_argument("Blake3_mini.feed: invalid range");
+  }
+}
+
 CAMLprim value blake3_mini_feed_string(value v_t, value v_s, value v_pos,
                                        value v_len) {
   CAMLparam4(v_t, v_s, v_pos, v_len);
 
   blake3_hasher *hasher = Blake3_val(v_t);
   const char *s = String_val(v_s);
-  size_t pos = Long_val(v_pos);
-  size_t len = Long_val(v_len);
+  intnat pos = Long_val(v_pos);
+  intnat len = Long_val(v_len);
+  blake3_mini_check_range(pos, len, caml_string_length(v_s));
   blake3_hasher_update(hasher, s + pos, len);
 
   CAMLreturn(Val_unit);
@@ -202,8 +210,9 @@ CAMLprim value blake3_mini_feed_bigstring_unlock(value v_t, value v_s,
   CAMLparam4(v_t, v_s, v_pos, v_len);
 
   blake3_hasher *hasher = Blake3_val(v_t);
-  size_t pos = Long_val(v_pos);
-  size_t len = Long_val(v_len);
+  intnat pos = Long_val(v_pos);
+  intnat len = Long_val(v_len);
+  blake3_mini_check_range(pos, len, Caml_ba_array_val(v_s)->dim[0]);
   char *s = Caml_ba_data_val(v_s);
   caml_register_global_root(&v_s);
   caml_release_runtime_system();

--- a/test/expect-tests/blake3/blake3_mini_tests.ml
+++ b/test/expect-tests/blake3/blake3_mini_tests.ml
@@ -68,3 +68,26 @@ let%expect_test "digest with hasher bigstring" =
   printf "%s\n" (Blake3_mini.Digest.to_hex digest);
   [%expect {| 7a7d692dfca02a756fea9a8a77903807 |}]
 ;;
+
+let report_invalid_range name f =
+  match f () with
+  | () -> printf "%s: accepted\n" name
+  | exception Invalid_argument _ -> printf "%s: rejected\n" name
+;;
+
+let%expect_test "invalid feed ranges" =
+  let hasher = Blake3_mini.create () in
+  report_invalid_range "string" (fun () ->
+    Blake3_mini.feed_string hasher "x" ~pos:1 ~len:1);
+  report_invalid_range "bytes" (fun () ->
+    Blake3_mini.feed_bytes hasher (Bytes.of_string "x") ~pos:1 ~len:1);
+  let bigstring = Bigarray.Array1.create Char C_layout 1 in
+  report_invalid_range "bigstring" (fun () ->
+    Blake3_mini.feed_bigstring_release_lock hasher bigstring ~pos:2 ~len:0);
+  [%expect
+    {|
+    string: accepted
+    bytes: accepted
+    bigstring: accepted
+    |}]
+;;

--- a/test/expect-tests/blake3/blake3_mini_tests.ml
+++ b/test/expect-tests/blake3/blake3_mini_tests.ml
@@ -86,8 +86,8 @@ let%expect_test "invalid feed ranges" =
     Blake3_mini.feed_bigstring_release_lock hasher bigstring ~pos:2 ~len:0);
   [%expect
     {|
-    string: accepted
-    bytes: accepted
-    bigstring: accepted
+    string: rejected
+    bytes: rejected
+    bigstring: rejected
     |}]
 ;;


### PR DESCRIPTION
The BLAKE3 feed stubs currently pass positions and lengths to C without validating them against the input. Negative values become large unsigned values, while oversized ranges can read past the supplied string, bytes, or bigstring.

This PR adds regression coverage for all three entry points and validates ranges before calling BLAKE3. The bound check uses `size - pos` after checking `pos <= size`, avoiding overflow in `pos + len`.

Tested with:

```console
dune runtest test/expect-tests/blake3
```