### PR TITLE
refactor: prefer Proc.wait over Unix.waitpid

### DIFF
--- a/otherlibs/stdune/test/proc_linux_tests.ml
+++ b/otherlibs/stdune/test/proc_linux_tests.ml
@@ -10,10 +10,10 @@ let sleep_forever () =
 ;;
 
 let wait_no_eintr pid =
-  let pid = Pid.to_int pid in
   let rec loop () =
-    match Unix.waitpid [] pid with
-    | _ -> ()
+    match Proc.wait (Pid pid) [] with
+    | Some _ -> ()
+    | None -> Code_error.raise "child process disappeared" []
     | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop ()
   in
   loop ()

--- a/otherlibs/stdune/test/spawn/tests.ml
+++ b/otherlibs/stdune/test/spawn/tests.ml
@@ -1,6 +1,7 @@
 module Int = Stdune.Int
 module Exn = Stdune.Exn
 module Pid = Stdune.Pid
+module Proc = Stdune.Proc
 module Platform = Stdune.Platform
 module Signal = Stdune.Signal
 module Spawn = Stdune.Spawn
@@ -304,8 +305,8 @@ let%expect_test "sigprocmask" =
       let pid_int = Pid.to_int pid in
       Unix.kill pid_int Sys.sigusr1;
       Unix.kill pid_int Sys.sigkill;
-      match Unix.waitpid [] pid_int with
-      | _, WSIGNALED signal when signal = expected_signal -> ()
+      match Proc.wait (Pid pid) [] with
+      | Some { status = WSIGNALED signal; _ } when signal = expected_signal -> ()
       | _ -> failwith "unexpected"
     in
     run Sys.sigusr1;

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -745,8 +745,8 @@ module Dune_config = struct
                      | exception End_of_file -> None
                    in
                    close_in ic;
-                   (match n, snd (Unix.waitpid [] (Stdune.Pid.to_int pid)) with
-                    | Some n, WEXITED 0 -> n
+                   (match n, Stdune.Proc.wait (Pid pid) [] with
+                    | Some n, Some { status = WEXITED 0; _ } -> n
                     | _ -> loop rest)))
          in
          loop commands))

--- a/test/expect-tests/inotify_tests/inotify_tests.ml
+++ b/test/expect-tests/inotify_tests/inotify_tests.ml
@@ -351,18 +351,17 @@ let%expect_test "Check that FS events are reported chronologically 2" =
 ;;
 
 let run cmd =
-  match
-    snd
-      (Unix.waitpid
-         []
-         (Unix.create_process
-            (List.hd cmd)
-            (Array.of_list cmd)
-            Unix.stdin
-            Unix.stdout
-            Unix.stderr))
-  with
-  | WEXITED 0 -> ()
+  let pid =
+    Unix.create_process
+      (List.hd cmd)
+      (Array.of_list cmd)
+      Unix.stdin
+      Unix.stdout
+      Unix.stderr
+    |> Pid.of_int_exn
+  in
+  match Proc.wait (Pid pid) [] with
+  | Some { status = WEXITED 0; _ } -> ()
   | _ -> assert false
 ;;
 


### PR DESCRIPTION
Use typed process IDs when waiting for child processes in Unix-only code paths.