### PR TITLE
stdune: support Proc.wait for PIDs on Windows

### DIFF
--- a/otherlibs/stdune/src/proc.ml
+++ b/otherlibs/stdune/src/proc.ml
@@ -5,6 +5,13 @@
    behaviour of [Unix.execve] on Unix. *)
 external sys_exit : int -> 'a = "caml_sys_exit"
 
+let waitpid pid flags =
+  match Unix.waitpid flags (Pid.to_int pid) with
+  | 0, _ -> None
+  | pid, status -> Some (Pid.of_int_exn pid, status)
+  | exception Unix.Unix_error (ECHILD, _, _) -> None
+;;
+
 let restore_cwd_and_execve prog argv ~env =
   let env = Env.to_unix env |> Array.of_list in
   let argv = Array.of_list (prog :: argv) in
@@ -13,11 +20,15 @@ let restore_cwd_and_execve prog argv ~env =
   Sys.chdir (Path.External.to_string Path.External.initial_cwd);
   if Sys.win32 || Platform.OS.value = Platform.OS.Haiku
   then (
-    let pid = Unix.create_process_env prog argv env Unix.stdin Unix.stdout Unix.stderr in
-    match snd (Unix.waitpid [] pid) with
-    | WEXITED n -> sys_exit n
-    | WSIGNALED _ -> sys_exit 255
-    | WSTOPPED _ -> assert false)
+    let pid =
+      Unix.create_process_env prog argv env Unix.stdin Unix.stdout Unix.stderr
+      |> Pid.of_int_exn
+    in
+    match waitpid pid [] with
+    | Some (_, WEXITED n) -> sys_exit n
+    | Some (_, WSIGNALED _) -> sys_exit 255
+    | Some (_, WSTOPPED _) -> assert false
+    | None -> Code_error.raise "child process disappeared" [])
   else (
     ignore (Unix.sigprocmask SIG_SETMASK [] : int list);
     Unix.execve prog argv env)
@@ -158,20 +169,29 @@ type wait =
   | Any
   | Pid of Pid.t
 
-let wait wait flags =
-  if Sys.win32
-  then Code_error.raise "wait4 not available on windows" []
-  else (
-    let pid =
-      match wait with
-      | Any -> -1
-      | Pid pid -> Pid.to_int pid
-    in
-    stub_wait4 pid flags
-    |> Option.map ~f:(fun (pid, status, end_time, resource_usage) ->
-      { Process_info.pid = Pid.of_int_exn pid
-      ; status
-      ; end_time = Time.of_ns end_time
-      ; resource_usage = Some resource_usage
-      }))
+let wait_win32 wait flags =
+  match wait with
+  | Any -> Code_error.raise "waiting for any process is not available on Windows" []
+  | Pid pid ->
+    (match waitpid pid flags with
+     | None -> None
+     | Some (pid, status) ->
+       Some { Process_info.pid; status; end_time = Time.now (); resource_usage = None })
 ;;
+
+let wait_unix wait flags =
+  let pid =
+    match wait with
+    | Any -> -1
+    | Pid pid -> Pid.to_int pid
+  in
+  stub_wait4 pid flags
+  |> Option.map ~f:(fun (pid, status, end_time, resource_usage) ->
+    { Process_info.pid = Pid.of_int_exn pid
+    ; status
+    ; end_time = Time.of_ns end_time
+    ; resource_usage = Some resource_usage
+    })
+;;
+
+let wait = if Sys.win32 then wait_win32 else wait_unix

--- a/otherlibs/stdune/src/proc.mli
+++ b/otherlibs/stdune/src/proc.mli
@@ -65,10 +65,10 @@ type wait =
   | Any
   | Pid of Pid.t
 
-(** This function is not implemented on Windows.
+(** On Windows, [Any] is not supported and successful results have no resource usage.
 
    Returns [None] if there are no children. If [WNOHANG] is passed, also
-   returns [None] if none of the proceseses are finished yet.
+   returns [None] if none of the processes are finished yet.
    When successful, returns information about the reaped process.
  *)
 val wait : wait -> Unix.wait_flag list -> Process_info.t option

--- a/otherlibs/stdune/test/spawn/tests.ml
+++ b/otherlibs/stdune/test/spawn/tests.ml
@@ -41,11 +41,12 @@ let%expect_test "non-existing dir" =
 ;;
 
 let wait pid =
-  match snd (Unix.waitpid [] (Pid.to_int pid)) with
-  | WEXITED 0 -> ()
-  | WEXITED n -> Printf.ksprintf failwith "exited with code %d" n
-  | WSIGNALED n -> Printf.ksprintf failwith "got signal %d" n
-  | WSTOPPED n -> Printf.ksprintf failwith "stopped with signal %d" n
+  match Proc.wait (Pid pid) [] with
+  | Some { status = WEXITED 0; _ } -> ()
+  | Some { status = WEXITED n; _ } -> Printf.ksprintf failwith "exited with code %d" n
+  | Some { status = WSIGNALED n; _ } -> Printf.ksprintf failwith "got signal %d" n
+  | Some { status = WSTOPPED n; _ } -> Printf.ksprintf failwith "stopped with signal %d" n
+  | None -> failwith "process disappeared"
 ;;
 
 let list_files = Filename.concat (Sys.getcwd ()) "exe/list_files.exe"

--- a/src/dune_scheduler/process_watcher.ml
+++ b/src/dune_scheduler/process_watcher.ml
@@ -126,14 +126,9 @@ exception Finished of Proc.Process_info.t
 let wait_nonblocking_win32 t =
   try
     Process_table.iter t ~f:(fun job ->
-      let pid, status = Unix.waitpid [ WNOHANG ] (Pid.to_int job.pid) in
-      if pid <> 0
-      then (
-        let now = Time.now () in
-        let info : Proc.Process_info.t =
-          { pid = Pid.of_int_exn pid; status; end_time = now; resource_usage = None }
-        in
-        raise_notrace (Finished info)));
+      match Proc.wait (Pid job.pid) [ WNOHANG ] with
+      | None -> ()
+      | Some proc_info -> raise_notrace (Finished proc_info));
     false
   with
   | Finished proc_info ->

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -358,7 +358,7 @@ let kill_and_wait_for_all_processes t =
   if Sys.win32
   then
     (* SIGTERM is not meaningful on Windows, and [Process_watcher.wait_unix]
-       would raise because [Proc.wait] has no implementation there. Send
+       would raise because [Proc.wait Any] is not supported there. Send
        SIGKILL directly; the main drain loop below observes exits via
        [jobs_completed] events pushed by the Win32 polling thread. *)
     Process_watcher.killall t.process_watcher Kill

--- a/test/expect-tests/foreign_stubs/archive_creation_behavior.ml
+++ b/test/expect-tests/foreign_stubs/archive_creation_behavior.ml
@@ -60,9 +60,11 @@ let spawn_and_capture ?env ~prog ~argv ~cwd () =
               ?env
               ())
       in
-      let waited_pid, status = Unix.waitpid [] (Pid.to_int pid) in
-      let waited_pid = Pid.of_int_exn waited_pid in
-      if waited_pid <> pid then Code_error.raise "waitpid returned another process" [];
+      let status =
+        match Proc.wait (Pid pid) [] with
+        | Some { status; _ } -> status
+        | None -> Code_error.raise "child process disappeared" []
+      in
       { status; stdout = Io.read_file stdout_path; stderr = Io.read_file stderr_path }))
 ;;
 

--- a/test/unit-tests/fswatch_win/fswatch_win_tests.ml
+++ b/test/unit-tests/fswatch_win/fswatch_win_tests.ml
@@ -262,8 +262,9 @@ let run cmd =
     |> Option.value_exn
     |> Path.to_string
   in
-  match snd (Unix.waitpid [] (Spawn.spawn ~prog ~argv:cmd () |> Pid.to_int)) with
-  | WEXITED 0 -> ()
+  let pid = Spawn.spawn ~prog ~argv:cmd () in
+  match Proc.wait (Pid pid) [] with
+  | Some { status = WEXITED 0; _ } -> ()
   | _ -> assert false
 ;;
 


### PR DESCRIPTION
Use the typed process API for Windows and cross-platform callers.
Proc.wait Any remains unsupported on Windows.