### PR TITLE
refactor(pkg): centralize project pin collection

### DIFF
--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -54,35 +54,6 @@ module Progress_indicator = struct
   let add_overlay (t : t) = Console.Status_line.add_overlay (Live (fun () -> pp t))
 end
 
-let project_and_package_pins project =
-  let dir = Dune_project.root project in
-  let pins = Dune_project.pins project in
-  let packages = Dune_project.packages project in
-  Pin.DB.add_opam_pins (Pin.DB.of_stanza ~dir pins) packages
-;;
-
-(* For recursive pins, we must traverse the pinned sources. The [project_pins]
-   are the initial pins that we have in our project. *)
-let resolve_project_pins project_pins =
-  let scan_project ~read ~(files : Filename.Array.Set.t) =
-    let read file = Memo.of_reproducible_fiber (read file) in
-    let open Memo.O in
-    (* Opam files may never contain recursive pins, so don't both reading them *)
-    Dune_project.gen_load
-      ~read
-      ~files
-      ~dir:Path.Source.root
-      ~infer_from_opam_files:false
-      ~load_opam_file_with_contents:Dune_pkg.Opam_file.load_opam_file_with_contents
-    >>| Option.map ~f:(fun project ->
-      let packages = Dune_project.packages project in
-      let pins = project_and_package_pins project in
-      pins, packages)
-    |> Memo.run
-  in
-  Pin.resolve project_pins ~scan_project
-;;
-
 module Platforms_by_message = struct
   module Message = struct
     type t =
@@ -358,7 +329,7 @@ let solve_lock_dir
       ~available_repos:repo_map
       ~repositories:(repositories_of_lock_dir workspace ~lock_dir_path)
   in
-  let* pins = resolve_project_pins project_pins in
+  let* pins = Pin.Project.resolve project_pins in
   let time_solve_start = Time.now () in
   progress_state := Some Progress_indicator.Per_lockdir.State.Solving;
   let* result =
@@ -523,10 +494,7 @@ let solve
 
 let project_pins =
   let open Memo.O in
-  Dune_rules.Dune_load.projects ()
-  >>| List.fold_left ~init:Pin.DB.empty ~f:(fun acc project ->
-    let pins = project_and_package_pins project in
-    Pin.DB.combine_exn acc pins)
+  Dune_rules.Dune_load.projects () >>| Pin.Project.collect_all
 ;;
 
 let lock ~version_preference ~lock_dirs_arg ~print_perf_stats ~portable_lock_dir =

--- a/src/dune_pkg/dune
+++ b/src/dune_pkg/dune
@@ -27,6 +27,7 @@
   stdune
   lmdb
   fiber
+  memo
   dune_scheduler
   dune_engine
   dune_util

--- a/src/dune_pkg/pin.ml
+++ b/src/dune_pkg/pin.ml
@@ -1,5 +1,6 @@
 open Import
 module Pin_stanza = Dune_lang.Pin_stanza
+module Dune_project = Dune_lang.Dune_project
 module Package = Pin_stanza.Package
 
 let local_package_of_pin (t : Pin_stanza.Package.t) ~url ~origin =
@@ -344,3 +345,36 @@ let resolve (t : DB.t) ~(scan_project : Scan_project.t)
   let+ () = loop Stack.empty t in
   !resolved
 ;;
+
+module Project = struct
+  let collect project =
+    let dir = Dune_project.root project in
+    let pins = Dune_project.pins project in
+    let packages = Dune_project.packages project in
+    DB.add_opam_pins (DB.of_stanza ~dir pins) packages
+  ;;
+
+  let collect_all projects =
+    List.fold_left projects ~init:DB.empty ~f:(fun acc project ->
+      DB.combine_exn acc (collect project))
+  ;;
+
+  let resolve project_pins =
+    let scan_project ~read ~files =
+      let open Memo.O in
+      let read file = Memo.of_reproducible_fiber (read file) in
+      Dune_project.gen_load
+        ~read
+        ~files
+        ~dir:Path.Source.root
+        ~infer_from_opam_files:false
+        ~load_opam_file_with_contents:Opam_file.load_opam_file_with_contents
+      >>| Option.map ~f:(fun project ->
+        let packages = Dune_project.packages project in
+        let pins = collect project in
+        pins, packages)
+      |> Memo.run
+    in
+    resolve project_pins ~scan_project
+  ;;
+end

--- a/src/dune_pkg/pin.mli
+++ b/src/dune_pkg/pin.mli
@@ -37,7 +37,7 @@ module Scan_project : sig
     -> (DB.t * Dune_lang.Package.t Package_name.Map.t) option Fiber.t
 end
 
-val resolve
-  :  DB.t
-  -> scan_project:Scan_project.t
-  -> Resolved_package.t Package_name.Map.t Fiber.t
+module Project : sig
+  val collect_all : Dune_lang.Dune_project.t list -> DB.t
+  val resolve : DB.t -> Resolved_package.t Package_name.Map.t Fiber.t
+end

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -14,7 +14,6 @@ include struct
   module Package_dependency = Package_dependency
   module Opam_solver = Opam_solver
   module Pin = Pin
-  module Opam_file = Opam_file
   module Sys_poll = Sys_poll
   module Pkg_workspace = Pkg_workspace
   module OpamUrl = OpamUrl
@@ -248,41 +247,7 @@ let lock_action
     }
 ;;
 
-let project_and_package_pins project =
-  let dir = Dune_project.root project in
-  let pins = Dune_project.pins project in
-  let packages = Dune_project.packages project in
-  Pin.DB.add_opam_pins (Pin.DB.of_stanza ~dir pins) packages
-;;
-
-(* CR-soon Alizter: This function is duplicated in bin/pkg/lock.ml. We should
-   factor out pin handling logic into a shared module in dune_pkg. *)
-let resolve_project_pins project_pins =
-  let scan_project ~read ~files =
-    let read file = Memo.of_reproducible_fiber (read file) in
-    Dune_project.gen_load
-      ~read
-      ~files
-      ~dir:Path.Source.root
-      ~infer_from_opam_files:false
-      ~load_opam_file_with_contents:Opam_file.load_opam_file_with_contents
-    >>| Option.map ~f:(fun project ->
-      let packages = Dune_project.packages project in
-      let pins = project_and_package_pins project in
-      pins, packages)
-    |> Memo.run
-  in
-  Pin.resolve project_pins ~scan_project
-;;
-
-(* CR-soon Alizter: This function is duplicated in bin/pkg/lock.ml. We should
-   factor out pin handling logic into a shared module in dune_pkg. *)
-let project_pins =
-  Dune_load.projects ()
-  >>| List.fold_left ~init:Pin.DB.empty ~f:(fun acc project ->
-    let pins = project_and_package_pins project in
-    Pin.DB.combine_exn acc pins)
-;;
+let project_pins = Dune_load.projects () >>| Pin.Project.collect_all
 
 let setup_lock_rules ~dir ~lock_dir : Gen_rules.result =
   let target = Path.Build.append_local dir lock_dir in
@@ -357,7 +322,7 @@ let setup_lock_rules ~dir ~lock_dir : Gen_rules.result =
               in
               let combined_pins = Pin.DB.combine_exn workspace_pins_db project_pins_db in
               Memo.return combined_pins
-              >>| resolve_project_pins
+              >>| Pin.Project.resolve
               >>= Memo.of_reproducible_fiber))
        in
        let version_preference =


### PR DESCRIPTION
Move project pin collection, recursive pin resolution, and multi-project
database construction into Dune_pkg.Pin for reuse by manual and
automatic locking.