### PR TITLE
refactor(pkg): centralize solver environment composition

### DIFF
--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -9,14 +9,10 @@ let solver_env
       ~solver_env_from_context
       ~unset_solver_vars_from_context
   =
-  let solver_env =
-    [ solver_env_from_current_system; solver_env_from_context ]
-    |> List.filter_opt
-    |> List.fold_left ~init:Solver_env.with_defaults ~f:Solver_env.extend
-  in
-  match unset_solver_vars_from_context with
-  | None -> solver_env
-  | Some unset_solver_vars -> Solver_env.unset_multi solver_env unset_solver_vars
+  Solver_env.combine
+    ~current_system:solver_env_from_current_system
+    ~context:solver_env_from_context
+    ~unset:unset_solver_vars_from_context
 ;;
 
 let poll_solver_env_from_current_system () =

--- a/src/dune_pkg/solver_env.ml
+++ b/src/dune_pkg/solver_env.ml
@@ -135,6 +135,17 @@ let unset_multi t variable_names =
     unset t variable_name)
 ;;
 
+let combine ~current_system ~context ~unset =
+  let t =
+    [ current_system; context ]
+    |> List.filter_opt
+    |> List.fold_left ~init:with_defaults ~f:extend
+  in
+  match unset with
+  | None -> t
+  | Some variables -> unset_multi t variables
+;;
+
 let remove_all_except t variable_names =
   Package_variable_name.Map.foldi t ~init:t ~f:(fun variable_name _value acc ->
     if Package_variable_name.Set.mem variable_names variable_name

--- a/src/dune_pkg/solver_env.mli
+++ b/src/dune_pkg/solver_env.mli
@@ -33,6 +33,12 @@ val pp : t -> 'a Pp.t
 val pp_oneline : t -> 'a Pp.t
 val unset_multi : t -> Package_variable_name.Set.t -> t
 
+val combine
+  :  current_system:t option
+  -> context:t option
+  -> unset:Package_variable_name.Set.t option
+  -> t
+
 (** [remove_all_except t names] returns an environment with the same bindings
     as those in [t] whose names also appear in [names]. *)
 val remove_all_except : t -> Package_variable_name.Set.t -> t

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -143,19 +143,14 @@ module Spec = struct
       | `Disabled -> false
     in
     let* solver_env =
-      (* CR-soon Alizter: This solver environment construction pattern (combining
-       solver_env_from_current_system with solver_env_from_context, then
-       unsetting vars) is similar to logic in bin/pkg/pkg_common.ml:solver_env
-       and bin/pkg/lock.ml. Consider sharing this pattern. *)
       let open Fiber.O in
       let+ solver_env_from_current_system =
         Sys_poll.make ~path:(Env_path.path env) |> Sys_poll.solver_env_from_current_system
       in
-      let solver_env =
-        [ solver_env_from_current_system; solver_env_from_context ]
-        |> List.fold_left ~init:Solver_env.with_defaults ~f:Solver_env.extend
-      in
-      Solver_env.unset_multi solver_env unset_solver_vars
+      Solver_env.combine
+        ~current_system:(Some solver_env_from_current_system)
+        ~context:(Some solver_env_from_context)
+        ~unset:(Some unset_solver_vars)
     in
     let* solver_result =
       if portable_lock_dir


### PR DESCRIPTION
Combine system and context solver environments and apply unset variables through Dune_pkg.Solver_env for both CLI and automatic locking.