### PR TITLE
refactor(lang): share command-line dependency parser

### DIFF
--- a/bin/arg.ml
+++ b/bin/arg.ml
@@ -71,14 +71,7 @@ module Dep = struct
       Some (if recursive then Dep_conf.Alias_rec s else Dep_conf.Alias s))
   ;;
 
-  let dep_parser =
-    Dune_lang.Syntax.set
-      Stanza.syntax
-      (Active Stanza.latest_version)
-      (String_with_vars.set_decoding_env
-         (Pform.Env.initial ~stanza:Stanza.latest_version ~extensions:[])
-         Dep_conf.decode)
-  ;;
+  let dep_parser = Dep_conf.command_line_parser ~stanza_version:Stanza.latest_version
 
   let parser s =
     match parse_alias s with

--- a/src/dune_lang/dep_conf.ml
+++ b/src/dune_lang/dep_conf.ml
@@ -151,6 +151,15 @@ let decode files =
 let decode_no_files = decode `Forbid
 let decode = decode `Allow
 
+let command_line_parser ~stanza_version =
+  Syntax.set
+    Stanza.syntax
+    (Active Stanza.latest_version)
+    (String_with_vars.set_decoding_env
+       (Pform.Env.initial ~stanza:stanza_version ~extensions:[])
+       decode)
+;;
+
 open Dune_sexp
 
 let encode = function

--- a/src/dune_lang/dep_conf.mli
+++ b/src/dune_lang/dep_conf.mli
@@ -52,4 +52,5 @@ val repr : t Repr.t
 include Conv.S with type t := t
 
 val decode_no_files : t Decoder.t
+val command_line_parser : stanza_version:Syntax.Version.t -> t Decoder.t
 val to_dyn : t Dyn.builder

--- a/src/dune_rpc_impl/dune_rules_rpc.ml
+++ b/src/dune_rpc_impl/dune_rules_rpc.ml
@@ -37,27 +37,13 @@ let register rpc =
   ()
 ;;
 
-include struct
-  open Dune_lang
-  module Stanza = Stanza
-  module String_with_vars = String_with_vars
-  module Pform = Pform
-end
-
-(* TODO un-copy-paste from dune/bin/arg.ml *)
-let dep_parser =
-  Dune_lang.Syntax.set Stanza.syntax (Active Stanza.latest_version) Dep_conf.decode
-;;
+(* Hardcoding the version is sufficient because this command is unstable and is
+   currently only used by tests. *)
+let dep_parser = Dep_conf.command_line_parser ~stanza_version:(3, 0)
 
 let parse_build_arg s =
   Dune_lang.Decoder.parse
     dep_parser
-    (Univ_map.set
-       Univ_map.empty
-       String_with_vars.decoding_env_key
-       (* CR-someday aalekseyev: hardcoding the version here is not
-          ideal, but it will do for now since this command is not
-          stable and we're only using it in tests. *)
-       (Pform.Env.initial ~stanza:(3, 0) ~extensions:[]))
+    Univ_map.empty
     (Dune_lang.Parser.parse_string ~fname:"dune rpc" ~mode:Dune_lang.Parser.Mode.Single s)
 ;;


### PR DESCRIPTION
Centralize dependency parser setup in Dep_conf and use it from both CLI argument handling and the RPC build request parser.