### PR TITLE
fix(rpc): restore process cwd inheritance on macOS

### DIFF
--- a/src/rpc/csexp_rpc.ml
+++ b/src/rpc/csexp_rpc.ml
@@ -17,14 +17,15 @@ module Socket = struct
 
   module Mac = struct
     external pthread_chdir : string -> unit = "dune_pthread_chdir"
+    external reset_pthread_cwd : unit -> unit = "dune_reset_pthread_cwd"
     external set_nosigpipe : Unix.file_descr -> unit = "dune_set_nosigpipe"
 
     let with_chdir fd ~socket ~f =
-      let old = Sys.getcwd () in
       let dir = Filename.dirname socket in
       let sock = Filename.basename socket in
       pthread_chdir dir;
-      Exn.protectx (Unix.ADDR_UNIX sock) ~f:(f fd) ~finally:(fun _ -> pthread_chdir old)
+      Exn.protectx (Unix.ADDR_UNIX sock) ~f:(f fd) ~finally:(fun _ ->
+        reset_pthread_cwd ())
     ;;
 
     let connect fd ~socket : unit =

--- a/src/rpc/csexp_rpc_stubs.c
+++ b/src/rpc/csexp_rpc_stubs.c
@@ -23,6 +23,9 @@ CAMLprim value dune_pthread_chdir_is_osx(value unit) {
 #ifndef SYS___pthread_chdir
 #define SYS___pthread_chdir 348
 #endif
+#ifndef SYS___pthread_fchdir
+#define SYS___pthread_fchdir 349
+#endif
 
 static int __pthread_chdir(const char *path) {
 #pragma clang diagnostic push
@@ -31,10 +34,25 @@ static int __pthread_chdir(const char *path) {
 #pragma clang diagnostic pop
 }
 
+static int __pthread_fchdir(int fd) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+  return syscall(SYS___pthread_fchdir, fd);
+#pragma clang diagnostic pop
+}
+
 CAMLprim value dune_pthread_chdir(value dir) {
   CAMLparam1(dir);
   if (__pthread_chdir(String_val(dir))) {
     uerror("__pthread_chdir", dir);
+  }
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value dune_reset_pthread_cwd(value unit) {
+  CAMLparam1(unit);
+  if (__pthread_fchdir(-1)) {
+    uerror("__pthread_fchdir", Nothing);
   }
   CAMLreturn(Val_unit);
 }
@@ -64,6 +82,12 @@ CAMLprim value dune_pthread_chdir_is_osx(value unit) {
 CAMLprim value dune_pthread_chdir(value unit) {
   CAMLparam1(unit);
   caml_invalid_argument("__pthread_chdir not implemented");
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value dune_reset_pthread_cwd(value unit) {
+  CAMLparam1(unit);
+  caml_invalid_argument("__pthread_fchdir not implemented");
   CAMLreturn(Val_unit);
 }
 

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -70,6 +70,35 @@ let temp_rpc_dir () =
   Temp.temp_dir ~parent_dir:(Path.of_string ".") ~prefix:"test" ~suffix:"dune_rpc"
 ;;
 
+let%expect_test "long unix socket bind restores thread cwd inheritance" =
+  let cwd_inherits_process_cwd =
+    if Platform.OS.value <> Darwin
+    then true
+    else (
+      let old_cwd = Sys.getcwd () in
+      let server =
+        let socket =
+          let tmp_dir = temp_rpc_dir () in
+          let socket_dir = Path.relative tmp_dir (String.make 104 'a') in
+          Path.relative socket_dir "dunerpc.sock" |> Path.to_absolute_filename
+        in
+        server (Unix.ADDR_UNIX socket)
+      in
+      let new_cwd = temp_rpc_dir () |> Path.to_absolute_filename in
+      let chdir_from_another_thread dir =
+        let thread = Thread.create Sys.chdir dir in
+        Thread.join thread
+      in
+      chdir_from_another_thread new_cwd;
+      let inherited = String.equal (Sys.getcwd ()) new_cwd in
+      chdir_from_another_thread old_cwd;
+      stop_server server;
+      inherited)
+  in
+  printfn "%b" cwd_inherits_process_cwd;
+  [%expect {| true |}]
+;;
+
 let%expect_test "csexp server create on unix sockets" =
   (let tmp_dir = temp_rpc_dir () in
    let addr : Unix.sockaddr =


### PR DESCRIPTION
The long Unix socket workaround sets a per-thread cwd. Restoring it with
pthread_chdir leaves the override active, so the thread no longer follows
changes to the process-wide cwd.

Reset the per-thread cwd with pthread_fchdir(-1), and cover the behavior
with a macOS regression test.