### PR TITLE
test(stdune): reproduce sendfile hang at premature EOF

### DIFF
--- a/otherlibs/stdune/test/dune
+++ b/otherlibs/stdune/test/dune
@@ -1,6 +1,12 @@
 (library
  (name stdune_unit_tests)
- (modules :standard \ path_external_build_tests path_tests proc_linux_tests)
+ (modules
+  :standard
+  \
+  path_external_build_tests
+  path_tests
+  proc_linux_tests
+  sendfile_tests)
  (inline_tests
   (deps
    (source_tree ../unit-tests/findlib-db)
@@ -50,6 +56,22 @@
 (library
  (name stdune_proc_linux_tests)
  (modules proc_linux_tests)
+ (enabled_if
+  (= %{system} linux))
+ (inline_tests)
+ (libraries
+  stdune
+  unix
+  ppx_expect.config
+  ppx_expect.config_types
+  base
+  ppx_inline_test.config)
+ (preprocess
+  (pps ppx_expect)))
+
+(library
+ (name stdune_sendfile_tests)
+ (modules sendfile_tests)
  (enabled_if
   (= %{system} linux))
  (inline_tests)

--- a/otherlibs/stdune/test/sendfile_tests.ml
+++ b/otherlibs/stdune/test/sendfile_tests.ml
@@ -1,0 +1,41 @@
+open Stdune
+
+external sendfile
+  :  src:Unix.file_descr
+  -> dst:Unix.file_descr
+  -> int
+  -> unit
+  = "stdune_sendfile"
+
+let sendfile_hangs_on_premature_eof () =
+  let dir = Temp.create Dir ~prefix:"sendfile" ~suffix:"test" in
+  let src = Path.relative dir "src" in
+  let dst = Path.relative dir "dst" in
+  Io.write_file src "";
+  match Unix.fork () with
+  | 0 ->
+    let src = Unix.openfile (Path.to_string src) [ O_RDONLY ] 0 in
+    let dst = Unix.openfile (Path.to_string dst) [ O_WRONLY; O_CREAT ] 0o600 in
+    (match sendfile ~src ~dst 1 with
+     | () -> Unix._exit 2
+     | exception Unix.Unix_error _ -> Unix._exit 0)
+  | child ->
+    let child = Pid.of_int_exn child in
+    let rec wait attempts =
+      match Proc.wait (Pid child) [ WNOHANG ] with
+      | None when attempts = 0 ->
+        Pid.kill_exn child `Pid Kill;
+        ignore (Proc.wait (Pid child) [] : Proc.Process_info.t option);
+        true
+      | None ->
+        Unix.sleepf 0.01;
+        wait (attempts - 1)
+      | Some _ -> false
+    in
+    wait 100
+;;
+
+let%expect_test "sendfile hangs if source ends before requested size" =
+  assert (sendfile_hangs_on_premature_eof ());
+  [%expect {||}]
+;;


### PR DESCRIPTION
The Linux copy path asks the sendfile stub to transfer the source size observed before the copy. If the source ends before that count, sendfile returns zero while the stub still has bytes remaining.

Call the raw stub in a child with an empty source and a one-byte request, then terminate the child after a bounded wait. This captures the existing nontermination without hanging the test runner.