### PR TITLE
fix(stdune): handle premature EOF in sendfile

### DIFF
--- a/otherlibs/stdune/src/copyfile_stubs.c
+++ b/otherlibs/stdune/src/copyfile_stubs.c
@@ -2,6 +2,8 @@
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
 
+#include <errno.h>
+
 #if defined(__APPLE__)
 #define _DARWIN_C_SOURCE
 
@@ -10,7 +12,6 @@
 #include <caml/unixsupport.h>
 
 #include <copyfile.h>
-#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/syslimits.h>
@@ -89,6 +90,10 @@ static ssize_t dune_sendfile(int in, int out, size_t length) {
     if (ret < 0) {
       return ret;
     }
+    if (ret == 0) {
+      errno = EIO;
+      return -1;
+    }
     length = length - ret;
   }
   return length;
@@ -106,6 +111,10 @@ static ssize_t dune_copy_file_range(int in, int out, size_t length) {
     ret = copy_file_range_fn(in, NULL, out, NULL, length, 0);
     if (ret < 0) {
       return dune_sendfile(in, out, length);
+    }
+    if (ret == 0) {
+      errno = EIO;
+      return -1;
     }
     length = length - ret;
   }

--- a/otherlibs/stdune/test/sendfile_tests.ml
+++ b/otherlibs/stdune/test/sendfile_tests.ml
@@ -7,7 +7,7 @@ external sendfile
   -> unit
   = "stdune_sendfile"
 
-let sendfile_hangs_on_premature_eof () =
+let sendfile_rejects_premature_eof () =
   let dir = Temp.create Dir ~prefix:"sendfile" ~suffix:"test" in
   let src = Path.relative dir "src" in
   let dst = Path.relative dir "dst" in
@@ -26,16 +26,17 @@ let sendfile_hangs_on_premature_eof () =
       | None when attempts = 0 ->
         Pid.kill_exn child `Pid Kill;
         ignore (Proc.wait (Pid child) [] : Proc.Process_info.t option);
-        true
+        false
       | None ->
         Unix.sleepf 0.01;
         wait (attempts - 1)
+      | Some { status = WEXITED 0; _ } -> true
       | Some _ -> false
     in
     wait 100
 ;;
 
-let%expect_test "sendfile hangs if source ends before requested size" =
-  assert (sendfile_hangs_on_premature_eof ());
+let%expect_test "sendfile rejects a source ending before the requested size" =
+  assert (sendfile_rejects_premature_eof ());
   [%expect {||}]
 ;;


### PR DESCRIPTION
sendfile and copy_file_range can return zero when they reach EOF. The
copy loops previously left the remaining length unchanged in that case
and retried forever.

Treat a zero-byte transfer with bytes remaining as EIO so the caller
receives a Unix error instead of hanging. Update the regression test to
require the child to terminate through that error path.