### PR TITLE
refactor(pkg): share workspace and project pin merging

### DIFF
--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -290,11 +290,11 @@ let solve_lock_dir
     match lock_dir with
     | None -> project_pins, Solver_env.popular_platform_envs
     | Some lock_dir ->
-      let workspace =
+      let pins =
         Pin.DB.Workspace.of_stanza workspace.pins
-        |> Pin.DB.Workspace.extract ~names:lock_dir.pins
+        |> Pin.DB.Workspace.extract_and_combine ~names:lock_dir.pins ~project_pins
       in
-      Pin.DB.combine_exn workspace project_pins, lock_dir.solve_for_platforms
+      pins, lock_dir.solve_for_platforms
   in
   let solver_env_from_context =
     Option.bind lock_dir ~f:(fun lock_dir -> lock_dir.solver_env)

--- a/src/dune_pkg/pin.ml
+++ b/src/dune_pkg/pin.ml
@@ -135,6 +135,10 @@ module DB = struct
       { all = []; map; context = Workspace }
     ;;
 
+    let extract_and_combine t ~names ~project_pins =
+      combine_exn (extract t ~names) project_pins
+    ;;
+
     let equal = String.Map.equal ~equal:Poly.equal
     let to_dyn = Dyn.opaque
     let hash = Poly.hash

--- a/src/dune_pkg/pin.mli
+++ b/src/dune_pkg/pin.mli
@@ -24,6 +24,7 @@ module DB : sig
     val of_stanza : Pin_stanza.Workspace.t -> t
     val empty : t
     val extract : t -> names:(Loc.t * string) list -> db
+    val extract_and_combine : t -> names:(Loc.t * string) list -> project_pins:db -> db
     val equal : t -> t -> bool
     val to_dyn : t -> Dyn.t
     val hash : t -> int

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -296,32 +296,28 @@ let setup_lock_rules ~dir ~lock_dir : Gen_rules.result =
               Opam_repo.resolve_repositories ~available_repos ~repositories
               |> Memo.of_non_reproducible_fiber))
        and+ pins =
-         (* CR-soon Alizter: This pin logic (extracting workspace pins,
-            combining with project pins) is duplicated in bin/pkg/lock.ml. The
-            pattern of Pin.DB.Workspace.extract and Pin.DB.combine_exn could be
-            factored into a shared helper. *)
          Action_builder.of_memo
            (Memo.of_thunk (fun () ->
               let open Memo.O in
               let* project_pins_db = project_pins in
-              let workspace_pins_db =
-                let workspace_pins = Pin.DB.Workspace.of_stanza workspace.pins in
-                let pin_map = Dune_lang.Pin_stanza.Workspace.map workspace.pins in
-                let all_pin_names =
-                  pin_map
-                  |> String.Map.to_list
-                  |> List.fold_left ~init:[] ~f:(fun acc (_repo_name, pkg_map) ->
-                    pkg_map
-                    |> Dune_lang.Package_name.Map.to_list
-                    |> List.fold_left
-                         ~init:acc
-                         ~f:(fun acc (pkg_name, ((loc, _url), _pkg)) ->
-                           (loc, Dune_lang.Package_name.to_string pkg_name) :: acc))
-                in
-                Pin.DB.Workspace.extract workspace_pins ~names:all_pin_names
+              let workspace_pins = Pin.DB.Workspace.of_stanza workspace.pins in
+              let pin_map = Dune_lang.Pin_stanza.Workspace.map workspace.pins in
+              let all_pin_names =
+                pin_map
+                |> String.Map.to_list
+                |> List.fold_left ~init:[] ~f:(fun acc (_repo_name, pkg_map) ->
+                  pkg_map
+                  |> Dune_lang.Package_name.Map.to_list
+                  |> List.fold_left
+                       ~init:acc
+                       ~f:(fun acc (pkg_name, ((loc, _url), _pkg)) ->
+                         (loc, Dune_lang.Package_name.to_string pkg_name) :: acc))
               in
-              let combined_pins = Pin.DB.combine_exn workspace_pins_db project_pins_db in
-              Memo.return combined_pins
+              Pin.DB.Workspace.extract_and_combine
+                workspace_pins
+                ~names:all_pin_names
+                ~project_pins:project_pins_db
+              |> Memo.return
               >>| Pin.Project.resolve
               >>= Memo.of_reproducible_fiber))
        in


### PR DESCRIPTION
Add one Pin.DB.Workspace operation for extracting selected workspace pins and combining them with project pins, and use it from both locking paths.