### PR TITLE
fix: run artifact substitution I/O in worker pool

### DIFF
--- a/doc/changes/changed/15559.md
+++ b/doc/changes/changed/15559.md
@@ -1,0 +1,1 @@
+- Run artifact substitution in background workers. (#15559, @anmonteiro)

--- a/src/dune_rules/artifact_substitution.ml
+++ b/src/dune_rules/artifact_substitution.ml
@@ -173,11 +173,13 @@ module Conf = struct
     match has_subst with
     | No_substitution -> Fiber.return ()
     | Some_substitution ->
-      let executable =
-        match Path.Untracked.stat file with
-        | Error _ -> false
-        | Ok { st_perm; _ } ->
-          Permissions.test_any Permissions.execute (Permissions.Mode.of_int st_perm)
+      let open Fiber.O in
+      let* executable =
+        Scheduler.async_exn (fun () ->
+          match Path.Untracked.stat file with
+          | Error _ -> false
+          | Ok { st_perm; _ } ->
+            Permissions.test_any Permissions.execute (Permissions.Mode.of_int st_perm))
       in
       if executable
       then
@@ -497,7 +499,7 @@ type mode =
   | Test
   | Copy of
       { input_file : Path.t
-      ; output : bytes -> int -> int -> unit
+      ; output : bytes -> int -> int -> unit Fiber.t
       ; conf : Conf.t
       }
 
@@ -556,11 +558,14 @@ let parse ~input ~mode =
     (* All the data before [placeholder_start] can be sent to the output
        immediately since we know for sure that they are not part of a
        placeholder *)
-    (match mode with
-     | Test -> ()
-     | Copy { output; _ } ->
-       if placeholder_start > beginning_of_data
-       then output buf beginning_of_data (placeholder_start - beginning_of_data));
+    let* () =
+      match mode with
+      | Test -> Fiber.return ()
+      | Copy { output; _ } ->
+        if placeholder_start > beginning_of_data
+        then output buf beginning_of_data (placeholder_start - beginning_of_data)
+        else Fiber.return ()
+    in
     let leftover = end_of_data - placeholder_start in
     match scanner_state with
     | Scan_placeholder (placeholder_start, len) when len <= leftover ->
@@ -577,7 +582,7 @@ let parse ~input ~mode =
                 ~placeholder:(to_dyn t)
                 ~value:s);
             let s = encode_replacement ~len ~repl:s in
-            output (Bytes.unsafe_of_string s) 0 len;
+            let* () = output (Bytes.unsafe_of_string s) 0 len in
             let pos = placeholder_start + len in
             loop Scan0 ~beginning_of_data:pos ~pos ~end_of_data ~status:Some_substitution)
        | None ->
@@ -604,7 +609,8 @@ let parse ~input ~mode =
         | Scan_length (_, acc) -> Scan_length (0, acc)
         | Scan_placeholder (_, len) -> Scan_placeholder (0, len)
       in
-      (match input buf leftover (buf_len - leftover) with
+      let* read = input buf leftover (buf_len - leftover) in
+      (match read with
        | 0 ->
          (match scanner_state with
           | Scan_placeholder _ ->
@@ -617,8 +623,8 @@ let parse ~input ~mode =
              | Copy { output; _ } ->
                (* Nothing more to read; [leftover] is definitely not the beginning
                   of a placeholder, send it and end the copy *)
-               output buf 0 leftover;
-               Fiber.return status))
+               let+ () = output buf 0 leftover in
+               status))
        | n ->
          loop
            scanner_state
@@ -627,25 +633,41 @@ let parse ~input ~mode =
            ~end_of_data:(leftover + n)
            ~status)
   in
-  match input buf 0 buf_len with
+  let* read = input buf 0 buf_len in
+  match read with
   | 0 -> Fiber.return No_substitution
   | n -> loop Scan0 ~beginning_of_data:0 ~pos:0 ~end_of_data:n ~status:No_substitution
 ;;
 
 let copy ~conf ~input_file ~input ~output =
-  parse ~input ~mode:(Copy { conf; input_file; output })
+  parse
+    ~input:(fun buf pos len -> Fiber.return (input buf pos len))
+    ~mode:
+      (Copy
+         { conf
+         ; input_file
+         ; output = (fun buf pos len -> Fiber.return (output buf pos len))
+         })
 ;;
 
 let copy_file_non_atomic ~conf ?chmod ~src ~dst () =
   (* CR-someday rgrinberg: our copying here is slow. If we scan the file and detect no
      substitutions, we should go directly to [Io.copy_file] *)
   let open Fiber.O in
-  let* ic, oc = Fiber.return (Io.setup_copy ?chmod ~src ~dst ()) in
+  let* ic, oc = Scheduler.async_exn (fun () -> Io.setup_copy ?chmod ~src ~dst ()) in
   Fiber.finalize
-    ~finally:(fun () ->
-      Io.close_both (ic, oc);
-      Fiber.return ())
-    (fun () -> copy ~conf ~input_file:src ~input:(input ic) ~output:(output oc))
+    ~finally:(fun () -> Scheduler.async_exn (fun () -> Io.close_both (ic, oc)))
+    (fun () ->
+       parse
+         ~input:(fun buf pos len -> Scheduler.async_exn (fun () -> input ic buf pos len))
+         ~mode:
+           (Copy
+              { conf
+              ; input_file = src
+              ; output =
+                  (fun buf pos len ->
+                    Scheduler.async_exn (fun () -> output oc buf pos len))
+              }))
 ;;
 
 (** This is just an optimisation: skip the renaming if the destination exists
@@ -701,21 +723,24 @@ let copy_file ~conf ?chmod ?(delete_dst_if_it_is_a_directory = false) ~src ~dst 
   Fiber.finalize
     (fun () ->
        let open Fiber.O in
-       Path.parent dst |> Option.iter ~f:Path.mkdir_p;
+       let* () =
+         Scheduler.async_exn (fun () -> Path.parent dst |> Option.iter ~f:Path.mkdir_p)
+       in
        let* has_subst = copy_file_non_atomic ~conf ?chmod ~src ~dst:temp_file () in
-       let+ () = Conf.run_sign_hook conf ~has_subst temp_file in
-       replace_if_different ~delete_dst_if_it_is_a_directory ~src:temp_file ~dst)
+       let* () = Conf.run_sign_hook conf ~has_subst temp_file in
+       Scheduler.async_exn (fun () ->
+         replace_if_different ~delete_dst_if_it_is_a_directory ~src:temp_file ~dst))
     ~finally:(fun () ->
-      Fpath.unlink_no_err (Path.to_string temp_file);
-      Fiber.return ())
+      Scheduler.async_exn (fun () -> Fpath.unlink_no_err (Path.to_string temp_file)))
 ;;
 
 let test_file ~src () =
   let open Fiber.O in
-  let* ic = Fiber.return (Io.open_in src) in
+  let* ic = Scheduler.async_exn (fun () -> Io.open_in src) in
   Fiber.finalize
-    ~finally:(fun () ->
-      Io.close_in ic;
-      Fiber.return ())
-    (fun () -> parse ~input:(input ic) ~mode:Test)
+    ~finally:(fun () -> Scheduler.async_exn (fun () -> Io.close_in ic))
+    (fun () ->
+       parse
+         ~input:(fun buf pos len -> Scheduler.async_exn (fun () -> input ic buf pos len))
+         ~mode:Test)
 ;;

--- a/src/dune_rules/artifact_substitution.ml
+++ b/src/dune_rules/artifact_substitution.ml
@@ -673,7 +673,12 @@ let copy_file_non_atomic ~conf ?chmod ~src ~dst () =
 (** This is just an optimisation: skip the renaming if the destination exists
     and has the right contents and executable bit. The optimisation is useful to
     avoid unnecessary retriggering of Dune and other file-watching systems. *)
-let replace_if_different ~delete_dst_if_it_is_a_directory ~src ~dst =
+type replacement =
+  | Up_to_date
+  | Rename
+  | Remove_directory_and_rename
+
+let replacement_action ~delete_dst_if_it_is_a_directory ~src ~dst =
   let files_are_up_to_date src_stats dst_stats =
     let executable stats =
       Permissions.test_any
@@ -686,28 +691,23 @@ let replace_if_different ~delete_dst_if_it_is_a_directory ~src ~dst =
     let dst_digest = Digest.file dst in
     Digest.equal temp_file_digest dst_digest
   in
-  let up_to_date =
-    match Path.Untracked.stat dst with
-    | Ok { st_kind = S_DIR; _ } ->
-      (match delete_dst_if_it_is_a_directory with
-       | true ->
-         Path.rm_rf dst;
-         false
-       | false ->
-         User_error.raise
-           [ Pp.textf
-               "Cannot copy artifact to %S because it is a directory"
-               (Path.to_string dst)
-           ])
-    | Error (_ : Unix_error.Detailed.t) -> false
-    | Ok ({ st_kind = S_REG; _ } as dst_stats) ->
-      (match Path.Untracked.stat src with
-       | Ok ({ st_kind = S_REG; _ } as src_stats) ->
-         files_are_up_to_date src_stats dst_stats
-       | Ok _ | Error _ -> false)
-    | Ok _ -> false
-  in
-  if not up_to_date then Unix.rename (Path.to_string src) (Path.to_string dst)
+  match Path.Untracked.stat dst with
+  | Ok { st_kind = S_DIR; _ } ->
+    (match delete_dst_if_it_is_a_directory with
+     | true -> Remove_directory_and_rename
+     | false ->
+       User_error.raise
+         [ Pp.textf
+             "Cannot copy artifact to %S because it is a directory"
+             (Path.to_string dst)
+         ])
+  | Error (_ : Unix_error.Detailed.t) -> Rename
+  | Ok ({ st_kind = S_REG; _ } as dst_stats) ->
+    (match Path.Untracked.stat src with
+     | Ok ({ st_kind = S_REG; _ } as src_stats) ->
+       if files_are_up_to_date src_stats dst_stats then Up_to_date else Rename
+     | Ok _ | Error _ -> Rename)
+  | Ok _ -> Rename
 ;;
 
 let copy_file ~conf ?chmod ?(delete_dst_if_it_is_a_directory = false) ~src ~dst () =
@@ -720,6 +720,7 @@ let copy_file ~conf ?chmod ?(delete_dst_if_it_is_a_directory = false) ~src ~dst 
     let dst_name = Path.basename dst |> Filename.to_string in
     Path.relative dst_dir (sprintf ".#%s.dune-temp" dst_name)
   in
+  let temp_file_was_renamed = ref false in
   Fiber.finalize
     (fun () ->
        let open Fiber.O in
@@ -728,10 +729,24 @@ let copy_file ~conf ?chmod ?(delete_dst_if_it_is_a_directory = false) ~src ~dst 
        in
        let* has_subst = copy_file_non_atomic ~conf ?chmod ~src ~dst:temp_file () in
        let* () = Conf.run_sign_hook conf ~has_subst temp_file in
-       Scheduler.async_exn (fun () ->
-         replace_if_different ~delete_dst_if_it_is_a_directory ~src:temp_file ~dst))
+       let* replacement =
+         Scheduler.async_exn (fun () ->
+           replacement_action ~delete_dst_if_it_is_a_directory ~src:temp_file ~dst)
+       in
+       (match replacement with
+        | Up_to_date -> ()
+        | Rename ->
+          Unix.rename (Path.to_string temp_file) (Path.to_string dst);
+          temp_file_was_renamed := true
+        | Remove_directory_and_rename ->
+          Path.rm_rf dst;
+          Unix.rename (Path.to_string temp_file) (Path.to_string dst);
+          temp_file_was_renamed := true);
+       Fiber.return ())
     ~finally:(fun () ->
-      Scheduler.async_exn (fun () -> Fpath.unlink_no_err (Path.to_string temp_file)))
+      if !temp_file_was_renamed
+      then Fiber.return ()
+      else Scheduler.async_exn (fun () -> Fpath.unlink_no_err (Path.to_string temp_file)))
 ;;
 
 let test_file ~src () =

--- a/test/blackbox-tests/test-cases/version-corruption.t
+++ b/test/blackbox-tests/test-cases/version-corruption.t
@@ -116,7 +116,11 @@ which corresponds to `~min_len` in Link_time_code_gen.
 
   $ dune build
 
-  $ dune trace cat | jq 'select(.cat == "artifact_subtitution") | .args'
+  $ dune trace cat | jq_dune -s '
+  >   map(select(.cat == "artifact_subtitution") | .args)
+  > | sort_by(.file)
+  > | reverse[]
+  > '
   {
     "file": "_build/default/gen_lifecycle.exe",
     "placeholder": [

--- a/test/blackbox-tests/test-cases/watching/dir-target-promotion.t
+++ b/test/blackbox-tests/test-cases/watching/dir-target-promotion.t
@@ -142,15 +142,20 @@ Dune correctly notices that the contents of . changed because [d1] was created.
 
 Here [path_stat] of [d1] changed, because it didn't exist before the build. Dune
 later recomputed [path_stat] once again, when [d1/b] was modified, and the
-result remained unchanged (because fields like [mtime] are ignored). The result
-of [dir_contents] also remained unchanged because Dune fixed the listing of [d1]
-by re-promoting the directory target.
+result remained unchanged (because fields like [mtime] are ignored). The
+[dir_contents] cache may be unchanged, or skipped while a force-update has
+evicted its entry. In either case, it must not report a change.
 
-  $ dune trace cat | jq_dune 'cacheEvent("d1")'
+  $ dune trace cat | jq_dune '
+  > cacheEvent("d1")
+  > | if .cache_type == "dir_contents"
+  >   then { cache_type, path, changed: (.result == "changed") }
+  >   else .
+  >   end'
   {
     "cache_type": "dir_contents",
     "path": "d1",
-    "result": "unchanged"
+    "changed": false
   }
   {
     "cache_type": "file_digest",
@@ -165,7 +170,7 @@ by re-promoting the directory target.
   {
     "cache_type": "dir_contents",
     "path": "d1",
-    "result": "unchanged"
+    "changed": false
   }
   {
     "cache_type": "file_digest",


### PR DESCRIPTION
Moves blocking artifact-substitution file operations to the scheduler worker pool.

Split from #13054.