### PR TITLE
feature: show build timing in batch mode

### DIFF
--- a/doc/changes/added/15564.md
+++ b/doc/changes/added/15564.md
@@ -1,0 +1,2 @@
+- Display build duration and average process parallelism in the status line for
+  batch builds. (#15564, @rgrinberg)

--- a/src/dune_engine/build_loop.ml
+++ b/src/dune_engine/build_loop.ml
@@ -81,39 +81,6 @@ let set_build_duration_section t message =
   t.build_duration_section <- Some (Console.Status_line.add_section message)
 ;;
 
-let parallelism ~build_duration ~process_time =
-  match
-    match Time.Span.compare build_duration Time.Span.zero with
-    | Eq | Lt -> None
-    | Gt ->
-      (try Some (Time.Span.to_secs process_time /. Time.Span.to_secs build_duration) with
-       | _ -> None)
-  with
-  | None -> ""
-  | Some s -> sprintf "%.1fx" s
-;;
-
-let format_timers =
-  let section = function
-    | "" -> ""
-    | s -> "[" ^ s ^ "]"
-  in
-  fun ~build_duration ~process_time ->
-    let parallelism = parallelism ~build_duration ~process_time in
-    let duration = sprintf "%.1fs" (Time.Span.to_secs build_duration) in
-    [ section duration; section parallelism ]
-    |> List.filter ~f:(function
-      | "" -> false
-      | _ -> true)
-    |> String.concat ~sep:" "
-;;
-
-let format_timers_now started_at =
-  format_timers
-    ~build_duration:(Time.diff (Time.now ()) started_at)
-    ~process_time:(Metrics.Build.process_time ())
-;;
-
 let build_finish t (build_result : Build_outcome.t) =
   let message =
     match build_result with
@@ -197,7 +164,8 @@ let request_restart t invalidation =
         set_status_overlay
           t
           (Live
-             (fun () -> Pp.textf "Restarting current build... %s" (format_timers_now now)));
+             (fun () ->
+               Pp.textf "Restarting current build... %s" (Build_timing.format_now now)));
         t.status <- Restarting_build run_id;
         let+ () = Process.Build.cancel_current () in
         Dune_trace.emit Build (fun () ->
@@ -227,7 +195,7 @@ let wait_for_file_event_debounce t =
        (fun () ->
          Pp.textf
            "Waiting for filesystem changes to settle... %s"
-           (format_timers_now started_at)));
+           (Build_timing.format_now started_at)));
   let rec loop () =
     match Debouncer.latest t.file_event_debouncer with
     | None -> Fiber.return ()
@@ -349,7 +317,7 @@ let run_current_build
   clear_status_overlay t;
   set_build_duration_section
     t
-    (Live (fun () -> Pp.text (format_timers_now build_started_at)));
+    (Live (fun () -> Pp.text (Build_timing.format_now build_started_at)));
   t.current_request <- Some request;
   let* outcome =
     Fiber.finalize
@@ -390,7 +358,7 @@ let run_current_build
    | `Done ->
      set_build_duration_section
        t
-       (Constant (Pp.text (format_timers ~build_duration ~process_time))));
+       (Constant (Pp.text (Build_timing.format ~build_duration ~process_time))));
   outcome, next, build_start_input_change_generation, build_start_wakeup_generation
 ;;
 

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1136,51 +1136,64 @@ let run_with_error_collection ?restart_started_at ~build_started_at ~build colle
        worth the effort. *)
     Fs_memo.invalidate_cached_timestamps ();
     State.reset_progress ();
-    let* () = State.reset_errors () in
-    let* outcome = collect_errors () in
-    Dtemp.clear ();
-    Sandbox.cleanup_pending_targets ();
-    Target_promotion.save ();
-    let* outcome =
-      let finalize_diff_promotion () =
-        protect ~f:Diff_promotion.finalize ~finally:Diff_promotion.clear_cache
-      in
-      match outcome with
-      | Ok res ->
-        finalize_diff_promotion ();
-        State.set Build_succeeded__now_waiting_for_changes;
-        Fiber.return (Ok res)
-      | Error exns ->
-        handle_final_exns exns;
-        finalize_diff_promotion ();
-        let final_status =
-          if List.exists exns ~f:caused_by_cancellation
-          then State.Restarting_current_build
-          else Build_failed__now_waiting_for_changes
-        in
-        State.set final_status;
-        Fiber.return (Error `Already_reported)
+    let timing_section =
+      match run_id with
+      | Batch ->
+        Some
+          (Console.Status_line.add_section
+             (Live (fun () -> Pp.text (Build_timing.format_now build_started_at))))
+      | Watch _ -> None
     in
-    Metrics.reset ();
-    let+ () = Scheduler.flush_file_watcher () in
-    Dune_trace.emit Build (fun () ->
-      let stop = Time.now () in
-      let restart_duration =
-        Option.map restart_started_at ~f:(fun restart_started_at ->
-          Time.diff stop restart_started_at)
-      in
-      Dune_trace.Event.watch_build_finish
-        ~run_id:(Run_id.to_int run_id)
-        ~outcome:
-          (match outcome with
-           | Ok _ -> `Success
-           | Error `Already_reported -> `Failure)
-        ~start:build_started_at
-        ~stop
-        ~restart_duration);
-    Dune_trace.capture_alloc_profile (`Build (Run_id.to_int run_id))
-    |> Option.iter ~f:Dune_trace.always_emit;
-    outcome
+    Fiber.finalize
+      (fun () ->
+         let* () = State.reset_errors () in
+         let* outcome = collect_errors () in
+         Dtemp.clear ();
+         Sandbox.cleanup_pending_targets ();
+         Target_promotion.save ();
+         let* outcome =
+           let finalize_diff_promotion () =
+             protect ~f:Diff_promotion.finalize ~finally:Diff_promotion.clear_cache
+           in
+           match outcome with
+           | Ok res ->
+             finalize_diff_promotion ();
+             State.set Build_succeeded__now_waiting_for_changes;
+             Fiber.return (Ok res)
+           | Error exns ->
+             handle_final_exns exns;
+             finalize_diff_promotion ();
+             let final_status =
+               if List.exists exns ~f:caused_by_cancellation
+               then State.Restarting_current_build
+               else Build_failed__now_waiting_for_changes
+             in
+             State.set final_status;
+             Fiber.return (Error `Already_reported)
+         in
+         Metrics.reset ();
+         let+ () = Scheduler.flush_file_watcher () in
+         Dune_trace.emit Build (fun () ->
+           let stop = Time.now () in
+           let restart_duration =
+             Option.map restart_started_at ~f:(fun restart_started_at ->
+               Time.diff stop restart_started_at)
+           in
+           Dune_trace.Event.watch_build_finish
+             ~run_id:(Run_id.to_int run_id)
+             ~outcome:
+               (match outcome with
+                | Ok _ -> `Success
+                | Error `Already_reported -> `Failure)
+             ~start:build_started_at
+             ~stop
+             ~restart_duration);
+         Dune_trace.capture_alloc_profile (`Build (Run_id.to_int run_id))
+         |> Option.iter ~f:Dune_trace.always_emit;
+         outcome)
+      ~finally:(fun () ->
+        Option.iter timing_section ~f:Console.Status_line.remove_section;
+        Fiber.return ())
   in
   Fiber.Mutex.with_lock State.build_mutex ~f:(fun () -> Process.Build.with_ build f)
 ;;

--- a/src/dune_engine/build_timing.ml
+++ b/src/dune_engine/build_timing.ml
@@ -1,0 +1,34 @@
+open Import
+
+let parallelism ~build_duration ~process_time =
+  match
+    match Time.Span.compare build_duration Time.Span.zero with
+    | Eq | Lt -> None
+    | Gt ->
+      (try Some (Time.Span.to_secs process_time /. Time.Span.to_secs build_duration) with
+       | _ -> None)
+  with
+  | None -> ""
+  | Some s -> sprintf "%.1fx" s
+;;
+
+let format =
+  let section = function
+    | "" -> ""
+    | s -> "[" ^ s ^ "]"
+  in
+  fun ~build_duration ~process_time ->
+    let parallelism = parallelism ~build_duration ~process_time in
+    let duration = sprintf "%.1fs" (Time.Span.to_secs build_duration) in
+    [ section duration; section parallelism ]
+    |> List.filter ~f:(function
+      | "" -> false
+      | _ -> true)
+    |> String.concat ~sep:" "
+;;
+
+let format_now started_at =
+  format
+    ~build_duration:(Time.diff (Time.now ()) started_at)
+    ~process_time:(Metrics.Build.process_time ())
+;;

--- a/src/dune_engine/build_timing.mli
+++ b/src/dune_engine/build_timing.mli
@@ -1,0 +1,4 @@
+open Import
+
+val format : build_duration:Time.Span.t -> process_time:Time.Span.t -> string
+val format_now : Time.t -> string

--- a/test/blackbox-tests/test-cases/watching/rpc-build-status-line.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-status-line.t
@@ -23,8 +23,8 @@ Forwarded builds display a rich status line once connected over RPC.
 
   $ stop_dune_quiet
 
-Batch builds also display the client count while their temporary RPC server is
-running.
+Batch builds display the build duration and parallelism alongside the client
+count while their temporary RPC server is running.
 
   $ STARTED="$PWD/batch-started"
   $ RELEASE="$PWD/batch-release"
@@ -54,6 +54,10 @@ running.
   > done
   $ tr '\r' '\n' < batch-output | grep -a -m 1 -o "\[rpc 1\]"
   [rpc 1]
+  $ tr '\r' '\n' < batch-output \
+  > | grep -a -E -m 1 -o "\[[0-9]+\.[0-9]s\] \[[0-9]+\.[0-9]x\]" \
+  > | sed -E 's/\[[0-9]+\.[0-9]s\]/[BUILD DURATION]/; s/\[[0-9]+\.[0-9]x\]/[PARALLELISM]/'
+  [BUILD DURATION] [PARALLELISM]
 
   $ touch "$RELEASE"
   $ if wait_for_pid_to_exit_with_timeout "$BATCH_PID" 200; then


### PR DESCRIPTION
Display build duration and average process parallelism in the status
line for batch builds. Share timing formatting with watch mode and add
regression coverage for batch status output.