### PR TITLE
[3.24.1] backport #15518

### DIFF
--- a/doc/changes/fixed/15518.md
+++ b/doc/changes/fixed/15518.md
@@ -1,0 +1,2 @@
+- Use installed filenames for local package binaries in `%{bin:...}` PATH
+  layouts on Windows (#15518, fixes #15512, @Alizter)

--- a/src/dune_rules/artifacts.ml
+++ b/src/dune_rules/artifacts.ml
@@ -27,8 +27,9 @@ type local_bins = path Filename.Map.t
 
 type t =
   { context : Context.t
-  ; (* Mapping from executable names to their actual path in the workspace.
-       The keys are the executable names without the .exe, even on Windows.
+  ; (* Mapping from binary lookup names to their definitions. On Windows, a
+       trailing [.exe] is removed from lookup names, while [Origin.dst] retains
+       the actual install filename.
        Enumerating binaries from install stanzas may involve expanding globs,
        but the artifacts database is depended on by the logic which expands
        globs. The computation of this field is deferred to break the cycle. *)
@@ -120,11 +121,11 @@ let binary t ?hint ?(where = Original_path) ~dir ~loc name =
        Ok (Path.build src))
 ;;
 
-let binary_package t ~dir name =
+let local_binary_install_name t ~dir name =
   analyze_binary t ~dir name
   >>| function
-  | `Origin { package; _ } -> package
-  | `Resolved _ | `None -> None
+  | `Origin { package = Some _; dst; _ } -> Some (Path.Local.basename dst)
+  | `Origin { package = None; _ } | `Resolved _ | `None -> None
 ;;
 
 let binary_available t ~dir name =

--- a/src/dune_rules/artifacts.mli
+++ b/src/dune_rules/artifacts.mli
@@ -39,7 +39,14 @@ val binary
   -> string
   -> Action.Prog.t Memo.t
 
-val binary_package : t -> dir:Path.Build.t -> string -> Package.Name.t option Memo.t
+(** Return the installed filename when the selected binary is from a local
+    package. *)
+val local_binary_install_name
+  :  t
+  -> dir:Path.Build.t
+  -> string
+  -> Filename.t option Memo.t
+
 val binary_available : t -> dir:Path.Build.t -> string -> bool Memo.t
 val add_binaries : t -> dir:Path.Build.t -> File_binding.Expanded.t list -> t
 

--- a/src/dune_rules/bin_layout.ml
+++ b/src/dune_rules/bin_layout.ml
@@ -1,24 +1,53 @@
 open Import
 
+module Entry = struct
+  module T = struct
+    type t =
+      { lookup_name : string
+      ; install_name : Filename.t
+      }
+
+    let repr =
+      Repr.record
+        "bin-layout-entry"
+        [ Repr.field "lookup_name" Repr.string ~get:(fun t -> t.lookup_name)
+        ; Repr.field "install_name" Filename.repr ~get:(fun t -> t.install_name)
+        ]
+    ;;
+
+    (* CR-someday Alizter: [Filename.t] is structurally a string and uses
+       [String.compare], but [Filename.repr] exposes it as a view, which
+       [Repr.Poly] conservatively rejects. Make its representation structural
+       so this comparison can be derived. *)
+    let compare x y =
+      let open Ordering.O in
+      let= () = String.compare x.lookup_name y.lookup_name in
+      Filename.compare x.install_name y.install_name
+    ;;
+  end
+
+  include T
+  include Repr.Make (T)
+
+  include Comparable.Make (struct
+      include T
+      include Repr.Make (T)
+    end)
+end
+
 module Key : sig
-  val encode : Filename.Set.t -> string
-  val decode : string -> Filename.Set.t
+  val encode : Entry.Set.t -> string
+  val decode : string -> Entry.Set.t
 end = struct
   (* [decode] is only called on digests produced by [encode] in the same
      process (deps are evaluated before paths under the layout dir are
      resolved), so the entry will always be present. Same pattern as
      [Ppx_driver.Key]. *)
-  let reverse_table : (Digest.t, Filename.Set.t) Table.t =
-    Table.create (module Digest) 128
-  ;;
+  let reverse_table : (Digest.t, Entry.Set.t) Table.t = Table.create (module Digest) 128
 
-  let encode bins =
-    let y =
-      Digest.repr
-        Repr.(list string)
-        (Filename.Set.to_list bins |> List.map ~f:Filename.to_string)
-    in
-    Table.set reverse_table y bins;
+  let encode entries =
+    let y = Digest.repr Repr.(list Entry.repr) (Entry.Set.to_list entries) in
+    Table.set reverse_table y entries;
     Digest.to_string y
   ;;
 
@@ -42,39 +71,48 @@ let layout_dir ~context key =
   Path.Build.L.relative (Install.Context.dir ~context) [ ".binaries"; key ]
 ;;
 
-let create context bins =
-  let bins = List.map bins ~f:Filename.of_string_exn |> Filename.Set.of_list in
-  let dir = Key.encode bins |> layout_dir ~context in
-  ( dir
-  , Filename.Set.to_list_map bins ~f:(fun name ->
-      Path.build (Path.Build.relative_fname dir name)) )
+let create context ~dir bin_names =
+  let open Memo.O in
+  let* artifacts =
+    let* sctx = Super_context.find_exn context in
+    Artifacts_db.get (Super_context.context sctx)
+  in
+  let+ entries =
+    Memo.List.filter_map bin_names ~f:(fun lookup_name ->
+      Artifacts.local_binary_install_name artifacts ~dir lookup_name
+      >>| Option.map ~f:(fun install_name -> { Entry.lookup_name; install_name }))
+  in
+  match entries with
+  | [] -> None
+  | _ :: _ ->
+    let entries = Entry.Set.of_list entries in
+    let layout_dir = Key.encode entries |> layout_dir ~context in
+    Some
+      ( layout_dir
+      , Entry.Set.to_list_map entries ~f:(fun { Entry.lookup_name = _; install_name } ->
+          Path.build (Path.Build.relative_fname layout_dir install_name)) )
 ;;
 
 let symlink_rules_for_key context_name ~dir key =
-  let bins = Key.decode key in
+  let entries = Key.decode key in
   let open Memo.O in
   let* artifacts =
     let* sctx = Super_context.find_exn context_name in
     Artifacts_db.get (Super_context.context sctx)
   in
-  Filename.Set.to_list bins
-  |> Memo.parallel_iter ~f:(fun name ->
+  Entry.Set.to_list entries
+  |> Memo.parallel_iter ~f:(fun ({ Entry.lookup_name; install_name } as entry) ->
     let* prog =
-      Artifacts.binary
-        artifacts
-        ~where:Original_path
-        ~dir
-        ~loc:None
-        (Filename.to_string name)
+      Artifacts.binary artifacts ~where:Original_path ~dir ~loc:None lookup_name
     in
     match prog with
     | Error _ ->
       Code_error.raise
         "Bin_layout.gen_rules: binary not found"
-        [ "name", Filename.to_dyn name; "context", Context_name.to_dyn context_name ]
+        [ "entry", Entry.to_dyn entry; "context", Context_name.to_dyn context_name ]
     | Ok src ->
       let { Action_builder.With_targets.build; targets } =
-        Action_builder.symlink ~src ~dst:(Path.Build.relative_fname dir name)
+        Action_builder.symlink ~src ~dst:(Path.Build.relative_fname dir install_name)
       in
       Rules.Produce.rule (Rule.make ~targets build))
 ;;

--- a/src/dune_rules/bin_layout.mli
+++ b/src/dune_rules/bin_layout.mli
@@ -1,10 +1,18 @@
 open Import
 
-(** Create a .binaries directory for the given binary names. Returns the
-    directory and the list of symlink paths for dependency tracking. The
-    symlinks are created as build rules keyed by a digest of the sorted
-    binary names. *)
-val create : Context_name.t -> string list -> Path.Build.t * Path.t list
+(** [create context ~dir bin_names] creates a .binaries directory for the
+    [%{bin:...}] names resolved from [dir], covering the names that resolve to
+    local package binaries. [context] must be the host context in which the
+    binaries run. Returns [None] when no name does. Otherwise returns the
+    directory and the list of symlink paths for dependency tracking; depend on
+    the paths before putting the directory on [PATH]. The symlinks are created
+    as build rules keyed by a digest of the sorted (lookup name, installed
+    filename) pairs. *)
+val create
+  :  Context_name.t
+  -> dir:Path.Build.t
+  -> string list
+  -> (Path.Build.t * Path.t list) option Memo.t
 
 (** Dispatch a path under [_build/install/<context>/.binaries/...].
     [rest] is the components after [.binaries].

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -135,20 +135,10 @@ let make_bin_env expander bin_names =
         (let open Memo.O in
          Expander.host_context expander >>| Context.name)
     in
-    let* origin_bin_names =
-      Action_builder.of_memo
-        (let open Memo.O in
-         let* artifacts =
-           let* sctx = Super_context.find_exn context in
-           Artifacts_db.get (Super_context.context sctx)
-         in
-         Memo.List.filter bin_names ~f:(fun name ->
-           Artifacts.binary_package artifacts ~dir name >>| Option.is_some))
-    in
-    (match origin_bin_names with
-     | [] -> Action_builder.return Env.empty
-     | _ ->
-       let layout_dir, files = Bin_layout.create context origin_bin_names in
+    let* layout = Action_builder.of_memo (Bin_layout.create context ~dir bin_names) in
+    (match layout with
+     | None -> Action_builder.return Env.empty
+     | Some (layout_dir, files) ->
        let+ () = Action_builder.paths files in
        (* The layout dir on PATH is an absolute build-tree path; dune's
           sandbox does not relocate PATH. See [bin-pform/sandbox.t]. *)

--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -29,6 +29,16 @@ make_dune_project() {
 	EOF
 }
 
+make_dune_project_with_package() {
+  local version="$1"
+  local package="$2"
+
+  make_dune_project "$version"
+  cat >> dune-project <<- EOF
+	(package (name ${package}))
+	EOF
+}
+
 make_dir_with_dune() {
   path="$1"
   mkdir -p "$path"

--- a/test/blackbox-tests/test-cases/bin-pform/dune
+++ b/test/blackbox-tests/test-cases/bin-pform/dune
@@ -1,0 +1,5 @@
+(cram
+ (applies_to windows-install-names)
+ (enabled_if
+  (= %{os_type} Win32))
+ (alias runtest-windows))

--- a/test/blackbox-tests/test-cases/bin-pform/windows-install-names.t
+++ b/test/blackbox-tests/test-cases/bin-pform/windows-install-names.t
@@ -1,0 +1,62 @@
+On Windows, artifact lookup uses extensionless executable names while the
+layout must use the actual installed filenames. Non-executable bin entries
+retain their declared extensions.
+
+  $ make_dune_project_with_package 3.24 mypkg
+  $ mkdir producer
+
+  $ cat >producer/launcher.ml <<'EOF'
+  > let () = print_endline "hello from launcher"
+  > EOF
+
+  $ cat >producer/tool.cmd <<'EOF'
+  > @echo off
+  > echo hello from tool
+  > EOF
+
+  $ cat >producer/dune <<'EOF'
+  > (executable
+  >  (name launcher)
+  >  (public_name launcher)
+  >  (package mypkg))
+  > (install
+  >  (package mypkg)
+  >  (section bin)
+  >  (files tool.cmd))
+  > EOF
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps %{bin:launcher} %{bin:tool.cmd})
+  >  (action
+  >   (progn
+  >    (with-stdout-to launcher.out (system "launcher"))
+  >    (with-stdout-to tool.out (system "tool.cmd")))))
+  > EOF
+
+On native Windows, both entries are callable by their lookup names:
+
+  $ dune build launcher.out tool.out
+  File "dune", lines 1-6, characters 0-168:
+  1 | (rule
+  2 |  (deps %{bin:launcher} %{bin:tool.cmd})
+  3 |  (action
+  4 |   (progn
+  5 |    (with-stdout-to launcher.out (system "launcher"))
+  6 |    (with-stdout-to tool.out (system "tool.cmd")))))
+  'launcher' is not recognized as an internal or external command,
+  operable program or batch file.
+  [1]
+  $ cat _build/default/launcher.out
+  cat: _build/default/launcher.out: No such file or directory
+  [1]
+  $ cat _build/default/tool.out
+  cat: _build/default/tool.out: No such file or directory
+  [1]
+
+The layout uses the installed filenames, including [.exe] only for the
+executable:
+
+  $ ls _build/install/default/.binaries/*
+  launcher
+  tool.cmd

--- a/test/blackbox-tests/test-cases/bin-pform/windows-install-names.t
+++ b/test/blackbox-tests/test-cases/bin-pform/windows-install-names.t
@@ -37,26 +37,14 @@ retain their declared extensions.
 On native Windows, both entries are callable by their lookup names:
 
   $ dune build launcher.out tool.out
-  File "dune", lines 1-6, characters 0-168:
-  1 | (rule
-  2 |  (deps %{bin:launcher} %{bin:tool.cmd})
-  3 |  (action
-  4 |   (progn
-  5 |    (with-stdout-to launcher.out (system "launcher"))
-  6 |    (with-stdout-to tool.out (system "tool.cmd")))))
-  'launcher' is not recognized as an internal or external command,
-  operable program or batch file.
-  [1]
   $ cat _build/default/launcher.out
-  cat: _build/default/launcher.out: No such file or directory
-  [1]
+  hello from launcher
   $ cat _build/default/tool.out
-  cat: _build/default/tool.out: No such file or directory
-  [1]
+  hello from tool
 
 The layout uses the installed filenames, including [.exe] only for the
 executable:
 
   $ ls _build/install/default/.binaries/*
-  launcher
+  launcher.exe
   tool.cmd


### PR DESCRIPTION
Backport #15517 and #15518 onto 3.24.1-rc.

This includes the Windows regression test followed by its fix.