### PR TITLE
doc(changelog): add entry for #15444

### DIFF
--- a/doc/changes/fixed/15444.md
+++ b/doc/changes/fixed/15444.md
@@ -1,0 +1,2 @@
+- Treat OCaml compiler packages version 5.5 or newer as relocatable so their
+  installations do not use the toolchain cache (#15444, fixes #15443, @Alizter)


### PR DESCRIPTION
## Description

Add the changelog entry omitted from #15444 for the OCaml 5.5+ relocatable compiler fix.

## Related

- #15444
- Fixes #15443

## Validation

Not run (changelog-only change).