### PR TITLE
[3.24.1] backport #15455

### DIFF
--- a/doc/changes/fixed/15455.md
+++ b/doc/changes/fixed/15455.md
@@ -1,0 +1,5 @@
+- Fix `build_runtime_flags` given in a `js_of_ocaml`/`wasm_of_ocaml` field of
+  an executable being silently ignored in separate compilation mode: such
+  executables were given the workspace-shared standalone runtime, which is
+  built with the default flags. Executables customizing `build_runtime_flags`
+  now get their own standalone runtime again. (#15455, @hhugo)

--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -1120,7 +1120,14 @@ let build_standalone_runtime cc ~loc ~in_context ~jsoo_mode:mode =
     assert (Js_of_ocaml.Mode.select ~mode ~js:(wasm_files = []) ~wasm:true);
     let runtime_files = javascript_files @ wasm_files in
     let* eligible =
-      if List.is_empty runtime_files
+      if
+        List.is_empty runtime_files
+        (* The shared runtime is built with the default flags, so an
+           executable customizing [build_runtime_flags] needs its own
+           runtime. *)
+        && Ordered_set_lang.Unexpanded.equal
+             (Js_of_ocaml.Flags.build_runtime flags)
+             Ordered_set_lang.Unexpanded.standard
       then
         Resolve.Memo.peek (Compilation_context.requires_link cc)
         >>| function

--- a/test/blackbox-tests/test-cases/jsoo/shared-runtime-build-runtime-flags.t
+++ b/test/blackbox-tests/test-cases/jsoo/shared-runtime-build-runtime-flags.t
@@ -1,0 +1,46 @@
+Regression test for per-executable build_runtime_flags in separate
+compilation.
+
+Since the introduction of the shared standalone runtime, an executable
+with no javascript_files of its own was always given the shared runtime,
+which is built with the default flags: its build_runtime_flags were
+silently dropped. Here --file must embed data.txt into the
+pseudo-filesystem of main.bc.js.
+
+  $ make_dune_project 3.19
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (modes js)
+  >  (js_of_ocaml
+  >   (compilation_mode separate)
+  >   (build_runtime_flags (:standard --file %{dep:data.txt}))))
+  > EOF
+  $ cat > main.ml <<EOF
+  > let () = print_endline "hi"
+  > EOF
+  $ echo EMBEDDED_PAYLOAD > data.txt
+
+  $ dune build ./main.bc.js
+  $ grep -c EMBEDDED_PAYLOAD _build/default/main.bc.js
+  1
+
+An executable with default build_runtime_flags still uses the shared
+runtime:
+
+  $ mkdir other
+  $ cat > other/dune <<EOF
+  > (executable
+  >  (name other)
+  >  (modes js)
+  >  (js_of_ocaml
+  >   (compilation_mode separate)))
+  > EOF
+  $ cat > other/other.ml <<EOF
+  > let () = print_endline "hi"
+  > EOF
+
+  $ dune build ./other/other.bc.js
+  $ find _build/default/.js -name 'runtime.bc.runtime.js' | wc -l | xargs
+  1


### PR DESCRIPTION
Backport #15455 onto `3.24.1-rc`.

The backport is signed off explicitly for DCO, and moves the changelog entry into `doc/changes/fixed/` for the point release.