### PR TITLE
[3.24.1] use fixed cppo source in revdeps

### DIFF
--- a/nix/revdeps.nix
+++ b/nix/revdeps.nix
@@ -40,6 +40,15 @@ let
           flambdaSupport = false;
         };
 
+        cppo = osuper.cppo.overrideAttrs (_: {
+          src = final.fetchFromGitHub {
+            owner = "ocaml-community";
+            repo = "cppo";
+            rev = "fe1e27112d34fd9a7f68f268508663d436d41ac6";
+            hash = "sha256-BMYjsAKshiRGPHERF0/kP0heb8ZHlq5eCpMDQQJ+F4U=";
+          };
+        });
+
         dune_3 = osuper.dune_3.overrideAttrs (old: {
           src = revdeps-dune;
           nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.git ];


### PR DESCRIPTION
Use the fixed `cppo` source revision in the `3.24.1-rc` reverse-dependency package scope.

The release branch’s existing package-set pins are left unchanged. Its pinned `cppo.1.8.0` source expects diagnostic filenames without a `./` prefix, while the release Dune reports paths such as `./file.cppo`. The selected upstream `cppo` revision accepts those paths.

This is a release-specific CI fix, not a backport of #15574.

Validation:
- `nix build .#revdeps.x86_64-linux.cppo --override-input revdeps-dune . --no-link` passes on the exact PR head (`ee1bf081`).
- No Dune test suite was run.