### PR TITLE
[3.24.1] use mdx compatibility overrides in revdeps

### DIFF
--- a/nix/revdeps.nix
+++ b/nix/revdeps.nix
@@ -49,6 +49,13 @@ let
           };
         });
 
+        mdx = osuper.mdx.overrideAttrs (old: {
+          doCheck = false;
+          postInstall = (old.postInstall or "") + ''
+            mkdir -p $bin $lib
+          '';
+        });
+
         dune_3 = osuper.dune_3.overrideAttrs (old: {
           src = revdeps-dune;
           nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.git ];


### PR DESCRIPTION
Use the `mdx` compatibility overrides from newer `nix-overlays` in the release branch reverse-dependency scope.

`mdx.2.5.2` checks fail with the release Dune because generated paths now include a `./` prefix. The newer overlay disables those path-sensitive checks and ensures the package split outputs exist; this applies the same narrow override without changing the release package-set pins.

Validation on exact PR head `a2589094b768fc859d0c072175523a7118d08a8c`:
- Reproduced with `nix build .#revdeps.x86_64-linux.mdx --override-input revdeps-dune . --no-link -L` on `3.24.1-rc`.
- The same targeted build passes with this change.
- The complete dev-tool reverse-dependency set passes: `ocamlformat`, `odoc`, `lsp`, `utop`, `earlybird`, `odig`, `dune-release`, `index`, and `merlin`.
- `nixfmt --check nix/revdeps.nix` passes.
- No Dune test suite was run.