### PR TITLE
[3.24.1] correct #15156 changelog placement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,12 +29,6 @@
 
 ### Changed
 
-- Path-valued pforms (`%{bin:...}`, `%{dep:...}`, `%{path:...}`, and
-  friends) now expand same-directory paths with a leading `./`, so that
-  shells like `bash` in `(bash ...)` and `(system ...)` actions execute
-  them directly instead of looking them up in `PATH`.
-  (#15156, fixes #15147, @Alizter)
-
 - Revert sandboxing Melange rules by default in the `(library ..)` and
   `(melange.emit ..)` stanzas. In Melange libraries with many modules, sandbox
   creation / destruction dominates build time and adds significant overhead to
@@ -128,6 +122,12 @@
   Rocq Build Language (`(using rocq <version>)`) instead. Projects that
   still declare `(using coq <version>)` now get an error pointing them
   at Rocq. (#14525, fixes #12788, @Alizter)
+
+- Path-valued pforms (`%{bin:...}`, `%{dep:...}`, `%{path:...}`, and
+  friends) now expand same-directory paths with a leading `./`, so that
+  shells like `bash` in `(bash ...)` and `(system ...)` actions execute
+  them directly instead of looking them up in `PATH`.
+  (#15156, fixes #15147, @Alizter)
 
 3.23.1 (2026-05-14)
 -------------------


### PR DESCRIPTION
Follow up on #15579 by moving the #15156 entry from the 3.24.1 section to `3.24.0 → Changed`.

#15156 shipped in 3.24.0. Its fragment was omitted when that release changelog was generated, but placing it under 3.24.1 would incorrectly present the behavior as a patch-release change.

Validation:
- `./dune.exe runtest doc/changes/scripts`
- diff is only the relocation within `CHANGES.md`
- no broader Dune test suite was run