### PR TITLE
feat(describe) Improve public/private name handling of libraries & executables

### DIFF
--- a/bin/describe/describe_external_lib_deps.ml
+++ b/bin/describe/describe_external_lib_deps.ml
@@ -41,22 +41,58 @@ module Item = struct
     ; dir : Path.Source.t
     ; external_deps : lib_dep list
     ; internal_deps : lib_dep list
-    ; names : string list
+    ; names : string list (* private names *)
+    ; public_names : string option list option
+      (* public names, if any are declared (one entry per private name, [None]
+         for those without a public name) *)
     ; package : Package.t option
     ; extensions : Filename.Extension.t list
     }
 
-  let to_dyn { kind; dir; external_deps; internal_deps; names; package; extensions } =
+  let to_dyn
+        ~split_public_names
+        { kind
+        ; dir
+        ; external_deps
+        ; internal_deps
+        ; names
+        ; public_names
+        ; package
+        ; extensions
+        }
+    =
     let open Dyn in
+    let name_fields =
+      if split_public_names
+      then (
+        let public_names =
+          match public_names with
+          | Some public_names -> public_names
+          | None -> List.map names ~f:(fun _ -> None)
+        in
+        [ "names", (list string) names
+        ; "public_names", (list (option string)) public_names
+        ])
+      else (
+        (* replace each private name by its public name when there is one *)
+        let best_names =
+          match public_names with
+          | None -> names
+          | Some public_names ->
+            List.map2 names public_names ~f:(fun name public_name ->
+              Option.value public_name ~default:name)
+        in
+        [ "names", (list string) best_names ])
+    in
     let record =
       record
-        [ "names", (list string) names
-        ; "extensions", (list Filename.Extension.to_dyn) extensions
-        ; "package", option Package.Name.to_dyn (Option.map ~f:Package.name package)
-        ; "source_dir", String (Path.Source.to_string dir)
-        ; "external_deps", list lib_dep_to_dyn external_deps
-        ; "internal_deps", list lib_dep_to_dyn internal_deps
-        ]
+        (name_fields
+         @ [ "extensions", (list Filename.Extension.to_dyn) extensions
+           ; "package", option Package.Name.to_dyn (Option.map ~f:Package.name package)
+           ; "source_dir", String (Path.Source.to_string dir)
+           ; "external_deps", list lib_dep_to_dyn external_deps
+           ; "internal_deps", list lib_dep_to_dyn internal_deps
+           ])
     in
     Variant (Kind.to_string kind, [ record ])
   ;;
@@ -112,7 +148,7 @@ let resolve_lib_deps db lib_deps =
   >>| List.concat
 ;;
 
-let resolve_libs db dir libraries preprocess names package kind extensions =
+let resolve_libs db dir libraries preprocess names public_names package kind extensions =
   let open Memo.O in
   let open Item in
   let* lib_deps = resolve_lib_deps db libraries in
@@ -124,7 +160,7 @@ let resolve_libs db dir libraries preprocess names package kind extensions =
       | Local lib -> Either.Left lib
       | External lib -> Either.Right lib)
   in
-  { external_deps; internal_deps; kind; names; package; dir; extensions }
+  { external_deps; internal_deps; kind; names; public_names; package; dir; extensions }
 ;;
 
 let exes_extensions (lib_config : Dune_rules.Lib_config.t) modes =
@@ -137,6 +173,13 @@ let exes_extensions (lib_config : Dune_rules.Lib_config.t) modes =
       ~ext_dll:lib_config.ext_dll)
 ;;
 
+(* Splits the executables' names into their private names and, when declared,
+   their public names *)
+let exe_names (exes : Dune_rules.Executables.t) =
+  ( Nonempty_list.to_list_map exes.names ~f:snd
+  , Option.map exes.public_names ~f:(Nonempty_list.to_list_map ~f:snd) )
+;;
+
 let libs db (context : Context.t) =
   let open Memo.O in
   let* dune_files = Context.name context |> Dune_rules.Dune_load.dune_files in
@@ -147,35 +190,45 @@ let libs db (context : Context.t) =
       match Stanza.repr stanza with
       | Dune_rules.Executables.T exes ->
         let* ocaml = Context.ocaml context in
+        let names, public_names = exe_names exes in
         resolve_libs
           db
           dir
           exes.buildable.libraries
           exes.buildable.preprocess.config
-          (Dune_rules.Executables.best_names exes)
+          names
+          public_names
           exes.package
           Item.Kind.Executables
           (exes_extensions ocaml.lib_config exes.modes)
         >>| List.singleton
       | Dune_rules.Library.T lib ->
+        let names = [ Lib_name.of_local lib.name |> Lib_name.to_string ] in
+        let public_names =
+          Option.map (Dune_rules.Library.public_name lib) ~f:(fun public_name ->
+            [ Some (Lib_name.to_string public_name) ])
+        in
         resolve_libs
           db
           dir
           lib.buildable.libraries
           lib.buildable.preprocess.config
-          [ Dune_rules.Library.best_name lib |> Lib_name.to_string ]
+          names
+          public_names
           (Dune_rules.Library.package lib)
           Item.Kind.Library
           []
         >>| List.singleton
       | Dune_rules.Tests.T tests ->
         let* ocaml = Context.ocaml context in
+        let names, public_names = exe_names tests.exes in
         resolve_libs
           db
           dir
           tests.exes.buildable.libraries
           tests.exes.buildable.preprocess.config
-          (Executables.best_names tests.exes)
+          names
+          public_names
           (if Option.is_none tests.package then tests.exes.package else tests.package)
           Item.Kind.Tests
           (exes_extensions ocaml.lib_config tests.exes.modes)
@@ -194,15 +247,30 @@ let external_resolved_libs (context : Context.t) =
     not (List.is_empty x.external_deps && List.is_empty x.internal_deps))
 ;;
 
-let to_dyn context_name external_resolved_libs =
+let to_dyn ~split_public_names context_name external_resolved_libs =
   let open Dyn in
-  Tuple [ String context_name; list Item.to_dyn external_resolved_libs ]
+  Tuple
+    [ String context_name; list (Item.to_dyn ~split_public_names) external_resolved_libs ]
+;;
+
+let arg_split_public_names =
+  let open Arg in
+  value
+  & flag
+  & info
+      [ "split-public-names" ]
+      ~doc:
+        (Some
+           "Report private names in the 'names' field and public names in a separate \
+            'public_names' field, rather than reporting the public name (falling back to \
+            the private name) in 'names'.")
 ;;
 
 let term =
   let+ builder = Common.Builder.term
   and+ context_name = Common.context_arg ~doc:(Some "Build context to use.")
   and+ _ = Describe_lang_compat.arg
+  and+ split_public_names = arg_split_public_names
   and+ format = Describe_format.arg in
   let common, config = Common.init builder in
   Scheduler_setup.go_with_rpc_server ~common ~config
@@ -218,7 +286,7 @@ let term =
     |> Dune_engine.Context_name.to_string
   in
   external_resolved_libs (Super_context.context super_context)
-  >>| to_dyn context_name
+  >>| to_dyn ~split_public_names context_name
   >>| Describe_format.print_dyn format
 ;;
 

--- a/bin/describe/describe_external_lib_deps.ml
+++ b/bin/describe/describe_external_lib_deps.ml
@@ -152,7 +152,7 @@ let libs db (context : Context.t) =
           dir
           exes.buildable.libraries
           exes.buildable.preprocess.config
-          (Nonempty_list.to_list_map exes.names ~f:snd)
+          (Dune_rules.Executables.best_names exes)
           exes.package
           Item.Kind.Executables
           (exes_extensions ocaml.lib_config exes.modes)
@@ -175,7 +175,7 @@ let libs db (context : Context.t) =
           dir
           tests.exes.buildable.libraries
           tests.exes.buildable.preprocess.config
-          (Nonempty_list.to_list_map tests.exes.names ~f:snd)
+          (Executables.best_names tests.exes)
           (if Option.is_none tests.package then tests.exes.package else tests.package)
           Item.Kind.Tests
           (exes_extensions ocaml.lib_config tests.exes.modes)

--- a/bin/describe/describe_external_lib_deps.ml
+++ b/bin/describe/describe_external_lib_deps.ml
@@ -41,22 +41,58 @@ module Item = struct
     ; dir : Path.Source.t
     ; external_deps : lib_dep list
     ; internal_deps : lib_dep list
-    ; names : string list
+    ; names : string list (* private names *)
+    ; public_names : string option list option
+      (* public names, if any are declared (one entry per private name, [None]
+         for those without a public name) *)
     ; package : Package.t option
     ; extensions : Filename.Extension.t list
     }
 
-  let to_dyn { kind; dir; external_deps; internal_deps; names; package; extensions } =
+  let to_dyn
+        ~split_public_names
+        { kind
+        ; dir
+        ; external_deps
+        ; internal_deps
+        ; names
+        ; public_names
+        ; package
+        ; extensions
+        }
+    =
     let open Dyn in
+    let name_fields =
+      if split_public_names
+      then (
+        let public_names =
+          match public_names with
+          | Some public_names -> public_names
+          | None -> List.map names ~f:(fun _ -> None)
+        in
+        [ "names", (list string) names
+        ; "public_names", (list (option string)) public_names
+        ])
+      else (
+        (* replace each private name by its public name when there is one *)
+        let best_names =
+          match public_names with
+          | None -> names
+          | Some public_names ->
+            List.map2 names public_names ~f:(fun name public_name ->
+              Option.value public_name ~default:name)
+        in
+        [ "names", (list string) best_names ])
+    in
     let record =
       record
-        [ "names", (list string) names
-        ; "extensions", (list Filename.Extension.to_dyn) extensions
-        ; "package", option Package.Name.to_dyn (Option.map ~f:Package.name package)
-        ; "source_dir", String (Path.Source.to_string dir)
-        ; "external_deps", list lib_dep_to_dyn external_deps
-        ; "internal_deps", list lib_dep_to_dyn internal_deps
-        ]
+        (name_fields
+         @ [ "extensions", (list Filename.Extension.to_dyn) extensions
+           ; "package", option Package.Name.to_dyn (Option.map ~f:Package.name package)
+           ; "source_dir", String (Path.Source.to_string dir)
+           ; "external_deps", list lib_dep_to_dyn external_deps
+           ; "internal_deps", list lib_dep_to_dyn internal_deps
+           ])
     in
     Variant (Kind.to_string kind, [ record ])
   ;;
@@ -112,7 +148,7 @@ let resolve_lib_deps db lib_deps =
   >>| List.concat
 ;;
 
-let resolve_libs db dir libraries preprocess names package kind extensions =
+let resolve_libs db dir libraries preprocess names public_names package kind extensions =
   let open Memo.O in
   let open Item in
   let* lib_deps = resolve_lib_deps db libraries in
@@ -124,7 +160,7 @@ let resolve_libs db dir libraries preprocess names package kind extensions =
       | Local lib -> Either.Left lib
       | External lib -> Either.Right lib)
   in
-  { external_deps; internal_deps; kind; names; package; dir; extensions }
+  { external_deps; internal_deps; kind; names; public_names; package; dir; extensions }
 ;;
 
 let exes_extensions (lib_config : Dune_rules.Lib_config.t) modes =
@@ -137,6 +173,13 @@ let exes_extensions (lib_config : Dune_rules.Lib_config.t) modes =
       ~ext_dll:lib_config.ext_dll)
 ;;
 
+(* Splits the executables' names into their private names and, when declared,
+   their public names *)
+let exe_names (exes : Dune_rules.Executables.t) =
+  ( Nonempty_list.to_list_map exes.names ~f:snd
+  , Option.map exes.public_names ~f:(Nonempty_list.to_list_map ~f:snd) )
+;;
+
 let libs db (context : Context.t) =
   let open Memo.O in
   let* dune_files = Context.name context |> Dune_rules.Dune_load.dune_files in
@@ -147,35 +190,45 @@ let libs db (context : Context.t) =
       match Stanza.repr stanza with
       | Dune_rules.Executables.T exes ->
         let* ocaml = Context.ocaml context in
+        let names, public_names = exe_names exes in
         resolve_libs
           db
           dir
           exes.buildable.libraries
           exes.buildable.preprocess.config
-          (Dune_rules.Executables.best_names exes)
+          names
+          public_names
           exes.package
           Item.Kind.Executables
           (exes_extensions ocaml.lib_config exes.modes)
         >>| List.singleton
       | Dune_rules.Library.T lib ->
+        let names = [ Lib_name.of_local lib.name |> Lib_name.to_string ] in
+        let public_names =
+          Option.map (Dune_rules.Library.public_name lib) ~f:(fun public_name ->
+            [ Some (Lib_name.to_string public_name) ])
+        in
         resolve_libs
           db
           dir
           lib.buildable.libraries
           lib.buildable.preprocess.config
-          [ Dune_rules.Library.best_name lib |> Lib_name.to_string ]
+          names
+          public_names
           (Dune_rules.Library.package lib)
           Item.Kind.Library
           []
         >>| List.singleton
       | Dune_rules.Tests.T tests ->
         let* ocaml = Context.ocaml context in
+        let names, public_names = exe_names tests.exes in
         resolve_libs
           db
           dir
           tests.exes.buildable.libraries
           tests.exes.buildable.preprocess.config
-          (Executables.best_names tests.exes)
+          names
+          public_names
           (if Option.is_none tests.package then tests.exes.package else tests.package)
           Item.Kind.Tests
           (exes_extensions ocaml.lib_config tests.exes.modes)
@@ -202,9 +255,23 @@ let external_resolved_libs ~include_empty (context : Context.t) =
   libs db context >>| filter_empty ~include_empty
 ;;
 
-let to_dyn context_name external_resolved_libs =
+let to_dyn ~split_public_names context_name external_resolved_libs =
   let open Dyn in
-  Tuple [ String context_name; list Item.to_dyn external_resolved_libs ]
+  Tuple
+    [ String context_name; list (Item.to_dyn ~split_public_names) external_resolved_libs ]
+;;
+
+let arg_split_public_names =
+  let open Arg in
+  value
+  & flag
+  & info
+      [ "split-public-names" ]
+      ~doc:
+        (Some
+           "Report private names in the 'names' field and public names in a separate \
+            'public_names' field, rather than reporting the public name (falling back to \
+            the private name) in 'names'.")
 ;;
 
 let arg_include_empty =
@@ -221,8 +288,9 @@ let term =
   let+ builder = Common.Builder.term
   and+ context_name = Common.context_arg ~doc:(Some "Build context to use.")
   and+ _ = Describe_lang_compat.arg
-  and+ format = Describe_format.arg
-  and+ include_empty = arg_include_empty in
+  and+ include_empty = arg_include_empty
+  and+ split_public_names = arg_split_public_names
+  and+ format = Describe_format.arg in
   let common, config = Common.init builder in
   Scheduler_setup.go_with_rpc_server ~common ~config
   @@ fun () ->
@@ -237,7 +305,7 @@ let term =
     |> Dune_engine.Context_name.to_string
   in
   external_resolved_libs ~include_empty (Super_context.context super_context)
-  >>| to_dyn context_name
+  >>| to_dyn ~split_public_names context_name
   >>| Describe_format.print_dyn format
 ;;
 

--- a/bin/describe/describe_tests.ml
+++ b/bin/describe/describe_tests.ml
@@ -63,7 +63,18 @@ module Crawl = struct
     match Stanza.repr stanza with
     | Tests.T (tests : Tests.t) ->
       let* enabled = Expander.eval_blang expander tests.enabled_if in
-      let names = Executables.best_names tests.exes in
+      (* the private names of the tests, each replaced by its public name when
+         there is one *)
+      let names =
+        let private_names = Nonempty_list.to_list_map tests.exes.names ~f:snd in
+        match tests.exes.public_names with
+        | None -> private_names
+        | Some public_names ->
+          List.map2
+            private_names
+            (Nonempty_list.to_list_map public_names ~f:snd)
+            ~f:(fun name public_name -> Option.value public_name ~default:name)
+      in
       let package =
         Option.map tests.package ~f:(fun p ->
           Dune_lang.Package.name p |> Dune_lang.Package_name.to_string)

--- a/bin/describe/describe_tests.ml
+++ b/bin/describe/describe_tests.ml
@@ -63,7 +63,7 @@ module Crawl = struct
     match Stanza.repr stanza with
     | Tests.T (tests : Tests.t) ->
       let* enabled = Expander.eval_blang expander tests.enabled_if in
-      let names = Nonempty_list.to_list_map tests.exes.names ~f:snd in
+      let names = Executables.best_names tests.exes in
       let package =
         Option.map tests.package ~f:(fun p ->
           Dune_lang.Package.name p |> Dune_lang.Package_name.to_string)

--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -465,7 +465,7 @@ module Crawl = struct
        | Ok libs ->
          let include_dirs = Obj_dir.all_cmis obj_dir in
          let exe_descr =
-           { Descr.Exe.names = Nonempty_list.to_list_map exes.names ~f:snd
+           { Descr.Exe.names = Executables.best_names exes
            ; requires = List.map ~f:uid_of_library libs
            ; modules
            ; include_dirs

--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -9,6 +9,10 @@ module Options = struct
        used at compile time) *)
     ; no_recursive : bool
       (* whether to only consider the provided directories and not descendants *)
+    ; split_public_names : bool
+      (* whether to report private names in the [name(s)] fields and public
+         names in a separate [public_name(s)] field, rather than reporting the
+         public name (falling back to the private name) in [name(s)] *)
     }
 
   (* whether to sanitize absolute paths of workspace items, and their UIDs, to
@@ -60,13 +64,27 @@ module Options = struct
               the workspace root when none are given.")
   ;;
 
+  let arg_split_public_names =
+    let open Arg in
+    value
+    & flag
+    & info
+        [ "split-public-names" ]
+        ~doc:
+          (Some
+             "Report private names in the 'name'/'names' fields and public names in a \
+              separate 'public_name'/'public_names' field, rather than reporting the \
+              public name (falling back to the private name) in 'name'/'names'.")
+  ;;
+
   let arg : t Term.t =
     let+ with_deps = arg_with_deps
     and+ with_pps = arg_with_pps
     and+ sanitize_for_tests_value = arg_sanitize_for_tests
-    and+ no_recursive = arg_no_recursive in
+    and+ no_recursive = arg_no_recursive
+    and+ split_public_names = arg_split_public_names in
     sanitize_for_tests := sanitize_for_tests_value;
-    { with_deps; with_pps; no_recursive }
+    { with_deps; with_pps; no_recursive; split_public_names }
   ;;
 end
 
@@ -144,7 +162,10 @@ module Descr = struct
   (* Description of executables *)
   module Exe = struct
     type t =
-      { names : string list (* names of the executable *)
+      { names : string list (* private names of the executables *)
+      ; public_names : string option list option
+        (* public names of the executables, if the stanza declares any (one
+           entry per executable, [None] for those without a public name) *)
       ; requires : Digest.t list
         (* list of direct dependencies to libraries, identified by their
              digests *)
@@ -154,12 +175,36 @@ module Descr = struct
 
     let map_path t ~f = { t with include_dirs = List.map ~f t.include_dirs }
 
+    (* [best_names] replaces each private name by its public name when there is one *)
+    let best_names { names; public_names; _ } =
+      match public_names with
+      | None -> names
+      | Some public_names ->
+        List.map2 names public_names ~f:(fun name public_name ->
+          Option.value public_name ~default:name)
+    ;;
+
     (* Conversion to the [Dyn.t] type *)
-    let to_dyn options { names; requires; modules; include_dirs } : Dyn.t =
+    let to_dyn options ({ names; public_names; requires; modules; include_dirs } as t)
+      : Dyn.t
+      =
       let open Dyn in
+      let name_fields =
+        if options.Options.split_public_names
+        then (
+          let public_names =
+            match public_names with
+            | Some public_names -> public_names
+            | None -> List.map names ~f:(fun _ -> None)
+          in
+          [ "names", (list string) names
+          ; "public_names", (list (option string)) public_names
+          ])
+        else [ "names", (list string) (best_names t) ]
+      in
       record
-        [ "names", List (List.map ~f:(fun name -> String name) names)
-        ; "requires", Dyn.(list string) (List.map ~f:Digest.to_string requires)
+      @@ name_fields
+      @ [ "requires", Dyn.(list string) (List.map ~f:Digest.to_string requires)
         ; "modules", list (Mod.to_dyn options) modules
         ; "include_dirs", list dyn_path include_dirs
         ]
@@ -170,7 +215,8 @@ module Descr = struct
 
   module Lib = struct
     type t =
-      { name : Lib_name.t (* name of the library *)
+      { name : Lib_name.t (* private name of the library *)
+      ; public_name : Lib_name.t option (* public name of the library, if any *)
       ; uid : Digest.t (* digest of the library *)
       ; local : bool (* whether this library is local *)
       ; requires : Digest.t list
@@ -186,14 +232,29 @@ module Descr = struct
       { t with source_dir = f t.source_dir; include_dirs = List.map ~f t.include_dirs }
     ;;
 
+    (* [best_name] is the public name when there is one, and the private name
+       otherwise *)
+    let best_name { name; public_name; _ } = Option.value public_name ~default:name
+
     (* Conversion to the [Dyn.t] type *)
-    let to_dyn options { name; uid; local; requires; source_dir; modules; include_dirs }
+    let to_dyn
+          options
+          ({ name; public_name; uid; local; requires; source_dir; modules; include_dirs }
+           as t)
       : Dyn.t
       =
       let open Dyn in
+      let name_fields =
+        if options.Options.split_public_names
+        then
+          [ "name", Lib_name.to_dyn name
+          ; "public_name", option Lib_name.to_dyn public_name
+          ]
+        else [ "name", Lib_name.to_dyn (best_name t) ]
+      in
       record
-        [ "name", Lib_name.to_dyn name
-        ; "uid", String (Digest.to_string uid)
+      @@ name_fields
+      @ [ "uid", String (Digest.to_string uid)
         ; "local", Bool local
         ; "requires", (list string) (List.map ~f:Digest.to_string requires)
         ; "source_dir", dyn_path source_dir
@@ -465,7 +526,9 @@ module Crawl = struct
        | Ok libs ->
          let include_dirs = Obj_dir.all_cmis obj_dir in
          let exe_descr =
-           { Descr.Exe.names = Executables.best_names exes
+           { Descr.Exe.names = Nonempty_list.to_list_map exes.names ~f:snd
+           ; public_names =
+               Option.map exes.public_names ~f:(Nonempty_list.to_list_map ~f:snd)
            ; requires = List.map ~f:uid_of_library libs
            ; modules
            ; include_dirs
@@ -480,8 +543,13 @@ module Crawl = struct
     match Resolve.peek requires with
     | Error () -> Memo.return None
     | Ok requires ->
-      let name = Lib.name lib in
       let info = Lib.info lib in
+      let name = Lib_id.name (Lib_info.lib_id info) in
+      let public_name =
+        match Lib_info.status info with
+        | Public _ | Installed -> Some (Lib.name lib)
+        | Private _ | Installed_private -> None
+      in
       let src_dir = Lib_info.src_dir info in
       let obj_dir = Lib_info.obj_dir info in
       let+ modules_ =
@@ -527,6 +595,7 @@ module Crawl = struct
       let include_dirs = Obj_dir.all_cmis obj_dir in
       let lib_descr =
         { Descr.Lib.name
+        ; public_name
         ; uid = uid_of_library lib
         ; local = Lib.is_local lib
         ; requires = List.map requires ~f:uid_of_library

--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -9,6 +9,10 @@ module Options = struct
        used at compile time) *)
     ; no_recursive : bool
       (* whether to only consider the provided directories and not descendants *)
+    ; split_public_names : bool
+      (* whether to report private names in the [name(s)] fields and public
+         names in a separate [public_name(s)] field, rather than reporting the
+         public name (falling back to the private name) in [name(s)] *)
     }
 
   (* whether to sanitize absolute paths of workspace items, and their UIDs, to
@@ -60,13 +64,27 @@ module Options = struct
               the workspace root when none are given.")
   ;;
 
+  let arg_split_public_names =
+    let open Arg in
+    value
+    & flag
+    & info
+        [ "split-public-names" ]
+        ~doc:
+          (Some
+             "Report private names in the 'name'/'names' fields and public names in a \
+              separate 'public_name'/'public_names' field, rather than reporting the \
+              public name (falling back to the private name) in 'name'/'names'.")
+  ;;
+
   let arg : t Term.t =
     let+ with_deps = arg_with_deps
     and+ with_pps = arg_with_pps
     and+ sanitize_for_tests_value = arg_sanitize_for_tests
-    and+ no_recursive = arg_no_recursive in
+    and+ no_recursive = arg_no_recursive
+    and+ split_public_names = arg_split_public_names in
     sanitize_for_tests := sanitize_for_tests_value;
-    { with_deps; with_pps; no_recursive }
+    { with_deps; with_pps; no_recursive; split_public_names }
   ;;
 end
 
@@ -144,7 +162,10 @@ module Descr = struct
   (* Description of executables *)
   module Exe = struct
     type t =
-      { names : string list (* names of the executable *)
+      { names : string list (* private names of the executables *)
+      ; public_names : string option list option
+        (* public names of the executables, if the stanza declares any (one
+           entry per executable, [None] for those without a public name) *)
       ; requires : Digest.t list
         (* list of direct dependencies to libraries, identified by their
              digests *)
@@ -154,12 +175,36 @@ module Descr = struct
 
     let map_path t ~f = { t with include_dirs = List.map ~f t.include_dirs }
 
+    (* [best_names] replaces each private name by its public name when there is one *)
+    let best_names { names; public_names; _ } =
+      match public_names with
+      | None -> names
+      | Some public_names ->
+        List.map2 names public_names ~f:(fun name public_name ->
+          Option.value public_name ~default:name)
+    ;;
+
     (* Conversion to the [Dyn.t] type *)
-    let to_dyn options { names; requires; modules; include_dirs } : Dyn.t =
+    let to_dyn options ({ names; public_names; requires; modules; include_dirs } as t)
+      : Dyn.t
+      =
       let open Dyn in
+      let name_fields =
+        if options.Options.split_public_names
+        then (
+          let public_names =
+            match public_names with
+            | Some public_names -> public_names
+            | None -> List.map names ~f:(fun _ -> None)
+          in
+          [ "names", (list string) names
+          ; "public_names", (list (option string)) public_names
+          ])
+        else [ "names", (list string) (best_names t) ]
+      in
       record
-        [ "names", List (List.map ~f:(fun name -> String name) names)
-        ; "requires", Dyn.(list string) (List.map ~f:Digest.to_string requires)
+      @@ name_fields
+      @ [ "requires", Dyn.(list string) (List.map ~f:Digest.to_string requires)
         ; "modules", list (Mod.to_dyn options) modules
         ; "include_dirs", list dyn_path include_dirs
         ]
@@ -170,7 +215,8 @@ module Descr = struct
 
   module Lib = struct
     type t =
-      { name : Lib_name.t (* name of the library *)
+      { name : Lib_name.t (* private name of the library *)
+      ; public_name : Lib_name.t option (* public name of the library, if any *)
       ; uid : Digest.t (* digest of the library *)
       ; local : bool (* whether this library is local *)
       ; requires : Digest.t list
@@ -186,14 +232,29 @@ module Descr = struct
       { t with source_dir = f t.source_dir; include_dirs = List.map ~f t.include_dirs }
     ;;
 
+    (* [best_name] is the public name when there is one, and the private name
+       otherwise *)
+    let best_name { name; public_name; _ } = Option.value public_name ~default:name
+
     (* Conversion to the [Dyn.t] type *)
-    let to_dyn options { name; uid; local; requires; source_dir; modules; include_dirs }
+    let to_dyn
+          options
+          ({ name; public_name; uid; local; requires; source_dir; modules; include_dirs }
+           as t)
       : Dyn.t
       =
       let open Dyn in
+      let name_fields =
+        if options.Options.split_public_names
+        then
+          [ "name", Lib_name.to_dyn name
+          ; "public_name", option Lib_name.to_dyn public_name
+          ]
+        else [ "name", Lib_name.to_dyn (best_name t) ]
+      in
       record
-        [ "name", Lib_name.to_dyn name
-        ; "uid", String (Digest.to_string uid)
+      @@ name_fields
+      @ [ "uid", String (Digest.to_string uid)
         ; "local", Bool local
         ; "requires", (list string) (List.map ~f:Digest.to_string requires)
         ; "source_dir", dyn_path source_dir
@@ -465,7 +526,9 @@ module Crawl = struct
        | Ok libs ->
          let include_dirs = Obj_dir.all_cmis obj_dir in
          let exe_descr =
-           { Descr.Exe.names = Executables.best_names exes
+           { Descr.Exe.names = Nonempty_list.to_list_map exes.names ~f:snd
+           ; public_names =
+               Option.map exes.public_names ~f:(Nonempty_list.to_list_map ~f:snd)
            ; requires = List.map ~f:uid_of_library libs
            ; modules
            ; include_dirs
@@ -480,8 +543,13 @@ module Crawl = struct
     match Resolve.peek requires with
     | Error () -> Memo.return None
     | Ok requires ->
-      let name = Lib.name lib in
       let info = Lib.info lib in
+      let name = Lib_id.name (Lib_info.lib_id info) in
+      let public_name =
+        match Lib_info.status info with
+        | Public _ | Installed -> Some (Lib.name lib)
+        | Private _ | Installed_private -> None
+      in
       let src_dir = Lib_info.src_dir info in
       let obj_dir = Lib_info.obj_dir info in
       let+ modules_ =
@@ -526,6 +594,7 @@ module Crawl = struct
       let include_dirs = Obj_dir.all_cmis obj_dir in
       let lib_descr =
         { Descr.Lib.name
+        ; public_name
         ; uid = uid_of_library lib
         ; local = Lib.is_local lib
         ; requires = List.map requires ~f:uid_of_library

--- a/doc/changes/added/15582.md
+++ b/doc/changes/added/15582.md
@@ -1,0 +1,4 @@
+- Add a `--split-public-names` flag to `dune describe workspace` and `dune
+  describe external-lib-deps`. When enabled, the `name`/`names` fields report
+  only private names and a new `public_name`/`public_names` field reports the
+  public names. (#15582, @natkarmios)

--- a/doc/changes/changed/15582.md
+++ b/doc/changes/changed/15582.md
@@ -1,3 +1,3 @@
 - `dune describe` now reports the public name of an executable (from
   `public_name`/`public_names`) instead of its private name when one is
-  available, falling back to the private name otherwise. (#99999, @natkarmios)
+  available, falling back to the private name otherwise. (#15582, @natkarmios)

--- a/doc/changes/changed/99999.md
+++ b/doc/changes/changed/99999.md
@@ -1,0 +1,3 @@
+- `dune describe` now reports the public name of an executable (from
+  `public_name`/`public_names`) instead of its private name when one is
+  available, falling back to the private name otherwise. (#99999, @natkarmios)

--- a/src/dune_rules/stanzas/executables.ml
+++ b/src/dune_rules/stanzas/executables.ml
@@ -6,6 +6,7 @@ module Names : sig
   type t
 
   val names : t -> (Loc.t * string) Nonempty_list.t
+  val public_names : t -> (Loc.t * string option) Nonempty_list.t option
   val package : t -> Package.t option
   val has_public_name : t -> bool
 
@@ -33,6 +34,11 @@ end = struct
     }
 
   let names t = t.names
+
+  let public_names t =
+    Option.map t.public ~f:(fun p -> Nonempty_list.of_list_exn p.public_names)
+  ;;
+
   let package t = Option.map t.public ~f:(fun p -> p.package)
   let has_public_name t = Option.is_some t.public
 
@@ -411,6 +417,7 @@ end
 
 type t =
   { names : (Loc.t * string) Nonempty_list.t
+  ; public_names : (Loc.t * string option) Nonempty_list.t option
   ; link_flags : Link_flags.Spec.t
   ; link_deps : Dep_conf.t list
   ; modes : Loc.t Link_mode.Map.t
@@ -504,6 +511,7 @@ let common =
   in
   fun names ~multi ->
     let has_public_name = Names.has_public_name names in
+    let public_names = Names.public_names names in
     let private_names = Names.names names in
     let install_conf =
       match Link_mode.Map.best_install_mode ~dune_version modes with
@@ -546,6 +554,7 @@ let common =
           [ Pp.textf "This field can only be used when linking a plugin." ]
     in
     { names = private_names
+    ; public_names
     ; link_flags
     ; link_deps
     ; modes
@@ -578,4 +587,14 @@ let has_foreign_cxx t = Buildable.has_foreign_cxx t.buildable
 let obj_dir t ~dir =
   let name = snd (Nonempty_list.hd t.names) in
   Obj_dir.make_exe ~dir ~name
+;;
+
+let best_names t =
+  let names = Nonempty_list.to_list_map t.names ~f:snd in
+  match t.public_names with
+  | None -> names
+  | Some public_names ->
+    let public_names = Nonempty_list.to_list_map public_names ~f:snd in
+    List.map2 names public_names ~f:(fun name public_name ->
+      Option.value public_name ~default:name)
 ;;

--- a/src/dune_rules/stanzas/executables.ml
+++ b/src/dune_rules/stanzas/executables.ml
@@ -588,13 +588,3 @@ let obj_dir t ~dir =
   let name = snd (Nonempty_list.hd t.names) in
   Obj_dir.make_exe ~dir ~name
 ;;
-
-let best_names t =
-  let names = Nonempty_list.to_list_map t.names ~f:snd in
-  match t.public_names with
-  | None -> names
-  | Some public_names ->
-    let public_names = Nonempty_list.to_list_map public_names ~f:snd in
-    List.map2 names public_names ~f:(fun name public_name ->
-      Option.value public_name ~default:name)
-;;

--- a/src/dune_rules/stanzas/executables.mli
+++ b/src/dune_rules/stanzas/executables.mli
@@ -39,6 +39,7 @@ end
 
 type t =
   { names : (Loc.t * string) Nonempty_list.t
+  ; public_names : (Loc.t * string option) Nonempty_list.t option
   ; link_flags : Dune_lang.Link_flags.Spec.t
   ; link_deps : Dep_conf.t list
   ; modes : Loc.t Link_mode.Map.t
@@ -65,3 +66,6 @@ val has_foreign_cxx : t -> bool
 val obj_dir : t -> dir:Path.Build.t -> Path.Build.t Obj_dir.t
 val single : t Dune_lang.Decoder.t
 val multi : t Dune_lang.Decoder.t
+
+(** Gets [names], with each replaced by its public name if available *)
+val best_names : t -> string list

--- a/src/dune_rules/stanzas/executables.mli
+++ b/src/dune_rules/stanzas/executables.mli
@@ -66,6 +66,3 @@ val has_foreign_cxx : t -> bool
 val obj_dir : t -> dir:Path.Build.t -> Path.Build.t Obj_dir.t
 val single : t Dune_lang.Decoder.t
 val multi : t Dune_lang.Decoder.t
-
-(** Gets [names], with each replaced by its public name if available *)
-val best_names : t -> string list

--- a/src/dune_rules/stanzas/library.ml
+++ b/src/dune_rules/stanzas/library.ml
@@ -410,6 +410,12 @@ let best_name t =
   | Public p -> snd p.name
 ;;
 
+let public_name t =
+  match t.visibility with
+  | Private _ -> None
+  | Public p -> Some (snd p.name)
+;;
+
 let is_virtual t = t.kind = Virtual
 let is_impl t = Option.is_some t.implements
 

--- a/src/dune_rules/stanzas/library.mli
+++ b/src/dune_rules/stanzas/library.mli
@@ -74,6 +74,10 @@ val foreign_lib_files
 val archive : t -> dir:Path.Build.t -> ext:Filename.Extension.t -> Path.Build.t
 
 val best_name : t -> Lib_name.t
+
+(** The public name of the library, if it has one. *)
+val public_name : t -> Lib_name.t option
+
 val is_virtual : t -> bool
 val is_impl : t -> bool
 val obj_dir : dir:Path.Build.t -> t -> Path.Build.t Obj_dir.t

--- a/src/dune_rules/stanzas/tests.ml
+++ b/src/dune_rules/stanzas/tests.ml
@@ -59,6 +59,7 @@ let gen_parse names =
             ; optional = false
             ; buildable
             ; names = Nonempty_list.of_list_exn names
+            ; public_names = None
             ; package = None
             ; promote = None
             ; install_conf = None

--- a/test/blackbox-tests/test-cases/describe/describe-executable-public-names.t
+++ b/test/blackbox-tests/test-cases/describe/describe-executable-public-names.t
@@ -1,0 +1,42 @@
+`dune describe` reports the public name of an executable when it has one
+========================================================================
+
+  $ make_dune_project_with_package 3.21 mypkg
+
+A single executable with a public name:
+
+  $ cat >dune <<EOF
+  > (executable
+  >  (name main)
+  >  (public_name my-tool)
+  >  (package mypkg))
+  > EOF
+
+  $ touch main.ml
+
+`dune describe` reports the public name rather than the private name:
+
+  $ dune describe | grep -A 2 '(executables'
+   (executables
+    ((names (my-tool))
+     (requires ())
+
+Multiple executables, where only some have a public name (a public name of
+`-` means no public name for that executable):
+
+  $ cat >dune <<EOF
+  > (executables
+  >  (names a b c)
+  >  (public_names x - z)
+  >  (package mypkg))
+  > EOF
+
+  $ touch a.ml b.ml c.ml
+
+The private name is used as a fallback when there is no public name:
+
+  $ dune describe | grep -A 3 '(executables'
+   (executables
+    ((names
+      (x b z))
+     (requires ())

--- a/test/blackbox-tests/test-cases/describe/describe-split-public-names.t
+++ b/test/blackbox-tests/test-cases/describe/describe-split-public-names.t
@@ -1,0 +1,175 @@
+The `--split-public-names` flag makes `dune describe` report private
+names in the `name`/`names` fields and public names in a separate
+`public_name`/`public_names` field, rather than reporting the public name
+(falling back to the private name) in `name`/`names`.
+============================================================================
+
+  $ make_dune_project_with_package 3.21 mypkg
+
+  $ mkdir bin lib helper priv
+
+Executables with a mix of public and private names, depending on a public and
+a private library:
+
+  $ cat >bin/dune <<EOF
+  > (executables
+  >  (names a b)
+  >  (public_names x -)
+  >  (package mypkg)
+  >  (libraries mypkg.mylib privlib))
+  > EOF
+  $ touch bin/a.ml bin/b.ml
+
+A public library, depending on another public library:
+
+  $ cat >lib/dune <<EOF
+  > (library
+  >  (name mylib)
+  >  (public_name mypkg.mylib)
+  >  (libraries mypkg.helper))
+  > EOF
+  $ touch lib/mylib.ml
+
+  $ cat >helper/dune <<EOF
+  > (library
+  >  (name helper)
+  >  (public_name mypkg.helper))
+  > EOF
+  $ touch helper/helper.ml
+
+A private library (no public name):
+
+  $ cat >priv/dune <<EOF
+  > (library
+  >  (name privlib))
+  > EOF
+  $ touch priv/privlib.ml
+
+`dune describe workspace`
+-------------------------
+
+With the flag, private names are reported in `names`/`name` and public names in
+`public_names`/`public_name`. Executables without a public name (here `b`) get a
+`()` entry, and a private library (here `privlib`) gets an empty `public_name`:
+
+  $ dune describe workspace --split-public-names --sanitize-for-tests | censor
+  ((root /WORKSPACE_ROOT)
+   (build_context _build/default)
+   (executables
+    ((names
+      (a b))
+     (public_names
+      ((x) ()))
+     (requires
+      ($DIGEST1 $DIGEST2))
+     (modules
+      (((name B)
+        (impl (_build/default/bin/b.ml))
+        (intf ())
+        (cmt (_build/default/bin/.a.eobjs/byte/dune__exe__B.cmt))
+        (cmti ()))
+       ((name A)
+        (impl (_build/default/bin/a.ml))
+        (intf ())
+        (cmt (_build/default/bin/.a.eobjs/byte/dune__exe__A.cmt))
+        (cmti ()))
+       ((name Dune__exe)
+        (impl (_build/default/bin/.a.eobjs/dune__exe.ml-gen))
+        (intf ())
+        (cmt (_build/default/bin/.a.eobjs/byte/dune__exe.cmt))
+        (cmti ()))))
+     (include_dirs (_build/default/bin/.a.eobjs/byte))))
+   (library
+    ((name helper)
+     (public_name (mypkg.helper))
+     (uid $DIGEST3)
+     (local true)
+     (requires ())
+     (source_dir _build/default/helper)
+     (modules
+      (((name Helper)
+        (impl (_build/default/helper/helper.ml))
+        (intf ())
+        (cmt (_build/default/helper/.helper.objs/byte/helper.cmt))
+        (cmti ()))))
+     (include_dirs (_build/default/helper/.helper.objs/byte))))
+   (library
+    ((name mylib)
+     (public_name (mypkg.mylib))
+     (uid $DIGEST1)
+     (local true)
+     (requires ($DIGEST3))
+     (source_dir _build/default/lib)
+     (modules
+      (((name Mylib)
+        (impl (_build/default/lib/mylib.ml))
+        (intf ())
+        (cmt (_build/default/lib/.mylib.objs/byte/mylib.cmt))
+        (cmti ()))))
+     (include_dirs (_build/default/lib/.mylib.objs/byte))))
+   (library
+    ((name privlib)
+     (public_name ())
+     (uid $DIGEST2)
+     (local true)
+     (requires ())
+     (source_dir _build/default/priv)
+     (modules
+      (((name Privlib)
+        (impl (_build/default/priv/privlib.ml))
+        (intf ())
+        (cmt (_build/default/priv/.privlib.objs/byte/privlib.cmt))
+        (cmti ()))))
+     (include_dirs (_build/default/priv/.privlib.objs/byte)))))
+
+`dune describe external-lib-deps`
+---------------------------------
+
+Without the flag, the public name (falling back to the private name) is used in
+`names`:
+
+  $ dune describe external-lib-deps
+  (default
+   ((library
+     ((names (mypkg.mylib))
+      (extensions ())
+      (package (mypkg))
+      (source_dir lib)
+      (external_deps ())
+      (internal_deps ((mypkg.helper required)))))
+    (executables
+     ((names
+       (x b))
+      (extensions (.exe))
+      (package (mypkg))
+      (source_dir bin)
+      (external_deps ())
+      (internal_deps
+       ((mypkg.mylib required)
+        (privlib required)))))))
+
+With the flag, private names are reported in `names` and public names in
+`public_names`:
+
+  $ dune describe external-lib-deps --split-public-names
+  (default
+   ((library
+     ((names (mylib))
+      (public_names ((mypkg.mylib)))
+      (extensions ())
+      (package (mypkg))
+      (source_dir lib)
+      (external_deps ())
+      (internal_deps ((mypkg.helper required)))))
+    (executables
+     ((names
+       (a b))
+      (public_names
+       ((x) ()))
+      (extensions (.exe))
+      (package (mypkg))
+      (source_dir bin)
+      (external_deps ())
+      (internal_deps
+       ((mypkg.mylib required)
+        (privlib required)))))))


### PR DESCRIPTION
- Make public/private name handling of `executables` in `dune describe workspace` and `dune describe external-lib-deps` consistent with `library`: public names are used where available
- Add a `--split-public-names` flag to these commands, which places private names in the existing `name(s)` fields, and public names in a separate `public_name(s)` field

Fixes #15497

## Checklist

- [x] Tests added, if applicable.
- [x] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [x] Documentation added for any user-facing changes.
