### PR TITLE
nix: restore x86_64-darwin binary package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -116,24 +116,46 @@
         }
       );
 
-      packages = forAllSystems (
-        pkgs:
+      packages =
         let
-          dune-package = import ./nix/dune-package.nix {
-            inherit nixpkgs ocaml-overlays pkgs;
-            src = ./.;
-          };
+          # Nixpkgs 26.11 dropped x86_64-darwin. Keep the Intel macOS binary
+          # on the last supported release.
+          nixpkgsDarwin = builtins.getFlake (
+            "github:NixOS/nixpkgs/fca2dbd4c00c3063235e56bb91758e24fc67b7b8"
+            + "?narHash=sha256-uH9LkreZXkpZXD0QOXBkQWnAHhlVuT0wUABFw7AN9BU%3D"
+          );
+          dune =
+            (import ./nix/dune-package.nix {
+              nixpkgs = nixpkgsDarwin;
+              inherit ocaml-overlays;
+              pkgs = nixpkgsDarwin.legacyPackages.x86_64-darwin;
+              src = ./.;
+            }).default;
         in
-        rec {
-          inherit (dune-package)
-            default
-            musl-static
-            windows-static
-            ;
-          dune = default;
-          dune-static = musl-static;
-        }
-      );
+        forAllSystems (
+          pkgs:
+          let
+            dune-package = import ./nix/dune-package.nix {
+              inherit nixpkgs ocaml-overlays pkgs;
+              src = ./.;
+            };
+          in
+          rec {
+            inherit (dune-package)
+              default
+              musl-static
+              windows-static
+              ;
+            dune = default;
+            dune-static = musl-static;
+          }
+        )
+        // {
+          x86_64-darwin = {
+            inherit dune;
+            default = dune;
+          };
+        };
 
       devShells = forAllSystems (
         pkgs:


### PR DESCRIPTION
## Summary

- restore the `packages.x86_64-darwin` flake output after nixpkgs unstable removed Intel Darwin from `lib.systems.flakeExposed`
- build the Intel macOS binary with a directly pinned Nixpkgs 26.05 revision and NAR hash
- keep all other package outputs on the existing nixpkgs input

## Context

The breaking `flake.lock` update landed in #15574 on July 20, 2026. The macOS CI was stuck waiting at the time, so it did not surface the missing `packages.x86_64-darwin` output when the update landed.

## Testing

- `nix eval --json path:.#packages.x86_64-darwin` confirms `default` and `dune` resolve to the same Darwin derivation
- `nix run path:.#formatter.x86_64-linux -- --check flake.nix`