### PR TITLE
fix(pkg): query enabled status through RPC

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -556,12 +556,7 @@ let run
            [ Pp.textf "Context %S not found!" (Dune_engine.Context_name.to_string name) ])
   in
   let* source_workspace = Memo.run (Source.Workspace.workspace ()) in
-  let lock_dir_paths =
-    Pkg.Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace
-      Pkg.Pkg_common.Lock_dirs_arg.all
-      source_workspace
-  in
-  if Pkg.Pkg_common.pkg_enabled ~workspace:source_workspace ~lock_dir_paths
+  if Source.Workspace.pkg_enabled source_workspace
   then
     User_error.raise
       [ Pp.text "dune install is not supported with Dune package management." ];

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -203,18 +203,6 @@ module Lock_dirs_arg = struct
   ;;
 end
 
-let pkg_enabled ~(workspace : Workspace.t) ~lock_dir_paths =
-  (* CR-Leonidas-from-XIV: change this logic when we stop detecting lock
-       directories in the source tree *)
-  let any_lockdir_exists =
-    List.exists lock_dir_paths ~f:(fun p -> Fpath.exists (Path.Source.to_string p))
-  in
-  match workspace.config.pkg_enabled with
-  | Set (_, `Enabled) -> true
-  | Set (_, `Disabled) -> false
-  | Unset -> any_lockdir_exists
-;;
-
 let check_pkg_management_enabled () =
   Memo.run
   @@

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -82,12 +82,6 @@ end
     [lock_dir]. *)
 val pp_packages : Dune_pkg.Lock_dir.Pkg.t list -> User_message.Style.t Pp.t
 
-(** [pkg_enabled ~workspace ~lock_dir_paths] returns [true] if package
-      management is enabled. This is intended to be used by commands that don't
-      run the build system. For commands that do run the build system, use
-      [Dune_rules.Lock_dir.lock_dir_active]. *)
-val pkg_enabled : workspace:Workspace.t -> lock_dir_paths:Path.Source.t list -> bool
-
 (** [check_pkg_management_enabled ()] checks if package management is enabled in the
     workspace configuration. Raises a user error if it is explicitly disabled. *)
 val check_pkg_management_enabled : unit -> unit Fiber.t

--- a/bin/pkg/pkg_enabled.ml
+++ b/bin/pkg/pkg_enabled.ml
@@ -1,20 +1,31 @@
 open Import
 
+let get_local_state () =
+  let open Memo.O in
+  let+ workspace = Workspace.workspace () in
+  Workspace.pkg_enabled workspace
+;;
+
 let term =
   let+ builder = Common.Builder.term in
-  let common, config = Common.init builder in
-  Scheduler_setup.go_with_rpc_server ~common ~config (fun () ->
-    Memo.run
-    (* CR-ElectreAAS: we should be using lock_dir_active *)
-    @@
-    let open Memo.O in
-    let+ workspace = Workspace.workspace () in
-    let lock_dir_paths =
-      Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace
-        Pkg_common.Lock_dirs_arg.all
-        workspace
+  let client_builder =
+    builder |> Common.Builder.forbid_builds |> Common.Builder.disable_log_file
+  in
+  let _, config = Common.init client_builder in
+  Scheduler_setup.no_build_no_rpc ~config (fun () ->
+    let open Fiber.O in
+    let+ enabled =
+      match Global_lock.lock () with
+      | Ok () -> Memo.run (get_local_state ())
+      | Error lock_held_by ->
+        Rpc.Rpc_common.fire_request
+          ~name:"pkg-enabled"
+          ~wait:false
+          ~lock_held_by
+          builder
+          Dune_rpc_impl.Decl.pkg_enabled
+          ()
     in
-    let enabled = Pkg_common.pkg_enabled ~workspace ~lock_dir_paths in
     match enabled with
     | true -> ()
     | false -> exit 1)
@@ -22,8 +33,9 @@ let term =
 
 let info =
   let doc =
-    "Check if the project indicates that dune's package management features should be \
-     enabled. Exits with 0 if package management is enabled and 1 otherwise."
+    "Check if dune's package management features are enabled. If an RPC server is \
+     running, use its configuration. Otherwise, use the project configuration and lock \
+     directories. Exits with 0 if package management is enabled and 1 otherwise."
   in
   Cmd.info "enabled" ~doc
 ;;

--- a/src/dune_rpc_impl/client.ml
+++ b/src/dune_rpc_impl/client.ml
@@ -3,7 +3,7 @@ open Import
 let client ?handler connection init ~f =
   Client.client
     ?handler
-    ~private_menu:[ Request Decl.build; Request Decl.status ]
+    ~private_menu:[ Request Decl.build; Request Decl.status; Request Decl.pkg_enabled ]
     connection
     init
     ~f

--- a/src/dune_rpc_impl/decl.ml
+++ b/src/dune_rpc_impl/decl.ml
@@ -54,5 +54,19 @@ module Build = struct
   ;;
 end
 
+module Pkg_enabled = struct
+  let v1 =
+    Decl.Request.make_current_gen
+      ~req:Conv.unit
+      ~resp:(Conv.enum [ "enabled", true; "disabled", false ])
+      ~version:1
+  ;;
+
+  let decl =
+    Decl.Request.make ~method_:(Method.Name.of_string "pkg-enabled") ~generations:[ v1 ]
+  ;;
+end
+
 let build = Build.decl
 let status = Status.decl
+let pkg_enabled = Pkg_enabled.decl

--- a/src/dune_rpc_impl/decl.mli
+++ b/src/dune_rpc_impl/decl.mli
@@ -19,3 +19,4 @@ end
 
 val build : (string list, Build_outcome_with_diagnostics.t) Decl.Request.t
 val status : (unit, Status.t) Decl.Request.t
+val pkg_enabled : (unit, bool) Decl.Request.t

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -25,6 +25,7 @@ end
 
 module Session = Rpc.Server.Session
 module Handler = Rpc.Server.Handler
+module Workspace = Source.Workspace
 module Source = Rpc.Long_poll.Source
 module Csexp_rpc = Rpc.Csexp_rpc
 
@@ -345,6 +346,13 @@ let handler (t : t Fdecl.t) : unit Handler.t =
       Fiber.return { Status.clients }
     in
     Handler.implement_request rpc Decl.status f
+  in
+  let () =
+    let f _ () =
+      let+ workspace = Memo.run (Workspace.workspace ()) in
+      Workspace.pkg_enabled workspace
+    in
+    Handler.implement_request rpc Decl.pkg_enabled f
   in
   let () =
     let f _ () =

--- a/src/source/workspace.ml
+++ b/src/source/workspace.ml
@@ -878,6 +878,20 @@ let hash { merlin_context; contexts; env; config; repos; lock_dirs; dir; pins } 
     , Pin_stanza.Workspace.hash pins )
 ;;
 
+let pkg_enabled { config; lock_dirs; _ } =
+  match config.pkg_enabled with
+  | Set (_, `Enabled) -> true
+  | Set (_, `Disabled) -> false
+  | Unset ->
+    (* CR-someday Alizter: Use the active lock directory instead of detecting lock
+       directories in the source tree. *)
+    let lock_dir_paths =
+      Path.Source.(relative root "dune.lock")
+      :: List.map lock_dirs ~f:(fun (lock_dir : Lock_dir.t) -> lock_dir.path)
+    in
+    List.exists lock_dir_paths ~f:(fun path -> Fpath.exists (Path.Source.to_string path))
+;;
+
 let source_path_of_lock_dir_path path =
   match (path : Path.t) with
   | In_source_tree s -> s

--- a/src/source/workspace.mli
+++ b/src/source/workspace.mli
@@ -146,6 +146,11 @@ type t = private
 val equal : t -> t -> bool
 val to_dyn : t -> Dyn.t
 val hash : t -> int
+
+(** Whether package management is enabled by the workspace configuration or by
+    the presence of a lock directory. *)
+val pkg_enabled : t -> bool
+
 val find_lock_dir : t -> Path.t -> Lock_dir.t option
 val add_repo : t -> Dune_pkg.Pkg_workspace.Repository.t -> t
 val default_repositories : Dune_pkg.Pkg_workspace.Repository.t list

--- a/test/blackbox-tests/test-cases/pkg/autolock-with-watch-server.t
+++ b/test/blackbox-tests/test-cases/pkg/autolock-with-watch-server.t
@@ -3,7 +3,6 @@ Reproducer for https://github.com/ocaml/dune/issues/13234
 
   $ mkrepo
   $ add_mock_repo_if_needed
-  $ enable_pkg
   $ mkpkg b 0.1
   $ mkpkg c 0.2
 
@@ -25,22 +24,20 @@ Make dune-project file with dependency on b:
   >  (public_name a))
   > EOF
 
-Package management is enabled and its status can be queried normally:
+Package management is disabled when there is no lockdir or explicit setting:
 
   $ dune pkg enabled
-
-Start dune (in passive watch mode)
-
-  $ start_dune
-
-The same status cannot be queried while the watch server is running. Reproducer
-for https://github.com/ocaml/dune/issues/15587
-
-  $ dune pkg enabled > .#pkg-enabled-output 2>&1
   [1]
-  $ sed 's/(pid: [0-9]*)/(pid: PID)/' .#pkg-enabled-output
-  Error: A running dune (pid: PID) instance has locked the build directory.
-  If this is not the case, please delete "_build/.lock".
+
+Start dune in passive watch mode with package management enabled on the command
+line:
+
+  $ start_dune --pkg enabled
+
+The status reported by the running server includes its command-line
+configuration. Fix for https://github.com/ocaml/dune/issues/15587
+
+  $ dune pkg enabled
 
   $ build a.exe
   Success

--- a/test/blackbox-tests/test-cases/pkg/pkg-enabled.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-enabled.t
@@ -88,3 +88,19 @@ higher precedence so it should be enabled:
   > EOF
   $ dune pkg enabled --config-file=config && echo "Workspace config overrides user config"
   Workspace config overrides user config
+
+The status reported by a running watch server also includes its command-line
+configuration. The command-line setting overrides the enabled workspace:
+
+  $ dune build --pkg disabled --passive-watch-mode > .#dune-output 2>&1 &
+  $ disown
+  $ wait_for_rpc_server
+  $ dune pkg enabled
+  [1]
+
+If the server exits without removing its RPC socket, the local state is used:
+
+  $ server_pid=$(cat _build/.lock)
+  $ kill -9 "$server_pid"
+  $ wait_for_pid_to_exit_with_timeout "$server_pid" 200
+  $ dune pkg enabled


### PR DESCRIPTION
Fixes #15587.

`dune pkg enabled` now queries a published Dune RPC server, so it observes transient server-side `--pkg enabled` and `--pkg disabled` settings without trying to acquire the build lock. When no server is running, it retains the local workspace/lockdir check.

The effective package-management check is shared between the local and server paths.

Follow-up to #15588.

Testing:
- `./dune.exe fmt`
- `./dune.exe build @check`
- scoped RPC and package/watch/lock tests