### PR TITLE
test: Surprising behaviour on anonymous actions with multiple aliases

### DIFF
--- a/test/blackbox-tests/test-cases/alias/alias-multiple.t
+++ b/test/blackbox-tests/test-cases/alias/alias-multiple.t
@@ -120,3 +120,61 @@ A similar test with a rule that produces a target
   $ dune clean
   $ dune build @b @c
   I have run
+
+A rule attached to several aliases must not make one alias pull in unrelated
+contributions to another alias. Here alias [a] also receives an unrelated
+action; building [b] must run only the shared action.
+  $ cat > dune << EOF
+  > (rule
+  >  (aliases a b)
+  >  (action (echo "I have run\n")))
+  > (rule
+  >  (alias a)
+  >  (action (echo "unrelated\n")))
+  > EOF
+
+  $ dune clean
+  $ dune build @b
+  I have run
+
+Building [a] still runs both the shared action and the action attached only
+to [a].
+  $ dune clean
+  $ dune build @a
+  I have run
+  unrelated
+
+The set of aliases determines the action's identity: neither duplicating an
+alias nor reordering the aliases should re-run the action.
+
+Duplicating an alias does not re-run the action:
+  $ cat > dune << EOF
+  > (rule
+  >  (aliases a)
+  >  (action (echo "I have run\n")))
+  > EOF
+  $ dune clean
+  $ dune build @a
+  I have run
+  $ cat > dune << EOF
+  > (rule
+  >  (aliases a a)
+  >  (action (echo "I have run\n")))
+  > EOF
+  $ dune build @a
+
+Reordering the aliases does not re-run the action:
+  $ cat > dune << EOF
+  > (rule
+  >  (aliases a b)
+  >  (action (echo "I have run\n")))
+  > EOF
+  $ dune clean
+  $ dune build @a @b
+  I have run
+  $ cat > dune << EOF
+  > (rule
+  >  (aliases b a)
+  >  (action (echo "I have run\n")))
+  > EOF
+  $ dune build @a @b

--- a/test/blackbox-tests/test-cases/alias/alias-multiple.t
+++ b/test/blackbox-tests/test-cases/alias/alias-multiple.t
@@ -121,33 +121,37 @@ A similar test with a rule that produces a target
   $ dune build @b @c
   I have run
 
-A rule attached to several aliases must not make one alias pull in unrelated
-contributions to another alias. Here alias [a] also receives an unrelated
-action; building [b] must run only the shared action.
+Rules with no targets can have surprising behavior.
+
+A when a target-less rule is attached to several aliases, the first listed
+alias is always built.
+
+Here, building [b] pulls in [a].
   $ cat > dune << EOF
   > (rule
   >  (aliases a b)
-  >  (action (echo "I have run\n")))
+  >  (action (echo "a and b\n")))
   > (rule
   >  (alias a)
-  >  (action (echo "unrelated\n")))
+  >  (action (echo "just a\n")))
+  > (rule
+  >  (alias b)
+  >  (action (echo "just b\n")))
   > EOF
 
   $ dune clean
   $ dune build @b
-  I have run
+  a and b
+  just a
+  just b
 
-Building [a] still runs both the shared action and the action attached only
-to [a].
+Building [a] does not pull in [b].
   $ dune clean
   $ dune build @a
-  I have run
-  unrelated
+  a and b
+  just a
 
-The set of aliases determines the action's identity: neither duplicating an
-alias nor reordering the aliases should re-run the action.
-
-Duplicating an alias does not re-run the action:
+Duplicating an alias causes a dependency cycle.
   $ cat > dune << EOF
   > (rule
   >  (aliases a)
@@ -162,8 +166,11 @@ Duplicating an alias does not re-run the action:
   >  (action (echo "I have run\n")))
   > EOF
   $ dune build @a
+  Error: Dependency cycle between:
+     alias a in dune:1
+  [1]
 
-Reordering the aliases does not re-run the action:
+Reordering the aliases causes the action to re-run.
   $ cat > dune << EOF
   > (rule
   >  (aliases a b)
@@ -178,3 +185,4 @@ Reordering the aliases does not re-run the action:
   >  (action (echo "I have run\n")))
   > EOF
   $ dune build @a @b
+  I have run


### PR DESCRIPTION
Related to #15576 & #15581 

Adds 3 tests for anonymous actions with multiple aliases, specifically:
- Building one of an action's aliases can pull in another alias
- Duplicating or re-ordering aliases in a rule does not cause a re-run

Note that all these tests currently fail, but are fixed by #15581:
<details>
<summary><b>Test results</b></summary>

```diff
File "test/blackbox-tests/test-cases/alias/alias-multiple.t", line 1, characters 0-0:
------ test/blackbox-tests/test-cases/alias/alias-multiple.t
++++++ test/blackbox-tests/test-cases/alias/alias-multiple.t.corrected
File "test/blackbox-tests/test-cases/alias/alias-multiple.t", line 139, characters 0-1:
 |
 |A rule attached to several aliases must not make one alias pull in unrelated
 |contributions to another alias. Here alias [a] also receives an unrelated
 |action; building [b] must run only the shared action.
 |  $ cat > dune << EOF
 |  > (rule
 |  >  (aliases a b)
 |  >  (action (echo "I have run\n")))
 |  > (rule
 |  >  (alias a)
 |  >  (action (echo "unrelated\n")))
 |  > EOF
 |
 |  $ dune clean
 |  $ dune build @b
 |  I have run
+|  unrelated
 |
 |Building [a] still runs both the shared action and the action attached only
 |to [a].
 |  $ dune clean
 |  $ dune build @a
 |  I have run
 |  unrelated
 |
 |The set of aliases determines the action's identity: neither duplicating an
 |alias nor reordering the aliases should re-run the action.
 |
 |Duplicating an alias does not re-run the action:
 |  $ cat > dune << EOF
 |  > (rule
 |  >  (aliases a)
 |  >  (action (echo "I have run\n")))
 |  > EOF
 |  $ dune clean
 |  $ dune build @a
 |  I have run
 |  $ cat > dune << EOF
 |  > (rule
 |  >  (aliases a a)
 |  >  (action (echo "I have run\n")))
 |  > EOF
 |  $ dune build @a
+|  Error: Dependency cycle between:
+|     alias a in dune:1
+|  [1]
 |
 |Reordering the aliases does not re-run the action:
 |  $ cat > dune << EOF
 |  > (rule
 |  >  (aliases a b)
 |  >  (action (echo "I have run\n")))
 |  > EOF
 |  $ dune clean
 |  $ dune build @a @b
 |  I have run
 |  $ cat > dune << EOF
 |  > (rule
 |  >  (aliases b a)
 |  >  (action (echo "I have run\n")))
 |  > EOF
 |  $ dune build @a @b
+|  I have run
```

</details>