### PR TITLE
mdx: add a dependency on `unix` required for mdx >=2.6

### DIFF
--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -464,7 +464,7 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~mdx_prog =
         (`Exe Nonempty_list.[ t.loc, name ])
         ~allow_overlaps:false
         ~forbidden_libraries:[]
-        (lib "mdx.test" :: lib "mdx.top" :: t.libraries)
+        (lib "mdx.test" :: lib "mdx.top" :: lib "unix" :: t.libraries)
         ~allow_unused_libraries:[]
         ~pps:[]
         ~dune_version


### PR DESCRIPTION
mdx >= 2.6 add a Unix dependency, which needs to be also added by the dune mdx rule since it uses implicit transitive dependencies. There shouldn't be any harm in adding this dependency to older mdx invocations.

The feature in mdx is https://github.com/realworldocaml/mdx/pull/476 by @talex5