### PR TITLE
ci: enable runtime5 for OxCaml trunk

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -210,6 +210,7 @@
             sphinx-design
             myst-parser
           ];
+          sourceDune = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
           makeDuneDevShell = import ./nix/dev-shell.nix {
             inherit
               pkgs
@@ -217,8 +218,8 @@
               testBuildInputs
               testNativeBuildInputs
               docInputs
+              sourceDune
               ;
-            sourceDune = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
           };
 
         in
@@ -320,7 +321,15 @@
             '';
           };
 
-          inherit (import ./nix/devShells/ox.nix { inherit pkgs makeDuneDevShell INSIDE_NIX; })
+          inherit
+            (import ./nix/devShells/ox.nix {
+              inherit
+                pkgs
+                makeDuneDevShell
+                sourceDune
+                INSIDE_NIX
+                ;
+            })
             bootstrap-ox
             ox-minimal
             ox-minimal-trunk

--- a/nix/devShells/ox.nix
+++ b/nix/devShells/ox.nix
@@ -5,11 +5,31 @@
 {
   pkgs,
   makeDuneDevShell,
+  sourceDune,
   INSIDE_NIX,
 }:
 
 let
   oxcaml-setup = import ../oxcaml.nix { inherit pkgs; };
+  duneVersion =
+    let
+      versionLine =
+        pkgs.lib.findFirst (line: pkgs.lib.strings.hasPrefix "  let latest = " line)
+          (throw "could not determine the Dune version")
+          (pkgs.lib.strings.splitString "\n" (builtins.readFile ../../otherlibs/dune-rpc/types.ml));
+      match = builtins.match "  let latest = ([0-9]+), ([0-9]+)" versionLine;
+    in
+    if match == null then
+      throw "could not parse the Dune version from '${versionLine}'"
+    else
+      "${builtins.elemAt match 0}.${builtins.elemAt match 1}.0";
+  sourceDuneForOx = sourceDune.overrideAttrs (old: {
+    __intentionallyOverridingVersion = true;
+    version = duneVersion;
+    postPatch = (old.postPatch or "") + ''
+      sed -i '/^(name dune)$/i(version ${duneVersion})' dune-project
+    '';
+  });
 in
 {
   bootstrap-ox = pkgs.mkShell {
@@ -51,12 +71,23 @@ in
       oself: osuper:
       (oxcaml-setup.packageSet oself osuper)
       // {
-        ocaml = oxcaml-setup.compiler.overrideAttrs (old: {
-          src = builtins.fetchGit {
-            url = "https://github.com/oxcaml/oxcaml.git";
-            ref = "main";
-          };
-        });
+        ocaml =
+          let
+            oxcamlFlake = builtins.getFlake "github:oxcaml/oxcaml/main";
+            oxcaml = oxcamlFlake.packages.${pkgs.stdenv.hostPlatform.system}.default;
+          in
+          oxcaml.overrideAttrs (old: {
+            NIX_CFLAGS_COMPILE = "-std=gnu17";
+            passthru = (old.passthru or { }) // pkgs.ocamlPackages.ocaml.passthru;
+            meta = (old.meta or { }) // pkgs.ocamlPackages.ocaml.meta;
+            nativeBuildInputs = [
+              sourceDuneForOx
+            ]
+            ++ builtins.filter (input: pkgs.lib.getName input != "dune") old.nativeBuildInputs;
+            postFixup = ''
+              remove-references-to -t ${sourceDuneForOx} $out/lib/ocaml/Makefile.config
+            '';
+          });
       };
     meta.description = ''
       Like ox-minimal but with the OxCaml trunk compiler.


### PR DESCRIPTION
## Summary

- evaluate OxCaml trunk through its own flake so its runtime5 configuration and locked Nix dependencies are used
- preserve the compiler metadata required by the OCaml package scope
- build OxCaml with the source-tree Dune and provide its development version during bootstrap

This fixes the `Revdeps development build` failure after OxCaml trunk moved to 5.4 and stopped supporting runtime4.

## Testing

- `nix develop .#ox-minimal-trunk --impure -c true`
- `nix fmt -- nix/devShells/ox.nix`
- `./dune.exe build @check`
- `git diff --check`