### PR TITLE
feat: dune shell for debugging rules

### DIFF
--- a/bin/action_runner.ml
+++ b/bin/action_runner.ml
@@ -2,25 +2,6 @@ open Import
 
 let name = Action_runner_name.of_string "action-runner"
 
-let find_in_path_exn prog =
-  match Bin.which ~path:(Env_path.path Env.initial) prog with
-  | Some path -> path
-  | None -> User_error.raise [ Pp.textf "unable to find %s in PATH" prog ]
-;;
-
-let has_directory_component prog =
-  String.exists prog ~f:(function
-    | '/' | '\\' -> true
-    | _ -> false)
-;;
-
-let dune_prog () =
-  let prog = Sys.executable_name in
-  if Filename.is_relative prog && not (has_directory_component prog)
-  then find_in_path_exn prog
-  else Path.of_filename_relative_to_initial_cwd prog
-;;
-
 let socketpair () =
   if Sys.win32
   then User_error.raise [ Pp.text "action runners are not supported on Windows" ];
@@ -58,7 +39,7 @@ let create ~config ~sandbox_actions =
         in
         let trace_fd = Dune_trace.duplicate_global_fd () in
         let prog, argv =
-          let dune_prog = dune_prog () in
+          let dune_prog = Util.dune_executable () in
           let worker_argv =
             [ Path.to_string dune_prog
             ; "internal"

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -14,6 +14,7 @@ include struct
   module Build_config = Build_config
   module Build_system = Build_system
   module Build_system_error = Build_system_error
+  module Rule_shell = Rule_shell
   module Load_rules = Load_rules
   module Action_builder = Dune_rules.Action_builder
   module Action = Action

--- a/bin/internal.ml
+++ b/bin/internal.ml
@@ -236,5 +236,6 @@ let group =
     ; Sexp_pp.command
     ; Sexp_to_csexp.command
     ; Cache_metadata.command
+    ; Shell.Internal_replay.command
     ]
 ;;

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -11,6 +11,7 @@ let all : _ Cmdliner.Cmd.t list =
       ; Install_uninstall.install
       ; Install_uninstall.uninstall
       ; Exec.command
+      ; Shell.command
       ; Subst.command
       ; Print_rules.command
       ; Ocaml.Utop.command

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -37,67 +37,6 @@ module Output_format = struct
   let all = [ "sexp", Sexp; "json", Json ]
 end
 
-let rec encode_action : Action.For_shell.t -> Dune_lang.t =
-  let module Outputs = Dune_lang.Action.Outputs in
-  let module File_perm = Dune_lang.Action.File_perm in
-  let module Inputs = Dune_lang.Action.Inputs in
-  let open Dune_lang in
-  let program = Encoder.string in
-  let string = Encoder.string in
-  let path = Encoder.string in
-  let target = Encoder.string in
-  function
-  | Run { prog; args; can_run_in_action_runner = _ } ->
-    List (atom "run" :: program prog :: List.map (Appendable_list.to_list args) ~f:string)
-  | With_accepted_exit_codes (pred, t) ->
-    List
-      [ atom "with-accepted-exit-codes"
-      ; Predicate_lang.encode Dune_sexp.Encoder.int pred
-      ; encode_action t
-      ]
-  | Chdir (a, r) -> List [ atom "chdir"; path a; encode_action r ]
-  | Setenv (k, v, r) -> List [ atom "setenv"; string k; string v; encode_action r ]
-  | Redirect_out (outputs, fn, perm, r) ->
-    List
-      [ atom (sprintf "with-%s-to%s" (Outputs.to_string outputs) (File_perm.suffix perm))
-      ; target fn
-      ; encode_action r
-      ]
-  | Redirect_in (inputs, fn, r) ->
-    List
-      [ atom (sprintf "with-%s-from" (Inputs.to_string inputs))
-      ; path fn
-      ; encode_action r
-      ]
-  | Ignore (outputs, r) ->
-    List [ atom (sprintf "ignore-%s" (Outputs.to_string outputs)); encode_action r ]
-  | Progn l -> List (atom "progn" :: List.map l ~f:encode_action)
-  | Concurrent l -> List (atom "concurrent" :: List.map l ~f:encode_action)
-  | Echo xs -> List (atom "echo" :: List.map xs ~f:string)
-  | Cat xs -> List (atom "cat" :: List.map xs ~f:path)
-  | Copy (x, y) -> List [ atom "copy"; path x; target y ]
-  | Symlink (x, y) -> List [ atom "symlink"; path x; target y ]
-  | Hardlink (x, y) -> List [ atom "hardlink"; path x; target y ]
-  | System x -> List [ atom "system"; string x ]
-  | Bash { script; can_run_in_action_runner = _ } -> List [ atom "bash"; string script ]
-  | Write_file (x, perm, y) ->
-    List [ atom ("write-file" ^ File_perm.suffix perm); target x; string y ]
-  | Rename (x, y) -> List [ atom "rename"; target x; target y ]
-  | Remove_tree x -> List [ atom "remove-tree"; target x ]
-  | Mkdir x -> List [ atom "mkdir"; target x ]
-  | Pipe (outputs, l) ->
-    List
-      (atom (sprintf "pipe-%s" (Outputs.to_string outputs)) :: List.map l ~f:encode_action)
-  | Diff { optional; file1; file2; mode = Binary; directory_diffs = _ } ->
-    assert (not optional);
-    List [ atom "cmp"; path file1; target file2 ]
-  | Diff { optional = false; file1; file2; mode = _; directory_diffs = _ } ->
-    List [ atom "diff"; path file1; target file2 ]
-  | Diff { optional = true; file1; file2; mode = _; directory_diffs = _ } ->
-    List [ atom "diff?"; path file1; target file2 ]
-  | Extension ext -> List [ atom "ext"; Dune_sexp.Quoted_string (Sexp.to_string ext) ]
-;;
-
 let encode_path p =
   let make constr arg =
     Dune_sexp.List [ Dune_sexp.atom constr; Dune_sexp.atom_or_quoted_string arg ]
@@ -203,7 +142,8 @@ let dep_repr =
 let deps_repr = Repr.view (Repr.list dep_repr) ~to_:Dep.Set.to_list
 
 let action_repr =
-  Repr.view syntax_repr ~to_:(fun action -> Action.for_shell action |> encode_action)
+  Repr.view syntax_repr ~to_:(fun action ->
+    Action.for_shell action |> Dune_rules.Action_for_shell.encode_for_rules)
 ;;
 
 let target_names ~root names =

--- a/bin/shell.ml
+++ b/bin/shell.ml
@@ -1,0 +1,600 @@
+open Import
+
+let doc = "Open a shell in the prepared environment of a rule action."
+
+let man =
+  [ `S "DESCRIPTION"
+  ; `P
+      {|$(b,dune shell TARGET) resolves one concrete target to its rule, builds the
+         rule's dependencies, and opens a shell in the exact execution location and
+         sandbox mode selected for its action.|}
+  ; `P
+      {|A command after $(b,--) is executed instead of an interactive shell. The
+         command receives the same prepared environment and working directory.|}
+  ; `Blocks Common.help_secs
+  ]
+;;
+
+let info = Cmd.info "shell" ~doc ~man
+
+let resolved_program ~env ~dir program =
+  match Filename.analyze_program_name program with
+  | Absolute -> Path.of_string program
+  | Relative_to_current_dir -> Path.relative dir program
+  | In_path ->
+    let path =
+      match Env.get env Env_path.var with
+      | None -> []
+      | Some value ->
+        Bin.parse value
+        |> List.map ~f:(fun entry ->
+          if String.is_empty entry
+          then dir
+          else if Filename.is_relative entry
+          then Path.relative dir entry
+          else Path.of_string entry)
+    in
+    (match Bin.which ~path program with
+     | Some path -> path
+     | None ->
+       User_error.raise
+         [ Pp.textf "Program %S was not found in the prepared PATH." program ])
+;;
+
+module Action_file = struct
+  let parse path =
+    let contents = Io.read_file path in
+    let ast =
+      Dune_lang.Parser.parse_string contents ~fname:(Path.to_string path) ~mode:Single
+    in
+    Dune_lang.Decoder.parse Dune_rules.Action_for_shell.Replay.decode Univ_map.empty ast
+  ;;
+
+  let expand parsed ~session_root ~dir ~loc =
+    let normalize_absolute path =
+      match String.drop_prefix path ~prefix:"/" with
+      | None ->
+        Code_error.raise
+          "dune shell replay expected an absolute POSIX path"
+          [ "path", Dyn.string path ]
+      | Some path ->
+        Path.Local.of_string path
+        |> Path.Local.to_string
+        |> Path.External.relative Path.External.root
+    in
+    let resolve ~dir path =
+      let absolute =
+        if Filename.is_relative path
+        then
+          Path.External.relative
+            (Path.External.of_string (Path.to_absolute_filename dir))
+            path
+        else Path.External.of_string path
+      in
+      normalize_absolute (Path.External.to_string absolute) |> Path.external_
+    in
+    let ensure_session_build_path path =
+      match Path.as_in_build_dir path with
+      | None -> path
+      | Some _ ->
+        if Path.equal path session_root || Path.is_descendant path ~of_:session_root
+        then path
+        else
+          User_error.raise
+            ~loc
+            [ Pp.textf
+                "Edited action path %s escapes the dune shell session."
+                (Path.to_string_maybe_quoted path)
+            ]
+    in
+    let path ~dir path =
+      let resolved = resolve ~dir path in
+      let localized = Path.Expert.try_localize_external resolved in
+      match Path.as_in_build_dir localized with
+      | Some _ -> ensure_session_build_path localized
+      | None -> resolved
+    in
+    let target ~dir target =
+      let path = path ~dir target in
+      match Path.as_in_build_dir path with
+      | Some target -> target
+      | None ->
+        User_error.raise
+          ~loc
+          [ Pp.textf
+              "Edited action target %s is outside the dune shell session."
+              (Path.to_string_maybe_quoted path)
+          ]
+    in
+    let program ~dir = function
+      | Action.For_shell.Program.Resolved program -> Ok (path ~dir program)
+      | Unresolved { context; program; hint } ->
+        Error (Action.Prog.Not_found.create ?hint ~context ~program ~loc:(Some loc) ())
+    in
+    let rec loop (action : Action.For_shell.t) ~dir =
+      match action with
+      | Run { prog; args; can_run_in_action_runner = _ } ->
+        Action.Run { prog = program ~dir prog; args; can_run_in_action_runner = false }
+      | With_accepted_exit_codes (codes, action) ->
+        Action.With_accepted_exit_codes (codes, loop action ~dir)
+      | Chdir (chdir, action) ->
+        let chdir = path ~dir chdir in
+        if
+          not (Path.equal chdir session_root || Path.is_descendant chdir ~of_:session_root)
+        then
+          User_error.raise
+            ~loc
+            [ Pp.text "Edited action chdir escapes the dune shell session." ];
+        Action.Chdir (chdir, loop action ~dir:chdir)
+      | Setenv (var, value, action) -> Action.Setenv (var, value, loop action ~dir)
+      | Redirect_out (outputs, target_, perm, action) ->
+        Action.Redirect_out (outputs, target ~dir target_, perm, loop action ~dir)
+      | Redirect_in (inputs, path_, action) ->
+        Action.Redirect_in (inputs, path ~dir path_, loop action ~dir)
+      | Ignore (outputs, action) -> Action.Ignore (outputs, loop action ~dir)
+      | Progn actions -> Action.Progn (List.map actions ~f:(loop ~dir))
+      | Concurrent actions -> Action.Concurrent (List.map actions ~f:(loop ~dir))
+      | Echo strings -> Action.Echo strings
+      | Cat paths -> Action.Cat (List.map paths ~f:(path ~dir))
+      | Copy (source, target_) -> Action.Copy (path ~dir source, target ~dir target_)
+      | Symlink (source, target_) ->
+        let target = target ~dir target_ in
+        let source_dir = Path.build (Path.Build.parent_exn target) in
+        let source =
+          resolve ~dir:source_dir source |> Path.Expert.try_localize_external
+        in
+        Action.Symlink (source, target)
+      | Hardlink (source, target_) ->
+        Action.Hardlink (path ~dir source, target ~dir target_)
+      | System command -> Action.System command
+      | Bash { script; can_run_in_action_runner = _ } ->
+        Action.Bash { script; can_run_in_action_runner = false }
+      | Write_file (target_, perm, contents) ->
+        Action.Write_file (target ~dir target_, perm, contents)
+      | Rename (source, target_) -> Action.Rename (target ~dir source, target ~dir target_)
+      | Remove_tree target_ -> Action.Remove_tree (target ~dir target_)
+      | Mkdir target_ -> Action.Mkdir (target ~dir target_)
+      | Pipe (outputs, actions) -> Action.Pipe (outputs, List.map actions ~f:(loop ~dir))
+      | Diff { optional; mode; file1; file2; directory_diffs } ->
+        Action.Diff
+          { optional
+          ; mode
+          ; file1 = path ~dir file1
+          ; file2 = target ~dir file2
+          ; directory_diffs
+          }
+      | Extension _ ->
+        User_error.raise ~loc [ Pp.text "Edited extension actions cannot be replayed." ]
+    in
+    loop parsed ~dir
+  ;;
+end
+
+module Metadata_codec = struct
+  module Conv = Dune_rpc.Conv
+
+  let strings = Conv.(list string)
+
+  let env =
+    Conv.iso strings (fun entries -> Env.of_unix (Array.of_list entries)) Env.to_unix
+  ;;
+
+  let targets =
+    let to_ (file_paths, dir_paths) =
+      Result.try_with (fun () ->
+        let paths paths =
+          List.map paths ~f:Path.Build.of_string |> Path.Build.Set.of_list
+        in
+        match
+          Targets.create ~files:(paths file_paths) ~dirs:(paths dir_paths)
+          |> Targets.validate
+        with
+        | Valid targets -> targets
+        | No_targets
+        | Inconsistent_parent_dir
+        | File_and_directory_target_with_the_same_name _ ->
+          Code_error.raise "invalid dune shell targets" [])
+    in
+    let from targets =
+      let payload path = Path.Build.local path |> Path.Local.to_string in
+      let files = ref [] in
+      let dirs = ref [] in
+      Targets.Validated.iter
+        targets
+        ~file:(fun path -> files := payload path :: !files)
+        ~dir:(fun path -> dirs := payload path :: !dirs);
+      List.rev !files, List.rev !dirs
+    in
+    Conv.iso_result Conv.(pair strings strings) to_ from
+  ;;
+
+  let optional_string = Conv.(option string)
+
+  (* Session data, in order: (workspace_root, build_dir, cwd),
+     ((session_root, temp_dir, dune_binary),
+      ((invocation_env, action_env, diff_command), targets)) *)
+  let session =
+    let open Conv in
+    pair
+      (triple string string string)
+      (pair (triple string string string) (pair (triple env env optional_string) targets))
+  ;;
+
+  let write path codec value =
+    Conv.to_sexp codec value |> Csexp.to_string |> Io.write_file path
+  ;;
+
+  let read path codec ~description =
+    let invalid details =
+      User_error.raise
+        ~loc:(Loc.in_file path)
+        (Pp.textf "Invalid %s in dune shell metadata." description :: details)
+    in
+    match Csexp.parse_string (Io.read_file path) with
+    | Error _ -> invalid []
+    | Ok sexp ->
+      (match Conv.of_sexp codec ~version:(0, 0) sexp with
+       | Ok value -> value
+       | Error error -> invalid [ Pp.text (Dyn.to_string (Conv.dyn_of_error error)) ])
+  ;;
+end
+
+let dune_binary () = Util.dune_executable () |> Path.to_absolute_filename
+let write_exact metadata name value = Io.write_file (Path.relative metadata name) value
+let build_path_payload path = Path.Build.local path |> Path.Local.to_string
+
+let write_runner metadata_dir =
+  let quote = String.quote_for_shell in
+  let command =
+    [ dune_binary (); "internal"; "shell-replay"; Path.to_absolute_filename metadata_dir ]
+    |> List.map ~f:quote
+    |> String.concat ~sep:" "
+  in
+  let contents = sprintf "#!/bin/sh\nexec %s\n" command in
+  List.iter [ "dune-run"; "run" ] ~f:(fun name ->
+    Io.write_file
+      (Path.relative metadata_dir name)
+      contents
+      ~perm:Permissions.Mode.executable_file)
+;;
+
+let mode_note = function
+  | None ->
+    "sandbox mode none: this is the real _build directory; commands and run write there \
+     directly."
+  | Some Sandbox_mode.Copy ->
+    "sandbox mode copy: this is the action's canonical digest sandbox, destroyed when \
+     the session ends."
+  | Some Sandbox_mode.Symlink ->
+    "sandbox mode symlink: dependencies may point at shared build artifacts."
+  | Some Sandbox_mode.Hardlink ->
+    "sandbox mode hardlink: writes may affect shared build artifacts."
+  | Some Sandbox_mode.Patch_back_source_tree ->
+    Code_error.raise "patch-back dune shell should have been rejected" []
+;;
+
+(* The session helper commands are bash functions sourced into the interactive
+   shell. They read the files written under [$DUNE_SHELL]. The help screen also
+   shows the consequential differences from a real action execution. *)
+let write_shell_init metadata ~mode ~has_direct_process_metadata =
+  let init = Path.relative metadata "init.bash" in
+  let command_fn, command_help =
+    if has_direct_process_metadata
+    then
+      ( {|show_command () {
+  cat "$DUNE_SHELL/command"
+}
+
+|}
+      , "  show_command   print the exact direct program, args, and env\n" )
+    else "", ""
+  in
+  let notes =
+    String.concat
+      ~sep:"\n"
+      [ mode_note mode
+      ; "This is not an isolation boundary; commands can modify your source tree."
+      ; "run clears the action's declared targets and replays only the action; it does \
+         not rebuild dependencies or pick up edits made after entry."
+      ]
+  in
+  let contents =
+    sprintf
+      {|# Loaded into the dune shell session. Passing --rcfile skips the user's
+# ~/.bashrc, so load it here to keep their normal environment, then define
+# the session helper commands on top and show the help screen.
+if [ -f "$HOME/.bashrc" ]; then . "$HOME/.bashrc"; fi
+
+run () {
+  "$DUNE_SHELL/dune-run" "$@"
+}
+
+show_action () {
+  cat "$DUNE_SHELL/action.sexp"
+}
+
+%shelp () {
+  cat <<'HELP'
+dune shell session commands:
+  run            replay the prepared action
+  show_action    print or edit the expanded action ($DUNE_SHELL/action.sexp)
+%s  help           show this message
+
+%s
+HELP
+}
+
+help
+|}
+      command_fn
+      command_help
+      notes
+  in
+  Io.write_file init contents;
+  init
+;;
+
+let prepared_temp_dir (shell : Rule_shell.t) =
+  match Env.get shell.replay_env Env.Var.temp_dir with
+  | Some temp_dir -> temp_dir
+  | None -> Code_error.raise "prepared dune shell environment has no temp dir" []
+;;
+
+let write_direct_process_metadata shell metadata =
+  match Rule_shell.direct_process shell with
+  | None -> false
+  | Some { program; args; dir; env } ->
+    let argv = Path.to_absolute_filename program :: args in
+    Metadata_codec.write
+      (Path.relative metadata "command.argv.csexp")
+      Metadata_codec.strings
+      argv;
+    Metadata_codec.write
+      (Path.relative metadata "command.env.csexp")
+      Metadata_codec.env
+      env;
+    write_exact metadata "command.cwd" (Path.to_absolute_filename dir);
+    Io.write_lines (Path.relative metadata "command.env") (Env.to_unix env);
+    List.map argv ~f:String.quote_for_shell
+    |> String.concat ~sep:" "
+    |> write_exact metadata "command";
+    true
+;;
+
+let write_metadata (shell : Rule_shell.t) ~metadata =
+  let metadata_absolute = Path.to_absolute_filename metadata in
+  let env =
+    shell.shell_env
+    |> Env.add ~var:"DUNE_SHELL" ~value:metadata_absolute
+    |> Env_path.cons ~dir:metadata
+  in
+  let action_contents =
+    Action.for_shell_replay shell.action ~dir:shell.dir
+    |> Dune_rules.Action_for_shell.Replay.encode
+    |> Dune_lang.pp
+    |> Format.asprintf "%a\n" Pp.to_fmt
+  in
+  Io.write_file (Path.relative metadata "action.sexp") action_contents;
+  Io.write_file
+    (Path.relative metadata "rule-digest")
+    (Digest.to_string shell.rule_digest ^ "\n");
+  Io.write_file
+    (Path.relative metadata "sandbox")
+    ((match shell.sandbox_dir with
+      | None -> "none"
+      | Some dir -> Path.to_absolute_filename (Path.build dir))
+     ^ "\n");
+  Io.write_file
+    (Path.relative metadata "sandbox-mode")
+    (Sandbox_mode.to_string shell.sandbox_mode ^ "\n");
+  let cwd = Path.as_in_build_dir_exn shell.dir in
+  let session_root = Option.value shell.sandbox_dir ~default:Path.Build.root in
+  let temp_dir = prepared_temp_dir shell in
+  Metadata_codec.write
+    (Path.relative metadata "session.csexp")
+    Metadata_codec.session
+    ( ( Path.to_absolute_filename Path.root
+      , Path.to_absolute_filename Path.build_dir
+      , build_path_payload cwd )
+    , ( (build_path_payload session_root, temp_dir, dune_binary ())
+      , ((Env.initial, shell.replay_env, !Clflags.diff_command), shell.targets) ) );
+  let has_direct_process_metadata = write_direct_process_metadata shell metadata in
+  write_runner metadata;
+  env, has_direct_process_metadata
+;;
+
+let resolve_rule ~target common =
+  let open Memo.O in
+  let* setup = Util.setup () in
+  let* requests =
+    Target.resolve_targets_exn (Common.root common) setup [ target ]
+    |> Action_builder.evaluate_and_collect_facts
+    >>| fst
+  in
+  let path =
+    match requests with
+    | [ Target.Request.File path ] -> path
+    | [ Alias _ ] ->
+      User_error.raise
+        [ Pp.text "dune shell requires a concrete file or directory target."
+        ; Pp.text "Aliases select multiple actions and are not supported yet."
+        ]
+    | [] | _ :: _ :: _ ->
+      User_error.raise [ Pp.text "dune shell requires exactly one concrete target." ]
+  in
+  Load_rules.get_rule path
+  >>| function
+  | Some rule -> rule
+  | None ->
+    User_error.raise
+      [ Pp.textf "No rule produces %s." (Path.to_string_maybe_quoted path) ]
+;;
+
+let locate_bash () =
+  match Bin.which ~path:(Env_path.path Env.initial) "bash" with
+  | Some bash -> bash
+  | None ->
+    User_error.raise
+      [ Pp.text "dune shell requires bash to open an interactive session."
+      ; Pp.text "Install bash, or use `dune shell TARGET -- COMMAND` to run a command."
+      ]
+;;
+
+let run_in_rule_shell ~target ~command common =
+  Build.build_memo_exn (fun () ->
+    let open Memo.O in
+    let* rule = resolve_rule ~target common in
+    Rule_shell.with_ rule ~f:(fun shell ->
+      let metadata =
+        Temp.create
+          ~perms:(Permissions.Mode.create ~user:Permissions.(read + write + execute) ())
+          Dir
+          ~prefix:"dune-shell"
+          ~suffix:"session"
+      in
+      Fiber.finalize
+        ~finally:(fun () ->
+          Temp.destroy Dir metadata;
+          Fiber.return ())
+        (fun () ->
+           let env, has_direct_process_metadata = write_metadata shell ~metadata in
+           (* Startup prints nothing from Dune itself. In an interactive session
+              the sourced [init.bash] shows the help screen; in command mode the
+              output belongs entirely to the user's command. *)
+           let program, args =
+             match command with
+             | [] ->
+               let init =
+                 write_shell_init
+                   metadata
+                   ~mode:shell.sandbox_mode
+                   ~has_direct_process_metadata
+                 |> Path.to_absolute_filename
+               in
+               locate_bash (), [ "--rcfile"; init ]
+             | program :: args -> resolved_program ~env ~dir:shell.dir program, args
+           in
+           Console.Status_line.clear ();
+           Dune_engine.Process.run_inherit_std_in_out_raw ~dir:shell.dir ~env program args
+           |> Fiber.map ~f:Dune_engine.Process.Failure_mode.exit_code_of_raw_status)))
+;;
+
+let term =
+  let+ builder = Common.Builder.term
+  and+ target = Arg.(required & pos 0 (some dep) None & info [] ~docv:"TARGET" ~doc:None)
+  and+ command =
+    Arg.(value & pos_right 0 string [] & info [] ~docv:"COMMAND" ~doc:None)
+  in
+  if Sys.win32
+  then
+    User_error.raise
+      [ Pp.text "dune shell does not support native Windows yet."
+      ; Pp.text "The replay runner currently requires a POSIX shell."
+      ];
+  let common, config = Common.init_build builder in
+  if Common.action_runner_requested common
+  then
+    User_error.raise
+      [ Pp.text "dune shell does not support external action runners."
+      ; Pp.text
+          "The shell and replay cannot reproduce action-runner or sandbox-actions \
+           process placement yet."
+      ; Pp.text "Run dune shell again without those options."
+      ];
+  match Common.watch common with
+  | Yes _ -> User_error.raise [ Pp.text "dune shell does not support watch mode." ]
+  | No ->
+    Global_lock.lock_exn ();
+    let exit_code =
+      Scheduler_setup.go_without_rpc_server ~common ~config (fun () ->
+        run_in_rule_shell ~target ~command common)
+    in
+    if exit_code <> 0
+    then (
+      Console.finish ();
+      exit exit_code)
+;;
+
+module Internal_replay = struct
+  let read_session metadata =
+    Metadata_codec.read
+      (Path.relative metadata "session.csexp")
+      Metadata_codec.session
+      ~description:"session data"
+  ;;
+
+  let initialize_paths ~workspace_root ~build_dir =
+    Path.set_root (Path.External.of_string workspace_root);
+    Path.Build.set_build_dir (Path.Outside_build_dir.of_string build_dir)
+  ;;
+
+  let clear_targets targets =
+    Targets.Validated.iter
+      targets
+      ~file:(fun path -> Path.rm_rf ~chmod:true (Path.build path))
+      ~dir:(fun path -> Path.rm_rf ~chmod:true (Path.build path));
+    Fiber.return ()
+  ;;
+
+  let command =
+    let info = Cmd.info "shell-replay" ~doc:"Replay a prepared dune shell action." in
+    let term =
+      let+ metadata =
+        Arg.(
+          required
+          & pos 0 (some string) None
+          & info [] ~docv:"SESSION" ~doc:(Some "dune shell metadata directory"))
+      and+ environment_restored =
+        Arg.(value & flag & info [ "environment-restored" ] ~doc:None)
+      in
+      let metadata = Path.of_filename_relative_to_initial_cwd metadata in
+      let (workspace_root, build_dir, cwd), session = read_session metadata in
+      let (session_root, temp_dir, dune_binary), session = session in
+      let (invocation_env, action_env, diff_command), targets = session in
+      if not environment_restored
+      then
+        Proc.restore_cwd_and_execve
+          dune_binary
+          [ "internal"
+          ; "shell-replay"
+          ; "--environment-restored"
+          ; Path.to_absolute_filename metadata
+          ]
+          ~env:invocation_env
+      else (
+        initialize_paths ~workspace_root ~build_dir;
+        let config = Dune_config_file.Dune_config.default in
+        Dune_config.init config ~watch:false;
+        Clflags.diff_command := diff_command;
+        Log.init No_log_file;
+        let action_path = Path.relative metadata "action.sexp" in
+        let dir = Path.Build.of_string cwd |> Path.build in
+        let session_root = Path.Build.of_string session_root |> Path.build in
+        let temp_dir = Path.of_string temp_dir in
+        let action =
+          Action_file.parse action_path
+          |> Action_file.expand ~session_root ~dir ~loc:(Loc.in_file action_path)
+        in
+        let exit_code =
+          Scheduler_setup.no_build_no_rpc ~config (fun () ->
+            let open Fiber.O in
+            let* () = clear_targets targets in
+            Dune_engine.Action_exec.replay
+              { targets
+              ; dir
+              ; env = action_env
+              ; rule_loc = Loc.in_file action_path
+              ; action
+              ; temp_dir
+              })
+        in
+        if exit_code <> 0
+        then (
+          Console.finish ();
+          exit exit_code))
+    in
+    Cmd.v info term
+  ;;
+end
+
+let command = Cmd.v info term

--- a/bin/shell.mli
+++ b/bin/shell.mli
@@ -1,0 +1,7 @@
+open Import
+
+module Internal_replay : sig
+  val command : unit Cmd.t
+end
+
+val command : unit Cmd.t

--- a/bin/target.mli
+++ b/bin/target.mli
@@ -1,5 +1,11 @@
 open Import
 
+module Request : sig
+  type t =
+    | File of Path.t
+    | Alias of Alias.t
+end
+
 type target_type =
   | File
   | Directory
@@ -16,6 +22,12 @@ val interpret_targets
   -> Dune_rules.Main.build_system
   -> Arg.Dep.t list
   -> unit Dune_engine.Action_builder.t
+
+val resolve_targets_exn
+  :  Workspace_root.t
+  -> Dune_rules.Main.build_system
+  -> Arg.Dep.t list
+  -> Request.t list Dune_engine.Action_builder.t
 
 val expand_path_from_root
   :  Workspace_root.t

--- a/bin/util.ml
+++ b/bin/util.ml
@@ -59,6 +59,21 @@ let restore_cwd_and_execve (root : Workspace_root.t) prog args env =
   Proc.restore_cwd_and_execve prog args ~env
 ;;
 
+let dune_executable () =
+  match Filename.analyze_program_name Sys.executable_name with
+  | Absolute | Relative_to_current_dir ->
+    Path.of_filename_relative_to_initial_cwd Sys.executable_name
+  | In_path ->
+    (match Bin.which ~path:(Env_path.path Env.initial) Sys.executable_name with
+     | Some path -> path
+     | None ->
+       User_error.raise
+         [ Pp.textf
+             "Unable to find the current executable %S in PATH."
+             Sys.executable_name
+         ])
+;;
+
 let setup () =
   let scheduler = Scheduler.t () in
   Console.Status_line.set

--- a/bin/util.mli
+++ b/bin/util.mli
@@ -9,4 +9,9 @@ type checked =
 
 val check_path : Context.t list -> Path.t -> checked
 val restore_cwd_and_execve : Workspace_root.t -> string -> string list -> Env.t -> 'a
+
+(** Resolve the Dune executable running this process, including when [argv[0]] was found
+    via [PATH]. *)
+val dune_executable : unit -> Path.t
+
 val setup : unit -> Dune_rules.Main.build_system Memo.t

--- a/doc/dune.inc
+++ b/doc/dune.inc
@@ -252,6 +252,15 @@
  (files   dune-runtest.1))
 
 (rule
+ (with-stdout-to dune-shell.1
+  (run dune shell --help=groff)))
+
+(install
+ (section man)
+ (package dune)
+ (files   dune-shell.1))
+
+(rule
  (with-stdout-to dune-show.1
   (run dune show --help=groff)))
 

--- a/otherlibs/stdune/src/signal.ml
+++ b/otherlibs/stdune/src/signal.ml
@@ -122,6 +122,10 @@ let to_int =
   | t -> Map.find_exn table t
 ;;
 
+external system_signal_number : int -> int = "stdune_system_signal_number" [@@noalloc]
+
+let to_system_int signal = to_int signal |> system_signal_number
+
 let of_int i =
   let table = Int.Map.of_list_exn (List.map all ~f:(fun (t, i) -> i, t)) in
   match Int.Map.find table i with

--- a/otherlibs/stdune/src/signal.mli
+++ b/otherlibs/stdune/src/signal.mli
@@ -36,6 +36,10 @@ type t =
 val name : t -> string
 
 val to_int : t -> int
+
+(* Unlike [to_int], this is suitable for constructing a shell-compatible exit
+   status. *)
+val to_system_int : t -> int
 val to_dyn : t -> Dyn.t
 val compare : t -> t -> Ordering.t
 val equal : t -> t -> bool

--- a/otherlibs/stdune/src/signal_stubs.c
+++ b/otherlibs/stdune/src/signal_stubs.c
@@ -1,5 +1,7 @@
 #include <caml/mlvalues.h>
 
+CAMLextern int caml_convert_signal_number(int);
+
 #ifdef _WIN32
 #include <caml/fail.h>
 #else
@@ -14,4 +16,8 @@ CAMLprim value stdune_winch_number(value vunit) {
 #else
   return Val_int(SIGWINCH);
 #endif
+}
+
+CAMLprim value stdune_system_signal_number(value signal) {
+  return Val_int(caml_convert_signal_number(Int_val(signal)));
 }

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -140,21 +140,37 @@ include Monoid.Make (struct
 type string = String.t
 
 module For_shell = struct
+  module Program = struct
+    type t =
+      | Resolved of string
+      | Unresolved of
+          { context : Context_name.t
+          ; program : Filename.t
+          ; hint : string option
+          }
+  end
+
   module type Ast =
     Action_intf.Ast
-    with type program = string
+    with type program = Program.t
     with type path = string
     with type target = string
     with type string = string
     with type ext = Sexp.t
 
   module rec Ast : Ast = Ast
-  include Make (String) (String) (String) (String) (Sexp) (Ast)
+  include Make (Program) (String) (String) (String) (Sexp) (Ast)
 end
 
 module Relativise = Action_mapper.Make (Ast) (For_shell.Ast)
 
-let for_shell t =
+module For_shell_path_mode = struct
+  type t =
+    | Display
+    | Replay
+end
+
+let for_shell_with_path_mode t ~dir ~path_mode =
   let rec loop t ~dir ~f_program ~f_string ~f_path ~f_target ~f_ext =
     match t with
     | Symlink (src, dst) ->
@@ -172,7 +188,7 @@ let for_shell t =
   let f_target ~dir x = Path.reach (Path.build x) ~from:dir in
   loop
     t
-    ~dir:Path.root
+    ~dir
     ~f_string:(fun ~dir:_ x -> x)
     ~f_path
     ~f_target
@@ -183,8 +199,23 @@ let for_shell t =
         (fun p -> Sexp.Atom (f_target p ~dir)))
     ~f_program:(fun ~dir x ->
       match x with
-      | Ok p -> Path.reach p ~from:dir
-      | Error e -> Filename.to_string e.program)
+      | Ok p ->
+        let program =
+          match path_mode with
+          | For_shell_path_mode.Display -> Path.reach p ~from:dir
+          | Replay -> Path.reach_for_running p ~from:dir
+        in
+        For_shell.Program.Resolved program
+      | Error { context; program; hint; loc = _ } ->
+        For_shell.Program.Unresolved { context; program; hint })
+;;
+
+let for_shell t =
+  for_shell_with_path_mode t ~dir:Path.root ~path_mode:For_shell_path_mode.Display
+;;
+
+let for_shell_replay t ~dir =
+  for_shell_with_path_mode t ~dir ~path_mode:For_shell_path_mode.Replay
 ;;
 
 let digest =
@@ -381,6 +412,18 @@ let rec is_dynamic = function
   | Diff _
   | Mkdir _ -> false
   | Extension (module A) -> A.Spec.is_dynamic
+;;
+
+let find_extension_name =
+  let rec loop = function
+    | Extension (module A) -> Some A.Spec.name
+    | t ->
+      fold_one_step t ~init:None ~f:(fun found child ->
+        match found with
+        | Some _ -> found
+        | None -> loop child)
+  in
+  loop
 ;;
 
 let rec runs_process = function

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -56,9 +56,19 @@ include
 include Monoid with type t := t
 
 module For_shell : sig
+  module Program : sig
+    type t =
+      | Resolved of string
+      | Unresolved of
+          { context : Context_name.t
+          ; program : Filename.t
+          ; hint : string option
+          }
+  end
+
   include
     Action_intf.Ast
-    with type program := string
+    with type program := Program.t
     with type path := string
     with type target := string
     with type string := string
@@ -67,6 +77,11 @@ end
 
 (** Convert the action to a format suitable for printing *)
 val for_shell : t -> For_shell.t
+
+(** Convert an action to the editable replay form. Relative paths are
+    interpreted from [dir], and resolved local programs retain an explicit path
+    instead of becoming PATH lookups. *)
+val for_shell_replay : t -> dir:Path.t -> For_shell.t
 
 val digest : Dune_digest.Manual.t -> t -> unit
 
@@ -78,6 +93,9 @@ val empty : t
 
 (** Checks, if action contains a [Dynamic_run]. *)
 val is_dynamic : t -> bool
+
+(** Return the name of the first action extension, if any. *)
+val find_extension_name : t -> string option
 
 (** Checks if executing the action may spawn a process. *)
 val runs_process : t -> bool

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -73,22 +73,50 @@ end
 
 open Fiber.O
 
+exception Shell_replay_failed of Process.Failure_mode.raw_status
+
 let exec_run ~(ectx : context) ~(eenv : env) ~can_run_in_action_runner prog args =
-  let metadata = { ectx.metadata with can_run_in_action_runner } in
-  let+ (_ : (unit, int) result) =
-    Process.run
-      ~display:!Clflags.display
-      (Accept eenv.exit_codes)
-      ~dir:eenv.working_dir
-      ~env:eenv.env
-      ~stdout_to:eenv.stdout_to
-      ~stderr_to:eenv.stderr_to
-      ~stdin_from:eenv.stdin_from
-      ~metadata
-      prog
-      args
+  let can_run_in_action_runner =
+    match ectx.mode with
+    | Build -> can_run_in_action_runner
+    | Shell_replay -> false
   in
-  ()
+  let metadata = { ectx.metadata with can_run_in_action_runner } in
+  match ectx.mode with
+  | Build ->
+    let+ (_ : (unit, int) result) =
+      Process.run
+        ~display:!Clflags.display
+        (Accept eenv.exit_codes)
+        ~dir:eenv.working_dir
+        ~env:eenv.env
+        ~stdout_to:eenv.stdout_to
+        ~stderr_to:eenv.stderr_to
+        ~stdin_from:eenv.stdin_from
+        ~metadata
+        prog
+        args
+    in
+    ()
+  | Shell_replay ->
+    let+ (), status =
+      Process.run
+        ~display:Quiet
+        Return_raw
+        ~dir:eenv.working_dir
+        ~env:eenv.env
+        ~stdout_to:eenv.stdout_to
+        ~stderr_to:eenv.stderr_to
+        ~stdin_from:eenv.stdin_from
+        ~metadata
+        prog
+        args
+    in
+    (match status with
+     | Process.Failure_mode.Exited exit_code ->
+       if not (Predicate.test eenv.exit_codes exit_code)
+       then raise (Shell_replay_failed status)
+     | Process.Failure_mode.Signaled _ -> raise (Shell_replay_failed status))
 ;;
 
 let bash_exn =
@@ -228,7 +256,11 @@ let rec exec t ~ectx ~eenv : Done_or_more_deps.t Fiber.t =
     Done
   | Pipe (outputs, l) -> exec_pipe ~ectx ~eenv outputs l
   | Diff diff ->
-    let+ () = Diff_action.exec ~patch_back:None ectx.rule_loc diff in
+    let+ () =
+      match ectx.mode with
+      | Build -> Diff_action.exec ~patch_back:None ectx.rule_loc diff
+      | Shell_replay -> Diff_action.exec_without_promotion ectx.rule_loc diff
+    in
     Done
   | Extension (module A) ->
     let metadata =
@@ -357,6 +389,36 @@ type input =
   ; action : Action.t
   }
 
+let prepare_env ~root ~env execution_parameters =
+  let env =
+    match
+      Execution_parameters.workspace_root_to_build_path_prefix_map execution_parameters
+    with
+    | Unset -> env
+    | Set target ->
+      Dune_util.Build_path_prefix_map.extend_build_path_prefix_map
+        env
+        `New_rules_have_precedence
+        (* TODO generify *)
+        [ Some { source = Path.to_absolute_filename root; target } ]
+  in
+  let var = "DUNE_PROJECT_ROOT" in
+  match Execution_parameters.action_project_root execution_parameters with
+  | None -> Env.remove env ~var
+  | Some project_root ->
+    (match Path.as_in_build_dir root with
+     | None -> env
+     | Some root ->
+       let project_root = Path.Build.append_source root project_root in
+       Env.add env ~var ~value:(Path.to_absolute_filename (Path.build project_root)))
+;;
+
+let prepare_chdirs action =
+  Action.chdirs action
+  |> Path.Build.Set.iter ~f:(fun path -> Path.mkdir_p (Path.build path));
+  Fiber.return ()
+;;
+
 let exec
       { targets; root; context; env; rule_loc; execution_parameters; action = t }
       ~build_deps
@@ -365,31 +427,9 @@ let exec
     let metadata =
       Process_metadata.create ~purpose:(Process_metadata.Build_job targets) ()
     in
-    { targets; metadata; context; rule_loc; build_deps }
+    { targets; metadata; context; rule_loc; build_deps; mode = Build }
   and eenv =
-    let env =
-      match
-        Execution_parameters.workspace_root_to_build_path_prefix_map execution_parameters
-      with
-      | Unset -> env
-      | Set target ->
-        Dune_util.Build_path_prefix_map.extend_build_path_prefix_map
-          env
-          `New_rules_have_precedence
-          (* TODO generify *)
-          [ Some { source = Path.to_absolute_filename root; target } ]
-    in
-    let env =
-      let var = "DUNE_PROJECT_ROOT" in
-      match Execution_parameters.action_project_root execution_parameters with
-      | None -> Env.remove env ~var
-      | Some project_root ->
-        (match Path.as_in_build_dir root with
-         | None -> env
-         | Some root ->
-           let project_root = Path.Build.append_source root project_root in
-           Env.add env ~var ~value:(Path.to_absolute_filename (Path.build project_root)))
-    in
+    let env = prepare_env ~root ~env execution_parameters in
     { working_dir = Path.root
     ; env
     ; stdout_to =
@@ -414,4 +454,64 @@ let exec
   | Error exns ->
     Error
       (List.map exns ~f:(fun (e : Exn_with_backtrace.t) -> Exec_result.Error.of_exn e.exn))
+;;
+
+type replay_input =
+  { targets : Targets.Validated.t
+  ; dir : Path.t
+  ; env : Env.t
+  ; rule_loc : Loc.t
+  ; action : Action.t
+  ; temp_dir : Path.t
+  }
+
+let replay { targets; dir; env; rule_loc; action; temp_dir } =
+  let () =
+    match Action.find_extension_name action with
+    | None -> ()
+    | Some name ->
+      Code_error.raise
+        "action extension passed to dune shell replay"
+        [ "extension", Dyn.string name ]
+  in
+  Dtemp.with_temp_dir_for_shell temp_dir ~f:(fun () ->
+    let build_deps (_ : Dep.Set.t) =
+      Code_error.raise "dynamic dependencies in a static dune shell replay" []
+    in
+    let ectx =
+      let metadata =
+        Process_metadata.create ~purpose:(Process_metadata.Build_job (Some targets)) ()
+      in
+      { targets = Some targets
+      ; metadata
+      ; context = None
+      ; rule_loc
+      ; build_deps
+      ; mode = Shell_replay
+      }
+    in
+    let eenv =
+      { working_dir = dir
+      ; env
+      ; stdout_to = Process.Io.inherit_stdout
+      ; stderr_to = Process.Io.inherit_stderr
+      ; stdin_from = Process.Io.null In
+      ; prepared_dependencies = Dependency.Set.empty
+      ; exit_codes = Predicate.create (Int.equal 0)
+      }
+    in
+    let open Fiber.O in
+    let* () = prepare_chdirs action in
+    Fiber.collect_errors (fun () -> exec_until_all_deps_ready action ~ectx ~eenv)
+    >>= function
+    | Ok _ -> Fiber.return 0
+    | Error errors ->
+      (match
+         List.find_map errors ~f:(fun { Exn_with_backtrace.exn; _ } ->
+           match exn with
+           | Shell_replay_failed status -> Some status
+           | _ -> None)
+       with
+       | Some status -> Fiber.return (Process.Failure_mode.exit_code_of_raw_status status)
+       | None -> Fiber.reraise_all errors))
 ;;

--- a/src/dune_engine/action_exec.mli
+++ b/src/dune_engine/action_exec.mli
@@ -37,7 +37,23 @@ type input =
   ; action : Action.t
   }
 
+val prepare_env : root:Path.t -> env:Env.t -> Execution_parameters.t -> Env.t
+
 val exec
   :  input
   -> build_deps:(Dep.Set.t -> Dep.Fact.t Dep.Map.t Fiber.t)
   -> Exec_result.t Fiber.t
+
+type replay_input =
+  { targets : Targets.Validated.t
+  ; dir : Path.t
+  ; env : Env.t
+  ; rule_loc : Loc.t
+  ; action : Action.t
+  ; temp_dir : Path.t
+  }
+
+(** Replay a static standard action with inherited standard streams.
+    A rejected process exit code is returned directly instead of being reported
+    as a Dune error. *)
+val replay : replay_input -> int Fiber.t

--- a/src/dune_engine/action_intf.ml
+++ b/src/dune_engine/action_intf.ml
@@ -105,12 +105,17 @@ module type Helpers = sig
 end
 
 module Exec = struct
+  type execution_mode =
+    | Build
+    | Shell_replay
+
   type context =
     { targets : Targets.Validated.t option
     ; context : Build_context.t option
     ; metadata : Process_metadata.t
     ; rule_loc : Loc.t
     ; build_deps : Dep.Set.t -> Dep.Facts.t Fiber.t
+    ; mode : execution_mode
     }
 
   type env =

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -367,6 +367,132 @@ module Internal = struct
     | File_target, Dir_target _ | Dir_target _, File_target -> false
   ;;
 
+  type prepared_rule_action =
+    { sandbox : Sandbox.t
+    ; action : Action.t
+    ; root : Path.t
+    ; context : Build_context.t option
+    ; env : Env.t
+    ; targets : Targets.Validated.t
+    ; rule_loc : Loc.t
+    ; execution_parameters : Execution_parameters.t
+    }
+
+  let evaluate_rule_action (rule : Rule.t) =
+    let { Rule.targets; action; _ } = rule in
+    let* execution_parameters =
+      match Dpath.Target_dir.of_target targets.root with
+      | Regular (With_context (context, _)) | Anonymous_action (With_context (context, _))
+        -> (Build_config.get ()).execution_parameters context ~dir:targets.root
+      | Anonymous_action Root | Regular Root | Invalid _ ->
+        Code_error.raise
+          "invalid dir for rule execution"
+          [ "dir", Path.Build.to_dyn targets.root ]
+    in
+    (* Note: we do not run the below in parallel with the above: if we fail to
+       compute action execution parameters, we have no use for the action and
+       might as well fail early, skipping unnecessary dependencies. The
+       function [(Build_config.get ()).execution_parameters] is likely
+       memoized, and the result is not expected to change often, so we do not
+       sacrifice too much performance here by executing it sequentially. *)
+    let+ action, facts = Action_builder.evaluate_and_collect_facts action in
+    action, facts, execution_parameters
+  ;;
+
+  let remove_rule_targets (targets : Targets.Validated.t) =
+    Rule_cache.Workspace_local.remove targets;
+    maybe_async_rule_file_op (fun () ->
+      let remove_target_dir dir =
+        let () = Rule_cache.Workspace_local.remove_subtree dir in
+        Path.rm_rf (Path.build dir)
+      in
+      let remove_target_file path =
+        match Fpath.unlink (Path.Build.to_string path) with
+        | Success -> ()
+        | Does_not_exist -> ()
+        | Is_a_directory ->
+          (* If target changed from a directory to a file, delete it anyway. *)
+          remove_target_dir path
+        | Error exn ->
+          Log.warn
+            "Error while removing target"
+            [ "path", Dyn.string (Path.Build.to_string path)
+            ; "error", Dyn.string (Printexc.to_string exn)
+            ]
+      in
+      Targets.Validated.iter targets ~file:remove_target_file ~dir:remove_target_dir)
+  ;;
+
+  let with_prepared_action_for_rule
+        ~rule_digest
+        ~action
+        ~facts
+        ~loc
+        ~execution_parameters
+        ~sandbox_mode
+        ~(targets : Targets.Validated.t)
+        ~f
+    =
+    let open Fiber.O in
+    let { Action.Full.action
+        ; env
+        ; locks
+        ; can_go_in_shared_cache = _
+        ; sandbox = _
+        ; corrections
+        }
+      =
+      action
+    in
+    let prepare_action sandbox =
+      let is_sandboxed = Sandbox.is_sandboxed sandbox in
+      let action = if is_sandboxed then Action.sandbox action sandbox else action in
+      let* () =
+        maybe_async_rule_file_op (fun () ->
+          Action.chdirs action
+          |> Path.Build.Set.iter ~f:(fun p -> Path.mkdir_p (Path.build p)))
+      in
+      let context = Build_context.of_build_path targets.root in
+      let root =
+        match context with
+        | None -> Path.Build.root
+        | Some context -> context.build_dir
+      in
+      let root = Path.build (Sandbox.map_path sandbox root) in
+      with_locks locks ~f:(fun () ->
+        f
+          { sandbox
+          ; action
+          ; root
+          ; context
+          ; env
+          ; targets
+          ; rule_loc = loc
+          ; execution_parameters
+          })
+    in
+    let deps, sandbox_dirs =
+      match sandbox_mode with
+      | None -> Path.Set.empty, Path.Build.Set.empty
+      | Some _ ->
+        ( Dep.Facts.paths
+            ~expand_aliases:
+              (Execution_parameters.expand_aliases_in_sandbox execution_parameters)
+            facts
+        , Dep.Facts.necessary_dirs_for_sandboxing facts )
+    in
+    Sandbox.with_
+      ~mode:sandbox_mode
+      (Option.value ~default:Ignore corrections)
+      ~rule_loc:loc
+      ~dirs:sandbox_dirs
+      ~deps
+      ~rule_dir:targets.root
+      ~rule_digest
+      ~targets
+      ~f:prepare_action
+  ;;
+
   let rec build_alias alias = Memo.exec (Lazy.force build_alias_memo) alias
   and build_file path = Memo.exec (Lazy.force build_file_memo) path >>| fst
 
@@ -421,46 +547,32 @@ module Internal = struct
         ~(targets : Targets.Validated.t)
     : Exec_result.t Fiber.t
     =
-    let open Fiber.O in
-    let { Action.Full.action
-        ; env
-        ; locks
-        ; can_go_in_shared_cache = _
-        ; sandbox = _
-        ; corrections
-        }
-      =
-      action
-    in
-    let execute_action sandbox =
-      let is_sandboxed = Sandbox.is_sandboxed sandbox in
-      let action = if is_sandboxed then Action.sandbox action sandbox else action in
-      let action =
-        (* We must add the creation of the stamp file after sandboxing it, as
-           otherwise the stamp file would end up inside the sandbox. This is
-           especially a problem for the [Patch_back_source_tree] sandboxing
-           mode. *)
-        match rule_kind with
-        | Normal_rule -> action
-        | Anonymous_action { stamp_file; capture_stdout; _ } ->
-          if capture_stdout
-          then Action.with_stdout_to stamp_file action
-          else Action.progn [ action; Action.write_file stamp_file "" ]
-      in
-      let* () =
-        maybe_async_rule_file_op (fun () ->
-          Action.chdirs action
-          |> Path.Build.Set.iter ~f:(fun p -> Path.mkdir_p (Path.build p)))
-      in
-      let context = Build_context.of_build_path targets.root in
-      let root =
-        match context with
-        | None -> Path.Build.root
-        | Some context -> context.build_dir
-      in
-      let root = Path.build (Sandbox.map_path sandbox root) in
-      let action_trace = Action_trace.create rule_digest in
-      with_locks locks ~f:(fun () ->
+    with_prepared_action_for_rule
+      ~rule_digest
+      ~action
+      ~facts
+      ~loc
+      ~execution_parameters
+      ~sandbox_mode
+      ~targets
+      ~f:
+        (fun
+          { sandbox; action; root; context; env; targets; rule_loc; execution_parameters }
+        ->
+        let open Fiber.O in
+        let action =
+          (* We must add the creation of the stamp file after sandboxing it, as
+             otherwise the stamp file would end up inside the sandbox. This is
+             especially a problem for the [Patch_back_source_tree] sandboxing
+             mode. *)
+          match rule_kind with
+          | Normal_rule -> action
+          | Anonymous_action { stamp_file; capture_stdout; _ } ->
+            if capture_stdout
+            then Action.with_stdout_to stamp_file action
+            else Action.progn [ action; Action.write_file stamp_file "" ]
+        in
+        let action_trace = Action_trace.create rule_digest in
         let* action_exec_result =
           let input =
             let env = Action_trace.add_to_env action_trace env in
@@ -468,7 +580,7 @@ module Internal = struct
             ; context (* can be derived from the root *)
             ; env
             ; targets = Some targets
-            ; rule_loc = loc
+            ; rule_loc
             ; execution_parameters
             ; action
             }
@@ -479,7 +591,7 @@ module Internal = struct
         let* action_exec_result = Action_exec.Exec_result.ok_exn action_exec_result in
         let* () = Action_trace.collect action_trace in
         let* () =
-          if not is_sandboxed
+          if not (Sandbox.is_sandboxed sandbox)
           then Fiber.return ()
           else (
             (* The stamp file for anonymous actions is always created outside
@@ -496,28 +608,8 @@ module Internal = struct
         in
         match produced_targets with
         | Ok produced_targets -> { Exec_result.produced_targets; action_exec_result }
-        | Error error -> User_error.raise ~loc (Targets.Produced.Error.message error))
-    in
-    let deps, sandbox_dirs =
-      match sandbox_mode with
-      | None -> Path.Set.empty, Path.Build.Set.empty
-      | Some _ ->
-        ( Dep.Facts.paths
-            ~expand_aliases:
-              (Execution_parameters.expand_aliases_in_sandbox execution_parameters)
-            facts
-        , Dep.Facts.necessary_dirs_for_sandboxing facts )
-    in
-    Sandbox.with_
-      ~mode:sandbox_mode
-      (Option.value ~default:Ignore corrections)
-      ~rule_loc:loc
-      ~dirs:sandbox_dirs
-      ~deps
-      ~rule_dir:targets.root
-      ~rule_digest
-      ~targets
-      ~f:execute_action
+        | Error error ->
+          User_error.raise ~loc:rule_loc (Targets.Produced.Error.message error))
 
   and promote_targets ~rule_mode ~targets ~promote_source =
     match rule_mode, !Clflags.promote with
@@ -527,24 +619,9 @@ module Internal = struct
       Target_promotion.promote ~targets ~promote ~promote_source
 
   and execute_rule_impl ~rule_kind rule =
-    let { Rule.id = _; targets; mode; action; info = _; loc } = rule in
+    let { Rule.id = _; targets; mode; action = _; info = _; loc } = rule in
     let head_target = Targets.Validated.head targets in
-    let* execution_parameters =
-      match Dpath.Target_dir.of_target targets.root with
-      | Regular (With_context (context, _)) | Anonymous_action (With_context (context, _))
-        -> (Build_config.get ()).execution_parameters context ~dir:targets.root
-      | Anonymous_action Root | Regular Root | Invalid _ ->
-        Code_error.raise
-          "invalid dir for rule execution"
-          [ "dir", Path.Build.to_dyn targets.root ]
-    in
-    (* Note: we do not run the below in parallel with the above: if we fail to
-       compute action execution parameters, we have no use for the action and
-       might as well fail early, skipping unnecessary dependencies. The
-       function [(Build_config.get ()).execution_parameters] is likely
-       memoized, and the result is not expected to change often, so we do not
-       sacrifice too much performance here by executing it sequentially. *)
-    let* action, facts = Action_builder.evaluate_and_collect_facts action in
+    let* action, facts, execution_parameters = evaluate_rule_action rule in
     let wrap_fiber f =
       Memo.of_reproducible_fiber
         (if Loc.is_none loc
@@ -624,33 +701,7 @@ module Internal = struct
         | None ->
           (* Step II. Remove stale targets both from the digest table and from
              the build directory. *)
-          Rule_cache.Workspace_local.remove targets;
-          let* () =
-            maybe_async_rule_file_op (fun () ->
-              let remove_target_dir dir =
-                let () = Rule_cache.Workspace_local.remove_subtree dir in
-                Path.rm_rf (Path.build dir)
-              in
-              let remove_target_file path =
-                match Fpath.unlink (Path.Build.to_string path) with
-                | Success -> ()
-                | Does_not_exist -> ()
-                | Is_a_directory ->
-                  (* If target changed from a directory to a file, delete
-                     in anyway. *)
-                  remove_target_dir path
-                | Error exn ->
-                  Log.warn
-                    "Error while removing target"
-                    [ "path", Dyn.string (Path.Build.to_string path)
-                    ; "error", Dyn.string (Printexc.to_string exn)
-                    ]
-              in
-              Targets.Validated.iter
-                targets
-                ~file:remove_target_file
-                ~dir:remove_target_dir)
-          in
+          let* () = remove_rule_targets targets in
           let* produced_targets, dynamic_deps_stages =
             (* Step III. Try to restore artifacts from the shared cache. *)
             Dune_cache.Shared.lookup ~can_go_in_shared_cache ~rule_digest ~targets

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -49,6 +49,63 @@ type rule_execution_result =
 val execute_rule : Rule.t -> rule_execution_result Memo.t
 val dep_on_alias_definition : Rules.Dir_rules.Alias_spec.item -> unit Action_builder.t
 
+(** {2 Sharing the rule execution pipeline}
+
+    These functions are part of the ordinary rule execution pipeline and are
+    exposed so that [dune shell] can prepare a rule action without executing
+    it. *)
+
+type prepared_rule_action =
+  { sandbox : Sandbox.t
+  ; action : Action.t
+  ; root : Path.t
+  ; context : Build_context.t option
+  ; env : Env.t
+  ; targets : Targets.Validated.t
+  ; rule_loc : Loc.t
+  ; execution_parameters : Execution_parameters.t
+  }
+
+(** Evaluate the rule's action and build the facts of its dependencies. *)
+val evaluate_rule_action
+  :  Rule.t
+  -> (Action.Full.t * Dep.Facts.t * Execution_parameters.t) Memo.t
+
+(** Remove the rule's declared targets both from the digest table and from
+    the build directory. *)
+val remove_rule_targets : Targets.Validated.t -> unit Fiber.t
+
+(** Prepare the rule's action in its normally selected sandbox and run [f]
+    while the sandbox and the rule's action locks are held. *)
+val with_prepared_action_for_rule
+  :  rule_digest:Digest.t
+  -> action:Action.Full.t
+  -> facts:Dep.Facts.t
+  -> loc:Loc.t
+  -> execution_parameters:Execution_parameters.t
+  -> sandbox_mode:Sandbox_mode.some option
+  -> targets:Targets.Validated.t
+  -> f:(prepared_rule_action -> 'a Fiber.t)
+  -> 'a Fiber.t
+
+(** Select the sandbox mode for a rule given its sandboxing configuration and
+    the sandboxing preference. *)
+val select_sandbox_mode
+  :  Sandbox_config.t
+  -> loc:Loc.t
+  -> sandboxing_preference:Sandbox_mode.t list
+  -> Sandbox_mode.t
+
+(** Compute the digest of a rule. This determines the shared-cache key and the
+    name of the rule's sandbox directory. *)
+val compute_rule_digest
+  :  Rule.t
+  -> facts:Dep.Facts.t
+  -> action:Action.Full.t
+  -> sandbox_mode:Sandbox_mode.t
+  -> execution_parameters:Execution_parameters.t
+  -> Digest.t
+
 (** {2 Running the build system} *)
 
 val run

--- a/src/dune_engine/diff_action.ml
+++ b/src/dune_engine/diff_action.ml
@@ -73,20 +73,21 @@ let promotion source_file =
   }
 ;;
 
-let run_change loc ~patch_back (mode : Diff.Mode.t) = function
+let run_change loc ~patch_back ~promote (mode : Diff.Mode.t) = function
   | Message messages -> User_error.raise ~loc messages
   | File_diff { source_file; file1; file2 } ->
     (match mode with
      | Text ->
        Print_diff.print
+         ?promotion:(Option.some_if promote (promotion source_file))
          ~patch_back
-         (promotion source_file)
          file1
          file2
          ~skip_trailing_cr:Sys.win32
      | Binary ->
+       let promotion = Option.some_if promote (promotion source_file) in
        User_error.raise
-         ~promotion:(promotion source_file)
+         ?promotion
          ~loc
          [ Pp.textf
              "Files %s and %s differ."
@@ -295,6 +296,7 @@ let plan_diff loc { Diff.optional; file1; file2; mode; directory_diffs } =
 let exec_plan
       loc
       ~patch_back
+      ~promote
       { Diff.optional; mode; file1; file2; _ }
       ({ changes; promotions } : plan)
   =
@@ -308,17 +310,25 @@ let exec_plan
       is_copied_from_source_tree (Path.build file2)
     in
     Fiber.finalize
-      (fun () -> Fiber.parallel_iter changes ~f:(run_change loc ~patch_back mode))
+      (fun () ->
+         Fiber.parallel_iter changes ~f:(run_change loc ~patch_back ~promote mode))
       ~finally:(fun () ->
         (match optional with
          | false ->
-           if in_source_or_target && not target_is_copied_from_source_tree
+           if promote && in_source_or_target && not target_is_copied_from_source_tree
            then register_promotions `Copy promotions
          | true ->
            if in_source_or_target
-           then register_promotions `Move promotions
+           then (if promote then register_promotions `Move promotions)
            else remove_intermediate_target file2);
         Fiber.return ())
 ;;
 
-let exec loc ~patch_back diff = exec_plan loc ~patch_back diff (plan_diff loc diff)
+let exec loc ~patch_back diff =
+  exec_plan loc ~patch_back ~promote:true diff (plan_diff loc diff)
+;;
+
+let exec_without_promotion loc diff =
+  let plan = plan_diff loc diff in
+  exec_plan loc ~patch_back:None ~promote:false diff plan
+;;

--- a/src/dune_engine/diff_action.mli
+++ b/src/dune_engine/diff_action.mli
@@ -5,3 +5,9 @@ val exec
   -> patch_back:Path.t option
   -> (Path.t, Path.Build.t) Stdune.Action_types.Diff.t
   -> unit Fiber.t
+
+(** Execute the comparison without registering any resulting promotion. *)
+val exec_without_promotion
+  :  Loc.t
+  -> (Path.t, Path.Build.t) Stdune.Action_types.Diff.t
+  -> unit Fiber.t

--- a/src/dune_engine/dtemp.ml
+++ b/src/dune_engine/dtemp.ml
@@ -1,16 +1,28 @@
 open Import
 
-let temp_dir = lazy (Temp.create Dir ~prefix:"build" ~suffix:"dune")
-let temp_dir_value = lazy (Path.to_absolute_filename (Lazy.force temp_dir))
-
-let file ~prefix ~suffix =
-  Temp.temp_in_dir File ~dir:(Lazy.force temp_dir) ~suffix ~prefix
-;;
+let default_temp_dir = lazy (Temp.create Dir ~prefix:"build" ~suffix:"dune")
+let temp_dir = ref None
+let get_temp_dir () = Option.value !temp_dir ~default:(Lazy.force default_temp_dir)
+let file ~prefix ~suffix = Temp.temp_in_dir File ~dir:(get_temp_dir ()) ~suffix ~prefix
 
 let add_to_env env =
-  let value = Lazy.force temp_dir_value in
+  let value = Path.to_absolute_filename (get_temp_dir ()) in
   Env.add env ~var:Env.Var.temp_dir ~value
 ;;
 
+let with_temp_dir_for_shell dir ~f =
+  let previous = !temp_dir in
+  temp_dir := Some dir;
+  Fiber.finalize f ~finally:(fun () ->
+    temp_dir := previous;
+    Fiber.return ())
+;;
+
 let destroy = Temp.destroy
-let clear () = if Lazy.is_val temp_dir then Temp.clear_dir (Lazy.force temp_dir)
+
+let clear () =
+  match !temp_dir with
+  | Some dir -> Temp.clear_dir dir
+  | None ->
+    if Lazy.is_val default_temp_dir then Temp.clear_dir (Lazy.force default_temp_dir)
+;;

--- a/src/dune_engine/dtemp.mli
+++ b/src/dune_engine/dtemp.mli
@@ -9,6 +9,10 @@ val file : prefix:string -> suffix:string -> Path.t
     environment with the temp var added. *)
 val add_to_env : Env.t -> Env.t
 
+(** Use the initiating build's temporary directory while replaying a [dune
+    shell] action. *)
+val with_temp_dir_for_shell : Path.t -> f:(unit -> 'a Fiber.t) -> 'a Fiber.t
+
 (** Destroy the temporary file or directory *)
 val destroy : Temp.what -> Path.t -> unit
 

--- a/src/dune_engine/dune_engine.ml
+++ b/src/dune_engine/dune_engine.ml
@@ -38,6 +38,7 @@ module Action_runner_worker = Action_runner_worker
 module Action_exec = Action_exec
 module Running_jobs = Running_jobs
 module Rule_cache = Rule_cache
+module Rule_shell = Rule_shell
 module Build_outcome = Build_outcome
 module Fs = Fs
 

--- a/src/dune_engine/print_diff.ml
+++ b/src/dune_engine/print_diff.ml
@@ -252,10 +252,10 @@ let prepare ~skip_trailing_cr promotion path1 path2 =
   prepare_with_labels ~skip_trailing_cr ~dir loc promotion (label1, path1) (label2, path2)
 ;;
 
-let print ~skip_trailing_cr ~patch_back promotion path1 path2 =
+let print ?promotion ~skip_trailing_cr ~patch_back path1 path2 =
   let p =
     match patch_back with
-    | None -> prepare ~skip_trailing_cr (Some promotion) path1 path2
+    | None -> prepare ~skip_trailing_cr promotion path1 path2
     | Some dir ->
       let path1 = Path.source (Path.drop_optional_build_context_src_exn path1) in
       let loc = Loc.in_file path1 in
@@ -265,7 +265,7 @@ let print ~skip_trailing_cr ~patch_back promotion path1 path2 =
         ~skip_trailing_cr
         ~dir
         loc
-        (Some promotion)
+        promotion
         (label1, path1)
         (label2, path2)
   in

--- a/src/dune_engine/print_diff.mli
+++ b/src/dune_engine/print_diff.mli
@@ -1,10 +1,12 @@
 open Import
 
-(** Diff two files that are expected not to match. *)
+(** Diff two files that are expected not to match. The optional
+    source-promotion annotation is attached to the rendered diff output and
+    errors. *)
 val print
-  :  skip_trailing_cr:bool
+  :  ?promotion:User_message.Diff_annot.t
+  -> skip_trailing_cr:bool
   -> patch_back:Path.t option
-  -> User_message.Diff_annot.t
   -> Path.t
   -> Path.t
   -> _ Fiber.t

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -24,10 +24,20 @@ let limit_output output ~n =
 ;;
 
 module Failure_mode = struct
+  type raw_status =
+    | Exited of int
+    | Signaled of Signal.t
+
+  let exit_code_of_raw_status = function
+    | Exited code -> code
+    | Signaled signal -> 128 + Signal.to_system_int signal
+  ;;
+
   type ('a, 'b) t =
     | Strict : ('a, 'a) t
     | Accept : int Predicate.t -> ('a, ('a, int) result) t
     | Return : ('a, 'a * int) t
+    | Return_raw : ('a, 'a * raw_status) t
     | Timeout :
         { timeout : Time.Span.t option
         ; failure_mode : ('a, 'b) t
@@ -37,22 +47,27 @@ module Failure_mode = struct
   let rec accepted_codes : type a b. (a, b) t -> int -> bool = function
     | Strict -> Int.equal 0
     | Accept exit_codes -> fun i -> Predicate.test exit_codes i
-    | Return -> fun _ -> true
+    | Return | Return_raw -> fun _ -> true
     | Timeout { failure_mode; _ } -> accepted_codes failure_mode
   ;;
 
   let exit_code_of_result = function
     | `Finished n -> n
     | `Timeout -> Code_error.raise "should not return `Timeout" []
+    | `Signaled _ -> Code_error.raise "should not return `Signaled" []
   ;;
 
   let timeout : type a b. (a, b) t -> Time.Span.t option = function
     | Timeout { timeout; _ } -> timeout
-    | Strict | Accept _ | Return -> None
+    | Strict | Accept _ | Return | Return_raw -> None
   ;;
 
   let rec map_result
-    : type a b. (a, b) t -> [ `Timeout | `Finished of int ] -> f:(unit -> a) -> b
+    : type a b.
+      (a, b) t
+      -> [ `Timeout | `Finished of int | `Signaled of Signal.t ]
+      -> f:(unit -> a)
+      -> b
     =
     fun mode result ~f ->
     match mode with
@@ -62,10 +77,21 @@ module Failure_mode = struct
        | 0 -> Ok (f ())
        | n -> Error n)
     | Return -> f (), exit_code_of_result result
+    | Return_raw ->
+      (match result with
+       | `Finished code -> f (), Exited code
+       | `Signaled signal -> f (), Signaled signal
+       | `Timeout -> Code_error.raise "should not return `Timeout" [])
     | Timeout { failure_mode; _ } ->
       (match result with
        | `Timeout -> Error `Timed_out
-       | `Finished _ -> Ok (map_result failure_mode result ~f))
+       | `Finished _ | `Signaled _ -> Ok (map_result failure_mode result ~f))
+  ;;
+
+  let rec returns_signals : type a b. (a, b) t -> bool = function
+    | Return_raw -> true
+    | Timeout { failure_mode; _ } -> returns_signals failure_mode
+    | Strict | Accept _ | Return -> false
   ;;
 end
 
@@ -145,6 +171,15 @@ module Io = struct
   let stderr =
     make_stderr ~output_on_success:Print ~output_limit:Action_output_limit.default
   ;;
+
+  let external_io ch =
+    let fd = descr_of_channel ch in
+    { kind = External; fd = lazy fd; channel = lazy ch; status = Keep_open }
+  ;;
+
+  let inherit_stdout = external_io (Out_chan Stdlib.stdout)
+  let inherit_stderr = external_io (Out_chan Stdlib.stderr)
+  let inherit_stdin = external_io (In_chan Stdlib.stdin)
 
   let stdin =
     terminal
@@ -1406,31 +1441,36 @@ let run_internal
        | Normal ->
          let output = Result.Out.get result.stdout ^ Result.Out.get result.stderr in
          Log.command ~command_line ~output ~exit_status:process_info.status;
-         let res =
-           match display, result.exit_status, output with
-           | Quiet, Ok n, "" -> n (* Optimisation for the common case *)
-           | Verbose, _, _ ->
-             Handle_exit_status.verbose
-               result.exit_status
-               ~id
-               ~metadata
-               ~dir
-               ~command_line:fancy_command_line
-               ~output
+         let status =
+           match result.exit_status with
+           | Error (Signaled signal) when Failure_mode.returns_signals fail_mode ->
+             `Signaled signal
            | _ ->
-             Handle_exit_status.non_verbose
-               result.exit_status
-               ~prog:prog_str
-               ~dir
-               ~command_line
-               ~output
-               ~metadata
-               ~verbosity:display
-               ~has_unexpected_stdout:result.stdout.unexpected_output
-               ~has_unexpected_stderr:result.stderr.unexpected_output
+             `Finished
+               (match display, result.exit_status, output with
+                | Quiet, Ok n, "" -> n (* Optimisation for the common case *)
+                | Verbose, _, _ ->
+                  Handle_exit_status.verbose
+                    result.exit_status
+                    ~id
+                    ~metadata
+                    ~dir
+                    ~command_line:fancy_command_line
+                    ~output
+                | _ ->
+                  Handle_exit_status.non_verbose
+                    result.exit_status
+                    ~prog:prog_str
+                    ~dir
+                    ~command_line
+                    ~output
+                    ~metadata
+                    ~verbosity:display
+                    ~has_unexpected_stdout:result.stdout.unexpected_output
+                    ~has_unexpected_stderr:result.stderr.unexpected_output)
          in
          Result.close result;
-         `Finished res, times))
+         status, times))
 ;;
 
 let run
@@ -1586,22 +1626,37 @@ let run_capture_line
 ;;
 
 let run_inherit_std_in_out =
-  let external_ ch =
-    let fd = Io.descr_of_channel ch in
-    { Io.kind = External; fd = lazy fd; channel = lazy ch; status = Keep_open }
-  in
   fun ?dir ?env prog args ->
+  run_internal
+    ?dir
+    ?env
+    ~display:Display.Quiet
+    ~stdout_to:Io.inherit_stdout
+    ~stderr_to:Io.inherit_stderr
+    ~stdin_from:Io.inherit_stdin
+    ~setpgid:None
+    Return
+    prog
+    args
+  >>| fst
+  >>| Failure_mode.exit_code_of_result
+;;
+
+let run_inherit_std_in_out_raw =
+  fun ?dir ?env prog args ->
+  let+ status, _ =
     run_internal
       ?dir
       ?env
       ~display:Display.Quiet
-      ~stdout_to:(external_ (Out_chan stdout))
-      ~stderr_to:(external_ (Out_chan stderr))
-      ~stdin_from:(external_ (In_chan stdin))
+      ~stdout_to:Io.inherit_stdout
+      ~stderr_to:Io.inherit_stderr
+      ~stdin_from:Io.inherit_stdin
       ~setpgid:None
-      Return
+      Return_raw
       prog
       args
-    >>| fst
-    >>| Failure_mode.exit_code_of_result
+  in
+  let (), status = Failure_mode.map_result Return_raw status ~f:ignore in
+  status
 ;;

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -5,6 +5,12 @@ open Action_types
 module Action_output_limit := Execution_parameters.Action_output_limit
 
 module Failure_mode : sig
+  type raw_status =
+    | Exited of int
+    | Signaled of Signal.t
+
+  val exit_code_of_raw_status : raw_status -> int
+
   (** How to handle sub-process failures. This type controls the way in which
       the process we are running can fail. *)
   type ('a, 'b) t =
@@ -13,6 +19,8 @@ module Failure_mode : sig
     (** Accept the following non-zero exit codes, and return [Error code] if
         the process exits with one of these codes. *)
     | Return : ('a, 'a * int) t (** Accept any error code and return it. *)
+    | Return_raw : ('a, 'a * raw_status) t
+    (** Return any exit status without rendering a Dune process error. *)
     | Timeout :
         { timeout : Time.Span.t option
         ; failure_mode : ('a, 'b) t
@@ -46,6 +54,11 @@ module Io : sig
     -> output_limit:Action_output_limit.t
     -> output t
 
+  (** Inherited output descriptors that bypass Dune's output capture. *)
+  val inherit_stdout : output t
+
+  val inherit_stderr : output t
+  val inherit_stdin : input t
   val stdin : input t
   val null : 'a mode -> 'a t
 
@@ -189,3 +202,12 @@ val run_inherit_std_in_out
   -> Path.t
   -> string list
   -> int Fiber.t
+
+(** Like [run_inherit_std_in_out], but preserves whether the process exited or
+    was terminated by a signal. *)
+val run_inherit_std_in_out_raw
+  :  ?dir:Path.t
+  -> ?env:Env.t
+  -> Path.t
+  -> string list
+  -> Failure_mode.raw_status Fiber.t

--- a/src/dune_engine/rule_shell.ml
+++ b/src/dune_engine/rule_shell.ml
@@ -1,0 +1,172 @@
+open Import
+open Memo.O
+
+(* Preparation of a rule action for an interactive [dune shell] session. The
+   machinery here reuses the ordinary rule execution pipeline ([dune_engine]
+   [Build_system]): it evaluates the rule's action, selects the sandbox mode,
+   removes the declared targets, and prepares the sandbox and locks. The
+   action itself is not executed; instead, [f] is run in the prepared
+   environment. *)
+
+let validate_action ~loc (action : Action.Full.t) =
+  if Action.is_dynamic action.action
+  then
+    User_error.raise
+      ~loc
+      [ Pp.text "dune shell does not support dynamic actions."
+      ; Pp.text
+          "The action can discover dependencies while it runs, after the shell \
+           environment has already been prepared."
+      ];
+  match Action.find_extension_name action.action with
+  | None -> ()
+  | Some name ->
+    User_error.raise
+      ~loc
+      [ Pp.textf "dune shell does not support the action extension %S." name
+      ; Pp.text "Use an ordinary build, or rewrite the rule with standard actions."
+      ]
+;;
+
+let map_targets sandbox (targets : Targets.Validated.t) =
+  let files, dirs =
+    Targets.Validated.fold
+      targets
+      ~init:(Path.Build.Set.empty, Path.Build.Set.empty)
+      ~file:(fun path (files, dirs) ->
+        Path.Build.Set.add files (Sandbox.map_path sandbox path), dirs)
+      ~dir:(fun path (files, dirs) ->
+        files, Path.Build.Set.add dirs (Sandbox.map_path sandbox path))
+  in
+  match Targets.create ~files ~dirs |> Targets.validate with
+  | Valid targets -> targets
+  | No_targets | Inconsistent_parent_dir | File_and_directory_target_with_the_same_name _
+    -> Code_error.raise "mapping dune shell targets produced invalid targets" []
+;;
+
+(* The leading wrappers the action interpreter executes before the action's
+   "body": [Chdir] and [Setenv] determine the working directory and
+   environment the body runs in, while the remaining wrappers only affect the
+   body's streams or failure handling. Single-element [Progn]s are
+   transparent. Returns the body together with the directory and environment
+   in effect at that point. *)
+let rec leading_context action ~dir ~env =
+  match action with
+  | Action.Chdir (dir, action) -> leading_context action ~dir ~env
+  | Setenv (var, value, action) ->
+    leading_context action ~dir ~env:(Env.add env ~var ~value)
+  | With_accepted_exit_codes (_, action)
+  | Redirect_out (_, _, _, action)
+  | Redirect_in (_, _, action)
+  | Ignore (_, action)
+  | Progn [ action ] -> leading_context action ~dir ~env
+  | _ -> action, dir, env
+;;
+
+type t =
+  { dir : Path.t
+  ; shell_env : Env.t
+  ; replay_env : Env.t
+  ; sandbox_dir : Path.Build.t option
+  ; sandbox_mode : Sandbox_mode.some option
+  ; action : Action.t
+  ; targets : Targets.Validated.t
+  ; rule_digest : Digest.t
+  }
+
+type direct_process =
+  { program : Path.t
+  ; args : string list
+  ; dir : Path.t
+  ; env : Env.t
+  }
+
+let bash = lazy (Bin.which ~path:(Env_path.path Env.initial) "bash")
+
+(* If the prepared action is a single process invocation modulo its leading
+   wrappers, return that direct process: its program, arguments, and the
+   working directory and environment the action interpreter would run it
+   with. *)
+let direct_process (shell : t) =
+  let body, dir, env =
+    leading_context shell.action ~dir:shell.dir ~env:shell.replay_env
+  in
+  match body with
+  | Run { prog = Ok program; args; can_run_in_action_runner = _ } ->
+    Some { program; args = Appendable_list.to_list args; dir; env }
+  | Run { prog = Error _; _ } -> None
+  | Bash { script; can_run_in_action_runner = _ } ->
+    Option.map (Lazy.force bash) ~f:(fun program ->
+      { program; args = [ "-e"; "-u"; "-o"; "pipefail"; "-c"; script ]; dir; env })
+  | _ -> None
+;;
+
+let with_ (rule : Rule.t) ~f =
+  let { Rule.targets = original_targets; loc; _ } = rule in
+  let* full_action, facts, execution_parameters =
+    Build_system.evaluate_rule_action rule
+  in
+  validate_action ~loc full_action;
+  let sandbox_mode =
+    Build_system.select_sandbox_mode
+      ~loc
+      full_action.sandbox
+      ~sandboxing_preference:(Build_config.get ()).sandboxing_preference
+  in
+  (match sandbox_mode with
+   | Some Patch_back_source_tree ->
+     User_error.raise
+       ~loc
+       [ Pp.text "dune shell does not support patch-back-source-tree rules."
+       ; Pp.text
+           "That mode performs implicit source-tree updates, whose shell semantics are \
+            not defined."
+       ]
+   | None | Some (Copy | Symlink | Hardlink) -> ());
+  let rule_digest =
+    Build_system.compute_rule_digest
+      rule
+      ~facts
+      ~action:full_action
+      ~sandbox_mode
+      ~execution_parameters
+  in
+  Memo.of_non_reproducible_fiber
+    (let open Fiber.O in
+     Path.mkdir_p (Path.build original_targets.root);
+     let* () = Build_system.remove_rule_targets original_targets in
+     Build_system.with_prepared_action_for_rule
+       ~rule_digest
+       ~action:full_action
+       ~facts
+       ~loc
+       ~execution_parameters
+       ~sandbox_mode
+       ~targets:original_targets
+       ~f:(fun { sandbox; action; root; env; _ } ->
+         let targets = map_targets sandbox original_targets in
+         let base_env = Action_exec.prepare_env ~root ~env execution_parameters in
+         let replay_env = Dtemp.add_to_env base_env in
+         let sandbox_dir =
+           Option.some_if
+             (Sandbox.is_sandboxed sandbox)
+             (Sandbox.map_path sandbox Path.Build.root)
+         in
+         let _, dir, shell_env =
+           leading_context
+             action
+             ~dir:(Path.build (Sandbox.map_path sandbox original_targets.root))
+             ~env:base_env
+         in
+         let shell_env = Dtemp.add_to_env shell_env in
+         f
+           { dir
+           ; shell_env
+           ; replay_env
+           ; sandbox_dir
+           ; sandbox_mode
+           ; action
+           ; targets
+           ; rule_digest
+           }))
+;;

--- a/src/dune_engine/rule_shell.mli
+++ b/src/dune_engine/rule_shell.mli
@@ -1,0 +1,39 @@
+open Import
+
+(** Preparation of a rule action for an interactive [dune shell] session. *)
+
+type t =
+  { dir : Path.t
+  ; shell_env : Env.t
+    (** The entry environment after common leading action wrappers and the
+        final Dune temporary-directory injection. *)
+  ; replay_env : Env.t
+    (** The base action environment. Scoped wrappers remain in [action]; the
+        Dune temporary-directory injection is already present. *)
+  ; sandbox_dir : Path.Build.t option
+  ; sandbox_mode : Sandbox_mode.some option
+  ; action : Action.t
+  ; targets : Targets.Validated.t
+  ; rule_digest : Digest.t
+  }
+
+type direct_process =
+  { program : Path.t
+  ; args : string list
+  ; dir : Path.t
+  ; env : Env.t
+  }
+
+(** If the prepared action is a single process invocation modulo its leading
+    wrappers, return that direct process: its program, arguments, and the
+    working directory and environment the action interpreter would run it
+    with. *)
+val direct_process : t -> direct_process option
+
+(** Build and evaluate all prerequisites of [rule], prepare the rule's action
+    in its normally selected execution location, and run [f] instead of the
+    action. Existing declared targets are removed as they are before ordinary
+    action execution. The selected action is not executed and its outputs are
+    not extracted, cached, or promoted. The execution location and the rule's
+    action locks remain owned by the build system until [f] returns. *)
+val with_ : Rule.t -> f:(t -> 'a Fiber.t) -> 'a Memo.t

--- a/src/dune_rules/action_for_shell.ml
+++ b/src/dune_rules/action_for_shell.ml
@@ -1,0 +1,239 @@
+open Import
+module Engine_action = Action
+
+module Encoding = struct
+  type t =
+    | Rules
+    | Replay
+end
+
+let encode_as encoding =
+  let module Outputs = Dune_lang.Action.Outputs in
+  let module File_perm = Dune_lang.Action.File_perm in
+  let module Inputs = Dune_lang.Action.Inputs in
+  let open Dune_lang in
+  let string = Encoder.string in
+  let path = Encoder.string in
+  let target = Encoder.string in
+  let program = function
+    | Engine_action.For_shell.Program.Resolved program -> Encoder.string program
+    | Unresolved { context; program; hint } ->
+      (match encoding with
+       | Encoding.Rules -> Encoder.string (Filename.to_string program)
+       | Replay ->
+         List
+           (atom "unresolved-program"
+            :: Encoder.string (Context_name.to_string context)
+            :: Encoder.string (Filename.to_string program)
+            ::
+            (match hint with
+             | None -> []
+             | Some hint -> [ Encoder.string hint ])))
+  in
+  let text_diff_name ~optional ~directory_diffs =
+    match encoding with
+    | Encoding.Rules -> if optional then "diff?" else "diff"
+    | Replay ->
+      (match optional, directory_diffs with
+       | false, true -> "diff"
+       | true, true -> "diff?"
+       | false, false -> "diff-no-directory"
+       | true, false -> "diff-no-directory?")
+  in
+  let rec encode : Engine_action.For_shell.t -> Dune_lang.t = function
+    | Run { prog; args; can_run_in_action_runner = _ } ->
+      List
+        (atom "run" :: program prog :: List.map (Appendable_list.to_list args) ~f:string)
+    | With_accepted_exit_codes (pred, action) ->
+      List
+        [ atom "with-accepted-exit-codes"
+        ; Predicate_lang.encode Dune_sexp.Encoder.int pred
+        ; encode action
+        ]
+    | Chdir (dir, action) -> List [ atom "chdir"; path dir; encode action ]
+    | Setenv (var, value, action) ->
+      List [ atom "setenv"; string var; string value; encode action ]
+    | Redirect_out (outputs, file, perm, action) ->
+      List
+        [ atom
+            (sprintf "with-%s-to%s" (Outputs.to_string outputs) (File_perm.suffix perm))
+        ; target file
+        ; encode action
+        ]
+    | Redirect_in (inputs, file, action) ->
+      List
+        [ atom (sprintf "with-%s-from" (Inputs.to_string inputs))
+        ; path file
+        ; encode action
+        ]
+    | Ignore (outputs, action) ->
+      List [ atom (sprintf "ignore-%s" (Outputs.to_string outputs)); encode action ]
+    | Progn actions -> List (atom "progn" :: List.map actions ~f:encode)
+    | Concurrent actions -> List (atom "concurrent" :: List.map actions ~f:encode)
+    | Echo strings -> List (atom "echo" :: List.map strings ~f:string)
+    | Cat paths -> List (atom "cat" :: List.map paths ~f:path)
+    | Copy (source, target_) -> List [ atom "copy"; path source; target target_ ]
+    | Symlink (source, target_) -> List [ atom "symlink"; path source; target target_ ]
+    | Hardlink (source, target_) -> List [ atom "hardlink"; path source; target target_ ]
+    | System command -> List [ atom "system"; string command ]
+    | Bash { script; can_run_in_action_runner = _ } -> List [ atom "bash"; string script ]
+    | Write_file (target_, perm, contents) ->
+      List
+        [ atom ("write-file" ^ File_perm.suffix perm); target target_; string contents ]
+    | Rename (source, target_) -> List [ atom "rename"; target source; target target_ ]
+    | Remove_tree target_ -> List [ atom "remove-tree"; target target_ ]
+    | Mkdir target_ -> List [ atom "mkdir"; target target_ ]
+    | Pipe (outputs, actions) ->
+      List
+        (atom (sprintf "pipe-%s" (Outputs.to_string outputs))
+         :: List.map actions ~f:encode)
+    | Diff { optional; file1; file2; mode = Binary; directory_diffs = _ } ->
+      assert (not optional);
+      List [ atom "cmp"; path file1; target file2 ]
+    | Diff { optional; file1; file2; mode = Text; directory_diffs } ->
+      List [ atom (text_diff_name ~optional ~directory_diffs); path file1; target file2 ]
+    | Extension extension ->
+      List [ atom "ext"; Dune_sexp.Quoted_string (Sexp.to_string extension) ]
+  in
+  encode
+;;
+
+let encode_for_rules = encode_as Encoding.Rules
+
+module Replay = struct
+  let encode = encode_as Encoding.Replay
+
+  let decode =
+    let open Dune_lang.Decoder in
+    let program =
+      enter
+      @@ sum
+           [ ( "unresolved-program"
+             , let+ context = string
+               and+ program = string
+               and+ hint = repeat string in
+               let hint =
+                 match hint with
+                 | [] -> None
+                 | [ hint ] -> Some hint
+                 | _ ->
+                   User_error.raise
+                     [ Pp.text
+                         "An unresolved-program accepts at most one diagnostic hint."
+                     ]
+               in
+               let program =
+                 match Filename.of_string program with
+                 | Some program -> program
+                 | None ->
+                   User_error.raise
+                     [ Pp.text "Invalid program name in unresolved-program." ]
+               in
+               Engine_action.For_shell.Program.Unresolved
+                 { context = Context_name.of_string context; program; hint } )
+           ]
+      <|> (string >>| fun program -> Engine_action.For_shell.Program.Resolved program)
+    in
+    let run =
+      let+ prog = program
+      and+ args = repeat string in
+      Engine_action.For_shell.Run
+        { prog; args = Appendable_list.of_list args; can_run_in_action_runner = false }
+    in
+    fix
+    @@ fun action ->
+    let unary make = string >>| make in
+    let binary make =
+      let+ first = string
+      and+ second = string in
+      make first second
+    in
+    let scoped make =
+      let+ value = string
+      and+ action = action in
+      make value action
+    in
+    let wrapped make = action >>| make in
+    let sequence make = repeat action >>| make in
+    let redirect_out outputs perm =
+      scoped (fun path action ->
+        Engine_action.For_shell.Redirect_out (outputs, path, perm, action))
+    in
+    let diff ~optional ~mode ~directory_diffs =
+      binary (fun file1 file2 ->
+        Engine_action.For_shell.Diff { optional; mode; file1; file2; directory_diffs })
+    in
+    sum
+      [ "run", run
+      ; ( "with-accepted-exit-codes"
+        , let+ codes = Predicate_lang.decode_one int
+          and+ action = action in
+          Engine_action.For_shell.With_accepted_exit_codes (codes, action) )
+      ; "chdir", scoped (fun dir action -> Engine_action.For_shell.Chdir (dir, action))
+      ; ( "setenv"
+        , let+ var = string
+          and+ value = string
+          and+ action = action in
+          Engine_action.For_shell.Setenv (var, value, action) )
+      ; "with-stdout-to", redirect_out Stdout Normal
+      ; "with-stdout-to-executable", redirect_out Stdout Executable
+      ; "with-stderr-to", redirect_out Stderr Normal
+      ; "with-stderr-to-executable", redirect_out Stderr Executable
+      ; "with-outputs-to", redirect_out Outputs Normal
+      ; "with-outputs-to-executable", redirect_out Outputs Executable
+      ; ( "with-stdin-from"
+        , scoped (fun path action ->
+            Engine_action.For_shell.Redirect_in (Stdin, path, action)) )
+      ; ( "ignore-stdout"
+        , wrapped (fun action -> Engine_action.For_shell.Ignore (Stdout, action)) )
+      ; ( "ignore-stderr"
+        , wrapped (fun action -> Engine_action.For_shell.Ignore (Stderr, action)) )
+      ; ( "ignore-outputs"
+        , wrapped (fun action -> Engine_action.For_shell.Ignore (Outputs, action)) )
+      ; "progn", sequence (fun actions -> Engine_action.For_shell.Progn actions)
+      ; "concurrent", sequence (fun actions -> Engine_action.For_shell.Concurrent actions)
+      ; ("echo", repeat string >>| fun strings -> Engine_action.For_shell.Echo strings)
+      ; ("cat", repeat string >>| fun paths -> Engine_action.For_shell.Cat paths)
+      ; ( "copy"
+        , binary (fun source target -> Engine_action.For_shell.Copy (source, target)) )
+      ; ( "symlink"
+        , binary (fun source target -> Engine_action.For_shell.Symlink (source, target)) )
+      ; ( "hardlink"
+        , binary (fun source target -> Engine_action.For_shell.Hardlink (source, target))
+        )
+      ; "system", unary (fun command -> Engine_action.For_shell.System command)
+      ; ( "bash"
+        , unary (fun script ->
+            Engine_action.For_shell.Bash { script; can_run_in_action_runner = false }) )
+      ; ( "write-file"
+        , binary (fun target contents ->
+            Engine_action.For_shell.Write_file (target, Normal, contents)) )
+      ; ( "write-file-executable"
+        , binary (fun target contents ->
+            Engine_action.For_shell.Write_file (target, Executable, contents)) )
+      ; ( "rename"
+        , binary (fun source target -> Engine_action.For_shell.Rename (source, target)) )
+      ; "remove-tree", unary (fun path -> Engine_action.For_shell.Remove_tree path)
+      ; "mkdir", unary (fun path -> Engine_action.For_shell.Mkdir path)
+      ; ( "pipe-stdout"
+        , sequence (fun actions -> Engine_action.For_shell.Pipe (Stdout, actions)) )
+      ; ( "pipe-stderr"
+        , sequence (fun actions -> Engine_action.For_shell.Pipe (Stderr, actions)) )
+      ; ( "pipe-outputs"
+        , sequence (fun actions -> Engine_action.For_shell.Pipe (Outputs, actions)) )
+      ; "diff", diff ~optional:false ~mode:Text ~directory_diffs:true
+      ; "diff?", diff ~optional:true ~mode:Text ~directory_diffs:true
+      ; "diff-no-directory", diff ~optional:false ~mode:Text ~directory_diffs:false
+      ; "diff-no-directory?", diff ~optional:true ~mode:Text ~directory_diffs:false
+      ; "cmp", diff ~optional:false ~mode:Binary ~directory_diffs:false
+      ; ( "ext"
+        , let+ (_ : string) = string in
+          User_error.raise
+            [ Pp.text "Edited extension actions cannot be replayed."
+            ; Pp.text
+                "Restore action.sexp and edit the underlying dune file instead; action \
+                 extensions do not provide an inverse decoder."
+            ] )
+      ]
+  ;;
+end

--- a/src/dune_rules/action_for_shell.mli
+++ b/src/dune_rules/action_for_shell.mli
@@ -1,0 +1,8 @@
+open Import
+
+val encode_for_rules : Action.For_shell.t Dune_lang.Encoder.t
+
+module Replay : sig
+  val encode : Action.For_shell.t Dune_lang.Encoder.t
+  val decode : Action.For_shell.t Dune_lang.Decoder.t
+end

--- a/src/dune_rules/dune_rules.ml
+++ b/src/dune_rules/dune_rules.ml
@@ -1,5 +1,6 @@
 module Alias_builder = Alias_builder
 module Action_builder = Action_builder
+module Action_for_shell = Action_for_shell
 module Alias = Alias0
 module Findlib = Findlib
 module Main = Main

--- a/test/blackbox-tests/test-cases/dune-shell/cli.t
+++ b/test/blackbox-tests/test-cases/dune-shell/cli.t
@@ -1,0 +1,178 @@
+`dune shell TARGET -- COMMAND...` is the non-interactive form.  Aliases,
+dynamic actions, and action extensions do not yet have a faithful
+single-rule session, so the first version rejects them explicitly instead of
+silently approximating them.
+
+  $ make_dune_project_with_extension 3.23 action-plugin 0.1
+
+  $ cat > dune <<'EOF'
+  > (env
+  >  (_
+  >   (env-vars (DUNE_SANDBOX none))))
+  > 
+  > (rule
+  >  (target ordinary)
+  >  (action (write-file %{target} ordinary)))
+  > 
+  > (rule
+  >  (targets configured configured-cwd)
+  >  (action
+  >   (progn
+  >    (with-stdout-to configured (echo %{profile}))
+  >    (with-stdout-to configured-cwd (run pwd)))))
+  > 
+  > (rule
+  >  (alias grouped)
+  >  (action (echo alias-action)))
+  > 
+  > (rule
+  >  (target dynamic)
+  >  (action
+  >   (progn
+  >    (dynamic-run dune_cmd exit-code 0)
+  >    (write-file %{target} dynamic))))
+  > 
+  > (rule
+  >  (target universe)
+  >  (deps (universe))
+  >  (action (write-file %{target} universe)))
+  > 
+  > (rule
+  >  (targets concurrent-a concurrent-b)
+  >  (action
+  >   (concurrent
+  >    (write-file concurrent-a a)
+  >    (write-file concurrent-b b))))
+  > 
+  > (rule
+  >  (target extension)
+  >  (action
+  >   (progn
+  >    (echo before-extension)
+  >    (format-dune-file dune extension))))
+  > EOF
+
+The command after [--] runs in the prepared environment.
+
+  $ dune shell _build/default/ordinary -- sh -c 'echo command-ran' 2>/dev/null
+  command-ran
+
+The live build preserves the configuration that selected the rule, including
+a non-default profile and build directory.  The shell and replayed action use
+the same exact mapped working directory.  Disabling dune's global lock for the
+runner does not matter because [dune-run] executes only the prepared action; it
+does not start another build system.
+
+  $ ROOT=$PWD dune shell --profile release --build-dir _custom --sandbox=copy \
+  >   _custom/default/configured -- sh -c '
+  > case "$PWD" in
+  >   "$ROOT"/_custom/.sandbox/*/default)
+  >     echo "configured-directory: exact" ;;
+  >   *) echo "configured-directory: unexpected: $PWD" ;;
+  > esac
+  > rm -f configured
+  > DUNE_CONFIG__GLOBAL_LOCK=disabled "$DUNE_SHELL/dune-run"
+  > printf "configured-profile: "; cat configured; echo
+  > if [ "$(cat configured-cwd)" = "$PWD" ]; then
+  >   echo "replay-directory: exact"
+  > else
+  >   echo "replay-directory: unexpected: $(cat configured-cwd)"
+  > fi
+  > '
+  configured-directory: exact
+  configured-profile: release
+  replay-directory: exact
+
+The initiating build system and its canonical sandbox operation stay live for
+the session; the ordinary build-directory lock is acquired like any other
+build command.
+Action runners change process placement and isolation.  Until a session can
+reproduce that configuration without breaking debugger ancestry, it is
+rejected explicitly.
+
+  $ if dune shell --sandbox=copy --sandbox-actions \
+  >      _build/default/ordinary -- true \
+  >      >sandbox-actions.stdout 2>sandbox-actions.stderr; then
+  >   echo "sandbox-actions: unexpectedly accepted"
+  > else
+  >   echo "sandbox-actions: rejected"
+  > fi
+  sandbox-actions: rejected
+  $ grep -Eqi 'external action runners' sandbox-actions.stderr &&
+  >   echo "sandbox-actions-error: specific"
+  sandbox-actions-error: specific
+
+An alias can contain several actions and therefore needs a selection
+mechanism before it can be supported.
+
+  $ if dune shell @grouped -- true >alias.stdout 2>alias.stderr; then
+  >   echo "alias: unexpectedly accepted"
+  > else
+  >   echo "alias: rejected"
+  > fi
+  alias: rejected
+  $ grep -qi 'Aliases select multiple actions' alias.stderr &&
+  >   echo "alias-error: specific"
+  alias-error: specific
+
+A dynamic action discovers dependencies while it runs, which is incompatible
+with preparing a complete session in advance.
+
+  $ if dune shell _build/default/dynamic -- true \
+  >      >dynamic.stdout 2>dynamic.stderr; then
+  >   echo "dynamic: unexpectedly accepted"
+  > else
+  >   echo "dynamic: rejected"
+  > fi
+  dynamic: rejected
+  $ grep -qi 'dynamic actions' dynamic.stderr &&
+  >   echo "dynamic-error: specific"
+  dynamic-error: specific
+
+A universe dependency contributes no concrete paths to the prepared
+environment, exactly as it does to a real build's sandbox, so the session can
+be prepared and the action replayed.
+
+  $ dune shell _build/default/universe -- sh -c '
+  > "$DUNE_SHELL/dune-run"
+  > printf "universe-target: "; cat universe
+  > '
+  universe-target: universe
+Concurrent groups replay with ordinary build semantics; when branches fail,
+the first failing branch's raw status is returned.
+
+  $ dune shell _build/default/concurrent-a -- sh -c '
+  > "$DUNE_SHELL/dune-run"
+  > printf "concurrent-a: "; cat concurrent-a; echo
+  > printf "concurrent-b: "; cat concurrent-b; echo
+  > '
+  concurrent-a: a
+  concurrent-b: b
+Static action extensions do not yet expose the raw-status and side-effect
+contract required by replay.  Nested extensions are rejected rather than
+silently using ordinary build semantics.
+
+  $ if dune shell _build/default/extension -- true \
+  >      >extension.stdout 2>extension.stderr; then
+  >   echo "extension: unexpectedly accepted"
+  > else
+  >   echo "extension: rejected"
+  > fi
+  extension: rejected
+  $ grep -qi 'action extension' extension.stderr &&
+  >   echo "extension-error: specific"
+  extension-error: specific
+
+Watch mode restarts the build between runs, which is incompatible with a
+long-lived prepared session, so it is rejected explicitly.
+
+  $ if dune shell -w _build/default/ordinary -- true \
+  >      >watch.stdout 2>watch.stderr; then
+  >   echo "watch: unexpectedly accepted"
+  > else
+  >   echo "watch: rejected"
+  > fi
+  watch: rejected
+  $ grep -qi 'watch mode' watch.stderr &&
+  >   echo "watch-error: specific"
+  watch-error: specific

--- a/test/blackbox-tests/test-cases/dune-shell/diff-replay.t
+++ b/test/blackbox-tests/test-cases/dune-shell/diff-replay.t
@@ -1,0 +1,52 @@
+Replay preserves diff behavior without applying Dune's post-action promotion
+effects.
+
+  $ make_dune_project 3.23
+
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (target corrected)
+  >  (action
+  >   (progn
+  >    (write-file corrected actual)
+  >    (diff expected corrected))))
+  > EOF
+  $ echo expected > expected
+
+Replay of a diff neither changes its source input nor registers a pending
+promotion.
+
+  $ dune shell --sandbox=copy _build/default/corrected -- sh -c '
+  > if "$DUNE_SHELL/dune-run" >diff.stdout 2>diff.stderr; then
+  >   echo "diff-replay: unexpectedly succeeded"
+  > else
+  >   echo "diff-replay: failed"
+  > fi
+  > test -s diff.stderr && echo "diff-output: shown"
+  > '
+  diff-replay: failed
+  diff-output: shown
+  $ printf "diff-source: "; cat expected
+  diff-source: expected
+  $ if test -n "$(dune promotion list)"; then
+  >   echo "diff-promotion: registered"
+  > else
+  >   echo "diff-promotion: absent"
+  > fi
+  diff-promotion: absent
+
+Replay retains the initiating invocation's configured diff command.
+
+  $ export DIFF_MARKER=$PWD/custom-diff-ran
+  $ cat > custom-diff <<'EOF'
+  > #!/bin/sh
+  > : > "$DIFF_MARKER"
+  > exit 1
+  > EOF
+  $ chmod +x custom-diff
+  $ dune shell --diff-command "$PWD/custom-diff" --sandbox=copy \
+  >   _build/default/corrected -- sh -c '
+  > "$DUNE_SHELL/dune-run" >/dev/null 2>&1 || :
+  > '
+  $ test -e custom-diff-ran && echo "diff-command: preserved"
+  diff-command: preserved

--- a/test/blackbox-tests/test-cases/dune-shell/directory-target.t
+++ b/test/blackbox-tests/test-cases/dune-shell/directory-target.t
@@ -1,0 +1,19 @@
+Directory targets and action [chdir] paths are recreated after replay clears
+the target.
+
+  $ make_dune_project_with_extension 3.23 directory-targets 0.1
+
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (targets (dir output-dir))
+  >  (action
+  >   (progn
+  >    (run mkdir -p output-dir)
+  >    (chdir output-dir (run sh -c "echo directory-target > value")))))
+  > EOF
+
+  $ dune shell --sandbox=copy _build/default/output-dir -- sh -c '
+  > "$DUNE_SHELL/dune-run"
+  > printf "directory-target: "; cat output-dir/value
+  > '
+  directory-target: directory-target

--- a/test/blackbox-tests/test-cases/dune-shell/edit-action.t
+++ b/test/blackbox-tests/test-cases/dune-shell/edit-action.t
@@ -1,0 +1,72 @@
+The expanded action is exposed as an editable file: editing
+[$DUNE_SHELL/action.sexp] changes what [run] replays, without rebuilding
+dependencies or re-resolving programs.
+
+  $ make_dune_project 3.23
+
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (target local-tool)
+  >  (deps local-tool-source)
+  >  (action (copy local-tool-source local-tool)))
+  > 
+  > (rule
+  >  (target local-tool-output)
+  >  (deps local-tool)
+  >  (action
+  >   (setenv LEADING_ACTION_ENV visible
+  >    (with-stdout-to %{target} (run ./local-tool)))))
+  > 
+  > (rule
+  >  (target repaired-tool-output)
+  >  (deps local-tool)
+  >  (action
+  >   (with-stdout-to %{target} (run not-in-prepared-path))))
+  > EOF
+
+  $ cat > local-tool-source <<'EOF'
+  > #!/bin/sh
+  > printf 'same-directory-tool:%s\n' "${LEADING_ACTION_ENV-unset}"
+  > EOF
+  $ chmod +x local-tool-source
+
+Removing the leading [setenv] wrapper from the editable action also removes
+that variable from replay; the shell's entry environment is not reused as the
+action's base environment.
+
+  $ dune shell --sandbox=copy _build/default/local-tool-output -- sh -c '
+  > printf "%s\n" "(with-stdout-to local-tool-output (run ./local-tool))" \
+  >   >"$DUNE_SHELL/action.sexp"
+  > "$DUNE_SHELL/dune-run"
+  > printf "edited-leading-env: "; cat local-tool-output
+  > '
+  edited-leading-env: same-directory-tool:unset
+
+An unresolved prepared program remains unresolved in metadata rather than
+being searched again. Editing that explicit form into the already prepared
+local executable then makes replay succeed.
+
+  $ dune shell --sandbox=copy _build/default/repaired-tool-output -- sh -c '
+  > grep -q "unresolved-program.*not-in-prepared-path" \
+  >   "$DUNE_SHELL/action.sexp" && echo "unresolved-program: preserved"
+  > sed -i.bak "s/(unresolved-program [^ ]* not-in-prepared-path)/.\/local-tool/" \
+  >   "$DUNE_SHELL/action.sexp"
+  > "$DUNE_SHELL/dune-run"
+  > printf "repaired-program-output: "; cat repaired-tool-output
+  > '
+  unresolved-program: preserved
+  repaired-program-output: same-directory-tool:unset
+
+An edited concurrent group replays with ordinary build semantics: both
+branches run, and a failing branch's raw status is returned without a Dune
+process diagnostic.
+
+  $ dune shell --sandbox=copy _build/default/local-tool-output -- sh -c '
+  > printf "%s\n" "(concurrent (run /bin/sh -c \"exit 2\") (echo done))" \
+  >   >"$DUNE_SHELL/action.sexp"
+  > "$DUNE_SHELL/dune-run" >concurrent.stdout 2>concurrent.stderr
+  > echo "edited-concurrent-status: $?"
+  > test ! -s concurrent.stderr && echo "edited-concurrent-error: silent"
+  > '
+  edited-concurrent-status: 2
+  edited-concurrent-error: silent

--- a/test/blackbox-tests/test-cases/dune-shell/entry-boundary.t
+++ b/test/blackbox-tests/test-cases/dune-shell/entry-boundary.t
@@ -1,0 +1,53 @@
+`dune shell` drives the ordinary live build to the selected rule's action
+boundary: dependencies are built and the declared targets are removed, but
+the selected action itself is not executed.
+
+  $ make_dune_project 3.23
+
+  $ mkdir sub
+  $ cat > sub/dune <<'EOF'
+  > (rule
+  >  (target prepared-input)
+  >  (deps source.txt)
+  >  (action (copy source.txt prepared-input)))
+  > 
+  > (rule
+  >  (targets out action-cwd)
+  >  (deps prepared-input)
+  >  (action
+  >   (progn
+  >    (with-stdout-to out (cat prepared-input))
+  >    (with-stdout-to action-cwd (run pwd))
+  >    (run sh -c ": > \"$DUNE_SHELL_ENTRY_BEACON\""))))
+  > EOF
+
+  $ echo initial > sub/source.txt
+  $ export DUNE_SHELL_ENTRY_BEACON=$PWD/selected-action-ran
+  $ dune build --sandbox=copy _build/default/sub/out
+  $ rm selected-action-ran
+
+Even when the selected target and all of its prerequisites are current, entry
+must still reach its action boundary, remove its old targets, and stop before
+executing the selected action.
+
+  $ dune shell --sandbox=copy _build/default/sub/out -- sh -c '
+  > test ! -e out && test ! -e action-cwd && echo "current-target: suspended"
+  > test ! -e "$DUNE_SHELL_ENTRY_BEACON" && echo "current-side-effect: suspended"
+  > printf "current-dependency: "; cat prepared-input
+  > '
+  current-target: suspended
+  current-side-effect: suspended
+  current-dependency: initial
+
+Now change an input of the generated prerequisite. Entry must rebuild that
+prerequisite and again stop at the selected action boundary.
+
+  $ echo refreshed > sub/source.txt
+  $ dune shell --sandbox=copy _build/default/sub/out -- sh -c '
+  > test ! -e out && test ! -e action-cwd && echo "refreshed-target: suspended"
+  > test ! -e "$DUNE_SHELL_ENTRY_BEACON" && echo "refreshed-side-effect: suspended"
+  > printf "refreshed-dependency: "; cat prepared-input
+  > '
+  refreshed-target: suspended
+  refreshed-side-effect: suspended
+  refreshed-dependency: refreshed

--- a/test/blackbox-tests/test-cases/dune-shell/executable-link.t
+++ b/test/blackbox-tests/test-cases/dune-shell/executable-link.t
@@ -1,0 +1,64 @@
+Replay uses Dune's action interpreter, not a shell rendering of the action.
+Linking an executable exercises a real internal rule with arguments and paths
+that cannot usefully be reconstructed by the test.
+
+  $ make_dune_project 3.23
+
+  $ cat > dune <<'EOF'
+  > (executable
+  >  (name main))
+  > EOF
+
+  $ cat > main.ml <<'EOF'
+  > let () = print_endline "linked by replay"
+  > EOF
+
+An internal compilation target lives below its object directory, but its
+prepared action runs from the context's source directory.  The shell follows
+the action's outer mapped [chdir], not the target directory.
+
+  $ dune shell --sandbox=copy \
+  >   _build/default/.main.eobjs/byte/dune__exe__Main.cmo -- sh -c 'printf "compiler-cwd: "; echo "$PWD"' | censor
+  compiler-cwd: $PWD/_build/.sandbox/$DIGEST/default
+
+The target is absent at the intercepted action boundary. Its prerequisites
+have already been built and materialized in the canonical action sandbox.
+Changing the source after entry therefore does not cause replay to run another
+build: the already-prepared link action still succeeds, and can be run again.
+
+  $ ROOT=$PWD dune shell --sandbox=copy _build/default/main.exe -- sh -c '
+  > printf "cwd: "; echo "$PWD"
+  > printf "%s\n" "$PWD" > "$ROOT/execution-path"
+  > test ! -e main.exe && echo "before: absent"
+  > printf "this is not valid OCaml\n" > "$ROOT/main.ml"
+  > "$DUNE_SHELL/dune-run"
+  > test -x main.exe && echo "first: executable"
+  > ./main.exe
+  > "$DUNE_SHELL/dune-run"
+  > test -x main.exe && echo "second: executable"
+  > ./main.exe
+  > ' | censor
+  cwd: $PWD/_build/.sandbox/$DIGEST/default
+  before: absent
+  first: executable
+  linked by replay
+  second: executable
+  linked by replay
+
+The ordinary [Sandbox.with_] lifetime ends with the shell child. The canonical
+sandbox is removed, and replay output is not extracted into the real build
+directory.
+
+  $ if test -e "$(cat execution-path)"; then
+  >   echo "sandbox-after-shell: present"
+  > else
+  >   echo "sandbox-after-shell: removed"
+  > fi
+  sandbox-after-shell: removed
+
+  $ if test -e _build/default/main.exe; then
+  >   echo "build target: present"
+  > else
+  >   echo "build target: absent"
+  > fi
+  build target: absent

--- a/test/blackbox-tests/test-cases/dune-shell/interactive-shell.t
+++ b/test/blackbox-tests/test-cases/dune-shell/interactive-shell.t
@@ -1,0 +1,124 @@
+With no command after the target, `dune shell` opens bash in the prepared
+environment.  Piping a script into its stdin keeps this path deterministic in
+a cram test.
+
+  $ make_dune_project 3.23
+
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (target prepared-input)
+  >  (deps input)
+  >  (action (with-stdout-to %{target} (cat input))))
+  > 
+  > (rule
+  >  (target out)
+  >  (deps prepared-input)
+  >  (action (with-stdout-to %{target} (cat prepared-input))))
+  > EOF
+
+  $ echo data > input
+
+The piped script runs inside the session shell.  A real interactive session
+loads the helper commands from its --rcfile automatically; a non-interactive
+bash driven by a pipe does not read the rcfile, so the script sources the same
+$DUNE_SHELL/init.bash itself.  It checks the exact mapped rule directory and
+the state at the intercepted action boundary, confirms the helper commands are
+available, and replays the action with [run].  Changing the source after entry
+must not start another build system: replay executes only the action against
+the dependencies already in the sandbox.
+
+  $ export ROOT=$PWD
+  $ dune shell --sandbox=copy _build/default/out <<'EOF' | censor
+  > . "$DUNE_SHELL/init.bash" >/dev/null 2>&1
+  > printf "cwd: "; echo "$PWD"
+  > test ! -e out && echo "target-on-entry: absent"
+  > printf "declared: "; cat prepared-input
+  > type run show_action help >/dev/null 2>&1 && echo "helpers: sourced"
+  > if test "$(type -P run)" = "$DUNE_SHELL/run"; then
+  >   echo "run-executable: on PATH"
+  > else
+  >   echo "run-executable: missing"
+  > fi
+  > show_action | grep -q with-stdout-to && echo "show_action: works"
+  > help | grep -qi 'not an isolation boundary' && echo "help-notes: shown"
+  > help | grep -qi 'sandbox mode copy' && echo "help-mode: shown"
+  > test -n "${TMPDIR:-${TEMP:-}}" && echo "tmpdir: set"
+  > printf 'changed after entry\n' > "$PWD/input"
+  > env run
+  > printf "replay: "; cat out
+  > printf "%s\n" "$PWD" > "$ROOT/execution-path"
+  > EOF
+  cwd: $PWD/_build/.sandbox/$DIGEST/default
+  target-on-entry: absent
+  declared: data
+  helpers: sourced
+  run-executable: on PATH
+  show_action: works
+  help-notes: shown
+  help-mode: shown
+  tmpdir: set
+  replay: data
+
+The live build owns the ordinary [Sandbox.with_] scope. Once the shell exits,
+that scope destroys the sandbox, and replay has not extracted its target into
+the real build directory.
+
+  $ test ! -e "$(cat execution-path)" && echo "sandbox-after-shell: removed"
+  sandbox-after-shell: removed
+  $ if test -e _build/default/out; then
+  >   echo "build-target-after-shell: present"
+  > else
+  >   echo "build-target-after-shell: absent"
+  > fi
+  build-target-after-shell: absent
+
+On systems with util-linux [script], exercise a real interactive shell through
+a pseudo-terminal.  The shell gives each foreground job control of the
+terminal, so Ctrl+C and Ctrl-\ stop those jobs without reaching the live Dune
+process.  Dune's progress line must also stay out of the shell session.
+
+  $ pty_status=0
+  $ if script --version 2>&1 | grep -q util-linux; then
+  >   export SHELL="$(command -v bash)"
+  >   export PTY_ECHO_OFF=$PWD/pty-echo-off
+  >   export PTY_INT_READY=$PWD/pty-int-ready
+  >   export PTY_INT_SURVIVED=$PWD/pty-int-survived
+  >   export PTY_QUIT_READY=$PWD/pty-quit-ready
+  >   export PTY_QUIT_SURVIVED=$PWD/pty-quit-survived
+  >   export PTY_SANDBOX=$PWD/pty-sandbox
+  >   {
+  >     printf '%s\n' 'stty -echo; : > "$PTY_ECHO_OFF"'
+  >     with_timeout dune_cmd wait-for-file-to-appear "$PTY_ECHO_OFF"
+  >     printf '%s\n' 'PS1=; PS2=; printf "__ENTERED__\n"'
+  >     printf '%s\n' 'printf "%s\n" "$PWD" > "$PTY_SANDBOX"'
+  >     printf '%s\n' 'sh -c ": > \"$PTY_INT_READY\"; exec sleep 30"'
+  >     with_timeout dune_cmd wait-for-file-to-appear "$PTY_INT_READY"
+  >     printf '\003'
+  >     printf '%s\n' ': > "$PTY_INT_SURVIVED"'
+  >     printf '%s\n' 'sh -c ": > \"$PTY_QUIT_READY\"; exec sleep 30"'
+  >     with_timeout dune_cmd wait-for-file-to-appear "$PTY_QUIT_READY"
+  >     printf '\034'
+  >     printf '%s\n' ': > "$PTY_QUIT_SURVIVED"'
+  >     printf '%s\n' 'printf "__LEAVING__\n"; exit'
+  >   } | with_timeout script -q -e -f -c \
+  >       'dune shell --display=progress --sandbox=copy _build/default/out' \
+  >       /dev/null >pty.transcript 2>&1
+  >   command_status=$?
+  >   tr -d '\r' <pty.transcript |
+  >     sed -n '/__ENTERED__/,/__LEAVING__/p' >pty-session
+  >   if test "$command_status" -eq 0 &&
+  >      test -e "$PTY_INT_SURVIVED" &&
+  >      test -e "$PTY_QUIT_SURVIVED" &&
+  >      test -s "$PTY_SANDBOX" &&
+  >      test ! -e "$(cat "$PTY_SANDBOX")" &&
+  >      grep -q 'session commands' pty.transcript &&
+  >      ! grep -q 'Done:' pty-session; then
+  >     :
+  >   else
+  >     pty_status=1
+  >     cat pty.transcript >&2
+  >   fi
+  > fi
+  > echo "pty-job-control: checked when supported"
+  > test "$pty_status" -eq 0
+  pty-job-control: checked when supported

--- a/test/blackbox-tests/test-cases/dune-shell/patch-back.t
+++ b/test/blackbox-tests/test-cases/dune-shell/patch-back.t
@@ -1,0 +1,24 @@
+Patch-back-source-tree rules intentionally propagate action writes to the
+source tree.  Exact replay would therefore perform implicit source updates,
+whose policy is deferred, so dune shell rejects them with a specific
+explanation.
+
+  $ make_dune_project 3.23
+
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (target out)
+  >  (deps (sandbox patch_back_source_tree))
+  >  (action (with-stdout-to %{target} (echo out))))
+  > EOF
+
+  $ if dune shell _build/default/out -- true \
+  >      >shell.stdout 2>shell.stderr; then
+  >   echo "patch-back: unexpectedly accepted"
+  > else
+  >   echo "patch-back: rejected"
+  > fi
+  patch-back: rejected
+  $ grep -qi 'patch-back-source-tree' shell.stderr &&
+  >   echo "patch-back-error: specific"
+  patch-back-error: specific

--- a/test/blackbox-tests/test-cases/dune-shell/process-metadata.t
+++ b/test/blackbox-tests/test-cases/dune-shell/process-metadata.t
@@ -1,0 +1,69 @@
+Direct process metadata preserves prepared executables, arguments,
+environments, and unresolved programs for inspection and debugging.
+
+  $ make_dune_project 3.23
+
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (target local-tool)
+  >  (deps local-tool-source)
+  >  (action (copy local-tool-source local-tool)))
+  > 
+  > (rule
+  >  (target local-tool-output)
+  >  (deps local-tool)
+  >  (action
+  >   (setenv LEADING_ACTION_ENV visible
+  >    (with-stdout-to %{target} (run ./local-tool)))))
+  > 
+  > (rule
+  >  (target bash-output)
+  >  (action (bash "echo bash-replay > bash-output")))
+  > EOF
+
+  $ cat > local-tool-source <<'EOF'
+  > #!/bin/sh
+  > printf 'same-directory-tool:%s\n' "${LEADING_ACTION_ENV-unset}"
+  > EOF
+  $ chmod +x local-tool-source
+
+A resolved executable in the action directory retains its [./] path instead
+of being searched through PATH. Leading action [setenv] modifiers are also
+part of the shell's prepared environment and of the recorded command
+environment.
+
+  $ dune shell --sandbox=copy _build/default/local-tool-output -- sh -c '
+  > printf "leading-action-env: %s\n" "$LEADING_ACTION_ENV"
+  > grep -q "(run ./local-tool)" "$DUNE_SHELL/action.sexp" &&
+  >   echo "local-program: exact path"
+  > test "$(cat "$DUNE_SHELL/command.cwd")" = "$PWD" &&
+  >   test -f "$DUNE_SHELL/command.argv.csexp" &&
+  >   test -f "$DUNE_SHELL/command.env.csexp" &&
+  >   grep -q "local-tool" "$DUNE_SHELL/command" &&
+  >   grep -q "^LEADING_ACTION_ENV=visible$" "$DUNE_SHELL/command.env" &&
+  >   echo "direct-process-metadata: exact"
+  > "$DUNE_SHELL/dune-run"
+  > printf "local-program-output: "; cat local-tool-output
+  > '
+  leading-action-env: visible
+  local-program: exact path
+  direct-process-metadata: exact
+  local-program-output: same-directory-tool:visible
+
+A [(bash ...)] action is also a literal single-process invocation. Its exact
+shell executable, arguments, cwd, and environment are exposed alongside a
+[(run ...)] action's metadata.
+
+  $ dune shell --sandbox=copy _build/default/bash-output -- sh -c '
+  > test -f "$DUNE_SHELL/command" &&
+  >   test -f "$DUNE_SHELL/command.argv.csexp" &&
+  >   test -f "$DUNE_SHELL/command.cwd" &&
+  >   test -f "$DUNE_SHELL/command.env.csexp" &&
+  >   grep -q "bash" "$DUNE_SHELL/command" &&
+  >   grep -q "pipefail" "$DUNE_SHELL/command.argv.csexp" &&
+  >   echo "bash-process-metadata: exact"
+  > "$DUNE_SHELL/dune-run"
+  > printf "bash-output: "; cat bash-output
+  > '
+  bash-process-metadata: exact
+  bash-output: bash-replay

--- a/test/blackbox-tests/test-cases/dune-shell/replay-environment.t
+++ b/test/blackbox-tests/test-cases/dune-shell/replay-environment.t
@@ -1,0 +1,66 @@
+The shell and replay share Dune's prepared action environment while keeping
+shell-control variables out of the replayed action.
+
+  $ make_dune_project 3.23
+
+  $ cat > dune <<'EOF'
+  > (env
+  >  (_
+  >   (env-vars (DUNE_SHELL_TEST_ENV prepared))))
+  > 
+  > (rule
+  >  (target action-env)
+  >  (action
+  >   (with-stdout-to %{target}
+  >    (run sh -c
+  >     "if test -n \"${DUNE_SHELL+x}\"; then
+  >        echo present
+  >      else
+  >        echo absent
+  >      fi"))))
+  > 
+  > (rule
+  >  (target prepared-env)
+  >  (action
+  >   (with-stdout-to %{target}
+  >    (run sh -c "printf '%s\\n' \"$DUNE_SHELL_TEST_ENV\""))))
+  > 
+  > (rule
+  >  (target prepared-temp)
+  >  (action
+  >   (setenv TMPDIR action-overridden-temp
+  >    (with-stdout-to %{target} (run sh -c "printf '%s\\n' \"$TMPDIR\"")))))
+  > EOF
+
+Shell-control variables are present for debugging but absent from the action;
+ordinary action-environment layers are present in both.
+
+  $ dune shell --sandbox=copy _build/default/action-env -- sh -c '
+  > test -n "$DUNE_SHELL" && echo "debug-command: DUNE_SHELL is set"
+  > "$DUNE_SHELL/dune-run"
+  > printf "action: DUNE_SHELL is "; cat action-env
+  > '
+  debug-command: DUNE_SHELL is set
+  action: DUNE_SHELL is absent
+
+  $ dune shell --sandbox=copy _build/default/prepared-env -- sh -c '
+  > printf "debug-command: %s\n" "$DUNE_SHELL_TEST_ENV"
+  > "$DUNE_SHELL/dune-run"
+  > printf "replayed-action: "; cat prepared-env
+  > '
+  debug-command: prepared
+  replayed-action: prepared
+
+Dune's execution-time temporary directory injection takes precedence over an
+action-level [setenv TMPDIR], just as it does for an ordinary action process.
+The shell and replay use that same initiating-build directory.
+
+  $ dune shell --sandbox=copy _build/default/prepared-temp -- sh -c '
+  > prepared_temp=$TMPDIR
+  > test -n "$TMPDIR" &&
+  >   test "$TMPDIR" != action-overridden-temp && echo "shell-temp: exact"
+  > "$DUNE_SHELL/dune-run"
+  > test "$(cat prepared-temp)" = "$prepared_temp" && echo "replay-temp: exact"
+  > '
+  shell-temp: exact
+  replay-temp: exact

--- a/test/blackbox-tests/test-cases/dune-shell/replay-status.t
+++ b/test/blackbox-tests/test-cases/dune-shell/replay-status.t
@@ -1,0 +1,71 @@
+Replay preserves raw process output and shell-compatible failure statuses.
+
+  $ make_dune_project 3.23
+
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (target raw)
+  >  (action
+  >   (run sh -c "echo raw-stdout; echo raw-stderr >&2; exit 9")))
+  > 
+  > (rule
+  >  (target signaled)
+  >  (action (run sh -c "kill -TERM $$")))
+  > 
+  > (rule
+  >  (target accepted-signaled)
+  >  (action
+  >   (with-accepted-exit-codes 143
+  >    (run sh -c "kill -TERM $$"))))
+  > 
+  > (rule
+  >  (target exit-seven)
+  >  (action (write-file %{target} seven)))
+  > EOF
+
+Replay returns raw stdout, stderr, and non-zero status.
+
+  $ dune shell --sandbox=copy _build/default/raw -- sh -c '
+  > "$DUNE_SHELL/dune-run" >replay.stdout 2>replay.stderr
+  > status=$?
+  > echo "status: $status"
+  > printf "stdout: "; cat replay.stdout
+  > printf "stderr: "; cat replay.stderr
+  > '
+  status: 9
+  stdout: raw-stdout
+  stderr: raw-stderr
+
+Signal termination is returned as the shell-compatible status without a Dune
+process diagnostic. A numeric accepted-exit predicate does not accidentally
+accept a signal.
+
+  $ for target in signaled accepted-signaled; do
+  >   dune shell --sandbox=copy _build/default/$target -- sh -c '
+  >     "$DUNE_SHELL/dune-run" >signal.stdout 2>signal.stderr
+  >     echo "status: $?"
+  >     test ! -s signal.stderr && echo "stderr: empty"
+  >   '
+  > done
+  status: 143
+  stderr: empty
+  status: 143
+  stderr: empty
+
+Command mode propagates the command's own exit status directly, without a
+wrapped Dune process error, and still cleans up the sandbox and metadata.
+
+  $ export ROOT=$PWD
+  $ dune shell --sandbox=copy _build/default/exit-seven -- sh -c '
+  > printf "%s\n" "$PWD" > "$ROOT/nonzero-sandbox"
+  > printf "%s\n" "$DUNE_SHELL" > "$ROOT/nonzero-metadata"
+  > exit 7
+  > ' \
+  >   >exit.stdout 2>exit.stderr
+  [7]
+  $ grep '^Error:' exit.stderr || echo "no wrapped error"
+  no wrapped error
+  $ test ! -e "$(cat nonzero-sandbox)" && echo "nonzero-sandbox: cleaned"
+  nonzero-sandbox: cleaned
+  $ test ! -e "$(cat nonzero-metadata)" && echo "nonzero-metadata: cleaned"
+  nonzero-metadata: cleaned

--- a/test/blackbox-tests/test-cases/dune-shell/sandbox-modes.t
+++ b/test/blackbox-tests/test-cases/dune-shell/sandbox-modes.t
@@ -1,0 +1,42 @@
+Explicit sandbox selections retain their normal filesystem semantics.
+
+  $ make_dune_project 3.23
+
+  $ mkdir sub
+  $ cat > sub/dune <<'EOF'
+  > (rule
+  >  (target prepared-input)
+  >  (deps source.txt)
+  >  (action (copy source.txt prepared-input)))
+  > 
+  > (rule
+  >  (target out)
+  >  (deps prepared-input)
+  >  (action (with-stdout-to out (cat prepared-input))))
+  > EOF
+  $ echo prepared > sub/source.txt
+
+Explicit symlink and hardlink selections use the canonical digest path and
+give dependencies the selected link semantics.
+
+  $ for mode in symlink hardlink; do
+  >   dune shell --sandbox="$mode" _build/default/sub/out -- sh -c '
+  >     selected=$(cat "$DUNE_SHELL/sandbox-mode")
+  >     echo "$selected"
+  >     printf "canonical-path: "; echo "$PWD"
+  >     case "$selected" in
+  >       symlink)
+  >         test -L prepared-input && echo "symlink-semantics: linked" ;;
+  >       hardlink)
+  >         links=$(dune_cmd stat hardlinks prepared-input)
+  >         test "$links" -gt 1 && echo "hardlink-semantics: shared" ;;
+  >     esac
+  >   ' | censor >"$mode.stdout"
+  >   printf "%s-mode: " "$mode"; cat "$mode.stdout"
+  > done
+  symlink-mode: symlink
+  canonical-path: $PWD/_build/.sandbox/$DIGEST/default/sub
+  symlink-semantics: linked
+  hardlink-mode: hardlink
+  canonical-path: $PWD/_build/.sandbox/$DIGEST/default/sub
+  hardlink-semantics: shared

--- a/test/blackbox-tests/test-cases/dune-shell/sandbox-none.t
+++ b/test/blackbox-tests/test-cases/dune-shell/sandbox-none.t
@@ -1,0 +1,87 @@
+For an ordinary rule with no command-line sandbox override, dune selects
+[none]. The action's actual execution location is the real build directory.
+The shell uses that location and warns that writes affect the build directly.
+
+  $ make_dune_project 3.2
+
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (target prepared-input)
+  >  (deps source-input)
+  >  (action (with-stdout-to %{target} (cat source-input))))
+  > 
+  > (rule
+  >  (target no-sandbox)
+  >  (deps prepared-input)
+  >  (action (with-stdout-to %{target} (cat prepared-input))))
+  > 
+  > (rule
+  >  (target unrelated)
+  >  (action (with-stdout-to %{target} (echo visible-in-real-build))))
+  > EOF
+
+  $ echo prepared > source-input
+  $ dune build _build/default/unrelated _build/default/no-sandbox
+
+The shell starts in the real build directory, with the declared target
+cleared and the other build artifacts visible.
+
+  $ ROOT=$PWD dune shell _build/default/no-sandbox -- sh -c '
+  > case "$PWD" in
+  >   "$ROOT"/_build/default) echo "directory: real build" ;;
+  >   *) echo "directory: unexpected: $PWD" ;;
+  > esac
+  > test ! -e no-sandbox && echo "declared-target-on-entry: cleared"
+  > printf "undeclared-build-target: "; cat unrelated; echo
+  > printf "prepared-dependency: "; cat prepared-input
+  > printf "changed after entry\n" > "$ROOT/source-input"
+  > "$DUNE_SHELL/dune-run"
+  > printf "target: "; cat no-sandbox
+  > '
+  directory: real build
+  declared-target-on-entry: cleared
+  undeclared-build-target: visible-in-real-build
+  prepared-dependency: prepared
+  target: prepared
+
+Replay under [none] writes directly into the configured build directory. The
+target therefore remains there after the live shell action returns; there is
+no sandbox root to extract or destroy. The changed source was not rebuilt by
+replay.
+
+  $ printf "target-after-shell: "; cat _build/default/no-sandbox
+  target-after-shell: prepared
+  $ printf "prepared-dependency-after-shell: "; cat _build/default/prepared-input
+  prepared-dependency-after-shell: prepared
+
+An interactive session under [none] warns in its help screen that this is the
+real build directory and that commands write there directly.
+
+  $ dune shell _build/default/no-sandbox <<'EOF' 2>/dev/null
+  > . "$DUNE_SHELL/init.bash" >/dev/null 2>&1
+  > help | grep -qi 'sandbox mode none' && echo "help-mode: none"
+  > help | grep -qi 'real _build' && echo "help-mode: warns real build"
+  > EOF
+  help-mode: none
+  help-mode: warns real build
+
+A source-copy rule reads directly from the source tree.  Its prepared path
+must round-trip through the editable action even though replay starts in the
+real build directory.
+
+  $ echo direct-source > direct-source
+  $ export TEST_SHELL="$(command -v sh)"
+  $ export TEST_CAT="$(command -v cat)"
+  $ dune shell _build/default/direct-source -- "$TEST_SHELL" -c '
+  > if test "$PWD" = "$1/_build/default"; then
+  >   echo "source-copy-cwd: exact"
+  > else
+  >   echo "source-copy-cwd: unexpected: $PWD"
+  > fi
+  > "$DUNE_SHELL/dune-run"
+  > printf "source-copy-replay: "; "$0" direct-source
+  > ' "$TEST_CAT" "$PWD"
+  source-copy-cwd: exact
+  source-copy-replay: direct-source
+  $ printf "source-copy-after-shell: "; cat _build/default/direct-source
+  source-copy-after-shell: direct-source

--- a/test/blackbox-tests/test-cases/dune-shell/session-lifecycle.t
+++ b/test/blackbox-tests/test-cases/dune-shell/session-lifecycle.t
@@ -1,0 +1,104 @@
+During a session the initiating build stays alive: its global lock, the
+rule's action locks, and the canonical digest sandbox are owned by the live
+build until the shell exits. Replay runs in that sandbox against the prepared
+snapshot, and everything is cleaned up afterwards.
+
+  $ make_dune_project 3.23
+
+  $ mkdir sub
+  $ cat > sub/dune <<'EOF'
+  > (env
+  >  (_
+  >   (env-vars (DUNE_SHELL_TEST_ENV prepared))))
+  > 
+  > (rule
+  >  (target prepared-input)
+  >  (deps source.txt)
+  >  (action (copy source.txt prepared-input)))
+  > 
+  > (rule
+  >  (targets out action-cwd)
+  >  (deps prepared-input)
+  >  (action
+  >   (progn
+  >    (with-stdout-to out (cat prepared-input))
+  >    (with-stdout-to action-cwd (run pwd))
+  >    (run sh -c ": > \"$DUNE_SHELL_ENTRY_BEACON\""))))
+  > EOF
+
+  $ echo initial > sub/source.txt
+  $ export DUNE_SHELL_ENTRY_BEACON=$PWD/selected-action-ran
+  $ dune build --sandbox=copy _build/default/sub/out
+  $ rm selected-action-ran
+  $ export ROOT=$PWD
+  $ DUNE_BINARY=$(command -v dune)
+  $ export DUNE_BINARY
+  $ dune shell --sandbox=copy _build/default/sub/out -- sh -c '
+  > printf "canonical-cwd: "; echo "$PWD"
+  > if test "$(cat "$ROOT/_build/.lock")" = "$PPID"; then
+  >   echo "live-build-lock: held"
+  > else
+  >   echo "live-build-lock: unexpected"
+  > fi
+  > if "$DUNE_BINARY" build --root "$ROOT" _build/default/sub/prepared-input \
+  >      >"$ROOT/second-dune.stdout" 2>"$ROOT/second-dune.stderr"; then
+  >   echo "advisory-lock: unexpectedly available"
+  > else
+  >   echo "advisory-lock: held"
+  > fi
+  > test -x "$DUNE_SHELL/dune-run" &&
+  >   test -f "$DUNE_SHELL/action.sexp" && echo "session-tools: ready"
+  > test ! -e "$DUNE_SHELL_ENTRY_BEACON" && echo "selected-action: suspended"
+  > printf "prepared-dependency: "; cat prepared-input
+  > printf "prepared-env: %s\n" "$DUNE_SHELL_TEST_ENV"
+  > "$DUNE_SHELL/dune-run"
+  > printf "first-replay: "; cat out
+  > test "$(cat action-cwd)" = "$PWD" && echo "replay-cwd: exact"
+  > echo post-entry > "$ROOT/sub/source.txt"
+  > "$DUNE_SHELL/dune-run"
+  > printf "snapshot-replay: "; cat out
+  > sed -i.bak "s/(cat prepared-input)/(echo edited-action)/" \
+  >   "$DUNE_SHELL/action.sexp"
+  > "$DUNE_SHELL/dune-run"
+  > printf "edited-replay: "; cat out; echo
+  > printf "%s\n" "(with-stdout-to edited-cwd (bash \"pwd\"))" \
+  >   >"$DUNE_SHELL/action.sexp"
+  > "$DUNE_SHELL/dune-run"
+  > test "$(cat edited-cwd)" = "$PWD" && echo "edited-wrapper-cwd: exact"
+  > printf "%s\n" "$PWD" > "$ROOT/session-sandbox"
+  > printf "%s\n" "$DUNE_SHELL" > "$ROOT/session-metadata"
+  > ' 2>shell-entry.stderr | censor
+  canonical-cwd: $PWD/_build/.sandbox/$DIGEST/default/sub
+  live-build-lock: held
+  advisory-lock: held
+  session-tools: ready
+  selected-action: suspended
+  prepared-dependency: initial
+  prepared-env: prepared
+  first-replay: initial
+  replay-cwd: exact
+  snapshot-replay: initial
+  edited-replay: edited-action
+  edited-wrapper-cwd: exact
+
+Dune prints nothing at startup. In command mode the output belongs entirely to
+the user's command; the per-topic session detail lives behind the sourced
+helper commands and the metadata files.
+
+  $ test ! -s shell-entry.stderr && echo "command-startup: silent"
+  command-startup: silent
+
+Returning from the command ends the live [Sandbox.with_] scope: the canonical
+sandbox and the disposable session metadata are removed, replay output is not
+extracted into the real build directory, and the build-directory lock is
+released.
+
+  $ test ! -e _build/default/sub/out && echo "build-target: absent"
+  build-target: absent
+  $ test ! -e "$(cat session-sandbox)" && echo "sandbox-cleanup: complete"
+  sandbox-cleanup: complete
+  $ test ! -e "$(cat session-metadata)" && echo "metadata-cleanup: complete"
+  metadata-cleanup: complete
+  $ dune build _build/default/sub/prepared-input
+  $ echo "live-build-lock-after-exit: released"
+  live-build-lock-after-exit: released


### PR DESCRIPTION
## Intro

Suppose I was interested in the linking step for the dune binary:

```console
[ali:~/dune]$ ./dune.exe shell %{bin:dune}
dune shell session commands:              
  run            replay the prepared action
  show_action    print or edit the expanded action ($DUNE_SHELL/action.sexp)
  show_command   print the exact direct program, args, and env
  help           show this message

sandbox mode none: this is the real _build directory; commands and run write there directly.
This is not an isolation boundary; commands can modify your source tree.
run clears the action's declared targets and replays only the action; it does not rebuild dependencies or pick up 
edits made after entry.

[ali:~/dune/_build/default]$ time run

real    0m0.860s
user    0m0.597s
sys     0m0.254s
```

If the rule was sandboxed, the interactive shell starts there:

```console
[ali:~/dune]$ ./dune.exe shell --sandbox=symlink %{bin:dune}
dune shell session commands:              
  run            replay the prepared action
  show_action    print or edit the expanded action ($DUNE_SHELL/action.sexp)
  show_command   print the exact direct program, args, and env
  help           show this message

sandbox mode symlink: dependencies may point at shared build artifacts.
This is not an isolation boundary; commands can modify your source tree.
run clears the action's declared targets and replays only the action; it does not rebuild dependencies or pick up 
edits made after entry.

[ali:~/dune/_build/.sandbox/6af6aec5e6e5addeea316f9bdb9540af/default]$ 
```

Here `run` is a shell script wrapping a way for dune to run the action of the rule to check its performance etc.

## Summary

- add `dune shell TARGET` to open an interactive shell or run a command at a prepared rule action boundary
- preserve the selected sandbox, execution directory, environment, live build, and locks for the session
- expose the expanded action as an editable file with `run` and `dune-run` replay helpers
- preserve raw process statuses and direct-process metadata for debugging tools
- reject action shapes and execution modes whose session semantics are not yet faithful

## Testing

- `./dune.exe build @check @fmt`
- `./dune.exe runtest test/blackbox-tests/test-cases/dune-shell`

Closes #3961