### PR TITLE
test(exec): add regression test for #15602

### DIFF
--- a/test/blackbox-tests/test-cases/exec/dune
+++ b/test/blackbox-tests/test-cases/exec/dune
@@ -1,0 +1,4 @@
+(cram
+ (applies_to exec-source-file-gh15602)
+ (enabled_if
+  (= %{system} linux)))

--- a/test/blackbox-tests/test-cases/exec/exec-source-file-gh15602.t
+++ b/test/blackbox-tests/test-cases/exec/exec-source-file-gh15602.t
@@ -1,0 +1,26 @@
+Regression test for GH-15602: `dune exec` used to hang when asked to execute a
+source file.
+
+  $ make_dune_project 3.24
+
+  $ mkdir bin
+  $ cat >bin/dune <<'EOF'
+  > (executable
+  >  (name main))
+  > EOF
+
+  $ cat >bin/main.ml <<'EOF'
+  > let () = print_endline "Hello, World!"
+  > EOF
+
+The executable runs normally:
+
+  $ dune exec -- ./bin/main.exe
+  Hello, World!
+
+Trying to execute the source file exits with an error. The timeout guards
+against the command hanging:
+
+  $ $timeout 2 dune exec ./bin/main.ml
+  Error: execve(./_build/default/bin/main.ml): Permission denied
+  [1]


### PR DESCRIPTION
## Description

Add a Linux-only regression test for the dune exec source-file hang reported in #15602. It times out on 3.24.1 and passes on main.

## Related Issue and Motivation

Relates to #15602 and the fix in #15286.

## Checklist

- [x] Tests added, if applicable.
- [ ] Change log entry added for any user-facing changes.
- [ ] Documentation added for any user-facing changes.