### PR TITLE
feat(pkg): support opam repository archive mirrors

### DIFF
--- a/doc/changes/added/15615.md
+++ b/doc/changes/added/15615.md
@@ -1,0 +1,3 @@
+- Support opam repository `archive-mirrors` in Dune package management,
+  storing them in lock directories and trying checksum-addressed mirrors before
+  package source URLs. (#15615, fixes #13130, @Alizter)

--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -164,11 +164,55 @@ let check_checksum checksum path =
   | None -> Ok ()
 ;;
 
-let with_download url checksum ~target ~f =
-  let url = OpamUrl.to_string url in
+let archive_mirror_url archive_mirror checksum =
+  OpamHash.to_path (Checksum.to_opam_hash checksum)
+  |> List.fold_left ~init:archive_mirror ~f:(fun url component ->
+    OpamUrl.append url component)
+;;
+
+let%test_module "archive mirror paths" =
+  (module struct
+    let check kind length character =
+      let digest = String.make length character in
+      let checksum = Checksum.of_string (sprintf "%s=%s" kind digest) in
+      let archive_mirror = OpamUrl.of_string "https://example.com/cache" in
+      let actual = archive_mirror_url archive_mirror checksum in
+      let expected =
+        sprintf "https://example.com/cache/%s/%c%c/%s" kind character character digest
+      in
+      String.equal (OpamUrl.to_string actual) expected
+    ;;
+
+    let%test "md5" = check "md5" 32 'a'
+    let%test "sha256" = check "sha256" 64 'b'
+    let%test "sha512" = check "sha512" 128 'c'
+  end)
+;;
+
+let download_to url ~temp_dir ~output =
+  match (url : OpamUrl.t).backend with
+  | `http -> Curl.run ~temp_dir ~url:(OpamUrl.to_string url) ~output
+  | `rsync when OpamUrl.is_local url ->
+    let source = Path.of_string_allow_outside_workspace url.path in
+    Fiber.return
+    @@
+      (match Io.copy_file ~src:source ~dst:output () with
+      | () -> Ok ()
+      | exception exn ->
+        Error
+          (User_message.make
+             [ Pp.textf "Unable to read archive mirror %s." (OpamUrl.to_string url)
+             ; Exn.pp exn
+             ]))
+  | `rsync | `git | `hg | `darcs ->
+    Code_error.raise "download_to: unsupported URL backend" [ "url", OpamUrl.to_dyn url ]
+;;
+
+let with_download primary_url archive_mirrors checksum ~target ~f =
+  let primary_url_string = OpamUrl.to_string primary_url in
   let temp_dir =
     let prefix = "dune" in
-    let suffix = Filename.basename url in
+    let suffix = Filename.basename primary_url_string in
     Temp_dir.dir_for_target ~target ~prefix ~suffix
   in
   let output = Path.relative temp_dir "download" in
@@ -176,17 +220,54 @@ let with_download url checksum ~target ~f =
     Temp.destroy Dir temp_dir;
     Fiber.return ())
   @@ fun () ->
-  Curl.run ~temp_dir ~url ~output
-  >>= function
-  | Error message -> Fiber.return @@ Error (Unavailable (Some message))
-  | Ok () ->
-    (match check_checksum checksum output with
-     | Ok () -> f output
-     | Error _ as e -> Fiber.return e)
+  let archive_mirrors =
+    match checksum with
+    | None -> []
+    | Some checksum ->
+      (* Unsupported mirrors are dropped with a warning when repository
+         metadata is read; this is a silent safety net for hand-edited
+         lock directories. *)
+      List.filter archive_mirrors ~f:OpamUrl.is_supported_archive_mirror
+      |> List.map ~f:(fun archive_mirror -> archive_mirror_url archive_mirror checksum)
+  in
+  let downloads =
+    List.map archive_mirrors ~f:(fun url -> `Mirror, url) @ [ `Primary, primary_url ]
+  in
+  let rec loop = function
+    | [] -> Code_error.raise "with_download: primary URL is missing" []
+    | (kind, download_url) :: downloads ->
+      download_to download_url ~temp_dir ~output
+      >>= (function
+       | Error message ->
+         (match kind with
+          | `Mirror -> loop downloads
+          | `Primary -> Fiber.return @@ Error (Unavailable (Some message)))
+       | Ok () ->
+         (match check_checksum checksum output with
+          | Ok () -> f output
+          | Error (Checksum_mismatch actual_checksum) as error ->
+            (match kind with
+             | `Primary -> Fiber.return error
+             | `Mirror ->
+               User_warning.emit
+                 [ Pp.textf
+                     "Ignoring archive from mirror %s because its checksum does not \
+                      match."
+                     (OpamUrl.to_string download_url)
+                 ; Pp.text "Expected checksum:"
+                 ; Checksum.pp (Option.value_exn checksum)
+                 ; Pp.text "Actual checksum:"
+                 ; Checksum.pp actual_checksum
+                 ];
+               loop downloads)
+          | Error (Unavailable _) ->
+            Code_error.raise "check_checksum returned Unavailable" []))
+  in
+  loop downloads
 ;;
 
-let fetch_curl ~unpack:unpack_flag ~checksum ~target (url : OpamUrl.t) =
-  with_download url checksum ~target ~f:(fun output ->
+let fetch_curl ~unpack:unpack_flag ~checksum ~archive_mirrors ~target (url : OpamUrl.t) =
+  with_download url archive_mirrors checksum ~target ~f:(fun output ->
     match unpack_flag with
     | false ->
       Unix.rename (Path.to_string output) (Path.to_string target);
@@ -359,7 +440,7 @@ let resolve_symlinks_in root =
     ()
 ;;
 
-let fetch ~unpack ~checksum ~target ~url:(url_loc, url) =
+let fetch ~unpack ~checksum ~archive_mirrors ~target ~url:(url_loc, url) =
   let event =
     Dune_trace.(
       Out.start (global ()) (fun () ->
@@ -382,8 +463,10 @@ let fetch ~unpack ~checksum ~target ~url:(url_loc, url) =
          | `git ->
            let* rev_store = Rev_store.get in
            fetch_git rev_store ~target ~url:(url_loc, url)
-         | `http -> fetch_curl ~unpack ~checksum ~target url
+         | `http -> fetch_curl ~unpack ~checksum ~archive_mirrors ~target url
          | `rsync ->
+           (* Local sources are already on disk, so archive mirrors are
+              never worth consulting for them. *)
            if not unpack
            then
              Code_error.raise
@@ -402,7 +485,7 @@ let fetch ~unpack ~checksum ~target ~url:(url_loc, url) =
 ;;
 
 let fetch_without_checksum ~unpack ~target ~url =
-  fetch ~unpack ~checksum:None ~url ~target
+  fetch ~unpack ~checksum:None ~archive_mirrors:[] ~url ~target
   >>| function
   | Ok () -> Ok ()
   | Error (Checksum_mismatch _) -> assert false

--- a/src/dune_pkg/fetch.mli
+++ b/src/dune_pkg/fetch.mli
@@ -4,8 +4,11 @@ type failure =
   | Checksum_mismatch of Checksum.t
   | Unavailable of User_message.t option
 
-(** [fetch ~checksum ~target url] will fetch [url] into [target]. It will verify
-    the downloaded file against [checksum], unless it [checksum] is [None].
+(** [fetch ~checksum ~archive_mirrors ~target url] will fetch [url] into
+    [target]. When [checksum] is present, checksum-addressed objects under
+    [archive_mirrors] are tried before [url]. Local (file) URLs are read
+    directly and never consult mirrors. Every downloaded file is verified
+    against [checksum], unless [checksum] is [None].
 
     return [Error (Checksum_mismatch _)] When the downloaded file doesn't match
     the expected [checksum], this will pass the actually computed checksum.
@@ -15,6 +18,7 @@ type failure =
 val fetch
   :  unpack:bool
   -> checksum:Checksum.t option
+  -> archive_mirrors:OpamUrl.t list
   -> target:Path.t
   -> url:Loc.t * OpamUrl.t
   -> (unit, failure) result Fiber.t

--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -455,6 +455,7 @@ let opam_package_to_lock_file_pkg
   in
   let opam_file = Resolved_package.opam_file resolved_package in
   let loc = Resolved_package.loc resolved_package in
+  let archive_mirrors = Resolved_package.archive_mirrors resolved_package in
   let extra_sources =
     OpamFile.OPAM.extra_sources opam_file
     |> List.map ~f:(fun (opam_basename, opam_url) ->
@@ -465,7 +466,7 @@ let opam_package_to_lock_file_pkg
           | [] -> None
           | checksum :: _ -> Some (Loc.none, Checksum.of_opam_hash checksum)
         in
-        { Source.url; checksum } ))
+        { Source.url; checksum; archive_mirrors } ))
   in
   let info =
     let url = OpamFile.OPAM.url opam_file in
@@ -478,7 +479,7 @@ let opam_package_to_lock_file_pkg
           |> Option.map ~f:(fun hash -> Loc.none, Checksum.of_opam_hash hash)
         in
         let url = Loc.none, OpamFile.URL.url url in
-        { Source.url; checksum })
+        { Source.url; checksum; archive_mirrors })
     in
     let dev =
       pinned

--- a/src/dune_pkg/opamUrl0.ml
+++ b/src/dune_pkg/opamUrl0.ml
@@ -13,6 +13,16 @@ let is_version_control t =
 
 let is_local t = String.equal t.transport "file"
 let is_supported_archive t = Option.is_some (Archive_driver.choose_for_filename t.path)
+let append t component = OpamUrl.Op.(t / component)
+
+(* Archive mirrors are checksum-addressed directories that dune reads
+   directly, so only URLs it can download bytes from qualify. *)
+let is_supported_archive_mirror t =
+  match t.backend with
+  | `http -> true
+  | `rsync -> is_local t
+  | `git | `hg | `darcs -> false
+;;
 
 let classify url loc =
   match (url : t).backend with
@@ -28,6 +38,14 @@ let classify url loc =
 ;;
 
 include Comparable.Make (Dune_lang.Url)
+
+let dedup_preserving_order urls =
+  let _, result =
+    List.fold_left urls ~init:(Set.empty, []) ~f:(fun (seen, result) url ->
+      if Set.mem seen url then seen, result else Set.add seen url, url :: result)
+  in
+  List.rev result
+;;
 
 let remote t ~loc rev_store = Rev_store.remote rev_store ~loc ~url:(OpamUrl.base_url t)
 

--- a/src/dune_pkg/opamUrl0.mli
+++ b/src/dune_pkg/opamUrl0.mli
@@ -2,6 +2,8 @@ open Stdune
 
 type t = OpamUrl.t
 
+exception Parse_error of string
+
 val equal : t -> t -> bool
 val hash : t -> int
 val to_string : t -> string
@@ -10,6 +12,15 @@ val of_string : string -> t
 val decode_loc : (Stdune.Loc.t * t) Dune_sexp.Decoder.t
 val rev : t -> string option
 val base_url : t -> string
+val append : t -> string -> t
+
+(** Removes duplicate URLs, keeping the first occurrence of each. *)
+val dedup_preserving_order : t list -> t list
+
+(** Whether dune can download archives from this URL: http, or a local
+    file path. *)
+val is_supported_archive_mirror : t -> bool
+
 val is_version_control : t -> bool
 
 (** [is_file t] is true iff [t] is a url beginning with "file://" *)

--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -3,6 +3,7 @@ open Fiber.O
 
 module Paths = struct
   let packages = Path.Local.of_string "packages"
+  let repo = Path.Local.of_string "repo"
 
   let package_root package_name =
     OpamPackage.Name.to_string package_name |> Path.Local.relative packages
@@ -17,6 +18,83 @@ module Paths = struct
   let files_dir package = Path.Local.relative (package_dir package) "files"
   let opam_file package = Path.Local.relative (package_dir package) "opam"
 end
+
+let has_url_scheme url =
+  match String.index url ':' with
+  | None -> false
+  | Some colon ->
+    colon + 2 < String.length url
+    && Char.equal url.[colon + 1] '/'
+    && Char.equal url.[colon + 2] '/'
+;;
+
+let repository_url_for_relative_mirrors (url : OpamUrl.t) =
+  let backend =
+    match url.transport with
+    | "http" | "https" -> `http
+    | "file" -> `rsync
+    | _ -> url.backend
+  in
+  { url with backend; hash = None }
+;;
+
+let archive_mirrors_of_repo_file ~loc ~repository_url contents =
+  match OpamFile.Repo.read_from_string contents with
+  | exception
+      ((OpamPp.Bad_format _ | OpamPp.Bad_format_list _ | OpamPp.Bad_version _) as exn) ->
+    User_warning.emit
+      ~loc
+      [ Pp.text "Ignoring archive mirrors from invalid opam repository metadata."
+      ; Pp.text (OpamPp.string_of_bad_format exn)
+      ];
+    []
+  | repo ->
+    OpamFile.Repo.dl_cache repo
+    |> List.filter_map ~f:(fun archive_mirror ->
+      if has_url_scheme archive_mirror
+      then (
+        match OpamUrl.of_string archive_mirror with
+        | archive_mirror -> Some archive_mirror
+        | exception OpamUrl.Parse_error message ->
+          User_warning.emit
+            ~loc
+            [ Pp.textf "Ignoring invalid opam archive mirror %S." archive_mirror
+            ; Pp.text message
+            ];
+          None)
+      else (
+        (* Relative mirrors resolve against the repository URL. A git URL
+           addresses a remote, not a directory dune can read from, so such
+           entries are skipped. The upstream opam repository declares a
+           relative "cache" aimed at opam's HTTP mirror; warning here would
+           fire on every solve. *)
+        match (repository_url : OpamUrl.t).backend with
+        | `git -> None
+        | `http | `rsync | `hg | `darcs ->
+          Some
+            (OpamUrl.append
+               (repository_url_for_relative_mirrors repository_url)
+               archive_mirror)))
+    |> List.filter ~f:(fun archive_mirror ->
+      let supported = OpamUrl.is_supported_archive_mirror archive_mirror in
+      if not supported
+      then
+        User_warning.emit
+          ~loc
+          [ Pp.textf
+              "Ignoring unsupported opam archive mirror %s."
+              (OpamUrl.to_string archive_mirror)
+          ];
+      supported)
+    |> OpamUrl.dedup_preserving_order
+;;
+
+let archive_mirrors_from_directory ~loc ~repository_url dir =
+  let repo_file = Path.append_local dir Paths.repo in
+  match Io.read_file repo_file with
+  | contents -> archive_mirrors_of_repo_file ~loc ~repository_url contents
+  | exception Unix.Unix_error (ENOENT, _, _) -> []
+;;
 
 module Serializable = struct
   type t = string
@@ -45,25 +123,33 @@ type t =
   { source : Source_backend.t
   ; loc : Loc.t
   ; serializable : Serializable.t option
+  ; archive_mirrors : OpamUrl.t list
   }
 
-let to_dyn { source; loc; serializable } =
+let to_dyn { source; loc; serializable; archive_mirrors } =
   Dyn.record
     [ "source", Source_backend.to_dyn source
     ; "loc", Loc.to_dyn loc
     ; "serializable", Dyn.option Serializable.to_dyn serializable
+    ; "archive_mirrors", Dyn.list OpamUrl.to_dyn archive_mirrors
     ]
 ;;
 
-let equal { source; serializable; loc } t =
+let equal { source; serializable; loc; archive_mirrors } t =
   Source_backend.equal source t.source
   && Option.equal Serializable.equal serializable t.serializable
   && Loc.equal loc t.loc
+  && List.equal OpamUrl.equal archive_mirrors t.archive_mirrors
 ;;
 
 let serializable { serializable; _ } = serializable
+let archive_mirrors { archive_mirrors; _ } = archive_mirrors
 
-let of_opam_repo_dir_path loc opam_repo_dir_path =
+let of_opam_repo_dir_path_with_archive_mirrors
+      loc
+      opam_repo_dir_path
+      initial_archive_mirrors
+  =
   (match Path.stat opam_repo_dir_path with
    | Error (Unix.ENOENT, _, _) ->
      User_error.raise
@@ -98,11 +184,30 @@ let of_opam_repo_dir_path loc opam_repo_dir_path =
      User_error.raise
        ~loc
        [ Pp.textf "could not read %s" (Path.to_string_maybe_quoted opam_repo_dir_path) ]);
-  { source = Directory opam_repo_dir_path; serializable = None; loc }
+  let repository_url : OpamUrl.t =
+    { transport = "file"
+    ; path = Path.to_string opam_repo_dir_path
+    ; hash = None
+    ; backend = `rsync
+    }
+  in
+  let archive_mirrors =
+    archive_mirrors_from_directory ~loc ~repository_url opam_repo_dir_path
+  in
+  { source = Directory opam_repo_dir_path
+  ; serializable = None
+  ; loc
+  ; archive_mirrors =
+      OpamUrl.dedup_preserving_order (initial_archive_mirrors @ archive_mirrors)
+  }
 ;;
 
-let of_git_repo loc url =
-  let+ at_rev =
+let of_opam_repo_dir_path loc opam_repo_dir_path =
+  of_opam_repo_dir_path_with_archive_mirrors loc opam_repo_dir_path []
+;;
+
+let of_git_repo_with_archive_mirrors loc url initial_archive_mirrors =
+  let* at_rev =
     let* rev_store = Rev_store.get in
     OpamUrl.resolve url ~loc rev_store
     >>= (function
@@ -110,6 +215,7 @@ let of_git_repo loc url =
      | Ok s -> OpamUrl.fetch_revision url ~loc s rev_store)
     >>| User_error.ok_exn
   in
+  let+ repo_file = Rev_store.At_rev.content at_rev Paths.repo in
   let serializable =
     Some
       (sprintf
@@ -119,8 +225,20 @@ let of_git_repo loc url =
        |> OpamUrl.of_string
        |> OpamUrl.to_string)
   in
-  { source = Repo at_rev; serializable; loc }
+  let archive_mirrors =
+    match repo_file with
+    | None -> []
+    | Some contents -> archive_mirrors_of_repo_file ~loc ~repository_url:url contents
+  in
+  { source = Repo at_rev
+  ; serializable
+  ; loc
+  ; archive_mirrors =
+      OpamUrl.dedup_preserving_order (initial_archive_mirrors @ archive_mirrors)
+  }
 ;;
+
+let of_git_repo loc url = of_git_repo_with_archive_mirrors loc url []
 
 let resolve_repositories ~available_repos ~repositories =
   repositories
@@ -135,9 +253,12 @@ let resolve_repositories ~available_repos ~repositories =
         ]
     | Some repo ->
       let loc, opam_url = Workspace.Repository.opam_url repo in
+      let archive_mirrors = Workspace.Repository.archive_mirrors repo in
       (match OpamUrl.classify opam_url loc with
-       | `Git -> of_git_repo loc opam_url
-       | `Path path -> Fiber.return @@ of_opam_repo_dir_path loc path
+       | `Git -> of_git_repo_with_archive_mirrors loc opam_url archive_mirrors
+       | `Path path ->
+         Fiber.return
+         @@ of_opam_repo_dir_path_with_archive_mirrors loc path archive_mirrors
        | `Archive ->
          User_error.raise
            ~loc
@@ -160,7 +281,7 @@ let content_digest t =
   | Directory path -> Path_digest.digest_with_lstat path
 ;;
 
-let load_opam_package_from_dir ~(dir : Path.t) package =
+let load_opam_package_from_dir ~(dir : Path.t) ~archive_mirrors package =
   let opam_file_path = Path.append_local dir (Paths.opam_file package) in
   match Fpath.exists (Path.to_string opam_file_path) with
   | false -> None
@@ -170,18 +291,25 @@ let load_opam_package_from_dir ~(dir : Path.t) package =
       let loc = Loc.in_file opam_file_path in
       loc, Opam_file.opam_file_of_path opam_file_path
     in
-    Some (Resolved_package.local_fs package opam_file ~dir ~files_dir ~url:None)
+    Some
+      (Resolved_package.local_fs
+         package
+         opam_file
+         ~dir
+         ~files_dir
+         ~url:None
+         ~archive_mirrors)
 ;;
 
 let load_packages_from_git rev_store opam_packages =
   let+ contents =
-    List.map opam_packages ~f:(fun (file, _, _, _) -> file)
+    List.map opam_packages ~f:(fun (file, _, _, _, _) -> file)
     |> Rev_store.content_of_files rev_store
   in
   List.map2
     opam_packages
     contents
-    ~f:(fun (opam_file, package, rev, files_dir) contents ->
+    ~f:(fun (opam_file, package, rev, files_dir, archive_mirrors) contents ->
       let opam_file =
         let path = opam_file |> Rev_store.File.path |> Path.of_local in
         let loc = Loc.in_file path in
@@ -192,7 +320,8 @@ let load_packages_from_git rev_store opam_packages =
         opam_file
         rev
         ~files_dir:(Some files_dir)
-        ~url:None)
+        ~url:None
+        ~archive_mirrors)
 ;;
 
 let all_packages_in_dir_at_path ~dir ~path loc =
@@ -285,7 +414,8 @@ let load_all_versions_by_keys ts =
     OpamPackage.Version.Map.values ts
     |> List.partition_map ~f:(fun (repo, (pkg : Key.t)) ->
       match pkg with
-      | Git (file, pkg, rev, files_dir) -> Left (file, pkg, rev, files_dir)
+      | Git (file, pkg, rev, files_dir) ->
+        Left (file, pkg, rev, files_dir, repo.archive_mirrors)
       | Directory pkg -> Right (repo, pkg))
   in
   let from_dirs =
@@ -296,7 +426,7 @@ let load_all_versions_by_keys ts =
           "impossible because all elements in from_dirs are from a directory"
           []
       | Directory dir ->
-        load_opam_package_from_dir ~dir pkg
+        load_opam_package_from_dir ~dir ~archive_mirrors:repo.archive_mirrors pkg
         |> Option.map ~f:(fun resolved_package -> pkg, resolved_package))
   in
   let+ from_git =
@@ -305,7 +435,7 @@ let load_all_versions_by_keys ts =
     | packages ->
       let* rev_store = Rev_store.get in
       let+ resolved_packages = load_packages_from_git rev_store packages in
-      List.map2 resolved_packages packages ~f:(fun resolved_package (_, pkg, _, _) ->
+      List.map2 resolved_packages packages ~f:(fun resolved_package (_, pkg, _, _, _) ->
         pkg, resolved_package)
   in
   from_dirs @ from_git
@@ -334,6 +464,10 @@ let packages_in_repo repo =
 module Private = struct
   let create ~source:serializable =
     let packages_dir_path = Path.of_string "/" in
-    { source = Directory packages_dir_path; serializable; loc = Loc.none }
+    { source = Directory packages_dir_path
+    ; serializable
+    ; loc = Loc.none
+    ; archive_mirrors = []
+    }
   ;;
 end

--- a/src/dune_pkg/opam_repo.mli
+++ b/src/dune_pkg/opam_repo.mli
@@ -35,6 +35,7 @@ val resolve_repositories
 
 val revision : t -> Rev_store.At_rev.t
 val serializable : t -> Serializable.t option
+val archive_mirrors : t -> OpamUrl.t list
 
 (** [content_digest t] digests the contents of an opam repository. For a Git
     repository, this is a digest of the commit SHA. For a directory-based

--- a/src/dune_pkg/pinned_package.ml
+++ b/src/dune_pkg/pinned_package.ml
@@ -97,7 +97,13 @@ let resolve_package { Local_package.loc; url = loc_url, url; name; version; orig
       let loc = Loc.in_file path in
       loc, Opam_file.opam_file_of_path path
     in
-    Resolved_package.local_fs package opam_file ~dir ~files_dir ~url:(Some url)
+    Resolved_package.local_fs
+      package
+      opam_file
+      ~dir
+      ~files_dir
+      ~url:(Some url)
+      ~archive_mirrors:[]
     |> Fiber.return
   | Git rev ->
     let+ contents =
@@ -125,5 +131,11 @@ let resolve_package { Local_package.loc; url = loc_url, url; name; version; orig
       let loc = Loc.in_file path in
       loc, Opam_file.opam_file_of_string_exn ~contents path
     in
-    Resolved_package.git_repo package opam_file rev ~files_dir ~url:(Some url)
+    Resolved_package.git_repo
+      package
+      opam_file
+      rev
+      ~files_dir
+      ~url:(Some url)
+      ~archive_mirrors:[]
 ;;

--- a/src/dune_pkg/resolved_package.ml
+++ b/src/dune_pkg/resolved_package.ml
@@ -10,6 +10,7 @@ type rest =
   ; extra_files : extra_files
   ; loc : Loc.t
   ; dune_build : bool
+  ; archive_mirrors : OpamUrl.t list
   }
 
 type nonrec t =
@@ -51,7 +52,12 @@ let extra_files = function
   | Rest t -> Some t.extra_files
 ;;
 
-let git_repo package (loc, opam_file) rev ~files_dir ~url =
+let archive_mirrors = function
+  | Dune -> []
+  | Rest t -> t.archive_mirrors
+;;
+
+let git_repo package (loc, opam_file) rev ~files_dir ~url ~archive_mirrors =
   let opam_file = Opam_file.opam_file_with ~package ~url opam_file in
   Rest
     { dune_build = false
@@ -59,10 +65,11 @@ let git_repo package (loc, opam_file) rev ~files_dir ~url =
     ; package
     ; opam_file
     ; extra_files = Git_files (files_dir, rev)
+    ; archive_mirrors
     }
 ;;
 
-let local_fs package (loc, opam_file) ~dir ~files_dir ~url =
+let local_fs package (loc, opam_file) ~dir ~files_dir ~url ~archive_mirrors =
   let files_dir = Option.map files_dir ~f:(Path.append_local dir) in
   let opam_file = Opam_file.opam_file_with ~package ~url opam_file in
   Rest
@@ -71,6 +78,7 @@ let local_fs package (loc, opam_file) ~dir ~files_dir ~url =
     ; package
     ; extra_files = Inside_files_dir files_dir
     ; opam_file
+    ; archive_mirrors
     }
 ;;
 
@@ -109,7 +117,14 @@ let local_package ~command_source (loc, opam_file) opam_package =
   in
   let opam_file = Opam_file.opam_file_with ~package:opam_package ~url:None opam_file in
   let package = OpamFile.OPAM.package opam_file in
-  Rest { dune_build; opam_file; package; loc; extra_files = Inside_files_dir None }
+  Rest
+    { dune_build
+    ; opam_file
+    ; package
+    ; loc
+    ; extra_files = Inside_files_dir None
+    ; archive_mirrors = []
+    }
 ;;
 
 open Fiber.O
@@ -216,6 +231,10 @@ let digest res_pkg =
           ; "version", Atom (OpamPackage.version opam_pkg |> OpamPackage.Version.to_string)
           ] )
     ; "dune_build", Atom (dune_build res_pkg |> Bool.to_string)
+    ; ( "archive_mirrors"
+      , List
+          (archive_mirrors res_pkg
+           |> List.map ~f:(fun url -> Sexp.Atom (OpamUrl.to_string url))) )
     ; ( "extra_files"
       , Atom
           (extra_files res_pkg

--- a/src/dune_pkg/resolved_package.mli
+++ b/src/dune_pkg/resolved_package.mli
@@ -6,6 +6,7 @@ val package : t -> OpamPackage.t
 val opam_file : t -> OpamFile.OPAM.t
 val loc : t -> Loc.t
 val with_opam_file : OpamFile.OPAM.t -> t -> t
+val archive_mirrors : t -> OpamUrl.t list
 
 (** Determines whether the package is to be built using Dune or not *)
 val dune_build : t -> bool
@@ -23,6 +24,7 @@ val git_repo
   -> Rev_store.At_rev.t
   -> files_dir:Path.Local.t option
   -> url:OpamUrl.t option
+  -> archive_mirrors:OpamUrl.t list
   -> t
 
 (** Creates a resolved package from a source stored in the local file system. *)
@@ -32,6 +34,7 @@ val local_fs
   -> dir:Path.t
   -> files_dir:Path.Local.t option
   -> url:OpamUrl.t option
+  -> archive_mirrors:OpamUrl.t list
   -> t
 
 (** Creates a resolved package from a source stored in the workspace. *)

--- a/src/dune_pkg/source.ml
+++ b/src/dune_pkg/source.ml
@@ -3,17 +3,22 @@ open Import
 type t =
   { url : Loc.t * OpamUrl.t
   ; checksum : (Loc.t * Checksum.t) option
+  ; archive_mirrors : OpamUrl.t list
   }
 
-let remove_locs { url = _loc, url; checksum } =
+let remove_locs { url = _loc, url; checksum; archive_mirrors } =
   { url = Loc.none, url
   ; checksum = Option.map checksum ~f:(fun (_loc, checksum) -> Loc.none, checksum)
+  ; archive_mirrors
   }
 ;;
 
 let equal
-      { url = loc, url; checksum }
-      { url = other_loc, other_url; checksum = other_checksum }
+      { url = loc, url; checksum; archive_mirrors }
+      { url = other_loc, other_url
+      ; checksum = other_checksum
+      ; archive_mirrors = other_archive_mirrors
+      }
   =
   Loc.equal loc other_loc
   && OpamUrl.equal url other_url
@@ -22,13 +27,15 @@ let equal
           Loc.equal loc other_loc && Checksum.equal checksum other_checksum)
        checksum
        other_checksum
+  && List.equal OpamUrl.equal archive_mirrors other_archive_mirrors
 ;;
 
-let hash { url; checksum } =
-  Tuple.T2.hash
+let hash { url; checksum; archive_mirrors } =
+  Tuple.T3.hash
     (Tuple.T2.hash Loc.hash OpamUrl.hash)
     (Option.hash (Tuple.T2.hash Loc.hash Checksum.hash))
-    (url, checksum)
+    (List.hash OpamUrl.hash)
+    (url, checksum, archive_mirrors)
 ;;
 
 let fetch_archive_cached =
@@ -66,7 +73,7 @@ let fetch_and_hash_archive_cached (url_loc, url) =
 ;;
 
 let compute_missing_checksum
-      ({ url = url_loc, url; checksum } as fetch)
+      ({ url = url_loc, url; checksum; archive_mirrors = _ } as fetch)
       package_name
       ~pinned
   =
@@ -92,7 +99,7 @@ let compute_missing_checksum
            ]);
     fetch_and_hash_archive_cached (url_loc, url)
     >>| Option.map ~f:(fun checksum ->
-      { url = url_loc, url; checksum = Some (Loc.none, checksum) })
+      { fetch with checksum = Some (Loc.none, checksum) })
     >>| Option.value ~default:fetch
 ;;
 
@@ -101,12 +108,16 @@ module Fields = struct
   let fetch = "fetch"
   let url = "url"
   let checksum = "checksum"
+  let archive_mirrors = "archive_mirrors"
 end
 
 let decode_fetch =
   let open Decoder in
   let+ url_loc, url = field Fields.url OpamUrl.decode_loc
-  and+ checksum = field_o Fields.checksum (located string) in
+  and+ checksum = field_o Fields.checksum (located string)
+  and+ archive_mirrors =
+    field Fields.archive_mirrors ~default:[] (repeat (OpamUrl.decode_loc >>| snd))
+  in
   let checksum =
     match checksum with
     | None -> None
@@ -114,13 +125,13 @@ let decode_fetch =
       let checksum = Checksum.of_string_user_error checksum |> User_error.ok_exn in
       Some (loc, checksum)
   in
-  { url = url_loc, url; checksum }
+  { url = url_loc, url; checksum; archive_mirrors }
 ;;
 
 let external_copy (loc, path) =
   let path = Path.External.to_string path in
   let url : OpamUrl.t = { transport = "file"; path; hash = None; backend = `rsync } in
-  { url = loc, url; checksum = None }
+  { url = loc, url; checksum = None; archive_mirrors = [] }
 ;;
 
 let decode =
@@ -141,10 +152,11 @@ let decode =
     ]
 ;;
 
-let encode_fetch_field { url = _loc, url; checksum } =
+let encode_fetch_field { url = _loc, url; checksum; archive_mirrors } =
   let open Encoder in
   [ field Fields.url string (OpamUrl.to_string url)
   ; field_o Fields.checksum Checksum.encode (Option.map checksum ~f:snd)
+  ; field_l Fields.archive_mirrors string (List.map archive_mirrors ~f:OpamUrl.to_string)
   ]
 ;;
 
@@ -160,6 +172,7 @@ let repr =
     [ Repr.field "url" url_repr ~get:(fun t -> snd t.url)
     ; Repr.field "checksum" (Repr.option Checksum.repr) ~get:(fun t ->
         Option.map t.checksum ~f:snd)
+    ; Repr.field "archive_mirrors" (Repr.list url_repr) ~get:(fun t -> t.archive_mirrors)
     ]
 ;;
 

--- a/src/dune_pkg/source.mli
+++ b/src/dune_pkg/source.mli
@@ -3,6 +3,7 @@ open Import
 type t =
   { url : Loc.t * OpamUrl.t
   ; checksum : (Loc.t * Checksum.t) option
+  ; archive_mirrors : OpamUrl.t list
   }
 
 val equal : t -> t -> bool

--- a/src/dune_pkg/workspace.ml
+++ b/src/dune_pkg/workspace.ml
@@ -23,24 +23,35 @@ module Repository = struct
   type t =
     { name : Name.t
     ; url : Loc.t * OpamUrl.t
+    ; archive_mirrors : OpamUrl.t list
     }
 
   let name { name; _ } = name
 
-  let to_dyn { name; url = _, url } =
+  let to_dyn { name; url = _, url; archive_mirrors } =
     let open Dyn in
-    variant "repository" [ Name.to_dyn name; string (OpamUrl.to_string url) ]
+    variant
+      "repository"
+      [ Name.to_dyn name
+      ; string (OpamUrl.to_string url)
+      ; list (fun url -> string (OpamUrl.to_string url)) archive_mirrors
+      ]
   ;;
 
-  let equal { name; url } t =
-    Name.equal name t.name && Tuple.T2.equal Loc.equal OpamUrl.equal url t.url
+  let equal { name; url; archive_mirrors } t =
+    Name.equal name t.name
+    && Tuple.T2.equal Loc.equal OpamUrl.equal url t.url
+    && List.equal OpamUrl.equal archive_mirrors t.archive_mirrors
   ;;
 
-  let hash { name; url } = Tuple.T2.hash Name.hash Poly.hash (name, url)
+  let hash { name; url; archive_mirrors } =
+    Tuple.T3.hash Name.hash Poly.hash (List.hash OpamUrl.hash) (name, url, archive_mirrors)
+  ;;
 
   let upstream =
     { name = "upstream"
     ; url = Loc.none, OpamUrl.of_string "git+https://github.com/ocaml/opam-repository.git"
+    ; archive_mirrors = [ OpamUrl.of_string "https://opam.ocaml.org/cache" ]
     }
   ;;
 
@@ -48,6 +59,7 @@ module Repository = struct
     { name = "overlay"
     ; url =
         Loc.none, OpamUrl.of_string "git+https://github.com/ocaml-dune/opam-overlays.git"
+    ; archive_mirrors = []
     }
   ;;
 
@@ -58,6 +70,7 @@ module Repository = struct
         , OpamUrl.of_string
             "git+https://github.com/ocaml-dune/opam-repository-relocatable.git#relocatable"
         )
+    ; archive_mirrors = []
     }
   ;;
 
@@ -67,6 +80,7 @@ module Repository = struct
         ( Loc.none
         , OpamUrl.of_string "git+https://github.com/ocaml-dune/ocaml-binary-packages.git"
         )
+    ; archive_mirrors = []
     }
   ;;
 
@@ -75,10 +89,11 @@ module Repository = struct
     fields
       (let+ name = field "name" Name.decode
        and+ url = field "url" OpamUrl.decode_loc in
-       { name; url })
+       { name; url; archive_mirrors = [] })
   ;;
 
-  let opam_url { name = _; url } = url
+  let opam_url { url; _ } = url
+  let archive_mirrors { archive_mirrors; _ } = archive_mirrors
 end
 
 let dev_tool_path_to_source_dir path =

--- a/src/dune_pkg/workspace.mli
+++ b/src/dune_pkg/workspace.mli
@@ -4,6 +4,7 @@ module Repository : sig
   type t
 
   val opam_url : t -> Loc.t * OpamUrl.t
+  val archive_mirrors : t -> OpamUrl.t list
   val hash : t -> int
   val to_dyn : t -> Dyn.t
   val equal : t -> t -> bool

--- a/src/dune_rules/fetch_rules.ml
+++ b/src/dune_rules/fetch_rules.ml
@@ -70,6 +70,7 @@ module Spec = struct
     { target : 'target
     ; url : Loc.t * OpamUrl.t
     ; checksum : (Loc.t * Checksum.t) option
+    ; archive_mirrors : OpamUrl.t list
     ; kind : kind
     }
 
@@ -80,7 +81,12 @@ module Spec = struct
   let bimap t _ g = { t with target = g t.target }
   let is_useful_to ~memoize = memoize
 
-  let encode { target; url = _, url; checksum; kind } _ encode_target : Sexp.t =
+  (* [archive_mirrors] is deliberately not part of the digest: mirrors
+     never change the produced content. With a checksum the output is
+     content-addressed, and without one mirrors are not consulted. *)
+  let encode { target; url = _, url; checksum; archive_mirrors = _; kind } _ encode_target
+    : Sexp.t
+    =
     List
       ([ encode_target target
        ; Sexp.Atom (OpamUrl.to_string url)
@@ -98,7 +104,11 @@ module Spec = struct
        | Some (_, checksum) -> [ Atom (Checksum.to_string checksum) ])
   ;;
 
-  let action { target; url = loc_url, url; checksum; kind } ~ectx:_ ~eenv:_ =
+  let action
+        { target; url = loc_url, url; checksum; archive_mirrors; kind }
+        ~ectx:_
+        ~eenv:_
+    =
     let open Fiber.O in
     let* () = Fiber.return () in
     let target = Path.build target in
@@ -109,6 +119,7 @@ module Spec = struct
           | `File -> false
           | `Directory -> true)
        ~checksum
+       ~archive_mirrors
        ~target
        ~url:(loc_url, url))
     >>= function
@@ -134,7 +145,22 @@ end
 
 module A = Action_ext.Make (Spec)
 
-let action ~url ~checksum ~target ~kind = A.action { Spec.target; checksum; url; kind }
+let action ~url ~checksum ~archive_mirrors ~target ~kind =
+  A.action { Spec.target; checksum; archive_mirrors; url; kind }
+;;
+
+type checksum_source =
+  { url : Loc.t * OpamUrl.t
+  ; checksum : Loc.t * Checksum.t
+  ; archive_mirrors : OpamUrl.t list
+  }
+
+let merge_checksum_sources a b =
+  { a with
+    archive_mirrors =
+      OpamUrl.dedup_preserving_order (a.archive_mirrors @ b.archive_mirrors)
+  }
+;;
 
 let extract_checksums_and_urls (lockdir : Dune_pkg.Lock_dir.t) =
   Dune_pkg.Lock_dir.Packages.to_pkg_list lockdir.packages
@@ -154,14 +180,29 @@ let extract_checksums_and_urls (lockdir : Dune_pkg.Lock_dir.t) =
              let url = source.url in
              (match source.checksum with
               | Some ((_, checksum) as checksum_with_loc) ->
-                Checksum.Map.set checksums checksum (url, checksum_with_loc), urls
+                let checksum_source =
+                  { url
+                  ; checksum = checksum_with_loc
+                  ; archive_mirrors = source.archive_mirrors
+                  }
+                in
+                ( Checksum.Map.update checksums checksum ~f:(function
+                    | None -> Some checksum_source
+                    | Some previous ->
+                      Some (merge_checksum_sources previous checksum_source))
+                , urls )
               | None -> checksums, Digest.Map.set urls (digest_of_url (snd url)) url)))
 ;;
 
 let find_checksum, find_url =
   let add_checksums_and_urls (checksums, urls) lockdir =
     let checksums', urls' = extract_checksums_and_urls lockdir in
-    Checksum.Map.superpose checksums checksums', Digest.Map.superpose urls urls'
+    ( Checksum.Map.merge checksums checksums' ~f:(fun _ a b ->
+        match a, b with
+        | None, None -> None
+        | Some source, None | None, Some source -> Some source
+        | Some a, Some b -> Some (merge_checksum_sources a b))
+    , Digest.Map.superpose urls urls' )
   in
   let all =
     Memo.lazy_ (fun () ->
@@ -212,7 +253,7 @@ let find_checksum, find_url =
   find_checksum, find_url
 ;;
 
-let gen_rules_for_checksum_or_url (loc_url, (url : OpamUrl.t)) checksum =
+let gen_rules_for_checksum_or_url (loc_url, (url : OpamUrl.t)) checksum archive_mirrors =
   let loc_url = Dune_pkg.Lock_dir.loc_in_source_tree loc_url in
   let checksum_or_url =
     match checksum with
@@ -245,7 +286,7 @@ let gen_rules_for_checksum_or_url (loc_url, (url : OpamUrl.t)) checksum =
         Action_builder.with_no_targets
           (let open Action_builder.O in
            let+ url = url in
-           action ~url:(loc_url, url) ~checksum ~target ~kind
+           action ~url:(loc_url, url) ~checksum ~archive_mirrors ~target ~kind
            |> Action.Full.make ~can_go_in_shared_cache:true)
     in
     let dir_rule =
@@ -284,15 +325,15 @@ let gen_rules ~dir ~components =
     |> Memo.return
   | [ "checksum"; checksum ] ->
     let checksum = Dune_pkg.Checksum.parse_string_exn (Loc.none, checksum) in
-    let+ url, checksum = find_checksum checksum in
-    gen_rules_for_checksum_or_url url (Some checksum)
+    let+ { url; checksum; archive_mirrors } = find_checksum checksum in
+    gen_rules_for_checksum_or_url url (Some checksum) archive_mirrors
   | [ "url"; digest ] ->
     let+ url =
       match Digest.from_hex digest with
       | Some s -> find_url s
       | None -> User_error.raise [ Pp.textf "invalid digest %s" digest ]
     in
-    gen_rules_for_checksum_or_url url None
+    gen_rules_for_checksum_or_url url None []
   | _ -> Memo.return Gen_rules.no_rules
 ;;
 
@@ -367,7 +408,12 @@ let fetch ~target kind (source : Source.t) =
       | `Directory_or_archive _ ->
         (* For local sources, we don't need an intermediate step copying to the
            .fetch context. This would just add pointless additional overhead. *)
-        action ~url:source.url ~checksum:source.checksum ~target ~kind
+        action
+          ~url:source.url
+          ~checksum:source.checksum
+          ~archive_mirrors:source.archive_mirrors
+          ~target
+          ~kind
     in
     Action.Full.make ~can_go_in_shared_cache:true action
     |> Action_builder.With_targets.return

--- a/test/blackbox-tests/test-cases/pkg/archive-mirrors.t
+++ b/test/blackbox-tests/test-cases/pkg/archive-mirrors.t
@@ -1,0 +1,302 @@
+Package archives can be fetched from an opam repository's archive mirrors.
+
+Set up a local repository whose mirror is relative to the repository root:
+
+  $ mkrepo
+  $ cat > mock-opam-repository/repo <<'EOF'
+  > opam-version: "2.0"
+  > archive-mirrors: "cache"
+  > EOF
+
+Put a package archive in the checksum-addressed location used by opam
+repository mirrors. The package's primary URL is unavailable, so building it
+can only succeed if Dune uses the mirror.
+
+  $ mkdir source
+  $ echo "from the mirror" > source/value
+  $ tar cf source.tar source
+  $ checksum=$(md5sum source.tar | cut -f1 -d' ')
+  $ prefix=$(printf '%s' "$checksum" | cut -c1-2)
+  $ cache=mock-opam-repository/cache/md5/$prefix
+  $ mkdir -p "$cache"
+  $ cp source.tar "$cache/$checksum"
+  $ touch fake-curls
+
+  $ mkpkg foo <<EOF
+  > url {
+  >  src: "http://localhost:9000/source.tar"
+  >  checksum: "md5=$checksum"
+  > }
+  > EOF
+
+  $ solve foo
+  Solution for dune.lock:
+  - foo.0.0.1
+
+The resolved mirror is recorded in the lock directory so builds do not depend
+on repository configuration:
+
+  $ print_source foo.0.0.1 | dune_cmd subst 'md5=[0-9a-f]+' 'md5=$HASH'
+  (source (fetch (url http://localhost:9000/source.tar) (checksum md5=$HASH) (archive_mirrors file://PWD/mock-opam-repository/cache)))
+
+  $ build_pkg foo
+
+A local (file) primary URL is read directly and mirrors are never consulted.
+The mirror object for this package is corrupt, so consulting it would emit a
+checksum warning:
+
+  $ mkdir local-source
+  $ echo "from the local file" > local-source/value
+  $ tar cf local.tar local-source
+  $ local_checksum=$(md5sum local.tar | cut -f1 -d' ')
+  $ local_prefix=$(printf '%s' "$local_checksum" | cut -c1-2)
+  $ local_cache=mock-opam-repository/cache/md5/$local_prefix
+  $ mkdir -p "$local_cache"
+  $ echo "not the local archive" > "$local_cache/$local_checksum"
+
+  $ mkpkg local-archive <<EOF
+  > url {
+  >  src: "file://$PWD/local.tar"
+  >  checksum: "md5=$local_checksum"
+  > }
+  > EOF
+
+  $ solve local-archive
+  Solution for dune.lock:
+  - local-archive.0.0.1
+
+The mirror is still recorded in the lock directory:
+
+  $ print_source local-archive.0.0.1 | dune_cmd subst 'md5=[0-9a-f]+' 'md5=$HASH'
+  (source (fetch (url file://PWD/local.tar) (checksum md5=$HASH) (archive_mirrors file://PWD/mock-opam-repository/cache)))
+
+  $ build_pkg local-archive
+
+If an object is absent from a mirror, Dune falls back to the package's primary
+URL:
+
+  $ mkdir fallback-source
+  $ echo "from the primary URL" > fallback-source/value
+  $ tar cf fallback.tar fallback-source
+  $ fallback_checksum=$(md5sum fallback.tar | cut -f1 -d' ')
+  $ echo fallback.tar > fake-curls
+
+  $ mkpkg fallback <<EOF
+  > url {
+  >  src: "http://localhost:1/fallback.tar"
+  >  checksum: "md5=$fallback_checksum"
+  > }
+  > EOF
+
+  $ solve fallback
+  Solution for dune.lock:
+  - fallback.0.0.1
+  $ build_pkg fallback
+  $ cat already-served
+  1
+
+A corrupt mirror object is ignored after checksum verification, and the
+primary URL is tried next:
+
+  $ mkdir verified-source
+  $ echo "checksum verified" > verified-source/value
+  $ tar cf verified.tar verified-source
+  $ verified_checksum=$(md5sum verified.tar | cut -f1 -d' ')
+  $ verified_prefix=$(printf '%s' "$verified_checksum" | cut -c1-2)
+  $ verified_cache=mock-opam-repository/cache/md5/$verified_prefix
+  $ mkdir -p "$verified_cache"
+  $ echo "not the requested archive" > "$verified_cache/$verified_checksum"
+  $ echo verified.tar >> fake-curls
+
+  $ mkpkg verified <<EOF
+  > url {
+  >  src: "http://localhost:2/verified.tar"
+  >  checksum: "md5=$verified_checksum"
+  > }
+  > EOF
+
+  $ solve verified
+  Solution for dune.lock:
+  - verified.0.0.1
+  $ build_pkg verified 2>&1 | dune_cmd subst "$PWD" PWD | dune_cmd subst 'cache/md5/[0-9a-f]+/[0-9a-f]+' 'cache/md5/$PREFIX/$HASH' | dune_cmd subst 'md5=[0-9a-f]+' 'md5=$HASH'
+  Warning: Ignoring archive from mirror
+  file://PWD/mock-opam-repository/cache/md5/$PREFIX/$HASH
+  because its checksum does not match.
+  Expected checksum:
+  md5=$HASH
+  Actual checksum:
+  md5=$HASH
+  $ cat already-served
+  1
+  2
+
+HTTP mirrors use the same checksum-addressed layout and are tried before the
+primary URL:
+
+  $ cat > mock-opam-repository/repo <<'EOF'
+  > opam-version: "2.0"
+  > archive-mirrors: "http://localhost:3"
+  > EOF
+  $ mkdir http-source
+  $ echo "from the HTTP mirror" > http-source/value
+  $ tar cf http.tar http-source
+  $ http_checksum=$(md5sum http.tar | cut -f1 -d' ')
+  $ echo http.tar >> fake-curls
+  $ echo http.tar >> fake-curls
+
+  $ mkpkg http-mirror <<EOF
+  > url {
+  >  src: "http://localhost:4/http.tar"
+  >  checksum: "md5=$http_checksum"
+  > }
+  > EOF
+
+  $ solve http-mirror
+  Solution for dune.lock:
+  - http-mirror.0.0.1
+  $ build_pkg http-mirror
+  $ cat already-served
+  1
+  2
+  3
+
+Archive mirrors also apply to extra sources:
+
+  $ cat > mock-opam-repository/repo <<'EOF'
+  > opam-version: "2.0"
+  > archive-mirrors: "cache"
+  > EOF
+  $ mkdir extra-main
+  $ echo "main source" > extra-main/value
+  $ tar cf extra-main.tar extra-main
+  $ echo "from the extra-source mirror" > extra.txt
+  $ extra_main_checksum=$(md5sum extra-main.tar | cut -f1 -d' ')
+  $ extra_checksum=$(md5sum extra.txt | cut -f1 -d' ')
+  $ extra_main_prefix=$(printf '%s' "$extra_main_checksum" | cut -c1-2)
+  $ extra_prefix=$(printf '%s' "$extra_checksum" | cut -c1-2)
+  $ mkdir -p "mock-opam-repository/cache/md5/$extra_main_prefix"
+  $ mkdir -p "mock-opam-repository/cache/md5/$extra_prefix"
+  $ cp extra-main.tar "mock-opam-repository/cache/md5/$extra_main_prefix/$extra_main_checksum"
+  $ cp extra.txt "mock-opam-repository/cache/md5/$extra_prefix/$extra_checksum"
+
+  $ mkpkg with-extra <<EOF
+  > build: ["sh" "-c" "grep -q 'from the extra-source mirror' extra.txt"]
+  > url {
+  >  src: "http://localhost:9001/extra-main.tar"
+  >  checksum: "md5=$extra_main_checksum"
+  > }
+  > extra-source "extra.txt" {
+  >  src: "http://localhost:9002/extra.txt"
+  >  checksum: "md5=$extra_checksum"
+  > }
+  > EOF
+
+  $ solve with-extra
+  Solution for dune.lock:
+  - with-extra.0.0.1
+  $ grep -c archive_mirrors dune.lock/with-extra.0.0.1.pkg
+  2
+  $ build_pkg with-extra
+
+When multiple packages use the same checksum, their repository mirrors are
+combined. This matters because the fetch rule itself is shared by checksum:
+
+  $ mkdir shared-source
+  $ echo "shared archive" > shared-source/value
+  $ tar cf shared.tar shared-source
+  $ shared_checksum=$(md5sum shared.tar | cut -f1 -d' ')
+  $ echo "not the shared archive" > corrupt-shared
+  $ echo corrupt-shared >> fake-curls
+  $ echo shared.tar >> fake-curls
+
+  $ mkdir -p repo-a/packages/mirror-a/mirror-a.0.0.1
+  $ mkdir -p repo-b/packages/mirror-b/mirror-b.0.0.1
+  $ cat > repo-a/repo <<'EOF'
+  > opam-version: "2.0"
+  > archive-mirrors: "http://localhost:5"
+  > EOF
+  $ cat > repo-b/repo <<'EOF'
+  > opam-version: "2.0"
+  > archive-mirrors: "http://localhost:6"
+  > EOF
+  $ cat > repo-a/packages/mirror-a/mirror-a.0.0.1/opam <<EOF
+  > opam-version: "2.0"
+  > url {
+  >  src: "http://localhost:9003/shared.tar"
+  >  checksum: "md5=$shared_checksum"
+  > }
+  > EOF
+  $ cat > repo-b/packages/mirror-b/mirror-b.0.0.1/opam <<EOF
+  > opam-version: "2.0"
+  > url {
+  >  src: "http://localhost:9004/shared.tar"
+  >  checksum: "md5=$shared_checksum"
+  > }
+  > EOF
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.20)
+  > (lock_dir
+  >  (repositories repo-a repo-b))
+  > (repository
+  >  (name repo-a)
+  >  (url "file://$PWD/repo-a"))
+  > (repository
+  >  (name repo-b)
+  >  (url "file://$PWD/repo-b"))
+  > EOF
+  $ cat > dune-project <<'EOF'
+  > (lang dune 3.20)
+  > (package
+  >  (name consumer)
+  >  (allow_empty)
+  >  (depends mirror-a mirror-b))
+  > EOF
+
+  $ dune_pkg_lock_normalized
+  Solution for dune.lock:
+  - mirror-a.0.0.1
+  - mirror-b.0.0.1
+  $ build_pkg mirror-a 2>&1 | dune_cmd subst 'md5/[0-9a-f]+/[0-9a-f]+' 'md5/$PREFIX/$HASH' | dune_cmd subst 'md5=[0-9a-f]+' 'md5=$HASH'
+  Warning: Ignoring archive from mirror
+  http://localhost:5/md5/$PREFIX/$HASH because its
+  checksum does not match.
+  Expected checksum:
+  md5=$HASH
+  Actual checksum:
+  md5=$HASH
+  $ cat already-served
+  1
+  2
+  3
+  5
+  6
+
+The repository metadata is also read when the opam repository comes from Git.
+Relative mirrors cannot be resolved against a git URL and are skipped, and
+mirrors whose scheme dune cannot download from are dropped with a warning at
+solve time:
+
+  $ cat > mock-opam-repository/repo <<'EOF'
+  > opam-version: "2.0"
+  > archive-mirrors: [
+  >   "cache"
+  >   "https://mirror.example/cache"
+  >   "git+ssh://mirror.example/cache"
+  > ]
+  > EOF
+  $ (
+  >   cd mock-opam-repository
+  >   git init --quiet
+  >   git add repo packages
+  >   git commit --quiet -m "Repository metadata"
+  > )
+  $ create_mock_repo "git+file://$PWD/mock-opam-repository"
+  $ make_project with-extra > dune-project
+  $ dune pkg lock 2>&1 | grep -A1 Warning
+  Warning: Ignoring unsupported opam archive mirror
+  git+ssh://mirror.example/cache.
+Both sources record only the absolute HTTP mirror:
+
+  $ grep -o 'archive_mirrors [^)]*' dune.lock/with-extra.0.0.1.pkg
+  archive_mirrors https://mirror.example/cache
+  archive_mirrors https://mirror.example/cache

--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -66,6 +66,7 @@
   e2e
   ocamlformat-dev-tool
   source-caching
+  archive-mirrors
   tarball
   pin-depends
   extra-sources
@@ -76,6 +77,7 @@
  (deps %{bin:md5sum})
  (applies_to
   source-caching
+  archive-mirrors
   extra-sources
   ocamlformat-dev-tool
   dev-tool-conflict-test
@@ -85,6 +87,7 @@
  (deps %{bin:tar})
  (applies_to
   source-caching
+  archive-mirrors
   tarball
   pin-depends
   extra-sources

--- a/test/expect-tests/dune_pkg/encode_decode_tests.ml
+++ b/test/expect-tests/dune_pkg/encode_decode_tests.ml
@@ -10,6 +10,13 @@ module Rev_store = Dune_pkg.Rev_store
 module Package_version = Dune_pkg.Package_version
 module Source = Dune_pkg.Source
 module Package_name = Dune_lang.Package_name
+module Repository = Dune_pkg.Pkg_workspace.Repository
+
+let%expect_test "upstream repository archive mirror" =
+  Repository.archive_mirrors Repository.upstream
+  |> List.iter ~f:(fun url -> print_endline (OpamUrl.to_string url));
+  [%expect {| https://opam.ocaml.org/cache |}]
+;;
 
 module Update = struct
   open Dyn
@@ -261,6 +268,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                 ; ( Path.Local.of_string "two"
                   , { url = Loc.none, OpamUrl.of_string "file://randomurl"
                     ; checksum = None
+                    ; archive_mirrors = []
                     } )
                 ]
             }
@@ -291,6 +299,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                         , Checksum.of_string
                             "sha256=adfc38f14c0188a2ad80d61451d011d27ab8839b717492d7ad42f7cb911c54c3"
                         )
+                  ; archive_mirrors = []
                   }
             }
         } )
@@ -312,6 +321,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                 Some
                   { url = Loc.none, OpamUrl.of_string "https://github.com/foo/c"
                   ; checksum = None
+                  ; archive_mirrors = []
                   }
             }
         } )
@@ -358,11 +368,22 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                         ; dev = false
                         ; avoid = false
                         ; source =
-                            Some { url = "file:///tmp/a"; checksum = None }
+                            Some
+                              { url = "file:///tmp/a"
+                              ; checksum = None
+                              ; archive_mirrors = []
+                              }
                         ; extra_sources =
-                            [ ("one", { url = "file:///tmp/a"; checksum = None })
+                            [ ("one",
+                               { url = "file:///tmp/a"
+                               ; checksum = None
+                               ; archive_mirrors = []
+                               })
                             ; ("two",
-                               { url = "file://randomurl"; checksum = None })
+                               { url = "file://randomurl"
+                               ; checksum = None
+                               ; archive_mirrors = []
+                               })
                             ]
                         }
                     ; exported_env = [ { op = =; var = "foo"; value = "bar" } ]
@@ -393,6 +414,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                               ; checksum =
                                   Some
                                     "sha256=adfc38f14c0188a2ad80d61451d011d27ab8839b717492d7ad42f7cb911c54c3"
+                              ; archive_mirrors = []
                               }
                         ; extra_sources = []
                         }
@@ -423,6 +445,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                             Some
                               { url = "https://github.com/foo/c"
                               ; checksum = None
+                              ; archive_mirrors = []
                               }
                         ; extra_sources = []
                         }

--- a/test/expect-tests/dune_pkg/fetch_tests.ml
+++ b/test/expect-tests/dune_pkg/fetch_tests.ml
@@ -43,7 +43,9 @@ let serve_once ~filename =
 let download ?(reproducible = true) ~unpack ~port ~filename ~target ?checksum () =
   let open Fiber.O in
   let url = url ~port ~filename in
-  let* res = Fetch.fetch ~unpack ~checksum ~target ~url:(Loc.none, url) in
+  let* res =
+    Fetch.fetch ~unpack ~checksum ~archive_mirrors:[] ~target ~url:(Loc.none, url)
+  in
   match res with
   | Error (Unavailable None) ->
     let errs = [ Pp.text "Failure while downloading" ] in


### PR DESCRIPTION
## Description

- Read `archive-mirrors` from an opam repository root `repo` file and resolve relative mirror URLs against the repository.
- Store mirrors in lock-directory archive sources so builds remain independent of the repository checkout.
- Fetch checksum-addressed mirror objects before the original archive URL, verify every result, and fall back on mirror misses or corruption.
- Configure the built-in opam repository with `https://opam.ocaml.org/cache`.

## Related Issue and Motivation

Opam repositories can provide stable archive mirrors for packages whose upstream source is unavailable or flaky. Dune package management currently ignores this metadata and always starts with the upstream URL.

Fixes #13130

## Testing

- `./dune.exe build @check @fmt`
- `./dune.exe runtest test/blackbox-tests/test-cases/pkg/archive-mirrors.t`
- `./dune.exe runtest test/expect-tests/dune_pkg`
- `./dune.exe runtest test/blackbox-tests/test-cases/pkg/compute-checksums-when-missing.t`
- Smoke-tested a `dune init project` lock/build against the central opam cache.

The full `@runtest` gate currently reaches three unrelated watch-mode tests that time out on their first RPC build in this local environment.

## Checklist

- [x] Tests added, if applicable.
- [x] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [ ] Documentation added for any user-facing changes (not applicable: this follows existing opam repository metadata).