### PR TITLE
test(pkg): validate-lockdir on a direct dune dependency

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/validate-lockdir-depends-on-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/validate-lockdir-depends-on-dune.t
@@ -18,3 +18,32 @@ Reproduce internal error with dune pkg validate-lockdir in #11188.
 
 Dune is able to verify this lock directory correctly:
   $ dune pkg validate-lockdir
+
+A direct dependency on dune from a workspace package is also intentionally
+absent from the solver's lockdir:
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.20)
+  > (package
+  >  (name direct)
+  >  (allow_empty)
+  >  (depends dune))
+  > EOF
+  $ dune_pkg_lock_normalized
+  Solution for dune.lock:
+  (no dependencies to lock)
+
+The solver evaluates the dependency formula with the running version of dune
+injected, but validation resolves the same formula without it and fails:
+
+  $ dune pkg validate-lockdir
+  Lockdir dune.lock does not contain a solution for local packages:
+  File "dune-project", lines 2-5, characters 0-55:
+  Error: The dependencies of local package "direct" could not be satisfied from
+  the lockdir:
+  Package "dune" is missing
+  Hint: The lockdir no longer contains a solution for the local packages in
+  this project. Regenerate the lockdir by running: 'dune pkg lock'
+  Error: Some lockdirs do not contain solutions for local packages:
+  - dune.lock
+  [1]


### PR DESCRIPTION
## Description

Add a regression test showing that `dune pkg validate-lockdir` rejects a freshly generated lock directory when a local workspace package depends directly on Dune. The solver injects the running Dune version and omits it from the lock directory, while validation currently resolves the dependency formula without that injection.

## Related Issue and Motivation

This captures the validation mismatch.

## Checklist

- [x] Tests added, if applicable.
- [ ] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes. (Not applicable: test-only change.)
- [ ] Documentation added for any user-facing changes. (Not applicable: test-only change.)