### PR TITLE
fix(pkg): evaluate local dependency formulas the way the solver does

### DIFF
--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -12,6 +12,29 @@ let add_self_to_filter_env package env variable =
     else env variable
 ;;
 
+let local_package_dependencies
+      (local_package : Local_package.For_solver.t)
+      ~env
+      ~with_test
+      ~packages
+      ~dune_version
+  =
+  let opam_package =
+    OpamPackage.create
+      (Package_name.to_opam_package_name local_package.name)
+      (Package_version.to_opam_package_version local_package.version)
+  in
+  let env = add_self_to_filter_env opam_package env in
+  let packages = Package_name.Map.set packages Dune_dep.name dune_version in
+  Resolve_opam_formula.filtered_formula_to_package_names
+    ~env
+    ~with_test
+    ~packages
+    (Dependency_formula.to_filtered_formula local_package.dependencies)
+  |> Result.map ~f:(fun { Resolve_opam_formula.regular; post = _ } ->
+    List.filter regular ~f:(Fun.negate (Package_name.equal Dune_dep.name)))
+;;
+
 let simplify_filter get_solver_var =
   OpamFilter.partial_eval (fun var ->
     match OpamVariable.Full.scope var with

--- a/src/dune_pkg/lock_pkg.mli
+++ b/src/dune_pkg/lock_pkg.mli
@@ -7,6 +7,22 @@ val add_self_to_filter_env
   -> OpamTypes.full_variable
   -> OpamVariable.variable_contents option
 
+(** Evaluate a local package's dependency formula. This is the single
+    implementation shared by the solver and by validation
+    ([Package_universe]), so the two cannot drift apart. The package's own
+    [name] and [version] are bound as self variables and the running version
+    of Dune is injected into [packages]. Only regular (non-post) dependencies
+    are returned. Dune is removed from the returned list because it is a
+    pseudo-package that is not written to lockdirs. [env] is the filter
+    environment before the self bindings are added. *)
+val local_package_dependencies
+  :  Local_package.For_solver.t
+  -> env:OpamFilter.env
+  -> with_test:bool
+  -> packages:Package_version.t Package_name.Map.t
+  -> dune_version:Package_version.t
+  -> (Package_name.t list, Resolve_opam_formula.unsatisfied_formula) result
+
 (** Convert a selected opam package to a package that dune can save to the lock
     directory *)
 val opam_package_to_lock_file_pkg

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -1558,27 +1558,14 @@ let reject_unreachable_packages =
         | None, Some (pkg : Local_package.For_solver.t) ->
           let deps =
             match
-              let env =
-                let opam_package =
-                  OpamPackage.create
-                    (Package_name.to_opam_package_name pkg.name)
-                    (Package_version.to_opam_package_version pkg.version)
-                in
-                Solver_env.to_env solver_env
-                |> Lock_pkg.add_self_to_filter_env opam_package
-              in
-              let with_test = with_test solver_env in
-              Dependency_formula.to_filtered_formula pkg.dependencies
-              |> Resolve_opam_formula.filtered_formula_to_package_names
-                   ~env
-                   ~with_test
-                   ~packages:
-                     (Package_name.Map.set pkgs_by_version Dune_dep.name dune_version)
+              Lock_pkg.local_package_dependencies
+                pkg
+                ~env:(Solver_env.to_env solver_env)
+                ~with_test:(with_test solver_env)
+                ~packages:pkgs_by_version
+                ~dune_version
             with
-            | Ok { regular; post = _ (* discard post deps *) } ->
-              (* remove Dune from the formula as we remove it from solutions *)
-              List.filter regular ~f:(fun pkg ->
-                not (Package_name.equal Dune_dep.name pkg))
+            | Ok regular -> regular
             | Error (`Formula_could_not_be_satisfied hints) ->
               (match hints with
                | [ (Unsatisfied_version_constraint { package_name; _ } as hint) ]

--- a/src/dune_pkg/package_universe.ml
+++ b/src/dune_pkg/package_universe.ml
@@ -48,18 +48,20 @@ let version_by_package_name ~platform local_packages (lock_dir : Lock_dir.t) =
 
 let concrete_dependencies_of_local_package t local_package_name ~with_test =
   let local_package = Package_name.Map.find_exn t.local_packages local_package_name in
+  let env =
+    Solver_stats.Expanded_variable_bindings.to_solver_env
+      t.lock_dir.expanded_solver_variable_bindings
+    |> Solver_env.to_env
+  in
   match
-    (Local_package.for_solver local_package).dependencies
-    |> Dependency_formula.to_filtered_formula
-    |> Resolve_opam_formula.filtered_formula_to_package_names
-         ~with_test
-         ~env:
-           (Solver_stats.Expanded_variable_bindings.to_solver_env
-              t.lock_dir.expanded_solver_variable_bindings
-            |> Solver_env.to_env)
-         ~packages:t.version_by_package_name
+    Lock_pkg.local_package_dependencies
+      (Local_package.for_solver local_package)
+      ~env
+      ~with_test
+      ~packages:t.version_by_package_name
+      ~dune_version:(Package_version.of_opam_package_version Dune_dep.version)
   with
-  | Ok { regular; post = _ } -> regular
+  | Ok regular -> regular
   | Error (`Formula_could_not_be_satisfied unsatisfied_formula_hints) ->
     User_error.raise
       ?hints:(Option.some_if with_test lockdir_regenerate_hints)

--- a/test/blackbox-tests/test-cases/pkg/validate-lockdir-depends-on-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/validate-lockdir-depends-on-dune.t
@@ -33,17 +33,7 @@ absent from the solver's lockdir:
   Solution for dune.lock:
   (no dependencies to lock)
 
-The solver evaluates the dependency formula with the running version of dune
-injected, but validation resolves the same formula without it and fails:
+Validation evaluates the dependency formula the same way the solver does, with
+the running version of dune injected, so the empty lockdir is accepted:
 
   $ dune pkg validate-lockdir
-  Lockdir dune.lock does not contain a solution for local packages:
-  File "dune-project", lines 2-5, characters 0-55:
-  Error: The dependencies of local package "direct" could not be satisfied from
-  the lockdir:
-  Package "dune" is missing
-  Hint: The lockdir no longer contains a solution for the local packages in
-  this project. Regenerate the lockdir by running: 'dune pkg lock'
-  Error: Some lockdirs do not contain solutions for local packages:
-  - dune.lock
-  [1]

--- a/test/blackbox-tests/test-cases/pkg/validate-lockdir-self-version.t
+++ b/test/blackbox-tests/test-cases/pkg/validate-lockdir-self-version.t
@@ -22,10 +22,20 @@ solver resolves it by binding the self variables:
   - foo.1.2.3
 
 Swap the locked dependency for a different version, violating the
-constraint. Validation evaluates the formula without the self bindings,
-which drops the version constraint instead of binding the package's own
-version, and the broken lockdir is accepted:
+constraint. Validation binds the self variables the same way the solver
+does and rejects the lockdir:
 
   $ sed -i.bak 's/1\.2\.3/9.9.9/' dune.lock/foo.1.2.3.pkg
   $ mv dune.lock/foo.1.2.3.pkg dune.lock/foo.9.9.9.pkg
   $ dune pkg validate-lockdir
+  Lockdir dune.lock does not contain a solution for local packages:
+  File "dune-project", lines 3-6, characters 0-67:
+  Error: The dependencies of local package "self" could not be satisfied from
+  the lockdir:
+  Found version "9.9.9" of package "foo" which doesn't satisfy the required
+  version constraint "= 1.2.3"
+  Hint: The lockdir no longer contains a solution for the local packages in
+  this project. Regenerate the lockdir by running: 'dune pkg lock'
+  Error: Some lockdirs do not contain solutions for local packages:
+  - dune.lock
+  [1]


### PR DESCRIPTION
## Description

Factor local-package dependency-formula evaluation into `Lock_pkg.local_package_dependencies` and use it from both the solver and `Package_universe`.

The shared path binds the local package name and version as self variables, injects the running Dune version, and removes the Dune pseudo-package from the concrete dependency list. This keeps validation aligned with lock solving and fixes both self-referencing version constraints and direct dependencies on Dune.

## Related Issue and Motivation

Depends on #15617, which adds the self-referencing constraint regression test. This PR is stacked on that change and remains a draft while the predecessor is under review.

## Checklist

- [x] Tests added in #15617.
- [ ] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [x] Documentation not applicable; this is an internal consistency fix.