### PR TITLE
test(pkg): stale lockdir with a workspace/lockdir name collision

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/validate-lockdir-stale-name-collision.t
+++ b/test/blackbox-tests/test-cases/pkg/validate-lockdir-stale-name-collision.t
@@ -1,0 +1,40 @@
+A lockdir that is both out of sync with the project and contains a package
+whose name is also a local package. The name collision is reported even
+though it may be a mere symptom of the staleness: relocking would remove
+the package from the lockdir.
+
+  $ mkrepo
+  $ mkpkg bar
+  $ solve_project <<EOF
+  > (lang dune 3.20)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends bar))
+  > EOF
+  Solution for dune.lock:
+  - bar.0.0.1
+
+Turn the locked dependency into a local package without relocking:
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.20)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends bar))
+  > (package
+  >  (name bar)
+  >  (allow_empty))
+  > EOF
+
+  $ dune pkg validate-lockdir
+  Lockdir dune.lock does not contain a solution for local packages:
+  File "dune-project", lines 6-8, characters 0-36:
+  Error: A package named "bar" is defined locally but is also present in the
+  lockdir
+  Hint: The lockdir no longer contains a solution for the local packages in
+  this project. Regenerate the lockdir by running: 'dune pkg lock'
+  Error: Some lockdirs do not contain solutions for local packages:
+  - dune.lock
+  [1]


### PR DESCRIPTION
## Description

Add a regression test for a lockdir that is both out of sync with the project and contains a package whose name is now defined locally.

Validation currently reports the workspace/lockdir name collision first, even though the collision is a symptom of staleness and relocking would remove the locked package. This captures the current behavior before the validation-ordering fix.

## Related Issue and Motivation

Part of #8652.

## Checklist

- [x] Tests added, if applicable.
- [x] Change log entry not applicable; this is a test-only change.
- [x] Documentation not applicable; this is a test-only change.