### PR TITLE
test(pkg): target contexts fall back to the default lockdir

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/target-context-lockdir.t
+++ b/test/blackbox-tests/test-cases/pkg/target-context-lockdir.t
@@ -1,0 +1,59 @@
+A target context must inherit the lockdir selected by its owning base context.
+For a default context targeting the findlib toolchain "foo", the derived
+context is named "default.foo".
+
+First configure the base context to use foo.lock and create a distinct package
+in each lockdir:
+
+  $ mkdir fallback
+  $ cd fallback
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.24)
+  > (context
+  >  (default
+  >   (lock_dir foo.lock)
+  >   (targets native foo)))
+  > (lock_dir
+  >  (path dune.lock))
+  > EOF
+
+  $ source_lock_dir=foo.lock make_lockdir
+  $ source_lock_dir=foo.lock make_lockpkg test <<EOF
+  > (version 0.0.1)
+  > (build (run echo "building from foo.lock"))
+  > EOF
+
+  $ make_lockdir
+  $ make_lockpkg test <<EOF
+  > (version 0.0.2)
+  > (build (run echo "building from dune.lock"))
+  > EOF
+
+The target context silently falls back to dune.lock instead of inheriting
+foo.lock from the default context:
+
+  $ dune build @@_build/default.foo/pkg-install
+  building from dune.lock
+
+In a fresh workspace with no dune.lock, a native-only build only needs the
+foo.lock selected by its context:
+
+  $ cd ..
+  $ mkdir native-only
+  $ cd native-only
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.24)
+  > (context
+  >  (default
+  >   (lock_dir foo.lock)
+  >   (targets native foo)))
+  > EOF
+
+  $ source_lock_dir=foo.lock make_lockdir
+  $ source_lock_dir=foo.lock make_lockpkg test <<EOF
+  > (version 0.0.1)
+  > (build (run echo "building from foo.lock"))
+  > EOF
+
+  $ dune build @@_build/default/pkg-install
+  building from foo.lock


### PR DESCRIPTION
## Description

Add regression coverage showing that a findlib-toolchain target context does not inherit the lockdir selected by its owning base context.

The target context currently falls back to `dune.lock`, so it can build a different package version from the base context. The test also covers a native-only workspace where the selected non-default lockdir should be sufficient.

## Related Issue and Motivation

Part of #8652.

## Checklist

- [x] Tests added, if applicable.
- [x] Change log entry not applicable; this is a test-only change.
- [x] Documentation not applicable; this is a test-only change.