### PR TITLE
test(rpc): reproduce skipped registry scan

### DIFF
--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
@@ -44,6 +44,70 @@ let run =
         Scheduler.Run.go config run ~timeout:(Time.Span.of_secs 5.0))
 ;;
 
+let%expect_test "poll skips scans after the registry mtime changes" =
+  let module IO = struct
+    let mtime = ref 0.0
+    let file : Registry.File.t option ref = ref None
+    let scans = ref 0
+    let stat _ = Fiber.return (Ok (`Mtime !mtime))
+
+    let scandir _ =
+      incr scans;
+      let files =
+        match !file with
+        | None -> []
+        | Some { Registry.File.path; _ } -> [ Filename.basename path ]
+      in
+      Fiber.return (Ok files)
+    ;;
+
+    let read_file path =
+      match !file with
+      | Some { Registry.File.path = registered_path; contents }
+        when String.equal path registered_path -> Fiber.return (Ok contents)
+      | None | Some _ -> Fiber.return (Error (Failure path))
+    ;;
+  end
+  in
+  let module Poll = Registry.Poll (Fiber) (IO) in
+  let case () =
+    let config =
+      Registry.Config.create
+        (Xdg.create
+           ~env:(function
+             | "XDG_RUNTIME_DIR" -> Some "."
+             | _ -> None)
+           ())
+    in
+    let registry = Registry.create config in
+    let poll description =
+      let+ result = Poll.poll registry in
+      match result with
+      | Error exn -> raise exn
+      | Ok refresh ->
+        printfn
+          "%s: scans=%d added=%d current=%d"
+          description
+          !IO.scans
+          (List.length (Registry.Refresh.added refresh))
+          (List.length (Registry.current registry))
+    in
+    let* () = poll "initial" in
+    let dune = Registry.Dune.create ~where:(`Unix "rpc") ~root:"." ~pid:1 in
+    let (`Caller_should_write file) = Registry.Config.register config dune in
+    IO.file := Some file;
+    IO.mtime := 1.0;
+    let* () = poll "after change" in
+    poll "subsequent poll"
+  in
+  run case;
+  [%expect
+    {|
+    initial: scans=1 added=0 current=0
+    after change: scans=1 added=0 current=0
+    subsequent poll: scans=1 added=0 current=0 |}]
+;;
+
 let%expect_test "turn on dune watch and wait until the connection is listed" =
   let case () =
     let runtime_dir = "_runtime_dir" in


### PR DESCRIPTION
Add a deterministic RPC registry polling test with controlled IO. The test polls an empty registry, adds a valid entry while changing the directory mtime, and records that the changed and subsequent polls neither rescan nor discover the entry.