### PR TITLE
fix(include-qualified): support qualified module references

### DIFF
--- a/bin/describe/describe_pp.ml
+++ b/bin/describe/describe_pp.ml
@@ -119,7 +119,9 @@ let find_module ~sctx file =
   | Some (m, _, _, origin) ->
     (match
        Dune_rules.Ml_sources.Origin.preprocess origin
-       |> Dune_lang.Preprocess.Per_module.find (Dune_rules.Module.name m)
+       |> Dune_lang.Preprocess.Per_module.find
+            ~path:(Dune_rules.Module.logical_path m)
+            ~name:(Dune_rules.Module.name m)
      with
      | Pps { staged = true; loc; _ } -> Some (`Staged_pps loc)
      | _ -> Some (`Module m))

--- a/bin/describe/describe_pp.ml
+++ b/bin/describe/describe_pp.ml
@@ -120,7 +120,9 @@ let find_module ~sctx file =
   | Some (m, _, _, origin) ->
     (match
        Dune_rules.Ml_sources.Origin.preprocess origin
-       |> Dune_lang.Preprocess.Per_module.find (Dune_rules.Module.name m)
+       |> Dune_lang.Preprocess.Per_module.find
+            ~path:(Dune_rules.Module.path m)
+            ~name:(Dune_rules.Module.name m)
      with
      | Pps { staged = true; loc; _ } -> Some (`Staged_pps loc)
      | _ -> Some (`Module m))

--- a/bin/describe/describe_pp.ml
+++ b/bin/describe/describe_pp.ml
@@ -120,9 +120,7 @@ let find_module ~sctx file =
   | Some (m, _, _, origin) ->
     (match
        Dune_rules.Ml_sources.Origin.preprocess origin
-       |> Dune_lang.Preprocess.Per_module.find
-            ~path:(Dune_rules.Module.path m)
-            ~name:(Dune_rules.Module.name m)
+       |> Dune_lang.Preprocess.Per_module.find (Dune_rules.Module.path m)
      with
      | Pps { staged = true; loc; _ } -> Some (`Staged_pps loc)
      | _ -> Some (`Module m))

--- a/bin/ocaml/top.ml
+++ b/bin/ocaml/top.ml
@@ -196,7 +196,12 @@ module Module = struct
         let module Merlin = Dune_rules.Merlin in
         let pps = Merlin.pp_config merlin ctx ~expander in
         let+ pps, _ = Action_builder.evaluate_and_collect_facts pps in
-        let pp = Dune_lang.Module_name.Per_item.get pps module_name in
+        let pp =
+          Dune_lang.Module_reference.Per_item.find
+            pps
+            ~path:(Dune_rules.Module.logical_path module_)
+            ~name:module_name
+        in
         match pp with
         | None -> None, None
         | Some pp_flags ->

--- a/bin/ocaml/top.ml
+++ b/bin/ocaml/top.ml
@@ -197,7 +197,12 @@ module Module = struct
         let module Merlin = Dune_rules.Merlin in
         let pps = Merlin.pp_config merlin ctx ~expander in
         let+ pps, _ = Action_builder.evaluate_and_collect_facts pps in
-        let pp = Dune_lang.Module_name.Per_item.get pps module_name in
+        let pp =
+          Dune_lang.Module_reference.Per_item.find
+            pps
+            ~path:(Dune_rules.Module.path module_)
+            ~name:module_name
+        in
         match pp with
         | None -> None, None
         | Some pp_flags ->

--- a/bin/ocaml/top.ml
+++ b/bin/ocaml/top.ml
@@ -118,10 +118,6 @@ module Module = struct
     if Filename.Extension.Or_empty.is_empty extension
     then User_error.raise [ Pp.text "file is missing an extension" ];
     let open Memo.O in
-    let module_name =
-      let name = Filename.remove_extension filename |> Filename.to_string in
-      Dune_lang.Module_name.of_string_user_error (Loc.none, name) |> User_error.ok_exn
-    in
     let* expander = Super_context.expander sctx ~dir in
     let* top_module_info = Dune_rules.Top_module.find_module sctx mod_ in
     match top_module_info with
@@ -198,10 +194,7 @@ module Module = struct
         let pps = Merlin.pp_config merlin ctx ~expander in
         let+ pps, _ = Action_builder.evaluate_and_collect_facts pps in
         let pp =
-          Dune_lang.Module_reference.Per_item.find
-            pps
-            ~path:(Dune_rules.Module.path module_)
-            ~name:module_name
+          Dune_lang.Module_reference.Per_item.find pps (Dune_rules.Module.path module_)
         in
         match pp with
         | None -> None, None

--- a/doc/changes/added/15633.md
+++ b/doc/changes/added/15633.md
@@ -1,0 +1,2 @@
+- Support qualified module references in fields such as `per_module` when using
+  `(include_subdirs qualified)` (#15633, fixes #15578, @anmonteiro)

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -47,6 +47,7 @@ module Dialect = Dialect
 module Lib_mode = Lib_mode
 module Melange = Melange
 module Module_name = Module_name
+module Module_reference = Module_reference
 module Pin_stanza = Pin_stanza
 module Preprocess = Preprocess
 module Link_flags = Link_flags

--- a/src/dune_lang/module_reference.ml
+++ b/src/dune_lang/module_reference.ml
@@ -1,0 +1,137 @@
+open Import
+
+module T = struct
+  type mode =
+    | Legacy
+    | Path
+
+  type t =
+    { loc : Loc.t
+    ; path : Module_name.Path.t
+    ; mode : mode
+    }
+
+  let mode_to_string = function
+    | Legacy -> "legacy"
+    | Path -> "path"
+  ;;
+
+  let compare t1 t2 =
+    let open Ordering.O in
+    let= () =
+      match t1.mode, t2.mode with
+      | Legacy, Legacy | Path, Path -> Eq
+      | Legacy, Path -> Lt
+      | Path, Legacy -> Gt
+    in
+    Module_name.Path.compare t1.path t2.path
+  ;;
+
+  let equal t1 t2 = compare t1 t2 |> Ordering.is_eq
+
+  let to_dyn { loc; path; mode } =
+    Dyn.record
+      [ "loc", Loc.to_dyn loc
+      ; "path", Module_name.Path.to_dyn path
+      ; "mode", Dyn.string (mode_to_string mode)
+      ]
+  ;;
+end
+
+include T
+
+let loc t = t.loc
+let path t = t.path
+let to_string t = Module_name.Path.to_string t.path
+
+let is_qualified t =
+  match t.path with
+  | _ :: _ :: _ -> true
+  | [ _ ] -> false
+;;
+
+let is_legacy t =
+  match t.mode with
+  | Legacy -> true
+  | Path -> false
+;;
+
+let make ~loc ~mode path = { loc; path; mode }
+
+let parse_component loc component =
+  Module_name.of_string_user_error (loc, component) |> User_error.ok_exn
+;;
+
+let of_string version (loc, value) =
+  let components = String.split value ~on:'.' in
+  let mode = if version >= (3, 25) then Path else Legacy in
+  if List.length components > 1 && version < (3, 25)
+  then
+    Syntax.Error.since loc Stanza.syntax (3, 25) ~what:"Using qualified module references";
+  let path = List.map components ~f:(parse_component loc) |> Nonempty_list.of_list_exn in
+  make ~loc ~mode path
+;;
+
+let decode =
+  let open Decoder in
+  let+ value = located string
+  and+ version = Syntax.get_exn Stanza.syntax in
+  of_string version value
+;;
+
+module Per_item = struct
+  module Base = Per_item.Make (T)
+  include Base
+  open Decoder
+
+  let repr value_repr =
+    Repr.view
+      Repr.(pair (list (triple String.repr String.repr Int.repr)) (list value_repr))
+      ~to_:(fun t ->
+        let references, values = enumerate t in
+        ( List.map references ~f:(fun (reference, index) ->
+            to_string reference, mode_to_string reference.mode, index)
+        , values ))
+  ;;
+
+  let decode ~default value =
+    peek_exn
+    >>= function
+    | List (loc, Atom (_, A "per_module") :: _) ->
+      sum
+        [ ( "per_module"
+          , let+ mappings =
+              repeat
+                (let+ value, references = pair value (repeat decode) in
+                 references, value)
+            in
+            of_mapping mappings ~default
+            |> function
+            | Ok t -> t
+            | Error (reference, _, _) ->
+              User_error.raise
+                ~loc
+                [ Pp.textf "module %s present in two different sets" (to_string reference)
+                ] )
+        ]
+    | _ -> value >>| for_all
+  ;;
+
+  let mode t =
+    match fst (enumerate t) with
+    | [] -> Path
+    | (reference, _) :: _ -> reference.mode
+  ;;
+
+  let find t ~path ~name =
+    let mode = mode t in
+    let path =
+      match mode with
+      | Legacy -> Nonempty_list.[ name ]
+      | Path -> path
+    in
+    Base.get t (make ~loc:Loc.none ~mode path)
+  ;;
+
+  let explicit_references t = fst (enumerate t) |> List.map ~f:fst
+end

--- a/src/dune_lang/module_reference.ml
+++ b/src/dune_lang/module_reference.ml
@@ -1,0 +1,136 @@
+open Import
+
+module T = struct
+  type mode =
+    | Legacy
+    | Path
+
+  type t =
+    { loc : Loc.t
+    ; path : Module_name.Path.t
+    ; mode : mode
+    }
+
+  let mode_to_string = function
+    | Legacy -> "legacy"
+    | Path -> "path"
+  ;;
+
+  let compare t1 t2 =
+    let open Ordering.O in
+    let= () =
+      match t1.mode, t2.mode with
+      | Legacy, Legacy | Path, Path -> Eq
+      | Legacy, Path -> Lt
+      | Path, Legacy -> Gt
+    in
+    Module_name.Path.compare t1.path t2.path
+  ;;
+
+  let equal t1 t2 = compare t1 t2 |> Ordering.is_eq
+
+  let to_dyn { loc; path; mode } =
+    Dyn.record
+      [ "loc", Loc.to_dyn loc
+      ; "path", Module_name.Path.to_dyn path
+      ; "mode", Dyn.string (mode_to_string mode)
+      ]
+  ;;
+end
+
+include T
+
+let loc t = t.loc
+let path t = t.path
+let to_string t = Module_name.Path.to_string t.path
+
+let is_qualified t =
+  match t.path with
+  | _ :: _ :: _ -> true
+  | [ _ ] -> false
+;;
+
+let make ~loc ~mode path = { loc; path; mode }
+
+let parse_component loc component =
+  Module_name.of_string_user_error (loc, component) |> User_error.ok_exn
+;;
+
+let of_string version (loc, value) =
+  let components = String.split value ~on:'.' in
+  let mode = if version >= (3, 25) then Path else Legacy in
+  (match components with
+   | _ :: _ :: _ when version < (3, 25) ->
+     Syntax.Error.since
+       loc
+       Stanza.syntax
+       (3, 25)
+       ~what:"Using qualified module references"
+   | _ -> ());
+  let path = List.map components ~f:(parse_component loc) |> Nonempty_list.of_list_exn in
+  make ~loc ~mode path
+;;
+
+let decode =
+  let open Decoder in
+  let+ value = located string
+  and+ version = Syntax.get_exn Stanza.syntax in
+  of_string version value
+;;
+
+module Per_item = struct
+  module Base = Per_item.Make (T)
+  include Base
+  open Decoder
+
+  let repr value_repr =
+    Repr.view
+      Repr.(pair (list (triple String.repr String.repr Int.repr)) (list value_repr))
+      ~to_:(fun t ->
+        let references, values = enumerate t in
+        ( List.map references ~f:(fun (reference, index) ->
+            to_string reference, mode_to_string reference.mode, index)
+        , values ))
+  ;;
+
+  let decode ~default value =
+    peek_exn
+    >>= function
+    | List (loc, Atom (_, A "per_module") :: _) ->
+      sum
+        [ ( "per_module"
+          , let+ mappings =
+              repeat
+                (let+ value, references = pair value (repeat decode) in
+                 references, value)
+            in
+            of_mapping mappings ~default
+            |> function
+            | Ok t -> t
+            | Error (reference, _, _) ->
+              User_error.raise
+                ~loc
+                [ Pp.textf "module %s present in two different sets" (to_string reference)
+                ] )
+        ]
+    | _ -> value >>| for_all
+  ;;
+
+  let mode t =
+    match fst (enumerate t) with
+    | [] -> Path
+    | (reference, _) :: _ -> reference.mode
+  ;;
+
+  let find t ~path ~name =
+    let mode = mode t in
+    let path =
+      match mode with
+      | Legacy -> Nonempty_list.[ name ]
+      | Path -> path
+    in
+    Base.get t (make ~loc:Loc.none ~mode path)
+  ;;
+
+  let explicit_references t = fst (enumerate t) |> List.map ~f:fst
+end

--- a/src/dune_lang/module_reference.ml
+++ b/src/dune_lang/module_reference.ml
@@ -27,8 +27,6 @@ module T = struct
     Module_name.Path.compare t1.path t2.path
   ;;
 
-  let equal t1 t2 = compare t1 t2 |> Ordering.is_eq
-
   let to_dyn { loc; path; mode } =
     Dyn.record
       [ "loc", Loc.to_dyn loc
@@ -59,14 +57,14 @@ let parse_component loc component =
 let of_string version (loc, value) =
   let components = String.split value ~on:'.' in
   let mode = if version >= (3, 25) then Path else Legacy in
-  (match components with
-   | _ :: _ :: _ when version < (3, 25) ->
+  (match mode, components with
+   | Legacy, _ :: _ :: _ ->
      Syntax.Error.since
        loc
        Stanza.syntax
        (3, 25)
        ~what:"Using qualified module references"
-   | _ -> ());
+   | (Legacy | Path), _ -> ());
   let path = List.map components ~f:(parse_component loc) |> Nonempty_list.of_list_exn in
   make ~loc ~mode path
 ;;
@@ -122,11 +120,11 @@ module Per_item = struct
     | (reference, _) :: _ -> reference.mode
   ;;
 
-  let find t ~path ~name =
+  let find t path =
     let mode = mode t in
     let path =
       match mode with
-      | Legacy -> Nonempty_list.[ name ]
+      | Legacy -> Nonempty_list.[ Nonempty_list.last path ]
       | Path -> path
     in
     Base.get t (make ~loc:Loc.none ~mode path)

--- a/src/dune_lang/module_reference.mli
+++ b/src/dune_lang/module_reference.mli
@@ -1,0 +1,32 @@
+open Import
+
+(** A reference to a module in a dune file.
+
+    Starting with version 3.25 of the dune language, references may contain
+    multiple components, for example [Foo.Bar]. *)
+type t
+
+val compare : t -> t -> Ordering.t
+val equal : t -> t -> bool
+val loc : t -> Loc.t
+val path : t -> Module_name.Path.t
+val to_string : t -> string
+val to_dyn : t -> Dyn.t
+val of_string : Syntax.Version.t -> Loc.t * string -> t
+val is_qualified : t -> bool
+val is_legacy : t -> bool
+val decode : t Decoder.t
+
+module Per_item : sig
+  include Per_item with type key = t
+
+  val decode : default:'a -> 'a Decoder.t -> 'a t Decoder.t
+  val repr : 'a Repr.t -> 'a t Repr.t
+
+  (** Find the value associated with a module. [path] is its logical path and
+      [name] is its final component. The latter preserves the lookup semantics
+      of dune language versions before 3.25. *)
+  val find : 'a t -> path:Module_name.Path.t -> name:Module_name.t -> 'a
+
+  val explicit_references : 'a t -> key list
+end

--- a/src/dune_lang/module_reference.mli
+++ b/src/dune_lang/module_reference.mli
@@ -6,26 +6,37 @@ open Import
     multiple components, for example [Foo.Bar]. *)
 type t
 
-val compare : t -> t -> Ordering.t
-val equal : t -> t -> bool
 val loc : t -> Loc.t
 val path : t -> Module_name.Path.t
 val to_string : t -> string
-val to_dyn : t -> Dyn.t
 val of_string : Syntax.Version.t -> Loc.t * string -> t
 val is_qualified : t -> bool
-val decode : t Decoder.t
 
 module Per_item : sig
-  include Per_item with type key = t
+  type key = t
+  type 'a t
+
+  val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+  val for_all : 'a -> 'a t
+  val map : 'a t -> f:('a -> 'b) -> 'b t
+  val fold : 'a t -> init:'acc -> f:('a -> 'acc -> 'acc) -> 'acc
+  val exists : 'a t -> f:('a -> bool) -> bool
+
+  module Make_monad_traversals (Monad : sig
+      include Monad.S
+
+      val all : 'a t list -> 'a list t
+    end) : sig
+    val fold : 'a t -> init:'acc -> f:('a -> 'acc -> 'acc Monad.t) -> 'acc Monad.t
+    val map : 'a t -> f:('a -> 'b Monad.t) -> 'b t Monad.t
+  end
 
   val decode : default:'a -> 'a Decoder.t -> 'a t Decoder.t
   val repr : 'a Repr.t -> 'a t Repr.t
 
-  (** Find the value associated with a module. [path] is its logical path and
-      [name] is its final component. The latter preserves the lookup semantics
-      of dune language versions before 3.25. *)
-  val find : 'a t -> path:Module_name.Path.t -> name:Module_name.t -> 'a
+  (** Find the value associated with a module by its logical path. In dune
+      language versions before 3.25, only the final component is used. *)
+  val find : 'a t -> Module_name.Path.t -> 'a
 
   val explicit_references : 'a t -> key list
 end

--- a/src/dune_lang/module_reference.mli
+++ b/src/dune_lang/module_reference.mli
@@ -1,0 +1,31 @@
+open Import
+
+(** A reference to a module in a dune file.
+
+    Starting with version 3.25 of the dune language, references may contain
+    multiple components, for example [Foo.Bar]. *)
+type t
+
+val compare : t -> t -> Ordering.t
+val equal : t -> t -> bool
+val loc : t -> Loc.t
+val path : t -> Module_name.Path.t
+val to_string : t -> string
+val to_dyn : t -> Dyn.t
+val of_string : Syntax.Version.t -> Loc.t * string -> t
+val is_qualified : t -> bool
+val decode : t Decoder.t
+
+module Per_item : sig
+  include Per_item with type key = t
+
+  val decode : default:'a -> 'a Decoder.t -> 'a t Decoder.t
+  val repr : 'a Repr.t -> 'a t Repr.t
+
+  (** Find the value associated with a module. [path] is its logical path and
+      [name] is its final component. The latter preserves the lookup semantics
+      of dune language versions before 3.25. *)
+  val find : 'a t -> path:Module_name.Path.t -> name:Module_name.t -> 'a
+
+  val explicit_references : 'a t -> key list
+end

--- a/src/dune_lang/preprocess.ml
+++ b/src/dune_lang/preprocess.ml
@@ -317,7 +317,7 @@ module Instrumentation = struct
 end
 
 module Per_module = struct
-  module Per_module = Module_name.Per_item
+  module Per_module = Module_reference.Per_item
 
   type 'a preprocess = 'a t
   type 'a t = 'a preprocess Per_module.t
@@ -326,7 +326,7 @@ module Per_module = struct
   let equal f x y = Per_module.equal (equal f) x y
   let decode = Per_module.decode decode ~default:No_preprocessing
   let no_preprocessing () = Per_module.for_all No_preprocessing
-  let find module_name t = Per_module.get t module_name
+  let find ~path ~name t = Per_module.find t ~path ~name
   let default () = Per_module.for_all No_preprocessing
 
   let pps t =
@@ -394,7 +394,7 @@ let preprocess_fields_with_prefix ~prefix:field_prefix =
     | Some _, None | None, _ -> []
     | Some (loc, deps), Some preprocess ->
       let deps_might_be_used =
-        Module_name.Per_item.exists preprocess ~f:(fun p ->
+        Module_reference.Per_item.exists preprocess ~f:(fun p ->
           match p with
           | Action _ | Pps _ -> true
           | No_preprocessing | Future_syntax _ -> false)
@@ -429,7 +429,7 @@ let preprocess_config ~preprocess ~instrumentation ~preprocessor_deps =
   let config =
     let init =
       let f libname = With_instrumentation.Ordinary libname in
-      Module_name.Per_item.map preprocess ~f:(map ~f)
+      Module_reference.Per_item.map preprocess ~f:(map ~f)
     in
     List.fold_left instrumentation ~init ~f:Per_module.add_instrumentation
   in

--- a/src/dune_lang/preprocess.ml
+++ b/src/dune_lang/preprocess.ml
@@ -328,7 +328,7 @@ module Per_module = struct
   let equal f x y = Per_module.equal (equal f) x y
   let decode = Per_module.decode decode ~default:No_preprocessing
   let no_preprocessing () = Per_module.for_all No_preprocessing
-  let find ~path ~name t = Per_module.find t ~path ~name
+  let find path t = Per_module.find t path
   let default () = Per_module.for_all No_preprocessing
 
   let pps t =

--- a/src/dune_lang/preprocess.ml
+++ b/src/dune_lang/preprocess.ml
@@ -319,7 +319,7 @@ module Instrumentation = struct
 end
 
 module Per_module = struct
-  module Per_module = Module_name.Per_item
+  module Per_module = Module_reference.Per_item
 
   type 'a preprocess = 'a t
   type 'a t = 'a preprocess Per_module.t
@@ -328,7 +328,7 @@ module Per_module = struct
   let equal f x y = Per_module.equal (equal f) x y
   let decode = Per_module.decode decode ~default:No_preprocessing
   let no_preprocessing () = Per_module.for_all No_preprocessing
-  let find module_name t = Per_module.get t module_name
+  let find ~path ~name t = Per_module.find t ~path ~name
   let default () = Per_module.for_all No_preprocessing
 
   let pps t =
@@ -396,7 +396,7 @@ let preprocess_fields_with_prefix ~prefix:field_prefix =
     | Some _, None | None, _ -> []
     | Some (loc, deps), Some preprocess ->
       let deps_might_be_used =
-        Module_name.Per_item.exists preprocess ~f:(fun p ->
+        Module_reference.Per_item.exists preprocess ~f:(fun p ->
           match p with
           | Action _ | Pps _ -> true
           | No_preprocessing | Future_syntax _ -> false)
@@ -431,7 +431,7 @@ let preprocess_config ~preprocess ~instrumentation ~preprocessor_deps =
   let config =
     let init =
       let f libname = With_instrumentation.Ordinary libname in
-      Module_name.Per_item.map preprocess ~f:(map ~f)
+      Module_reference.Per_item.map preprocess ~f:(map ~f)
     in
     List.fold_left instrumentation ~init ~f:Per_module.add_instrumentation
   in

--- a/src/dune_lang/preprocess.mli
+++ b/src/dune_lang/preprocess.mli
@@ -80,7 +80,7 @@ end
 
 module Per_module : sig
   type 'a preprocess := 'a t
-  type 'a t = 'a preprocess Module_name.Per_item.t
+  type 'a t = 'a preprocess Module_reference.Per_item.t
 
   val repr : 'a Repr.t -> 'a t Repr.t
   val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
@@ -88,8 +88,8 @@ module Per_module : sig
   val no_preprocessing : unit -> 'a t
   val default : unit -> 'a t
 
-  (** [find module_name] find the preprocessing specification for a given module *)
-  val find : Module_name.t -> 'a t -> 'a preprocess
+  (** Find the preprocessing specification for a module. *)
+  val find : path:Module_name.Path.t -> name:Module_name.t -> 'a t -> 'a preprocess
 
   val pps : Without_instrumentation.t t -> Without_instrumentation.t list
 
@@ -111,7 +111,7 @@ type preprocess =
   }
 
 val preprocess_config
-  :  preprocess:Without_instrumentation.t t Module_name.Per_item.t
+  :  preprocess:Without_instrumentation.t t Module_reference.Per_item.t
   -> instrumentation:Instrumentation.t list
   -> preprocessor_deps:Dep_conf.t list
   -> preprocess

--- a/src/dune_lang/preprocess.mli
+++ b/src/dune_lang/preprocess.mli
@@ -89,7 +89,7 @@ module Per_module : sig
   val default : unit -> 'a t
 
   (** Find the preprocessing specification for a module. *)
-  val find : path:Module_name.Path.t -> name:Module_name.t -> 'a t -> 'a preprocess
+  val find : Module_name.Path.t -> 'a t -> 'a preprocess
 
   val pps : Without_instrumentation.t t -> Without_instrumentation.t list
 

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -119,6 +119,7 @@ include struct
   module Dialect = Dialect
   module Lib_mode = Lib_mode
   module Module_name = Module_name
+  module Module_reference = Module_reference
   module Preprocess = Preprocess
   module Dune_project = Dune_project
   module File_binding = File_binding

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -127,6 +127,7 @@ include struct
   module Dialect = Dialect
   module Lib_mode = Lib_mode
   module Module_name = Module_name
+  module Module_reference = Module_reference
   module Preprocess = Preprocess
   module Dune_project = Dune_project
   module File_binding = File_binding

--- a/src/dune_rules/instrumentation.ml
+++ b/src/dune_rules/instrumentation.ml
@@ -12,7 +12,7 @@ let filter_map_resolve (t : _ Preprocess.t) ~f =
   | (No_preprocessing | Action _ | Future_syntax _) as t -> Resolve.Memo.return t
 ;;
 
-module Resolve_traversals = Module_name.Per_item.Make_monad_traversals (Resolve.Memo)
+module Resolve_traversals = Module_reference.Per_item.Make_monad_traversals (Resolve.Memo)
 
 let fold = Resolve_traversals.fold
 

--- a/src/dune_rules/instrumentation.mli
+++ b/src/dune_rules/instrumentation.mli
@@ -1,7 +1,7 @@
 open Import
 
 val fold
-  :  'a Module_name.Per_item.t
+  :  'a Module_reference.Per_item.t
   -> init:'b
   -> f:('a -> 'b -> 'b Resolve.Memo.t)
   -> 'b Resolve.Memo.t

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -41,7 +41,12 @@ let setup_melange_sources_copy_rules ~sctx ~dir ~preprocess modules =
       | true -> Memo.return ()
       | false ->
         let builder =
-          match Preprocess.Per_module.find (Module.name m) preprocess with
+          match
+            Preprocess.Per_module.find
+              ~path:(Module.logical_path m)
+              ~name:(Module.name m)
+              preprocess
+          with
           | Pps { staged = false; _ } ->
             (* Non-staged PPX preprocessing receives [-loc-filename] separately,
                so adding a line directive here would shift diagnostics twice. *)

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -59,12 +59,7 @@ let setup_melange_sources_copy_rules ~sctx ~dir ~preprocess modules =
       | true -> Memo.return ()
       | false ->
         let builder =
-          match
-            Preprocess.Per_module.find
-              ~path:(Module.path m)
-              ~name:(Module.name m)
-              preprocess
-          with
+          match Preprocess.Per_module.find (Module.path m) preprocess with
           | Pps { staged = false; _ } ->
             (* Non-staged PPX preprocessing receives [-loc-filename] separately,
                so adding a line directive here would shift diagnostics twice. *)

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -59,7 +59,12 @@ let setup_melange_sources_copy_rules ~sctx ~dir ~preprocess modules =
       | true -> Memo.return ()
       | false ->
         let builder =
-          match Preprocess.Per_module.find (Module.name m) preprocess with
+          match
+            Preprocess.Per_module.find
+              ~path:(Module.path m)
+              ~name:(Module.name m)
+              preprocess
+          with
           | Pps { staged = false; _ } ->
             (* Non-staged PPX preprocessing receives [-loc-filename] separately,
                so adding a line directive here would shift diagnostics twice. *)

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -120,7 +120,7 @@ module Processed = struct
   type t =
     { config : config
     ; per_file_config : module_config Path.Build.Map.t
-    ; pp_config : pp_flag option Module_name.Per_item.t
+    ; pp_config : pp_flag option Module_reference.Per_item.t
     }
 
   type output_format =
@@ -164,7 +164,7 @@ module Processed = struct
           ~get:(fun t -> t.per_file_config)
       ; Repr.field
           "pp_config"
-          (Module_name.Per_item.repr (Repr.option pp_flag_repr))
+          (Module_reference.Per_item.repr (Repr.option pp_flag_repr))
           ~get:(fun t -> t.pp_config)
       ]
   ;;
@@ -176,7 +176,7 @@ module Processed = struct
 
     let name = "merlin-conf"
     let sharing = false
-    let version = 8
+    let version = 9
 
     let repr =
       Repr.view Repr.string ~to_:(fun _ -> "Use [dune ocaml dump-dot-merlin] instead")
@@ -355,7 +355,7 @@ module Processed = struct
     List.iter
       pp_configs
       ~f:
-        (Module_name.Per_item.fold ~init:() ~f:(fun pp () ->
+        (Module_reference.Per_item.fold ~init:() ~f:(fun pp () ->
            Option.iter pp ~f:(fun { flag; args } ->
              printf "# FLG %s\n" (Pp_kind.to_flag flag ^ " " ^ quote_for_dot_merlin args))));
     List.iter flags ~f:(fun flags ->
@@ -396,7 +396,12 @@ module Processed = struct
               similar to Copy_line_directive to handle this. *)
            Path.Build.Map.find per_file_config (remove_extension file))
     in
-    let pp = Module_name.Per_item.get pp_config (Module.name module_) in
+    let pp =
+      Module_reference.Per_item.find
+        pp_config
+        ~path:(Module.logical_path module_)
+        ~name:(Module.name module_)
+    in
     let unit_name = Module_name.Unique.to_string (Module.obj_name module_) in
     to_sexp ~unit_name ~opens ~pp ~reader config
   ;;
@@ -406,7 +411,12 @@ module Processed = struct
     |> List.map ~f:(fun (source_path, { module_; opens; reader }) ->
       let module_name = Module.name module_ in
       let unit_name = Module_name.Unique.to_string (Module.obj_name module_) in
-      let pp = Module_name.Per_item.get pp_config module_name in
+      let pp =
+        Module_reference.Per_item.find
+          pp_config
+          ~path:(Module.logical_path module_)
+          ~name:module_name
+      in
       let config = to_sexp ~unit_name ~reader ~opens ~pp config in
       Dump_entry.{ module_name; source_path; config })
   ;;
@@ -547,7 +557,7 @@ module Unprocessed = struct
     ; requires_hidden : Lib.t list Resolve.t
     ; flags : string list Action_builder.t
     ; preprocess :
-        Preprocess.Without_instrumentation.t Preprocess.t Module_name.Per_item.t
+        Preprocess.Without_instrumentation.t Preprocess.t Module_reference.Per_item.t
     ; libname : Lib_name.Local.t option
     ; objs_dirs : Path.Set.t
     ; extensions : string option Ml_kind.Dict.t list
@@ -693,7 +703,7 @@ module Unprocessed = struct
   ;;
 
   module Per_item_action_builder =
-    Module_name.Per_item.Make_monad_traversals (Action_builder)
+    Module_reference.Per_item.Make_monad_traversals (Action_builder)
 
   let pp_config t ctx ~expander =
     Per_item_action_builder.map

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -416,12 +416,7 @@ module Processed = struct
            Path.Build.Map.find per_file_config (remove_extension file)
            |> Option.map ~f:(fun config -> Without_extension, config))
     in
-    let pp =
-      Module_reference.Per_item.find
-        pp_config
-        ~path:(Module.path module_)
-        ~name:(Module.name module_)
-    in
+    let pp = Module_reference.Per_item.find pp_config (Module.path module_) in
     let unit_name = Module_name.Unique.to_string (Module.obj_name module_) in
     match_kind, to_sexp ~unit_name ~opens ~pp ~reader config
   ;;
@@ -456,12 +451,7 @@ module Processed = struct
     |> List.map ~f:(fun (source_path, { module_; opens; reader }) ->
       let module_name = Module.name module_ in
       let unit_name = Module_name.Unique.to_string (Module.obj_name module_) in
-      let pp =
-        Module_reference.Per_item.find
-          pp_config
-          ~path:(Module.path module_)
-          ~name:module_name
-      in
+      let pp = Module_reference.Per_item.find pp_config (Module.path module_) in
       let config = to_sexp ~unit_name ~reader ~opens ~pp config in
       Dump_entry.{ module_name; source_path; config })
   ;;

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -125,7 +125,7 @@ module Processed = struct
   type configuration =
     { config : config
     ; per_file_config : module_config Path.Build.Map.t
-    ; pp_config : pp_flag option Module_name.Per_item.t
+    ; pp_config : pp_flag option Module_reference.Per_item.t
     }
 
   type t = configuration Nonempty_list.t
@@ -171,7 +171,7 @@ module Processed = struct
           ~get:(fun t -> t.per_file_config)
       ; Repr.field
           "pp_config"
-          (Module_name.Per_item.repr (Repr.option pp_flag_repr))
+          (Module_reference.Per_item.repr (Repr.option pp_flag_repr))
           ~get:(fun t -> t.pp_config)
       ]
   ;;
@@ -184,7 +184,7 @@ module Processed = struct
 
     let name = "merlin-conf"
     let sharing = false
-    let version = 10
+    let version = 11
 
     let repr =
       Repr.view Repr.string ~to_:(fun _ -> "Use [dune ocaml dump-dot-merlin] instead")
@@ -370,7 +370,7 @@ module Processed = struct
     List.iter
       pp_configs
       ~f:
-        (Module_name.Per_item.fold ~init:() ~f:(fun pp () ->
+        (Module_reference.Per_item.fold ~init:() ~f:(fun pp () ->
            Option.iter pp ~f:(fun { flag; args } ->
              printf "# FLG %s\n" (Pp_kind.to_flag flag ^ " " ^ quote_for_dot_merlin args))));
     List.iter flags ~f:(fun flags ->
@@ -416,7 +416,12 @@ module Processed = struct
            Path.Build.Map.find per_file_config (remove_extension file)
            |> Option.map ~f:(fun config -> Without_extension, config))
     in
-    let pp = Module_name.Per_item.get pp_config (Module.name module_) in
+    let pp =
+      Module_reference.Per_item.find
+        pp_config
+        ~path:(Module.path module_)
+        ~name:(Module.name module_)
+    in
     let unit_name = Module_name.Unique.to_string (Module.obj_name module_) in
     match_kind, to_sexp ~unit_name ~opens ~pp ~reader config
   ;;
@@ -451,7 +456,12 @@ module Processed = struct
     |> List.map ~f:(fun (source_path, { module_; opens; reader }) ->
       let module_name = Module.name module_ in
       let unit_name = Module_name.Unique.to_string (Module.obj_name module_) in
-      let pp = Module_name.Per_item.get pp_config module_name in
+      let pp =
+        Module_reference.Per_item.find
+          pp_config
+          ~path:(Module.path module_)
+          ~name:module_name
+      in
       let config = to_sexp ~unit_name ~reader ~opens ~pp config in
       Dump_entry.{ module_name; source_path; config })
   ;;
@@ -605,7 +615,7 @@ module Unprocessed = struct
     ; requires_hidden : Lib.t list Resolve.t
     ; flags : string list Action_builder.t
     ; preprocess :
-        Preprocess.Without_instrumentation.t Preprocess.t Module_name.Per_item.t
+        Preprocess.Without_instrumentation.t Preprocess.t Module_reference.Per_item.t
     ; libname : Lib_name.Local.t option
     ; objs_dirs : Path.Set.t
     ; extensions : string option Ml_kind.Dict.t list
@@ -751,7 +761,7 @@ module Unprocessed = struct
   ;;
 
   module Per_item_action_builder =
-    Module_name.Per_item.Make_monad_traversals (Action_builder)
+    Module_reference.Per_item.Make_monad_traversals (Action_builder)
 
   let pp_config t ctx ~expander =
     Per_item_action_builder.map

--- a/src/dune_rules/merlin/merlin.mli
+++ b/src/dune_rules/merlin/merlin.mli
@@ -52,7 +52,8 @@ val make
   -> requires_hidden:Lib.t list Resolve.t
   -> stdlib_dir:Path.t
   -> flags:Ocaml_flags.t
-  -> preprocess:Preprocess.Without_instrumentation.t Preprocess.t Module_name.Per_item.t
+  -> preprocess:
+       Preprocess.Without_instrumentation.t Preprocess.t Module_reference.Per_item.t
   -> libname:Lib_name.Local.t option
   -> modules:Modules.With_vlib.t
   -> obj_dir:Path.Build.t Obj_dir.t
@@ -81,4 +82,4 @@ val pp_config
   :  t
   -> Context.t
   -> expander:Expander.t
-  -> Processed.pp_flag option Module_name.Per_item.t Action_builder.t
+  -> Processed.pp_flag option Module_reference.Per_item.t Action_builder.t

--- a/src/dune_rules/merlin/merlin.mli
+++ b/src/dune_rules/merlin/merlin.mli
@@ -52,7 +52,8 @@ val make
   -> requires_hidden:Lib.t list Resolve.t
   -> stdlib_dir:Path.t
   -> flags:Ocaml_flags.t
-  -> preprocess:Preprocess.Without_instrumentation.t Preprocess.t Module_name.Per_item.t
+  -> preprocess:
+       Preprocess.Without_instrumentation.t Preprocess.t Module_reference.Per_item.t
   -> libname:Lib_name.Local.t option
   -> modules:Modules.With_vlib.t
   -> obj_dir:Path.Build.t Obj_dir.t
@@ -84,4 +85,4 @@ val pp_config
   :  t
   -> Context.t
   -> expander:Expander.t
-  -> Processed.pp_flag option Module_name.Per_item.t Action_builder.t
+  -> Processed.pp_flag option Module_reference.Per_item.t Action_builder.t

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -495,7 +495,7 @@ let modules_and_obj_dir t ~libs ~for_ =
 
 let modules t ~libs ~for_ = modules_and_obj_dir t ~libs ~for_ >>| fst
 
-let virtual_modules ~lookup_vlib ~libs ~for_ vlib =
+let virtual_modules ~lookup_vlib ~libs ~for_ ~version vlib =
   let+ modules =
     match Lib_info.modules vlib ~for_ with
     | External modules ->
@@ -505,7 +505,7 @@ let virtual_modules ~lookup_vlib ~libs ~for_ vlib =
       lookup_vlib ~dir:src_dir
       >>= modules ~libs ~for_:(Library (Lib_info.lib_id vlib |> Lib_id.to_local_exn))
   in
-  let existing_virtual_modules = Modules.virtual_module_names modules in
+  let existing_virtual_modules = Modules.virtual_module_names ~version modules in
   let allow_new_public_modules = Modules.wrapped modules |> Wrapped.to_bool |> not in
   { Modules_field_evaluator.Implementation.existing_virtual_modules
   ; allow_new_public_modules
@@ -691,6 +691,47 @@ let has_instances (lib : Buildable.t) =
     | Direct _ | Re_export _ | Select _ -> false)
 ;;
 
+let validate_module_references ~include_subdirs ~modules per_module =
+  let module_paths =
+    Module_trie.fold modules ~init:Module_name.Path.Set.empty ~f:(fun module_ acc ->
+      Module_name.Path.Set.add acc (Module.logical_path module_))
+  in
+  Module_reference.Per_item.explicit_references per_module
+  |> List.iter ~f:(fun reference ->
+    if not (Module_reference.is_legacy reference)
+    then (
+      let path = Module_reference.path reference in
+      if
+        Module_reference.is_qualified reference
+        &&
+        match include_subdirs with
+        | Include_subdirs.Include Qualified -> false
+        | No | Include Unqualified -> true
+      then
+        User_error.raise
+          ~loc:(Module_reference.loc reference)
+          [ Pp.textf
+              "Qualified module reference %S may only be used with (include_subdirs \
+               qualified)."
+              (Module_reference.to_string reference)
+          ];
+      if not (Module_name.Path.Set.mem module_paths path)
+      then
+        User_error.raise
+          ~loc:(Module_reference.loc reference)
+          [ Pp.textf "Module %s doesn't exist." (Module_reference.to_string reference) ]))
+;;
+
+let validate_buildable_preprocessing ~include_subdirs ~modules ~for_ buildable =
+  let preprocess =
+    match (for_ : Compilation_mode.t) with
+    | Ocaml -> buildable.Buildable.preprocess
+    | Melange -> buildable.melange_preprocess
+  in
+  validate_module_references ~include_subdirs ~modules preprocess.config;
+  validate_module_references ~include_subdirs ~modules buildable.lint
+;;
+
 let make_lib_modules
       ~expander
       ~dir
@@ -747,7 +788,7 @@ let make_lib_modules
       let+ kind =
         let+ impl =
           let* vlib = Lib.implements resolved |> Option.value_exn >>| Lib.info in
-          virtual_modules ~lookup_vlib ~libs ~for_ vlib |> Resolve.Memo.lift_memo
+          virtual_modules ~lookup_vlib ~libs ~for_ ~version vlib |> Resolve.Memo.lift_memo
         in
         Modules_field_evaluator.Implementation impl
       in
@@ -773,9 +814,13 @@ let make_lib_modules
       ~private_modules:
         (Option.value ~default:Ordered_set_lang.Unexpanded.standard lib.private_modules)
       ~src_dir:dir
+      ~include_subdirs
       modules_settings
       ~version
       ~for_
+  in
+  let () =
+    validate_buildable_preprocessing ~include_subdirs ~modules ~for_ lib.buildable
   in
   let () =
     match lib.stdlib, include_subdirs with
@@ -1107,6 +1152,7 @@ let modules_of_stanzas =
   let make_executables
         ~dir
         ~expander
+        ~include_subdirs
         ~(modules : Module.Source.t Module_trie.Unchecked.t)
         ~project
         exes
@@ -1123,9 +1169,17 @@ let modules_of_stanzas =
         ~src_dir:dir
         ~kind:Modules_field_evaluator.Exe_or_normal_lib
         ~private_modules:Ordered_set_lang.Unexpanded.standard
+        ~include_subdirs
         ~version:exes.dune_version
         modules_settings
         ~for_:Ocaml
+    in
+    let () =
+      validate_buildable_preprocessing
+        ~include_subdirs
+        ~modules
+        ~for_:Ocaml
+        exes.buildable
     in
     let has_instances = has_instances exes.buildable in
     let modules =
@@ -1136,8 +1190,10 @@ let modules_of_stanzas =
     in
     `Executables { Per_stanza.stanza = exes; sources; modules; obj_dir; dir }
   in
-  let make_tests ~dir ~expander ~modules ~project tests =
-    let+ result = make_executables ~dir ~expander ~modules ~project tests.Tests.exes in
+  let make_tests ~dir ~expander ~include_subdirs ~modules ~project tests =
+    let+ result =
+      make_executables ~dir ~expander ~include_subdirs ~modules ~project tests.Tests.exes
+    in
     match result with
     | `Executables group_part -> `Tests { group_part with stanza = tests }
   in
@@ -1215,7 +1271,7 @@ let modules_of_stanzas =
                    ~for_
                    exes.buildable.libraries
                in
-               make_executables ~dir ~expander ~modules ~project exes
+               make_executables ~dir ~expander ~include_subdirs ~modules ~project exes
              | Tests.T tests ->
                let modules =
                  Generated_modules.with_lib_select_deps
@@ -1226,7 +1282,7 @@ let modules_of_stanzas =
                    ~for_
                    tests.exes.buildable.libraries
                in
-               make_tests ~dir ~expander ~modules ~project tests
+               make_tests ~dir ~expander ~include_subdirs ~modules ~project tests
              | Melange_stanzas.Emit.T mel ->
                let obj_dir = Obj_dir.make_melange_emit ~dir ~name:mel.target in
                let+ sources, modules =
@@ -1248,8 +1304,16 @@ let modules_of_stanzas =
                    ~version
                    ~private_modules:Ordered_set_lang.Unexpanded.standard
                    ~src_dir:dir
+                   ~include_subdirs
                    ~for_:Melange
                    mel.modules
+               in
+               let () =
+                 validate_module_references
+                   ~include_subdirs
+                   ~modules
+                   mel.preprocess.config;
+                 validate_module_references ~include_subdirs ~modules mel.lint
                in
                let modules =
                  Modules.make_wrapped

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -477,7 +477,7 @@ let modules_and_obj_dir t ~libs ~for_ =
 
 let modules t ~libs ~for_ = modules_and_obj_dir t ~libs ~for_ >>| fst
 
-let virtual_modules ~lookup_vlib ~libs ~for_ vlib =
+let virtual_modules ~lookup_vlib ~libs ~for_ ~version vlib =
   let+ modules =
     match Lib_info.modules vlib ~for_ with
     | External modules ->
@@ -487,7 +487,7 @@ let virtual_modules ~lookup_vlib ~libs ~for_ vlib =
       lookup_vlib ~dir:src_dir
       >>= modules ~libs ~for_:(Library (Lib_info.lib_id vlib |> Lib_id.to_local_exn))
   in
-  let existing_virtual_modules = Modules.virtual_module_names modules in
+  let existing_virtual_modules = Modules.virtual_module_names ~version modules in
   let allow_new_public_modules = Modules.wrapped modules |> Wrapped.to_bool |> not in
   { Modules_field_evaluator.Implementation.existing_virtual_modules
   ; allow_new_public_modules
@@ -678,6 +678,35 @@ let has_instances (lib : Buildable.t) =
     | Direct _ | Re_export _ | Select _ -> false)
 ;;
 
+let validate_qualified_module_references ~include_subdirs per_module =
+  Module_reference.Per_item.explicit_references per_module
+  |> List.iter ~f:(fun reference ->
+    if
+      Module_reference.is_qualified reference
+      &&
+      match include_subdirs with
+      | Include_subdirs.Include Qualified -> false
+      | No | Include Unqualified -> true
+    then
+      User_error.raise
+        ~loc:(Module_reference.loc reference)
+        [ Pp.textf
+            "Qualified module reference %S may only be used with (include_subdirs \
+             qualified)."
+            (Module_reference.to_string reference)
+        ])
+;;
+
+let validate_buildable_preprocessing ~include_subdirs ~for_ buildable =
+  let preprocess =
+    match (for_ : Compilation_mode.t) with
+    | Ocaml -> buildable.Buildable.preprocess
+    | Melange -> buildable.melange_preprocess
+  in
+  validate_qualified_module_references ~include_subdirs preprocess.config;
+  validate_qualified_module_references ~include_subdirs buildable.lint
+;;
+
 let make_lib_modules
       ~expander
       ~dir
@@ -734,7 +763,7 @@ let make_lib_modules
       let+ kind =
         let+ impl =
           let* vlib = Lib.implements resolved |> Option.value_exn >>| Lib.info in
-          virtual_modules ~lookup_vlib ~libs ~for_ vlib |> Resolve.Memo.lift_memo
+          virtual_modules ~lookup_vlib ~libs ~for_ ~version vlib |> Resolve.Memo.lift_memo
         in
         Modules_field_evaluator.Implementation impl
       in
@@ -760,10 +789,12 @@ let make_lib_modules
       ~private_modules:
         (Option.value ~default:Ordered_set_lang.Unexpanded.standard lib.private_modules)
       ~src_dir:dir
+      ~include_subdirs
       modules_settings
       ~version
       ~for_
   in
+  let () = validate_buildable_preprocessing ~include_subdirs ~for_ lib.buildable in
   let () =
     match lib.stdlib, include_subdirs with
     | Some stdlib, Include Qualified ->
@@ -1095,6 +1126,7 @@ let modules_of_stanzas =
   let make_executables
         ~dir
         ~expander
+        ~include_subdirs
         ~(modules : Module.Source.t Module_trie.Unchecked.t)
         ~project
         exes
@@ -1111,9 +1143,13 @@ let modules_of_stanzas =
         ~src_dir:dir
         ~kind:Modules_field_evaluator.Exe_or_normal_lib
         ~private_modules:Ordered_set_lang.Unexpanded.standard
+        ~include_subdirs
         ~version:exes.dune_version
         modules_settings
         ~for_:Ocaml
+    in
+    let () =
+      validate_buildable_preprocessing ~include_subdirs ~for_:Ocaml exes.buildable
     in
     let has_instances = has_instances exes.buildable in
     let modules =
@@ -1124,8 +1160,10 @@ let modules_of_stanzas =
     in
     `Executables { Per_stanza.stanza = exes; sources; modules; obj_dir; dir }
   in
-  let make_tests ~dir ~expander ~modules ~project tests =
-    let+ result = make_executables ~dir ~expander ~modules ~project tests.Tests.exes in
+  let make_tests ~dir ~expander ~include_subdirs ~modules ~project tests =
+    let+ result =
+      make_executables ~dir ~expander ~include_subdirs ~modules ~project tests.Tests.exes
+    in
     match result with
     | `Executables group_part -> `Tests { group_part with stanza = tests }
   in
@@ -1203,7 +1241,7 @@ let modules_of_stanzas =
                    ~for_
                    exes.buildable.libraries
                in
-               make_executables ~dir ~expander ~modules ~project exes
+               make_executables ~dir ~expander ~include_subdirs ~modules ~project exes
              | Tests.T tests ->
                let modules =
                  Generated_modules.with_lib_select_deps
@@ -1214,7 +1252,7 @@ let modules_of_stanzas =
                    ~for_
                    tests.exes.buildable.libraries
                in
-               make_tests ~dir ~expander ~modules ~project tests
+               make_tests ~dir ~expander ~include_subdirs ~modules ~project tests
              | Melange_stanzas.Emit.T mel ->
                let obj_dir =
                  Obj_dir.make_for_exe_target ~dir (Melange_stanzas.Emit.exe_target mel)
@@ -1238,8 +1276,15 @@ let modules_of_stanzas =
                    ~version
                    ~private_modules:Ordered_set_lang.Unexpanded.standard
                    ~src_dir:dir
+                   ~include_subdirs
                    ~for_:Melange
                    mel.modules
+               in
+               let () =
+                 validate_qualified_module_references
+                   ~include_subdirs
+                   mel.preprocess.config;
+                 validate_qualified_module_references ~include_subdirs mel.lint
                in
                let modules =
                  Modules.make_wrapped

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -612,23 +612,27 @@ module Parser_generators = struct
         | Ocamllex { loc; _ }
         | Ocamlyacc { loc; _ }
         | Menhir { Menhir_stanza.merge_into = None; loc; _ } ->
-          Module_trie.Unchecked.map expanded ~f:(fun (_, (module_name, basename)) ->
-            let module_path =
-              Nonempty_list.(
-                map (module_path @ [ module_name ]) ~f:Module_name.Unchecked.allow_invalid)
-            in
-            let original_path =
-              let base_path = Path.Build.relative src_dir basename in
-              let ext = Targets.extension ~for_ in
-              Path.Build.set_extension base_path ~ext
-            in
-            ( loc
-            , make_module
-                ~module_path
-                ~original_path
-                ~root_dir
-                ~for_parser_gen:for_
-                ~for_:mode ))
+          Module_trie.Unchecked.mapi
+            expanded
+            ~f:(fun path (_, (_module_name, basename)) ->
+              let trie_path = Nonempty_list.(module_path @ path) in
+              let module_path =
+                Nonempty_list.map trie_path ~f:Module_name.Unchecked.allow_invalid
+              in
+              let original_path =
+                let base_path = Path.Build.relative src_dir basename in
+                let ext = Targets.extension ~for_ in
+                Path.Build.set_extension base_path ~ext
+              in
+              let m =
+                make_module
+                  ~module_path
+                  ~original_path
+                  ~root_dir
+                  ~for_parser_gen:for_
+                  ~for_:mode
+              in
+              loc, m)
         | Menhir { Menhir_stanza.merge_into = Some basename; loc; _ } ->
           let impl =
             let original_path =

--- a/src/dune_rules/module.ml
+++ b/src/dune_rules/module.ml
@@ -160,6 +160,13 @@ module Source = struct
   let name t = Nonempty_list.last t.path
   let path t = t.path
 
+  let logical_path t =
+    match List.rev (Nonempty_list.to_list t.path) with
+    | name :: parent :: rest when Module_name.equal name parent ->
+      Nonempty_list.of_list_exn (List.rev (parent :: rest))
+    | _ -> t.path
+  ;;
+
   let choose_file { files = { impl; intf }; path = _ } =
     match intf, impl with
     | None, None -> assert false
@@ -203,6 +210,7 @@ end
 
 type t =
   { source : Source.t
+  ; logical_path : Module_name.Path.t
   ; obj_name : Module_name.Unique.t
   ; pp : (string list Action_builder.t * Sandbox_config.t) option
   ; visibility : Visibility.t
@@ -212,6 +220,7 @@ type t =
 
 let name t = Source.name t.source
 let path t = t.source.path
+let logical_path t = t.logical_path
 let kind t = t.kind
 let pp_flags t = t.pp
 let install_as t = t.install_as
@@ -251,7 +260,14 @@ let of_source ~install_as ~obj_name ~visibility ~(kind : Kind.t) (source : Sourc
          indication by the caller. *)
       Module_name.Unique.of_path_assuming_needs_no_mangling_allow_invalid file.path
   in
-  { install_as; source; obj_name; pp = None; visibility; kind }
+  { install_as
+  ; source
+  ; logical_path = Source.logical_path source
+  ; obj_name
+  ; pp = None
+  ; visibility
+  ; kind
+  }
 ;;
 
 let has t ~ml_kind =
@@ -294,9 +310,10 @@ let map_files t ~f =
 let src_dir t = Source.src_dir t.source
 let set_pp t pp = { t with pp }
 
-let to_dyn { source; obj_name; pp; visibility; kind; install_as } =
+let to_dyn { source; logical_path; obj_name; pp; visibility; kind; install_as } =
   Dyn.record
     [ "source", Source.to_dyn source
+    ; "logical_path", Module_name.Path.to_dyn logical_path
     ; "obj_name", Module_name.Unique.to_dyn obj_name
     ; "pp", Dyn.(option string) (Option.map ~f:(fun _ -> "has pp") pp)
     ; "visibility", Visibility.to_dyn visibility
@@ -361,7 +378,10 @@ module Obj_map = struct
     end)
 end
 
-let encode ({ source; obj_name; pp = _; visibility; kind; install_as = _ } as t) ~src_dir =
+let encode
+      ({ source; logical_path; obj_name; pp = _; visibility; kind; install_as = _ } as t)
+      ~src_dir
+  =
   let open Dune_lang.Encoder in
   let has_impl = has t ~ml_kind:Impl in
   let kind =
@@ -377,10 +397,16 @@ let encode ({ source; obj_name; pp = _; visibility; kind; install_as = _ } as t)
     | Intf_only
     | Parameter -> Some kind
   in
+  let logical_path =
+    if Module_name.Path.equal logical_path (Source.logical_path source)
+    then []
+    else Module_name.Path.encode logical_path
+  in
   record_fields
     [ field "obj_name" Module_name.Unique.encode obj_name
     ; field "visibility" Visibility.encode visibility
     ; field_o "kind" Kind.encode kind
+    ; field_l "logical_path" Fun.id logical_path
     ; field_l "source" Fun.id (Source.encode ~dir:src_dir source)
     ]
 ;;
@@ -392,6 +418,7 @@ let decode ~src_dir =
     (let+ obj_name = field "obj_name" Module_name.Unique.decode
      and+ visibility = field "visibility" Visibility.decode
      and+ kind = field_o "kind" K.decode
+     and+ logical_path = field_o "logical_path" Module_name.Path.decode
      and+ source = field "source" (Source.decode ~dir:src_dir) in
      let kind =
        match kind with
@@ -399,7 +426,8 @@ let decode ~src_dir =
        | None when Option.is_some source.files.impl -> Impl
        | None -> Intf_only
      in
-     { install_as = None; source; obj_name; pp = None; kind; visibility })
+     let logical_path = Option.value logical_path ~default:(Source.logical_path source) in
+     { install_as = None; source; logical_path; obj_name; pp = None; kind; visibility })
 ;;
 
 let pped =

--- a/src/dune_rules/module.ml
+++ b/src/dune_rules/module.ml
@@ -232,7 +232,7 @@ type t =
   }
 
 let name t = Source.name t.source
-let path t = t.source.path
+let path t = Source.path t.source
 let kind t = t.kind
 let pp_flags t = t.pp
 let install_as t = t.install_as

--- a/src/dune_rules/module.mli
+++ b/src/dune_rules/module.mli
@@ -38,6 +38,7 @@ module Source : sig
   val files : t -> File.t list
   val files_by_ml_kind : t -> File.t option Ml_kind.Dict.t
   val path : t -> Module_name.Path.t
+  val logical_path : t -> Module_name.Path.t
   val to_dyn : t -> Dyn.t
   val src_dir : t -> Path.t
 end
@@ -54,6 +55,7 @@ val of_source : visibility:Visibility.t -> kind:Kind.t -> Source.t -> t
 
 val name : t -> Module_name.t
 val path : t -> Module_name.Path.t
+val logical_path : t -> Module_name.Path.t
 val source : t -> ml_kind:Ml_kind.t -> File.t option
 val source_without_pp : t -> ml_kind:Ml_kind.t -> Path.t option
 val pp_flags : t -> (string list Action_builder.t * Sandbox_config.t) option

--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -973,10 +973,16 @@ let fold_user_written t ~f ~init =
   | Wrapped { group; _ } -> Group.fold group ~init ~f
 ;;
 
-let virtual_module_names =
+let virtual_module_names ~version =
   fold ~init:Module_name.Path.Set.empty ~f:(fun m acc ->
     match Module.kind m with
-    | Virtual -> Module_name.Path.Set.add acc [ Module.name m ]
+    | Virtual ->
+      let path =
+        if version < (3, 25)
+        then Nonempty_list.[ Module.name m ]
+        else Module.logical_path m
+      in
+      Module_name.Path.Set.add acc path
     | _ -> acc)
 ;;
 

--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -955,10 +955,14 @@ let fold_user_written t ~f ~init =
   | Wrapped { group; _ } -> Group.fold group ~init ~f
 ;;
 
-let virtual_module_names =
+let virtual_module_names ~version =
   fold ~init:Module_name.Path.Set.empty ~f:(fun m acc ->
     match Module.kind m with
-    | Virtual -> Module_name.Path.Set.add acc [ Module.name m ]
+    | Virtual ->
+      let path =
+        if version < (3, 25) then Nonempty_list.[ Module.name m ] else Module.path m
+      in
+      Module_name.Path.Set.add acc path
     | _ -> acc)
 ;;
 

--- a/src/dune_rules/modules.mli
+++ b/src/dune_rules/modules.mli
@@ -54,7 +54,10 @@ end
 val obj_map : t -> Sourced_module.t Module_name.Unique.Map.t
 
 (** Returns only the virtual module names in the library *)
-val virtual_module_names : t -> Module_name.Path.Set.t
+val virtual_module_names
+  :  version:Dune_lang.Syntax.Version.t
+  -> t
+  -> Module_name.Path.Set.t
 
 val wrapped : t -> Wrapped.t
 val source_dirs : t -> Path.Set.t

--- a/src/dune_rules/modules_field_evaluator.ml
+++ b/src/dune_rules/modules_field_evaluator.ml
@@ -18,7 +18,7 @@ type kind =
   | Exe_or_normal_lib
   | Parameter
 
-module Key = struct
+module Trie_key = struct
   type t = Module_name.Unchecked.Path.t
 
   let compare = Module_name.Unchecked.Path.compare
@@ -26,7 +26,42 @@ module Key = struct
   module Map = Module_trie.Unchecked
 end
 
+module Key = struct
+  type t = Module_name.Unchecked.Path.t
+
+  let compare = Module_name.Unchecked.Path.compare
+
+  module Map = Module_name.Unchecked.Path.Map
+end
+
 module Unordered = Ordered_set_lang.Unordered (Key)
+module Unordered_trie = Ordered_set_lang.Unordered (Trie_key)
+
+module Indexed_source = struct
+  type t =
+    { logical_path : Module_name.Unchecked.Path.t
+    ; source_path : Module_name.Unchecked.Path.t
+    ; source : Module.Source.t
+    }
+end
+
+let unchecked_path path = Nonempty_list.map path ~f:Module_name.unchecked
+
+let source_path ~version source =
+  if version < (3, 25)
+  then Nonempty_list.[ Module.Source.name source |> Module_name.unchecked ]
+  else Module.Source.logical_path source |> unchecked_path
+;;
+
+let logical_source_path path =
+  match List.rev (Nonempty_list.to_list path) with
+  | name :: parent :: rest
+    when Module_name.equal
+           (Module_name.Unchecked.allow_invalid name)
+           (Module_name.Unchecked.allow_invalid parent) ->
+    Nonempty_list.of_list_exn (List.rev (parent :: rest))
+  | _ -> path
+;;
 
 let expand_all_unchecked =
   let key (name, _) = Nonempty_list.[ name ] in
@@ -36,63 +71,86 @@ let expand_all_unchecked =
       let open Action_builder.O in
       let+ set = Expander.expand_ordered_set_lang expander osl in
       let standard = Module_trie.Unchecked.empty in
-      Unordered.eval_loc set ~parse ~key ~standard
+      Unordered_trie.eval_loc set ~parse ~key ~standard
     in
     Action_builder.evaluate_and_collect_facts expand_and_eval >>| fst
 ;;
 
 let eval0 =
   let key = function
-    | Error s -> Nonempty_list.[ s ]
-    | Ok m -> [ Module.Source.name m |> Module_name.unchecked ]
+    | Error path -> path
+    | Ok { Indexed_source.logical_path; _ } -> logical_path
   in
   (* Fake modules are modules that do not exist but it doesn't matter because
      they are only removed from a set (for jbuild file compatibility) *)
   let expand_and_eval t set ~parse ~key ~standard =
     let open Action_builder.O in
     let+ set = Expander.expand_ordered_set_lang t set in
-    let fake_modules = ref Module_name.Unchecked.Map.empty in
+    let fake_modules = ref Module_name.Unchecked.Path.Map.empty in
     let r =
       let parse ~loc x = parse ~loc ~fake_modules x in
       Unordered.eval_loc set ~parse ~key ~standard
     in
     r, !fake_modules
   in
-  let parse ~all_modules ~loc ~fake_modules s =
-    let name = Module_name.of_string_allow_invalid (loc, s) in
-    let path = Nonempty_list.[ name ] in
-    match Module_trie.Unchecked.find all_modules path with
-    | Some m -> Ok m
+  let parse ~all_modules ~include_subdirs ~version ~loc ~fake_modules s =
+    let path =
+      if version < (3, 25)
+      then (
+        if List.length (String.split s ~on:'.') > 1
+        then Module_reference.of_string version (loc, s) |> ignore;
+        Nonempty_list.[ Module_name.of_string_allow_invalid (loc, s) ])
+      else (
+        let reference = Module_reference.of_string version (loc, s) in
+        let path = Module_reference.path reference in
+        if
+          Module_reference.is_qualified reference
+          &&
+          match include_subdirs with
+          | Include_subdirs.Include Qualified -> false
+          | No | Include Unqualified -> true
+        then
+          User_error.raise
+            ~loc
+            [ Pp.textf
+                "Qualified module reference %S may only be used with (include_subdirs \
+                 qualified)."
+                (Module_reference.to_string reference)
+            ];
+        unchecked_path path)
+    in
+    match Module_name.Unchecked.Path.Map.find all_modules path with
+    | Some source -> Ok source
     | None ->
-      fake_modules := Module_name.Unchecked.Map.set !fake_modules name loc;
-      Error name
+      fake_modules := Module_name.Unchecked.Path.Map.set !fake_modules path loc;
+      Error path
   in
-  fun ~expander ~loc ~all_modules ~standard osl ->
-    let parse = parse ~all_modules in
-    let standard = Module_trie.Unchecked.map standard ~f:(fun m -> loc, Ok m) in
+  fun ~expander ~loc ~all_modules ~include_subdirs ~version ~standard osl ->
+    let parse = parse ~all_modules ~include_subdirs ~version in
+    let standard = Module_name.Unchecked.Path.Map.map standard ~f:(fun m -> loc, Ok m) in
     let+ (modules, fake_modules), _ =
       Action_builder.evaluate_and_collect_facts
         (expand_and_eval expander ~parse ~standard ~key osl)
     in
     let modules =
-      Module_trie.Unchecked.filter_map modules ~f:(fun (loc, m) ->
+      Module_name.Unchecked.Path.Map.filter_map modules ~f:(fun (loc, m) ->
         match m with
-        | Ok m -> Some (loc, m)
-        | Error s ->
+        | Ok { Indexed_source.source; _ } -> Some (loc, source)
+        | Error path ->
           User_error.raise
             ~loc
             [ Pp.textf
                 "Module %s doesn't exist."
-                (Module_name.to_string (Module_name.Unchecked.allow_invalid s))
+                (Module_name.Unchecked.Path.to_string path)
             ])
     in
-    Module_name.Unchecked.Map.iteri
-      ~f:(fun m loc ->
+    Module_name.Unchecked.Path.Map.iteri
+      ~f:(fun path loc ->
         User_error.raise
           ~loc
           [ Pp.textf
               "Module %s is excluded but it doesn't exist."
-              (Module_name.to_string (Module_name.Unchecked.allow_invalid m))
+              (Module_name.Unchecked.Path.to_string path)
           ])
       fake_modules;
     modules
@@ -132,13 +190,13 @@ let find_errors
        why the code is implemented this way. *)
     List.fold_left
       [ intf_only; virtual_modules; private_modules ]
-      ~init:(Module_trie.Unchecked.map modules ~f:snd)
+      ~init:(Module_name.Unchecked.Path.Map.map modules ~f:snd)
       ~f:(fun acc map ->
-        Module_trie.Unchecked.foldi map ~init:acc ~f:(fun name (_loc, m) acc ->
-          Module_trie.Unchecked.set acc name m))
+        Module_name.Unchecked.Path.Map.foldi map ~init:acc ~f:(fun name (_loc, m) acc ->
+          Module_name.Unchecked.Path.Map.set acc name m))
   in
   let errors =
-    Module_trie.Unchecked.foldi all ~init:[] ~f:(fun module_name module_ acc ->
+    Module_name.Unchecked.Path.Map.foldi all ~init:[] ~f:(fun module_name module_ acc ->
       let has_impl = Module.Source.has module_ ~ml_kind:Impl in
       let has_intf = Module.Source.has module_ ~ml_kind:Intf in
       let impl_vmodule =
@@ -147,10 +205,10 @@ let find_errors
         in
         Module_name.Path.Set.mem existing_virtual_modules module_name
       in
-      let modules = Module_trie.Unchecked.find modules module_name in
-      let private_ = Module_trie.Unchecked.find private_modules module_name in
-      let virtual_ = Module_trie.Unchecked.find virtual_modules module_name in
-      let intf_only = Module_trie.Unchecked.find intf_only module_name in
+      let modules = Module_name.Unchecked.Path.Map.find modules module_name in
+      let private_ = Module_name.Unchecked.Path.Map.find private_modules module_name in
+      let virtual_ = Module_name.Unchecked.Path.Map.find virtual_modules module_name in
+      let intf_only = Module_name.Unchecked.Path.Map.find intf_only module_name in
       let with_property prop f acc =
         match prop with
         | None -> acc
@@ -189,7 +247,7 @@ let find_errors
   let unimplemented_virt_modules =
     Module_name.Path.Set.filter existing_virtual_modules ~f:(fun module_name ->
       let module_name = Nonempty_list.map module_name ~f:Module_name.unchecked in
-      match Module_trie.Unchecked.find all module_name with
+      match Module_name.Unchecked.Path.Map.find all module_name with
       | None -> true
       | Some m -> not (Module.Source.has m ~ml_kind:Impl))
   in
@@ -360,12 +418,13 @@ let check_invalid_module_listing
 
 let eval
       ~expander
-      ~modules:(all_modules : Module.Source.t Module_trie.Unchecked.t)
+      ~modules:(all_modules : Indexed_source.t Module_name.Unchecked.Path.Map.t)
       ~stanza_loc
       ~private_modules
       ~kind
       ~for_
       ~src_dir
+      ~include_subdirs
       ~is_vendored
       ~version
       { Modules_settings.modules = _; root_module; modules_without_implementation }
@@ -373,7 +432,7 @@ let eval
   =
   (* Fake modules are modules that do not exist but it doesn't matter because
      they are only removed from a set (for jbuild file compatibility) *)
-  let eval = eval0 ~expander ~loc:stanza_loc ~all_modules in
+  let eval = eval0 ~expander ~loc:stanza_loc ~all_modules ~include_subdirs ~version in
   let allow_new_public_modules =
     match kind with
     | Exe_or_normal_lib | Virtual _ | Parameter -> true
@@ -385,15 +444,21 @@ let eval
     | Implementation { existing_virtual_modules; _ } -> existing_virtual_modules
   in
   let+ intf_only =
-    eval ~standard:Module_trie.Unchecked.empty modules_without_implementation
+    eval ~standard:Module_name.Unchecked.Path.Map.empty modules_without_implementation
   and+ virtual_modules =
     match kind with
-    | Exe_or_normal_lib | Implementation _ -> Memo.return Module_trie.Unchecked.empty
+    | Exe_or_normal_lib | Implementation _ ->
+      Memo.return Module_name.Unchecked.Path.Map.empty
     | Virtual { virtual_modules } ->
-      eval ~standard:Module_trie.Unchecked.empty virtual_modules
+      eval ~standard:Module_name.Unchecked.Path.Map.empty virtual_modules
     | Parameter ->
-      Memo.return (Module_trie.Unchecked.map ~f:(fun v -> stanza_loc, v) all_modules)
-  and+ private_modules = eval ~standard:Module_trie.Unchecked.empty private_modules in
+      Memo.return
+        (Module_name.Unchecked.Path.Map.map
+           ~f:(fun { Indexed_source.source; _ } -> stanza_loc, source)
+           all_modules)
+  and+ private_modules =
+    eval ~standard:Module_name.Unchecked.Path.Map.empty private_modules
+  in
   let is_parameter =
     match kind with
     | Parameter -> true
@@ -411,24 +476,37 @@ let eval
     ~is_vendored
     ~is_parameter
     ~version;
-  let modules = Module_trie.Unchecked.check_exn modules in
+  let modules =
+    Module_name.Unchecked.Path.Map.foldi
+      modules
+      ~init:Module_trie.Unchecked.empty
+      ~f:(fun logical_path (loc, m) acc ->
+        let { Indexed_source.source_path; _ } =
+          Module_name.Unchecked.Path.Map.find_exn all_modules logical_path
+        in
+        Module_trie.Unchecked.set acc source_path (loc, m))
+    |> Module_trie.Unchecked.check_exn
+  in
   let all_modules =
     Module_trie.mapi modules ~f:(fun _path (_, m) ->
-      let name = Nonempty_list.[ Module.Source.name m |> Module_name.unchecked ] in
+      let logical_path = source_path ~version m in
       let visibility =
-        if Module_trie.Unchecked.mem private_modules name
+        if Module_name.Unchecked.Path.Map.mem private_modules logical_path
         then Visibility.Private
         else Public
       in
       let kind =
         if is_parameter
         then Module.Kind.Parameter
-        else if Module_trie.Unchecked.mem virtual_modules name
+        else if Module_name.Unchecked.Path.Map.mem virtual_modules logical_path
         then Virtual
         else if Module.Source.has m ~ml_kind:Impl
         then (
-          let name = Module.Source.name m in
-          if Module_name.Path.Set.mem existing_virtual_modules [ name ]
+          let path =
+            source_path ~version m
+            |> Nonempty_list.map ~f:Module_name.Unchecked.allow_invalid
+          in
+          if Module_name.Path.Set.mem existing_virtual_modules path
           then Impl_vmodule
           else Impl)
         else Intf_only
@@ -454,14 +532,33 @@ let eval
       ~kind
       ~for_
       ~src_dir
+      ~include_subdirs
       ~version
       (settings : Modules_settings.t)
   =
   Memo.push_stack_frame ~human_readable_description:(fun () ->
     Pp.textf "(modules) field at %s" (Loc.to_file_colon_line stanza_loc))
   @@ fun () ->
+  let all_modules_by_path =
+    Module_trie.Unchecked.foldi
+      all_modules
+      ~init:Module_name.Unchecked.Path.Map.empty
+      ~f:(fun path m acc ->
+        let logical_path = if version < (3, 25) then path else logical_source_path path in
+        Module_name.Unchecked.Path.Map.set
+          acc
+          logical_path
+          { Indexed_source.logical_path; source_path = path; source = m })
+  in
   let* modules0 =
-    eval0 ~expander ~loc:stanza_loc ~all_modules ~standard:all_modules settings.modules
+    eval0
+      ~expander
+      ~loc:stanza_loc
+      ~all_modules:all_modules_by_path
+      ~include_subdirs
+      ~version
+      ~standard:all_modules_by_path
+      settings.modules
   in
   let* is_vendored =
     match Path.Build.drop_build_context src_dir with
@@ -470,12 +567,13 @@ let eval
   in
   eval
     ~expander
-    ~modules:all_modules
+    ~modules:all_modules_by_path
     ~stanza_loc
     ~private_modules
     ~kind
     ~for_
     ~src_dir
+    ~include_subdirs
     ~is_vendored
     settings
     modules0

--- a/src/dune_rules/modules_field_evaluator.ml
+++ b/src/dune_rules/modules_field_evaluator.ml
@@ -40,14 +40,14 @@ module Unordered_trie = Ordered_set_lang.Unordered (Trie_key)
 module Indexed_source = struct
   type t =
     { logical_path : Module_name.Unchecked.Path.t
-    ; source_path : Module_name.Unchecked.Path.t
+    ; trie_path : Module_name.Unchecked.Path.t
     ; source : Module.Source.t
     }
 end
 
 let unchecked_path path = Nonempty_list.map path ~f:Module_name.unchecked
 
-let source_path ~version source =
+let reference_path ~version source =
   if version < (3, 25)
   then Nonempty_list.[ Module.Source.name source |> Module_name.unchecked ]
   else Module.Source.path source |> unchecked_path
@@ -87,7 +87,7 @@ let eval0 =
     let path =
       if version < (3, 25)
       then (
-        if List.length (String.split s ~on:'.') > 1
+        if String.contains s '.'
         then Module_reference.of_string version (loc, s) |> ignore;
         Nonempty_list.[ Module_name.of_string_allow_invalid (loc, s) ])
       else (
@@ -471,15 +471,15 @@ let eval
       modules
       ~init:Module_trie.Unchecked.empty
       ~f:(fun logical_path (loc, m) acc ->
-        let { Indexed_source.source_path; _ } =
+        let { Indexed_source.trie_path; _ } =
           Module_name.Unchecked.Path.Map.find_exn all_modules logical_path
         in
-        Module_trie.Unchecked.set acc source_path (loc, m))
+        Module_trie.Unchecked.set acc trie_path (loc, m))
     |> Module_trie.Unchecked.check_exn
   in
   let all_modules =
     Module_trie.mapi modules ~f:(fun _path (_, m) ->
-      let logical_path = source_path ~version m in
+      let logical_path = reference_path ~version m in
       let visibility =
         if Module_name.Unchecked.Path.Map.mem private_modules logical_path
         then Visibility.Private
@@ -493,7 +493,7 @@ let eval
         else if Module.Source.has m ~ml_kind:Impl
         then (
           let path =
-            source_path ~version m
+            reference_path ~version m
             |> Nonempty_list.map ~f:Module_name.Unchecked.allow_invalid
           in
           if Module_name.Path.Set.mem existing_virtual_modules path
@@ -540,7 +540,7 @@ let eval
         Module_name.Unchecked.Path.Map.set
           acc
           logical_path
-          { Indexed_source.logical_path; source_path = path; source = m })
+          { Indexed_source.logical_path; trie_path = path; source = m })
   in
   let* modules0 =
     eval0

--- a/src/dune_rules/modules_field_evaluator.ml
+++ b/src/dune_rules/modules_field_evaluator.ml
@@ -18,7 +18,7 @@ type kind =
   | Exe_or_normal_lib
   | Parameter
 
-module Key = struct
+module Trie_key = struct
   type t = Module_name.Unchecked.Path.t
 
   let compare = Module_name.Unchecked.Path.compare
@@ -26,7 +26,32 @@ module Key = struct
   module Map = Module_trie.Unchecked
 end
 
+module Key = struct
+  type t = Module_name.Unchecked.Path.t
+
+  let compare = Module_name.Unchecked.Path.compare
+
+  module Map = Module_name.Unchecked.Path.Map
+end
+
 module Unordered = Ordered_set_lang.Unordered (Key)
+module Unordered_trie = Ordered_set_lang.Unordered (Trie_key)
+
+module Indexed_source = struct
+  type t =
+    { logical_path : Module_name.Unchecked.Path.t
+    ; source_path : Module_name.Unchecked.Path.t
+    ; source : Module.Source.t
+    }
+end
+
+let unchecked_path path = Nonempty_list.map path ~f:Module_name.unchecked
+
+let source_path ~version source =
+  if version < (3, 25)
+  then Nonempty_list.[ Module.Source.name source |> Module_name.unchecked ]
+  else Module.Source.path source |> unchecked_path
+;;
 
 let expand_all_unchecked =
   let key (name, _) = Nonempty_list.[ name ] in
@@ -36,63 +61,86 @@ let expand_all_unchecked =
       let open Action_builder.O in
       let+ set = Expander.expand_ordered_set_lang expander osl in
       let standard = Module_trie.Unchecked.empty in
-      Unordered.eval_loc set ~parse ~key ~standard
+      Unordered_trie.eval_loc set ~parse ~key ~standard
     in
     Action_builder.evaluate_and_collect_facts expand_and_eval >>| fst
 ;;
 
 let eval0 =
   let key = function
-    | Error s -> Nonempty_list.[ s ]
-    | Ok m -> [ Module.Source.name m |> Module_name.unchecked ]
+    | Error path -> path
+    | Ok { Indexed_source.logical_path; _ } -> logical_path
   in
   (* Fake modules are modules that do not exist but it doesn't matter because
      they are only removed from a set (for jbuild file compatibility) *)
   let expand_and_eval t set ~parse ~key ~standard =
     let open Action_builder.O in
     let+ set = Expander.expand_ordered_set_lang t set in
-    let fake_modules = ref Module_name.Unchecked.Map.empty in
+    let fake_modules = ref Module_name.Unchecked.Path.Map.empty in
     let r =
       let parse ~loc x = parse ~loc ~fake_modules x in
       Unordered.eval_loc set ~parse ~key ~standard
     in
     r, !fake_modules
   in
-  let parse ~all_modules ~loc ~fake_modules s =
-    let name = Module_name.of_string_allow_invalid (loc, s) in
-    let path = Nonempty_list.[ name ] in
-    match Module_trie.Unchecked.find all_modules path with
-    | Some m -> Ok m
+  let parse ~all_modules ~include_subdirs ~version ~loc ~fake_modules s =
+    let path =
+      if version < (3, 25)
+      then (
+        if List.length (String.split s ~on:'.') > 1
+        then Module_reference.of_string version (loc, s) |> ignore;
+        Nonempty_list.[ Module_name.of_string_allow_invalid (loc, s) ])
+      else (
+        let reference = Module_reference.of_string version (loc, s) in
+        let path = Module_reference.path reference in
+        if
+          Module_reference.is_qualified reference
+          &&
+          match include_subdirs with
+          | Include_subdirs.Include Qualified -> false
+          | No | Include Unqualified -> true
+        then
+          User_error.raise
+            ~loc
+            [ Pp.textf
+                "Qualified module reference %S may only be used with (include_subdirs \
+                 qualified)."
+                (Module_reference.to_string reference)
+            ];
+        unchecked_path path)
+    in
+    match Module_name.Unchecked.Path.Map.find all_modules path with
+    | Some source -> Ok source
     | None ->
-      fake_modules := Module_name.Unchecked.Map.set !fake_modules name loc;
-      Error name
+      fake_modules := Module_name.Unchecked.Path.Map.set !fake_modules path loc;
+      Error path
   in
-  fun ~expander ~loc ~all_modules ~standard osl ->
-    let parse = parse ~all_modules in
-    let standard = Module_trie.Unchecked.map standard ~f:(fun m -> loc, Ok m) in
+  fun ~expander ~loc ~all_modules ~include_subdirs ~version ~standard osl ->
+    let parse = parse ~all_modules ~include_subdirs ~version in
+    let standard = Module_name.Unchecked.Path.Map.map standard ~f:(fun m -> loc, Ok m) in
     let+ (modules, fake_modules), _ =
       Action_builder.evaluate_and_collect_facts
         (expand_and_eval expander ~parse ~standard ~key osl)
     in
     let modules =
-      Module_trie.Unchecked.filter_map modules ~f:(fun (loc, m) ->
+      Module_name.Unchecked.Path.Map.filter_map modules ~f:(fun (loc, m) ->
         match m with
-        | Ok m -> Some (loc, m)
-        | Error s ->
+        | Ok { Indexed_source.source; _ } -> Some (loc, source)
+        | Error path ->
           User_error.raise
             ~loc
             [ Pp.textf
                 "Module %s doesn't exist."
-                (Module_name.to_string (Module_name.Unchecked.allow_invalid s))
+                (Module_name.Unchecked.Path.to_string path)
             ])
     in
-    Module_name.Unchecked.Map.iteri
-      ~f:(fun m loc ->
+    Module_name.Unchecked.Path.Map.iteri
+      ~f:(fun path loc ->
         User_error.raise
           ~loc
           [ Pp.textf
               "Module %s is excluded but it doesn't exist."
-              (Module_name.to_string (Module_name.Unchecked.allow_invalid m))
+              (Module_name.Unchecked.Path.to_string path)
           ])
       fake_modules;
     modules
@@ -132,13 +180,13 @@ let find_errors
        why the code is implemented this way. *)
     List.fold_left
       [ intf_only; virtual_modules; private_modules ]
-      ~init:(Module_trie.Unchecked.map modules ~f:snd)
+      ~init:(Module_name.Unchecked.Path.Map.map modules ~f:snd)
       ~f:(fun acc map ->
-        Module_trie.Unchecked.foldi map ~init:acc ~f:(fun name (_loc, m) acc ->
-          Module_trie.Unchecked.set acc name m))
+        Module_name.Unchecked.Path.Map.foldi map ~init:acc ~f:(fun name (_loc, m) acc ->
+          Module_name.Unchecked.Path.Map.set acc name m))
   in
   let errors =
-    Module_trie.Unchecked.foldi all ~init:[] ~f:(fun module_name module_ acc ->
+    Module_name.Unchecked.Path.Map.foldi all ~init:[] ~f:(fun module_name module_ acc ->
       let has_impl = Module.Source.has module_ ~ml_kind:Impl in
       let has_intf = Module.Source.has module_ ~ml_kind:Intf in
       let impl_vmodule =
@@ -147,10 +195,10 @@ let find_errors
         in
         Module_name.Path.Set.mem existing_virtual_modules module_name
       in
-      let modules = Module_trie.Unchecked.find modules module_name in
-      let private_ = Module_trie.Unchecked.find private_modules module_name in
-      let virtual_ = Module_trie.Unchecked.find virtual_modules module_name in
-      let intf_only = Module_trie.Unchecked.find intf_only module_name in
+      let modules = Module_name.Unchecked.Path.Map.find modules module_name in
+      let private_ = Module_name.Unchecked.Path.Map.find private_modules module_name in
+      let virtual_ = Module_name.Unchecked.Path.Map.find virtual_modules module_name in
+      let intf_only = Module_name.Unchecked.Path.Map.find intf_only module_name in
       let with_property prop f acc =
         match prop with
         | None -> acc
@@ -189,7 +237,7 @@ let find_errors
   let unimplemented_virt_modules =
     Module_name.Path.Set.filter existing_virtual_modules ~f:(fun module_name ->
       let module_name = Nonempty_list.map module_name ~f:Module_name.unchecked in
-      match Module_trie.Unchecked.find all module_name with
+      match Module_name.Unchecked.Path.Map.find all module_name with
       | None -> true
       | Some m -> not (Module.Source.has m ~ml_kind:Impl))
   in
@@ -360,12 +408,13 @@ let check_invalid_module_listing
 
 let eval
       ~expander
-      ~modules:(all_modules : Module.Source.t Module_trie.Unchecked.t)
+      ~modules:(all_modules : Indexed_source.t Module_name.Unchecked.Path.Map.t)
       ~stanza_loc
       ~private_modules
       ~kind
       ~for_
       ~src_dir
+      ~include_subdirs
       ~is_vendored
       ~version
       { Modules_settings.modules = _; root_module; modules_without_implementation }
@@ -373,7 +422,7 @@ let eval
   =
   (* Fake modules are modules that do not exist but it doesn't matter because
      they are only removed from a set (for jbuild file compatibility) *)
-  let eval = eval0 ~expander ~loc:stanza_loc ~all_modules in
+  let eval = eval0 ~expander ~loc:stanza_loc ~all_modules ~include_subdirs ~version in
   let allow_new_public_modules =
     match kind with
     | Exe_or_normal_lib | Virtual _ | Parameter -> true
@@ -385,15 +434,21 @@ let eval
     | Implementation { existing_virtual_modules; _ } -> existing_virtual_modules
   in
   let+ intf_only =
-    eval ~standard:Module_trie.Unchecked.empty modules_without_implementation
+    eval ~standard:Module_name.Unchecked.Path.Map.empty modules_without_implementation
   and+ virtual_modules =
     match kind with
-    | Exe_or_normal_lib | Implementation _ -> Memo.return Module_trie.Unchecked.empty
+    | Exe_or_normal_lib | Implementation _ ->
+      Memo.return Module_name.Unchecked.Path.Map.empty
     | Virtual { virtual_modules } ->
-      eval ~standard:Module_trie.Unchecked.empty virtual_modules
+      eval ~standard:Module_name.Unchecked.Path.Map.empty virtual_modules
     | Parameter ->
-      Memo.return (Module_trie.Unchecked.map ~f:(fun v -> stanza_loc, v) all_modules)
-  and+ private_modules = eval ~standard:Module_trie.Unchecked.empty private_modules in
+      Memo.return
+        (Module_name.Unchecked.Path.Map.map
+           ~f:(fun { Indexed_source.source; _ } -> stanza_loc, source)
+           all_modules)
+  and+ private_modules =
+    eval ~standard:Module_name.Unchecked.Path.Map.empty private_modules
+  in
   let is_parameter =
     match kind with
     | Parameter -> true
@@ -411,24 +466,37 @@ let eval
     ~is_vendored
     ~is_parameter
     ~version;
-  let modules = Module_trie.Unchecked.check_exn modules in
+  let modules =
+    Module_name.Unchecked.Path.Map.foldi
+      modules
+      ~init:Module_trie.Unchecked.empty
+      ~f:(fun logical_path (loc, m) acc ->
+        let { Indexed_source.source_path; _ } =
+          Module_name.Unchecked.Path.Map.find_exn all_modules logical_path
+        in
+        Module_trie.Unchecked.set acc source_path (loc, m))
+    |> Module_trie.Unchecked.check_exn
+  in
   let all_modules =
     Module_trie.mapi modules ~f:(fun _path (_, m) ->
-      let name = Nonempty_list.[ Module.Source.name m |> Module_name.unchecked ] in
+      let logical_path = source_path ~version m in
       let visibility =
-        if Module_trie.Unchecked.mem private_modules name
+        if Module_name.Unchecked.Path.Map.mem private_modules logical_path
         then Visibility.Private
         else Public
       in
       let kind =
         if is_parameter
         then Module.Kind.Parameter
-        else if Module_trie.Unchecked.mem virtual_modules name
+        else if Module_name.Unchecked.Path.Map.mem virtual_modules logical_path
         then Virtual
         else if Module.Source.has m ~ml_kind:Impl
         then (
-          let name = Module.Source.name m in
-          if Module_name.Path.Set.mem existing_virtual_modules [ name ]
+          let path =
+            source_path ~version m
+            |> Nonempty_list.map ~f:Module_name.Unchecked.allow_invalid
+          in
+          if Module_name.Path.Set.mem existing_virtual_modules path
           then Impl_vmodule
           else Impl)
         else Intf_only
@@ -454,14 +522,35 @@ let eval
       ~kind
       ~for_
       ~src_dir
+      ~include_subdirs
       ~version
       (settings : Modules_settings.t)
   =
   Memo.push_stack_frame ~human_readable_description:(fun () ->
     Pp.textf "(modules) field at %s" (Loc.to_file_colon_line stanza_loc))
   @@ fun () ->
+  let all_modules_by_path =
+    Module_trie.Unchecked.foldi
+      all_modules
+      ~init:Module_name.Unchecked.Path.Map.empty
+      ~f:(fun path m acc ->
+        let logical_path =
+          if version < (3, 25) then path else Module.Source.path m |> unchecked_path
+        in
+        Module_name.Unchecked.Path.Map.set
+          acc
+          logical_path
+          { Indexed_source.logical_path; source_path = path; source = m })
+  in
   let* modules0 =
-    eval0 ~expander ~loc:stanza_loc ~all_modules ~standard:all_modules settings.modules
+    eval0
+      ~expander
+      ~loc:stanza_loc
+      ~all_modules:all_modules_by_path
+      ~include_subdirs
+      ~version
+      ~standard:all_modules_by_path
+      settings.modules
   in
   let* is_vendored =
     match Path.Build.drop_build_context src_dir with
@@ -470,12 +559,13 @@ let eval
   in
   eval
     ~expander
-    ~modules:all_modules
+    ~modules:all_modules_by_path
     ~stanza_loc
     ~private_modules
     ~kind
     ~for_
     ~src_dir
+    ~include_subdirs
     ~is_vendored
     settings
     modules0

--- a/src/dune_rules/modules_field_evaluator.mli
+++ b/src/dune_rules/modules_field_evaluator.mli
@@ -33,6 +33,7 @@ val eval
   -> kind:kind
   -> for_:Compilation_mode.t
   -> src_dir:Path.Build.t
+  -> include_subdirs:Include_subdirs.t
   -> version:Dune_lang.Syntax.Version.t
   -> Modules_settings.t
   -> ((Loc.t * Module.Source.t) Module_trie.t * Module.t Module_trie.t) Memo.t

--- a/src/dune_rules/pp_spec.ml
+++ b/src/dune_rules/pp_spec.ml
@@ -1,20 +1,26 @@
 open Import
 
-type t = (Module.t -> lint:bool -> Module.t Memo.t) Module_name.Per_item.t
+type t = (Module.t -> lint:bool -> Module.t Memo.t) Module_reference.Per_item.t
 
 let make x = x
-let dummy : t = Module_name.Per_item.for_all (fun m ~lint:_ -> Memo.return m)
-let pp_module t ?(lint = true) m = Module_name.Per_item.get t (Module.name m) m ~lint
-let pp_module_as t ?(lint = true) name m = Module_name.Per_item.get t name m ~lint
+let dummy : t = Module_reference.Per_item.for_all (fun m ~lint:_ -> Memo.return m)
+let find t m ~name = Module_reference.Per_item.find t ~path:(Module.logical_path m) ~name
+let pp_module t ?(lint = true) m = find t m ~name:(Module.name m) m ~lint
+let pp_module_as t ?(lint = true) name m = find t m ~name m ~lint
 
 let pped_modules_map preprocess v =
   let map =
-    Module_name.Per_item.map preprocess ~f:(fun pp ->
+    Module_reference.Per_item.map preprocess ~f:(fun pp ->
       match Preprocess.remove_future_syntax ~for_:Compiler pp v with
       | No_preprocessing -> Module.ml_source
       | Action (_, _) -> fun m -> Module.ml_source (Module.pped m)
       | Pps { loc = _; pps = _; flags = _; staged } ->
         if staged then Module.ml_source else fun m -> Module.pped (Module.ml_source m))
   in
-  Staged.stage (fun m -> Module_name.Per_item.get map (Module.name m) m)
+  Staged.stage (fun m ->
+    Module_reference.Per_item.find
+      map
+      ~path:(Module.logical_path m)
+      ~name:(Module.name m)
+      m)
 ;;

--- a/src/dune_rules/pp_spec.ml
+++ b/src/dune_rules/pp_spec.ml
@@ -4,8 +4,10 @@ type t = (Module.t -> lint:bool -> Module.t Memo.t) Module_reference.Per_item.t
 
 let make x = x
 let dummy : t = Module_reference.Per_item.for_all (fun m ~lint:_ -> Memo.return m)
-let find t m ~name = Module_reference.Per_item.find t ~path:(Module.path m) ~name
-let pp_module t ?(lint = true) m = find t m ~name:(Module.name m) m ~lint
+
+let pp_module t ?(lint = true) m =
+  Module_reference.Per_item.find t (Module.path m) m ~lint
+;;
 
 let pped_modules_map preprocess v =
   let map =
@@ -16,8 +18,7 @@ let pped_modules_map preprocess v =
       | Pps { loc = _; pps = _; flags = _; staged } ->
         if staged then Module.ml_source else fun m -> Module.pped (Module.ml_source m))
   in
-  Staged.stage (fun m ->
-    Module_reference.Per_item.find map ~path:(Module.path m) ~name:(Module.name m) m)
+  Staged.stage (fun m -> Module_reference.Per_item.find map (Module.path m) m)
 ;;
 
 let pped_modules preprocess version modules =

--- a/src/dune_rules/pp_spec.ml
+++ b/src/dune_rules/pp_spec.ml
@@ -1,21 +1,23 @@
 open Import
 
-type t = (Module.t -> lint:bool -> Module.t Memo.t) Module_name.Per_item.t
+type t = (Module.t -> lint:bool -> Module.t Memo.t) Module_reference.Per_item.t
 
 let make x = x
-let dummy : t = Module_name.Per_item.for_all (fun m ~lint:_ -> Memo.return m)
-let pp_module t ?(lint = true) m = Module_name.Per_item.get t (Module.name m) m ~lint
+let dummy : t = Module_reference.Per_item.for_all (fun m ~lint:_ -> Memo.return m)
+let find t m ~name = Module_reference.Per_item.find t ~path:(Module.path m) ~name
+let pp_module t ?(lint = true) m = find t m ~name:(Module.name m) m ~lint
 
 let pped_modules_map preprocess v =
   let map =
-    Module_name.Per_item.map preprocess ~f:(fun pp ->
+    Module_reference.Per_item.map preprocess ~f:(fun pp ->
       match Preprocess.remove_future_syntax ~for_:Compiler pp v with
       | No_preprocessing -> Module.ml_source
       | Action (_, _) -> fun m -> Module.ml_source (Module.pped m)
       | Pps { loc = _; pps = _; flags = _; staged } ->
         if staged then Module.ml_source else fun m -> Module.pped (Module.ml_source m))
   in
-  Staged.stage (fun m -> Module_name.Per_item.get map (Module.name m) m)
+  Staged.stage (fun m ->
+    Module_reference.Per_item.find map ~path:(Module.path m) ~name:(Module.name m) m)
 ;;
 
 let pped_modules preprocess version modules =

--- a/src/dune_rules/pp_spec.mli
+++ b/src/dune_rules/pp_spec.mli
@@ -6,7 +6,7 @@ open Import
 type t
 
 val dummy : t
-val make : (Module.t -> lint:bool -> Module.t Memo.t) Module_name.Per_item.t -> t
+val make : (Module.t -> lint:bool -> Module.t Memo.t) Module_reference.Per_item.t -> t
 
 (** Setup the preprocessing rules for the following modules and returns the
     translated modules *)
@@ -17,6 +17,6 @@ val pp_module : t -> ?lint:bool -> Module.t -> Module.t Memo.t
 val pp_module_as : t -> ?lint:bool -> Module_name.t -> Module.t -> Module.t Memo.t
 
 val pped_modules_map
-  :  Preprocess.Without_instrumentation.t Preprocess.t Module_name.Per_item.t
+  :  Preprocess.Without_instrumentation.t Preprocess.t Module_reference.Per_item.t
   -> Ocaml.Version.t
   -> (Module.t -> Module.t) Staged.t

--- a/src/dune_rules/pp_spec.mli
+++ b/src/dune_rules/pp_spec.mli
@@ -6,19 +6,19 @@ open Import
 type t
 
 val dummy : t
-val make : (Module.t -> lint:bool -> Module.t Memo.t) Module_name.Per_item.t -> t
+val make : (Module.t -> lint:bool -> Module.t Memo.t) Module_reference.Per_item.t -> t
 
 (** Setup the preprocessing rules for the following modules and returns the
     translated modules *)
 val pp_module : t -> ?lint:bool -> Module.t -> Module.t Memo.t
 
 val pped_modules_map
-  :  Preprocess.Without_instrumentation.t Preprocess.t Module_name.Per_item.t
+  :  Preprocess.Without_instrumentation.t Preprocess.t Module_reference.Per_item.t
   -> Ocaml.Version.t
   -> (Module.t -> Module.t) Staged.t
 
 val pped_modules
-  :  Preprocess.Without_instrumentation.t Preprocess.t Module_name.Per_item.t
+  :  Preprocess.Without_instrumentation.t Preprocess.t Module_reference.Per_item.t
   -> Ocaml.Version.t
   -> Modules.t
   -> Modules.t Memo.t

--- a/src/dune_rules/pp_spec_rules.ml
+++ b/src/dune_rules/pp_spec_rules.ml
@@ -154,7 +154,7 @@ let lint_module sctx ~sandbox ~dir ~expander ~lint ~lib_name ~scope =
     Super_context.add_alias_action sctx (Alias.make Alias0.lint ~dir) build ~dir
   in
   let lint =
-    Module_name.Per_item.map lint ~f:(function
+    Module_reference.Per_item.map lint ~f:(function
       | Preprocess.No_preprocessing -> fun ~source:_ ~ast:_ -> Memo.return ()
       | Future_syntax loc ->
         User_error.raise ~loc [ Pp.text "'compat' cannot be used as a linter" ]
@@ -220,7 +220,12 @@ let lint_module sctx ~sandbox ~dir ~expander ~lint ~lib_name ~scope =
   in
   Staged.stage
   @@ fun ~(source : Module.t) ~ast ->
-  Module_name.Per_item.get lint (Module.name source) ~source ~ast
+  Module_reference.Per_item.find
+    lint
+    ~path:(Module.logical_path source)
+    ~name:(Module.name source)
+    ~source
+    ~ast
 ;;
 
 let pp_one_module
@@ -403,7 +408,7 @@ let make
   let preprocessor_deps = preprocessor_deps @ instrumentation_deps in
   let+ ocaml = Context.ocaml (Super_context.context sctx) in
   let preprocess =
-    Module_name.Per_item.map preprocess ~f:(fun pp ->
+    Module_reference.Per_item.map preprocess ~f:(fun pp ->
       Preprocess.remove_future_syntax ~for_:Compiler pp ocaml.version)
   in
   let env, sandbox =
@@ -429,7 +434,7 @@ let make
     let sandbox = sandbox_of_setting sandbox in
     Staged.unstage (lint_module sctx ~sandbox ~dir ~expander ~lint ~lib_name ~scope)
   in
-  Module_name.Per_item.map preprocess ~f:(fun spec ->
+  Module_reference.Per_item.map preprocess ~f:(fun spec ->
     Staged.unstage
     @@ pp_one_module
          sctx

--- a/src/dune_rules/pp_spec_rules.ml
+++ b/src/dune_rules/pp_spec_rules.ml
@@ -214,12 +214,7 @@ let lint_module sctx ~sandbox ~pps_sandbox ~dir ~expander ~lint ~lib_name ~scope
   in
   Staged.stage
   @@ fun ~(source : Module.t) ~ast ->
-  Module_reference.Per_item.find
-    lint
-    ~path:(Module.path source)
-    ~name:(Module.name source)
-    ~source
-    ~ast
+  Module_reference.Per_item.find lint (Module.path source) ~source ~ast
 ;;
 
 let pp_one_module

--- a/src/dune_rules/pp_spec_rules.ml
+++ b/src/dune_rules/pp_spec_rules.ml
@@ -147,7 +147,7 @@ let lint_module sctx ~sandbox ~pps_sandbox ~dir ~expander ~lint ~lib_name ~scope
     Super_context.add_alias_action sctx [ Alias.make Alias0.lint ~dir ] build ~dir
   in
   let lint =
-    Module_name.Per_item.map lint ~f:(function
+    Module_reference.Per_item.map lint ~f:(function
       | Preprocess.No_preprocessing -> fun ~source:_ ~ast:_ -> Memo.return ()
       | Future_syntax loc ->
         User_error.raise ~loc [ Pp.text "'compat' cannot be used as a linter" ]
@@ -214,7 +214,12 @@ let lint_module sctx ~sandbox ~pps_sandbox ~dir ~expander ~lint ~lib_name ~scope
   in
   Staged.stage
   @@ fun ~(source : Module.t) ~ast ->
-  Module_name.Per_item.get lint (Module.name source) ~source ~ast
+  Module_reference.Per_item.find
+    lint
+    ~path:(Module.path source)
+    ~name:(Module.name source)
+    ~source
+    ~ast
 ;;
 
 let pp_one_module
@@ -397,7 +402,7 @@ let make
   let context = Super_context.context sctx in
   let+ ocaml = Context.ocaml context in
   let preprocess =
-    Module_name.Per_item.map preprocess ~f:(fun pp ->
+    Module_reference.Per_item.map preprocess ~f:(fun pp ->
       Preprocess.remove_future_syntax ~for_:Compiler pp ocaml.version)
   in
   let env, sandbox =
@@ -431,7 +436,7 @@ let make
     Staged.unstage
       (lint_module sctx ~sandbox ~pps_sandbox ~dir ~expander ~lint ~lib_name ~scope)
   in
-  Module_name.Per_item.map preprocess ~f:(fun spec ->
+  Module_reference.Per_item.map preprocess ~f:(fun spec ->
     Staged.unstage
     @@ pp_one_module
          sctx

--- a/src/dune_rules/stanzas/buildable.ml
+++ b/src/dune_rules/stanzas/buildable.ml
@@ -61,7 +61,7 @@ let decode_melange_preprocess =
     | Some _, None | None, _ -> []
     | Some (loc, deps), Some preprocess ->
       let deps_might_be_used =
-        Module_name.Per_item.exists preprocess ~f:(fun p ->
+        Module_reference.Per_item.exists preprocess ~f:(fun p ->
           match p with
           | Preprocess.Action _ | Preprocess.Pps _ -> true
           | Preprocess.No_preprocessing | Preprocess.Future_syntax _ -> false)

--- a/src/dune_rules/stanzas/buildable.mli
+++ b/src/dune_rules/stanzas/buildable.mli
@@ -46,7 +46,7 @@ val decode_modules : Modules_settings.t Dune_lang.Decoder.fields_parser
 
 (* Parser for the lint field *)
 val decode_lint
-  : Preprocess.Without_instrumentation.t Preprocess.t Module_name.Per_item.t
+  : Preprocess.Without_instrumentation.t Preprocess.t Module_reference.Per_item.t
       Dune_lang.Decoder.fields_parser
 
 (* Parser for allow_overlapping_dependencies *)

--- a/src/dune_rules/stanzas/lint.mli
+++ b/src/dune_rules/stanzas/lint.mli
@@ -5,5 +5,5 @@ type t = Preprocess.Without_instrumentation.t Preprocess.Per_module.t
 val decode
   : Preprocess.Without_instrumentation.t Preprocess.Per_module.t Dune_lang.Decoder.t
 
-val default : (Loc.t * Lib_name.t) Preprocess.t Module_name.Per_item.t
+val default : (Loc.t * Lib_name.t) Preprocess.t Module_reference.Per_item.t
 val no_lint : t

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -194,7 +194,7 @@ module Stanza = struct
       let* cctx =
         let dune_version = Scope.project scope |> Dune_project.dune_version in
         let* preprocessing =
-          let preprocess = Module_name.Per_item.for_all toplevel.pps in
+          let preprocess = Module_reference.Per_item.for_all toplevel.pps in
           Pp_spec_rules.make
             sctx
             ~dir

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -195,7 +195,7 @@ module Stanza = struct
       let* cctx =
         let dune_version = Scope.project scope |> Dune_project.dune_version in
         let* preprocessing =
-          let preprocess = Module_name.Per_item.for_all toplevel.pps in
+          let preprocess = Module_reference.Per_item.for_all toplevel.pps in
           Pp_spec_rules.make
             sctx
             ~dir

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -213,7 +213,7 @@ let setup sctx ~dir =
     else Preprocess.Pps { loc = Loc.none; pps; flags = []; staged = false }
   in
   let* preprocessing =
-    let preprocess = Module_name.Per_item.for_all pps in
+    let preprocess = Module_reference.Per_item.for_all pps in
     Pp_spec_rules.make
       sctx
       ~dir

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -202,7 +202,7 @@ let setup sctx ~dir =
     else Preprocess.Pps { loc = Loc.none; pps; flags = []; staged = false }
   in
   let* preprocessing =
-    let preprocess = Module_name.Per_item.for_all pps in
+    let preprocess = Module_reference.Per_item.for_all pps in
     Pp_spec_rules.make
       sctx
       ~dir

--- a/test/blackbox-tests/test-cases/include-qualified/nested-virtual.t/dune-project
+++ b/test/blackbox-tests/test-cases/include-qualified/nested-virtual.t/dune-project
@@ -1,1 +1,4 @@
-(lang dune 3.7)
+(lang dune 3.25)
+
+(package
+ (name vlib))

--- a/test/blackbox-tests/test-cases/include-qualified/nested-virtual.t/run.t
+++ b/test/blackbox-tests/test-cases/include-qualified/nested-virtual.t/run.t
@@ -1,7 +1,18 @@
 We can nested modules virtual
   $ dune build @all
-  File "vlib/dune", line 5, characters 18-26:
-  5 |  (virtual_modules bar/virt))
-                        ^^^^^^^^
-  Error: Module Bar/virt doesn't exist.
-  [1]
+
+The logical path is preserved when the virtual library is installed:
+
+  $ dune install --prefix="$PWD/prefix"
+  $ mkdir -p external/bar
+  $ cp impl/bar/virt.ml external/bar/virt.ml
+  $ cat >external/dune-project <<'EOF'
+  > (lang dune 3.25)
+  > EOF
+  $ cat >external/dune <<'EOF'
+  > (include_subdirs qualified)
+  > (library
+  >  (name impl)
+  >  (implements vlib))
+  > EOF
+  $ OCAMLPATH="$PWD/prefix/lib" dune build --root external @all

--- a/test/blackbox-tests/test-cases/include-qualified/nested-virtual.t/run.t
+++ b/test/blackbox-tests/test-cases/include-qualified/nested-virtual.t/run.t
@@ -1,11 +1,32 @@
 We can nested modules virtual
+  $ mkdir -p vlib/group impl/group vlib/foo/foo impl/foo/foo
+  $ cat >vlib/group/group.mli <<'EOF'
+  > val value : int
+  > EOF
+  $ cat >impl/group/group.ml <<'EOF'
+  > let value = 42
+  > EOF
+  $ cat >vlib/foo/foo/foo.mli <<'EOF'
+  > val value : int
+  > EOF
+  $ cat >impl/foo/foo/foo.ml <<'EOF'
+  > let value = 42
+  > EOF
   $ dune build @all
 
 The logical path is preserved when the virtual library is installed:
 
   $ dune install --prefix="$PWD/prefix"
+  $ grep -o '(path Group Group)' prefix/lib/vlib/dune-package
+  (path Group Group)
+  $ grep -o '(path Foo Foo Foo)' prefix/lib/vlib/dune-package
+  (path Foo Foo Foo)
   $ mkdir -p external/bar
   $ cp impl/bar/virt.ml external/bar/virt.ml
+  $ mkdir external/group
+  $ cp impl/group/group.ml external/group/group.ml
+  $ mkdir -p external/foo/foo
+  $ cp impl/foo/foo/foo.ml external/foo/foo/foo.ml
   $ cat >external/dune-project <<'EOF'
   > (lang dune 3.25)
   > EOF

--- a/test/blackbox-tests/test-cases/include-qualified/nested-virtual.t/vlib/dune
+++ b/test/blackbox-tests/test-cases/include-qualified/nested-virtual.t/vlib/dune
@@ -2,4 +2,5 @@
 
 (library
  (name vlib)
- (virtual_modules bar/virt))
+ (public_name vlib)
+ (virtual_modules Bar.Virt))

--- a/test/blackbox-tests/test-cases/include-qualified/nested-virtual.t/vlib/dune
+++ b/test/blackbox-tests/test-cases/include-qualified/nested-virtual.t/vlib/dune
@@ -3,4 +3,4 @@
 (library
  (name vlib)
  (public_name vlib)
- (virtual_modules Bar.Virt))
+ (virtual_modules Bar.Virt Foo.Foo Group))

--- a/test/blackbox-tests/test-cases/include-qualified/pp.t/dune
+++ b/test/blackbox-tests/test-cases/include-qualified/pp.t/dune
@@ -5,4 +5,4 @@
  (preprocess
   (per_module
    ((action
-     (run cat %{input-file})) bar/ppme))))
+     (run cat %{input-file})) Bar.Ppme))))

--- a/test/blackbox-tests/test-cases/include-qualified/pp.t/dune-project
+++ b/test/blackbox-tests/test-cases/include-qualified/pp.t/dune-project
@@ -1,1 +1,1 @@
-(lang dune 3.7)
+(lang dune 3.25)

--- a/test/blackbox-tests/test-cases/include-qualified/pp.t/run.t
+++ b/test/blackbox-tests/test-cases/include-qualified/pp.t/run.t
@@ -1,10 +1,2 @@
 We can set preprocessing options for nested modules
   $ dune build @all
-  File "dune", line 8, characters 30-38:
-  8 |      (run cat %{input-file})) bar/ppme))))
-                                    ^^^^^^^^
-  Error: "bar/ppme" is an invalid module name.
-  Module names must be non-empty, start with a letter, and composed only of the
-  following characters: 'A'..'Z', 'a'..'z', '_', ''' or '0'..'9'.
-  Hint: barppme would be a correct module name
-  [1]

--- a/test/blackbox-tests/test-cases/include-qualified/preprocess-per-module.t
+++ b/test/blackbox-tests/test-cases/include-qualified/preprocess-per-module.t
@@ -1,7 +1,7 @@
-Reproduction for GH-15578: qualified modules cannot be selected in
+Regression test for GH-15578: qualified modules can be selected in
 `(preprocess (per_module ...))`.
 
-  $ make_dune_project 3.24
+  $ make_dune_project 3.25
 
   $ mkdir foo
   $ touch foo/bar.ml
@@ -17,14 +17,6 @@ Reproduction for GH-15578: qualified modules cannot be selected in
   > EOF
 
   $ dune build
-  File "dune", line 7, characters 30-37:
-  7 |      (run cat %{input-file})) foo.bar))))
-                                    ^^^^^^^
-  Error: "foo.bar" is an invalid module name.
-  Module names must be non-empty, start with a letter, and composed only of the
-  following characters: 'A'..'Z', 'a'..'z', '_', ''' or '0'..'9'.
-  Hint: foo_bar would be a correct module name
-  [1]
 
 Using a slash instead does not work either:
 
@@ -47,3 +39,219 @@ Using a slash instead does not work either:
   following characters: 'A'..'Z', 'a'..'z', '_', ''' or '0'..'9'.
   Hint: foobar would be a correct module name
   [1]
+
+Qualified references are only available starting with Dune 3.25:
+
+  $ mkdir version-gate
+  $ cd version-gate
+  $ make_dune_project 3.24
+  $ mkdir foo
+  $ touch foo/bar.ml
+  $ cat >dune <<'EOF'
+  > (include_subdirs qualified)
+  > (library
+  >  (name x)
+  >  (preprocess
+  >   (per_module
+  >    ((action
+  >      (run cat %{input-file})) Foo.Bar))))
+  > EOF
+  $ dune build
+  File "dune", line 7, characters 30-37:
+  7 |      (run cat %{input-file})) Foo.Bar))))
+                                    ^^^^^^^
+  Error: Using qualified module references is only available since version 3.25
+  of the dune language. Please update your dune-project file to have (lang dune
+  3.25).
+  [1]
+  $ cd ..
+
+They are rejected when the effective `(include_subdirs)` mode is not
+`qualified`:
+
+  $ mkdir unqualified
+  $ cd unqualified
+  $ make_dune_project 3.25
+  $ touch bar.ml
+  $ cat >dune <<'EOF'
+  > (library
+  >  (name x)
+  >  (preprocess
+  >   (per_module
+  >    ((action
+  >      (run cat %{input-file})) Foo.Bar))))
+  > EOF
+  $ dune build
+  File "dune", line 6, characters 30-37:
+  6 |      (run cat %{input-file})) Foo.Bar))))
+                                    ^^^^^^^
+  Error: Qualified module reference "Foo.Bar" may only be used with
+  (include_subdirs qualified).
+  [1]
+  $ cd ..
+
+Unlike legacy `(per_module ...)`, qualified references are also checked against
+the modules selected by the stanza:
+
+  $ mkdir missing
+  $ cd missing
+  $ make_dune_project 3.25
+  $ mkdir foo
+  $ touch foo/bar.ml
+  $ cat >dune <<'EOF'
+  > (include_subdirs qualified)
+  > (library
+  >  (name x)
+  >  (preprocess
+  >   (per_module
+  >    ((action
+  >      (run cat %{input-file})) Foo.Missing))))
+  > EOF
+  $ dune build
+  File "dune", line 7, characters 30-41:
+  7 |      (run cat %{input-file})) Foo.Missing))))
+                                    ^^^^^^^^^^^
+  Error: Module Foo.Missing doesn't exist.
+  [1]
+  $ cd ..
+
+The full path distinguishes a root module from a nested module with the same
+leaf name. Different preprocessors must be applied to each one:
+
+  $ mkdir exact
+  $ cd exact
+  $ make_dune_project 3.25
+  $ mkdir foo
+  $ echo 'This is not OCaml.' >bar.ml
+  $ echo 'This is not OCaml either.' >foo/bar.ml
+  $ cat >main.ml <<'EOF'
+  > let () =
+  >   print_endline Refs.Bar.marker;
+  >   print_endline Refs.Foo.Bar.marker
+  > EOF
+  $ cat >dune <<'EOF'
+  > (include_subdirs qualified)
+  > (library
+  >  (name refs)
+  >  (modules Bar Foo.Bar)
+  >  (preprocess
+  >   (per_module
+  >    ((action
+  >      (run echo "let marker = \"root\"")) Bar)
+  >    ((action
+  >      (run echo "let marker = \"nested\"")) Foo.Bar))))
+  > (executable
+  >  (name main)
+  >  (modules Main)
+  >  (libraries refs))
+  > EOF
+  $ dune exec ./main.exe
+  root
+  nested
+  $ cd ..
+
+A module group interface is named by the group path, without repeating the
+last component:
+
+  $ mkdir group-interface
+  $ cd group-interface
+  $ make_dune_project 3.25
+  $ mkdir foo
+  $ echo 'This is not OCaml.' >foo/foo.ml
+  $ cat >foo/bar.ml <<'EOF'
+  > let marker = "nested"
+  > EOF
+  $ cat >main.ml <<'EOF'
+  > let () =
+  >   print_endline Group.Foo.marker;
+  >   print_endline Group.Foo.Bar.marker
+  > EOF
+  $ cat >dune <<'EOF'
+  > (include_subdirs qualified)
+  > (library
+  >  (name group)
+  >  (modules Foo Foo.Bar)
+  >  (preprocess
+  >   (per_module
+  >    ((action
+  >      (run echo "let marker = \"group\"\nmodule Bar = Bar")) Foo))))
+  > (executable
+  >  (name main)
+  >  (modules Main)
+  >  (libraries group))
+  > EOF
+  $ dune exec ./main.exe
+  group
+  nested
+  $ cd ..
+
+Modules produced by `(select ...)` participate in qualified reference
+resolution:
+
+  $ mkdir selected
+  $ cd selected
+  $ make_dune_project 3.25
+  $ mkdir foo
+  $ echo 'This is not OCaml.' >foo/generated.fallback.ml
+  $ cat >main.ml <<'EOF'
+  > let () = print_endline Selected.Foo.Generated.marker
+  > EOF
+  $ cat >dune <<'EOF'
+  > (include_subdirs qualified)
+  > (library
+  >  (name selected)
+  >  (modules Foo.Generated)
+  >  (libraries
+  >   (select foo/generated.ml from
+  >    (-> foo/generated.fallback.ml)))
+  >  (preprocess
+  >   (per_module
+  >    ((action
+  >      (run echo "let marker = \"selected\"")) Foo.Generated))))
+  > (executable
+  >  (name main)
+  >  (modules Main)
+  >  (libraries selected))
+  > EOF
+  $ dune exec ./main.exe
+  selected
+  $ cd ..
+
+The effective mode of a `(subdir ...)` stanza is used for validation:
+
+  $ mkdir subdir-stanza
+  $ cd subdir-stanza
+  $ make_dune_project 3.25
+  $ mkdir -p nested/foo
+  $ echo 'This is not OCaml.' >nested/foo/bar.ml
+  $ cat >dune <<'EOF'
+  > (subdir nested
+  >  (include_subdirs qualified)
+  >  (library
+  >   (name nested)
+  >   (preprocess
+  >    (per_module
+  >     ((action
+  >       (run echo "let marker = \"nested\"")) Foo.Bar)))))
+  > EOF
+  $ dune build
+  $ cd ..
+
+Before Dune 3.25, a single module name keeps its legacy leaf-name semantics:
+
+  $ mkdir legacy
+  $ cd legacy
+  $ make_dune_project 3.24
+  $ mkdir foo
+  $ echo 'This is not OCaml.' >foo/bar.ml
+  $ cat >dune <<'EOF'
+  > (include_subdirs qualified)
+  > (library
+  >  (name legacy)
+  >  (preprocess
+  >   (per_module
+  >    ((action
+  >      (run echo "let marker = \"legacy\"")) Bar))))
+  > EOF
+  $ dune build
+  $ cd ..

--- a/test/blackbox-tests/test-cases/include-qualified/preprocess-per-module.t
+++ b/test/blackbox-tests/test-cases/include-qualified/preprocess-per-module.t
@@ -217,6 +217,44 @@ resolution:
   $ dune exec --root=selected ./main.exe
   selected
 
+A selected module can provide a group interface, whose logical path omits the
+repeated trie component:
+
+  $ mkdir selected-group
+  $ cat >selected-group/dune-project <<'EOF'
+  > (lang dune 3.25)
+  > EOF
+  $ mkdir selected-group/foo
+  $ echo 'This is not OCaml.' >selected-group/foo/foo.fallback.ml
+  $ cat >selected-group/foo/bar.ml <<'EOF'
+  > let marker = "nested"
+  > EOF
+  $ cat >selected-group/main.ml <<'EOF'
+  > let () =
+  >   print_endline Selected_group.Foo.marker;
+  >   print_endline Selected_group.Foo.Bar.marker
+  > EOF
+  $ cat >selected-group/dune <<'EOF'
+  > (include_subdirs qualified)
+  > (library
+  >  (name selected_group)
+  >  (modules Foo Foo.Bar)
+  >  (libraries
+  >   (select foo/foo.ml from
+  >    (-> foo/foo.fallback.ml)))
+  >  (preprocess
+  >   (per_module
+  >    ((action
+  >      (run echo "let marker = \"group\"\nmodule Bar = Bar")) Foo))))
+  > (executable
+  >  (name main)
+  >  (modules Main)
+  >  (libraries selected_group))
+  > EOF
+  $ dune exec --root=selected-group ./main.exe
+  group
+  nested
+
 The effective mode of a `(subdir ...)` stanza is used for validation:
 
   $ mkdir subdir-stanza

--- a/test/blackbox-tests/test-cases/include-qualified/preprocess-per-module.t
+++ b/test/blackbox-tests/test-cases/include-qualified/preprocess-per-module.t
@@ -43,11 +43,12 @@ Using a slash instead does not work either:
 Qualified references are only available starting with Dune 3.25:
 
   $ mkdir version-gate
-  $ cd version-gate
-  $ make_dune_project 3.24
-  $ mkdir foo
-  $ touch foo/bar.ml
-  $ cat >dune <<'EOF'
+  $ cat >version-gate/dune-project <<'EOF'
+  > (lang dune 3.24)
+  > EOF
+  $ mkdir version-gate/foo
+  $ touch version-gate/foo/bar.ml
+  $ cat >version-gate/dune <<'EOF'
   > (include_subdirs qualified)
   > (library
   >  (name x)
@@ -56,24 +57,26 @@ Qualified references are only available starting with Dune 3.25:
   >    ((action
   >      (run cat %{input-file})) Foo.Bar))))
   > EOF
-  $ dune build
+  $ dune build --root=version-gate
+  Entering directory 'version-gate'
   File "dune", line 7, characters 30-37:
   7 |      (run cat %{input-file})) Foo.Bar))))
                                     ^^^^^^^
   Error: Using qualified module references is only available since version 3.25
   of the dune language. Please update your dune-project file to have (lang dune
   3.25).
+  Leaving directory 'version-gate'
   [1]
-  $ cd ..
 
 They are rejected when the effective `(include_subdirs)` mode is not
 `qualified`:
 
   $ mkdir unqualified
-  $ cd unqualified
-  $ make_dune_project 3.25
-  $ touch bar.ml
-  $ cat >dune <<'EOF'
+  $ cat >unqualified/dune-project <<'EOF'
+  > (lang dune 3.25)
+  > EOF
+  $ touch unqualified/bar.ml
+  $ cat >unqualified/dune <<'EOF'
   > (library
   >  (name x)
   >  (preprocess
@@ -81,55 +84,32 @@ They are rejected when the effective `(include_subdirs)` mode is not
   >    ((action
   >      (run cat %{input-file})) Foo.Bar))))
   > EOF
-  $ dune build
+  $ dune build --root=unqualified
+  Entering directory 'unqualified'
   File "dune", line 6, characters 30-37:
   6 |      (run cat %{input-file})) Foo.Bar))))
                                     ^^^^^^^
   Error: Qualified module reference "Foo.Bar" may only be used with
   (include_subdirs qualified).
+  Leaving directory 'unqualified'
   [1]
-  $ cd ..
-
-Unlike legacy `(per_module ...)`, qualified references are also checked against
-the modules selected by the stanza:
-
-  $ mkdir missing
-  $ cd missing
-  $ make_dune_project 3.25
-  $ mkdir foo
-  $ touch foo/bar.ml
-  $ cat >dune <<'EOF'
-  > (include_subdirs qualified)
-  > (library
-  >  (name x)
-  >  (preprocess
-  >   (per_module
-  >    ((action
-  >      (run cat %{input-file})) Foo.Missing))))
-  > EOF
-  $ dune build
-  File "dune", line 7, characters 30-41:
-  7 |      (run cat %{input-file})) Foo.Missing))))
-                                    ^^^^^^^^^^^
-  Error: Module Foo.Missing doesn't exist.
-  [1]
-  $ cd ..
 
 The full path distinguishes a root module from a nested module with the same
 leaf name. Different preprocessors must be applied to each one:
 
   $ mkdir exact
-  $ cd exact
-  $ make_dune_project 3.25
-  $ mkdir foo
-  $ echo 'This is not OCaml.' >bar.ml
-  $ echo 'This is not OCaml either.' >foo/bar.ml
-  $ cat >main.ml <<'EOF'
+  $ cat >exact/dune-project <<'EOF'
+  > (lang dune 3.25)
+  > EOF
+  $ mkdir exact/foo
+  $ echo 'This is not OCaml.' >exact/bar.ml
+  $ echo 'This is not OCaml either.' >exact/foo/bar.ml
+  $ cat >exact/main.ml <<'EOF'
   > let () =
   >   print_endline Refs.Bar.marker;
   >   print_endline Refs.Foo.Bar.marker
   > EOF
-  $ cat >dune <<'EOF'
+  $ cat >exact/dune <<'EOF'
   > (include_subdirs qualified)
   > (library
   >  (name refs)
@@ -145,28 +125,49 @@ leaf name. Different preprocessors must be applied to each one:
   >  (modules Main)
   >  (libraries refs))
   > EOF
-  $ dune exec ./main.exe
+  $ dune exec --root=exact ./main.exe
   root
   nested
-  $ cd ..
+
+The full path can also select the sole module of an executable:
+
+  $ mkdir singleton-executable
+  $ cat >singleton-executable/dune-project <<'EOF'
+  > (lang dune 3.25)
+  > EOF
+  $ mkdir singleton-executable/foo
+  $ echo 'This is not OCaml.' >singleton-executable/foo/main.ml
+  $ cat >singleton-executable/dune <<'EOF'
+  > (include_subdirs qualified)
+  > (executable
+  >  (name main)
+  >  (modules Foo.Main)
+  >  (preprocess
+  >   (per_module
+  >    ((action
+  >      (run echo "let () = print_endline \"singleton\"")) Foo.Main))))
+  > EOF
+  $ dune exec --root=singleton-executable ./main.exe
+  singleton
 
 A module group interface is named by the group path, without repeating the
 last component:
 
   $ mkdir group-interface
-  $ cd group-interface
-  $ make_dune_project 3.25
-  $ mkdir foo
-  $ echo 'This is not OCaml.' >foo/foo.ml
-  $ cat >foo/bar.ml <<'EOF'
+  $ cat >group-interface/dune-project <<'EOF'
+  > (lang dune 3.25)
+  > EOF
+  $ mkdir group-interface/foo
+  $ echo 'This is not OCaml.' >group-interface/foo/foo.ml
+  $ cat >group-interface/foo/bar.ml <<'EOF'
   > let marker = "nested"
   > EOF
-  $ cat >main.ml <<'EOF'
+  $ cat >group-interface/main.ml <<'EOF'
   > let () =
   >   print_endline Group.Foo.marker;
   >   print_endline Group.Foo.Bar.marker
   > EOF
-  $ cat >dune <<'EOF'
+  $ cat >group-interface/dune <<'EOF'
   > (include_subdirs qualified)
   > (library
   >  (name group)
@@ -180,23 +181,23 @@ last component:
   >  (modules Main)
   >  (libraries group))
   > EOF
-  $ dune exec ./main.exe
+  $ dune exec --root=group-interface ./main.exe
   group
   nested
-  $ cd ..
 
 Modules produced by `(select ...)` participate in qualified reference
 resolution:
 
   $ mkdir selected
-  $ cd selected
-  $ make_dune_project 3.25
-  $ mkdir foo
-  $ echo 'This is not OCaml.' >foo/generated.fallback.ml
-  $ cat >main.ml <<'EOF'
+  $ cat >selected/dune-project <<'EOF'
+  > (lang dune 3.25)
+  > EOF
+  $ mkdir selected/foo
+  $ echo 'This is not OCaml.' >selected/foo/generated.fallback.ml
+  $ cat >selected/main.ml <<'EOF'
   > let () = print_endline Selected.Foo.Generated.marker
   > EOF
-  $ cat >dune <<'EOF'
+  $ cat >selected/dune <<'EOF'
   > (include_subdirs qualified)
   > (library
   >  (name selected)
@@ -213,18 +214,18 @@ resolution:
   >  (modules Main)
   >  (libraries selected))
   > EOF
-  $ dune exec ./main.exe
+  $ dune exec --root=selected ./main.exe
   selected
-  $ cd ..
 
 The effective mode of a `(subdir ...)` stanza is used for validation:
 
   $ mkdir subdir-stanza
-  $ cd subdir-stanza
-  $ make_dune_project 3.25
-  $ mkdir -p nested/foo
-  $ echo 'This is not OCaml.' >nested/foo/bar.ml
-  $ cat >dune <<'EOF'
+  $ cat >subdir-stanza/dune-project <<'EOF'
+  > (lang dune 3.25)
+  > EOF
+  $ mkdir -p subdir-stanza/nested/foo
+  $ echo 'This is not OCaml.' >subdir-stanza/nested/foo/bar.ml
+  $ cat >subdir-stanza/dune <<'EOF'
   > (subdir nested
   >  (include_subdirs qualified)
   >  (library
@@ -234,17 +235,17 @@ The effective mode of a `(subdir ...)` stanza is used for validation:
   >     ((action
   >       (run echo "let marker = \"nested\"")) Foo.Bar)))))
   > EOF
-  $ dune build
-  $ cd ..
+  $ dune build --root=subdir-stanza
 
 Before Dune 3.25, a single module name keeps its legacy leaf-name semantics:
 
   $ mkdir legacy
-  $ cd legacy
-  $ make_dune_project 3.24
-  $ mkdir foo
-  $ echo 'This is not OCaml.' >foo/bar.ml
-  $ cat >dune <<'EOF'
+  $ cat >legacy/dune-project <<'EOF'
+  > (lang dune 3.24)
+  > EOF
+  $ mkdir legacy/foo
+  $ echo 'This is not OCaml.' >legacy/foo/bar.ml
+  $ cat >legacy/dune <<'EOF'
   > (include_subdirs qualified)
   > (library
   >  (name legacy)
@@ -253,5 +254,4 @@ Before Dune 3.25, a single module name keeps its legacy leaf-name semantics:
   >    ((action
   >      (run echo "let marker = \"legacy\"")) Bar))))
   > EOF
-  $ dune build
-  $ cd ..
+  $ dune build --root=legacy

--- a/test/blackbox-tests/test-cases/include-qualified/private-modules.t
+++ b/test/blackbox-tests/test-cases/include-qualified/private-modules.t
@@ -1,20 +1,27 @@
 Marking modules as private
 
-  $ make_dune_project 3.7
+  $ make_dune_project 3.24
 
   $ cat >dune <<EOF
   > (include_subdirs qualified)
   > (library
   >  (name foolib)
-  >  (private_modules baz/foo))
+  >  (private_modules Baz.Foo))
   > EOF
 
   $ mkdir baz
   $ touch baz/foo.ml
 
+Qualified references in module fields are version gated too:
+
   $ dune build
   File "dune", line 4, characters 18-25:
-  4 |  (private_modules baz/foo))
+  4 |  (private_modules Baz.Foo))
                         ^^^^^^^
-  Error: Module Baz/foo doesn't exist.
+  Error: Using qualified module references is only available since version 3.25
+  of the dune language. Please update your dune-project file to have (lang dune
+  3.25).
   [1]
+
+  $ make_dune_project 3.25
+  $ dune build

--- a/test/blackbox-tests/test-cases/install/dune-package-source-path.t
+++ b/test/blackbox-tests/test-cases/install/dune-package-source-path.t
@@ -97,11 +97,11 @@ Test paths on public libraries with `.` are correct
           (source (path Child Bar) (impl (path sub/child/bar.ml))))))
         (source (path Foo) (impl (path sub/foo.ml))))))
 
-A singleton with a repeated logical path retains an unambiguous installed path:
+A singleton with a repeated logical path is escaped in the installed file:
 
   $ mkdir -p c/foo/foo
   $ cat > c/dune-project <<EOF
-  > (lang dune 3.24)
+  > (lang dune 3.25)
   > (package (name c))
   > EOF
   $ cat > c/dune <<EOF
@@ -109,7 +109,8 @@ A singleton with a repeated logical path retains an unambiguous installed path:
   > (library
   >  (name singleton)
   >  (public_name c.singleton)
-  >  (wrapped false))
+  >  (wrapped false)
+  >  (modules Foo.Foo))
   > EOF
   $ cat > c/foo/foo/foo.ml <<EOF
   > let x = "foo"

--- a/test/blackbox-tests/test-cases/melange/preprocess.t
+++ b/test/blackbox-tests/test-cases/melange/preprocess.t
@@ -66,3 +66,25 @@ Reason dialect preprocessor to the PPX driver.
   > EOF
 
   $ dune build @reason-pps/mel
+
+Qualified module references work in a `melange.emit` stanza too:
+
+  $ mkdir qualified
+  $ cd qualified
+  $ make_melange_project 3.25 1.0
+  $ mkdir foo
+  $ echo 'This is not OCaml.' >foo/bar.ml
+  $ cat >dune <<'EOF'
+  > (include_subdirs qualified)
+  > (melange.emit
+  >  (target output)
+  >  (modules Foo.Bar)
+  >  (alias mel)
+  >  (emit_stdlib false)
+  >  (preprocess
+  >   (per_module
+  >    ((action
+  >      (run echo "let marker = \"qualified\"")) Foo.Bar))))
+  > EOF
+  $ dune build @mel
+  $ cd ..


### PR DESCRIPTION
Support qualified module references in fields such as `(per_module ...)` when using `(include_subdirs qualified)`, gated on Dune language 3.25.

Depends on #16322.

Fixes #15578.