### PR TITLE
fix(rpc): rescan registry after mtime changes

### DIFF
--- a/doc/changes/fixed/15634.md
+++ b/doc/changes/fixed/15634.md
@@ -1,0 +1,3 @@
+- Rescan the RPC registry when its directory mtime changes, allowing clients
+  that poll before Dune registers to discover the new instance (#15634, fixes
+  #15630, @rgrinberg)

--- a/otherlibs/dune-rpc/registry.ml
+++ b/otherlibs/dune-rpc/registry.ml
@@ -169,11 +169,10 @@ struct
     let** (`Mtime mtime) = IO.stat dir in
     let skip =
       match t.last_mtime with
-      | Some last_mtime -> last_mtime <> mtime
-      | None ->
-        t.last_mtime <- Some mtime;
-        false
+      | Some last_mtime -> last_mtime = mtime
+      | None -> false
     in
+    t.last_mtime <- Some mtime;
     if skip
     then Fiber.return (Ok Refresh.empty)
     else

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
@@ -104,8 +104,8 @@ let%expect_test "poll skips scans after the registry mtime changes" =
   [%expect
     {|
     initial: scans=1 added=0 current=0
-    after change: scans=1 added=0 current=0
-    subsequent poll: scans=1 added=0 current=0 |}]
+    after change: scans=2 added=1 current=1
+    subsequent poll: scans=2 added=0 current=1 |}]
 ;;
 
 let%expect_test "turn on dune watch and wait until the connection is listed" =


### PR DESCRIPTION
## Description

Skip RPC registry scans only when the directory mtime is unchanged, and record each newly observed mtime. This allows clients that poll before Dune registers to discover the new registry entry while avoiding repeated scans afterward.

## Related Issue and Motivation

Fixes #15630. The regression test was added in #15632.

## Checklist

- [x] Tests added in #15632.
- [x] Change log entry added.
- [x] Documentation is not applicable to this bug fix.