### PR TITLE
fix(pkg): unify workspace and lockdir dependency traversal

### DIFF
--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -1025,17 +1025,6 @@ module Packages = struct
     |> Package_name.Map.map ~f:Package_version.Map.of_list_exn
   ;;
 
-  (* [choose_pkg_for_platform t name ~platform] returns the package whose name
-     is [name] which is enabled on [platform], and returns [None] if either no
-     package exists whose name is [name] or if there is no version of the
-     package that is enabled on [platform]. *)
-  let choose_pkg_for_platform t name ~platform =
-    let open Option.O in
-    Package_name.Map.find t name
-    >>| Package_version.Map.values
-    >>= List.find ~f:(Pkg.is_enabled_on_platform ~platform)
-  ;;
-
   let pkgs_on_platform_by_name t ~platform =
     Package_name.Map.filter_map t ~f:(fun version_map ->
       Package_version.Map.values version_map
@@ -1773,45 +1762,6 @@ module Load_immediate = Make_load (struct
 
 let read_disk = Load_immediate.load
 let read_disk_exn = Load_immediate.load_exn
-
-let transitive_dependency_closure t ~platform start =
-  let missing_packages =
-    let all_packages_in_lock_dir = Package_name.Set.of_keys t.packages in
-    Package_name.Set.diff start all_packages_in_lock_dir
-  in
-  match Package_name.Set.is_empty missing_packages with
-  | false -> Error (`Missing_packages missing_packages)
-  | true ->
-    let to_visit = Queue.create () in
-    let push_set = Package_name.Set.iter ~f:(Queue.push to_visit) in
-    push_set start;
-    let rec loop seen =
-      match Queue.pop to_visit with
-      | None -> seen
-      | Some node ->
-        let unseen_deps =
-          (* Note that the call to [Packages.choose_pkg_for_platform] won't
-             in general return [None] because [t] guarantees that its map of
-             dependencies is closed under "depends on". Sometimes a package
-             (such as dune) is explicitly removed from the closure in which
-             case we will have a [None] and ignore it. *)
-          Package_name.Set.(
-            diff
-              (of_list_map
-                 ~f:(fun depend -> depend.name)
-                 ((let open Option.O in
-                   let* pkg =
-                     Packages.choose_pkg_for_platform t.packages node ~platform
-                   in
-                   Conditional_choice.choose_for_platform pkg.depends ~platform)
-                  |> Option.value ~default:[]))
-              seen)
-        in
-        push_set unseen_deps;
-        loop (Package_name.Set.union seen unseen_deps)
-    in
-    Ok (loop start)
-;;
 
 let compute_missing_checksums t ~pinned_packages =
   let open Fiber.O in

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -171,18 +171,6 @@ module Make_load (Io : sig
   val load_exn : Path.t -> t Io.t
 end
 
-(** [transitive_dependency_closure t ~platform names] returns the set of package names
-    making up the transitive closure of dependencies of the set [names], or
-    [Error (`Missing_packages missing_packages)] if if any element of [names]
-    is not found in the lockdir. [missing_packages] is a subset of [names]
-    not present in the lockdir. As a package's dependencies may vary between
-    platforms, a description of the current platform must also be provided. *)
-val transitive_dependency_closure
-  :  t
-  -> platform:Solver_env.t
-  -> Package_name.Set.t
-  -> (Package_name.Set.t, [ `Missing_packages of Package_name.Set.t ]) result
-
 (** Attempt to download and compute checksums for packages that have source
     archive urls but no checksum. *)
 val compute_missing_checksums : t -> pinned_packages:Package_name.Set.t -> t Fiber.t

--- a/src/dune_pkg/package_universe.ml
+++ b/src/dune_pkg/package_universe.ml
@@ -4,6 +4,7 @@ type t =
   { local_packages : Local_package.t Package_name.Map.t
   ; lock_dir : Lock_dir.t
   ; platform : Solver_env.t
+  ; lock_packages : Lock_dir.Pkg.t Package_name.Map.t
   ; version_by_package_name : Package_version.t Package_name.Map.t
   }
 
@@ -18,14 +19,13 @@ let lockdir_regenerate_hints =
   ]
 ;;
 
-let version_by_package_name ~platform local_packages (lock_dir : Lock_dir.t) =
+let version_by_package_name local_packages lock_packages =
   let from_local_packages =
     Package_name.Map.map local_packages ~f:(fun (local_package : Local_package.t) ->
       local_package.version)
   in
   let from_lock_dir =
-    Lock_dir.Packages.pkgs_on_platform_by_name ~platform lock_dir.packages
-    |> Package_name.Map.map ~f:(fun (pkg : Lock_dir.Pkg.t) -> pkg.info.version)
+    Package_name.Map.map lock_packages ~f:(fun (pkg : Lock_dir.Pkg.t) -> pkg.info.version)
   in
   let exception Duplicate_package of Package_name.t in
   try
@@ -88,52 +88,6 @@ let all_non_local_dependencies_of_local_packages t =
   Package_name.Set.diff
     all_dependencies_of_local_packages
     (Package_name.Set.of_keys t.local_packages)
-;;
-
-let check_for_unnecessary_packges_in_lock_dir
-      ~platform
-      (lock_dir : Lock_dir.t)
-      all_non_local_dependencies_of_local_packages
-  =
-  let packages = Lock_dir.Packages.pkgs_on_platform_by_name lock_dir.packages ~platform in
-  let unneeded_packages_in_lock_dir =
-    let locked_transitive_closure_of_local_package_dependencies =
-      match
-        Lock_dir.transitive_dependency_closure
-          lock_dir
-          ~platform
-          all_non_local_dependencies_of_local_packages
-      with
-      | Ok x -> x
-      | Error (`Missing_packages missing_packages) ->
-        (* Resolving the dependency formulae would have failed if there were any missing packages in the lockdir. *)
-        Code_error.raise
-          "Missing packages from lockdir after confirming no missing packages in lockdir"
-          [ "missing package", Package_name.Set.to_dyn missing_packages ]
-    in
-    let all_locked_packages = Package_name.Set.of_keys packages in
-    Package_name.Set.diff
-      all_locked_packages
-      locked_transitive_closure_of_local_package_dependencies
-  in
-  if Package_name.Set.is_empty unneeded_packages_in_lock_dir
-  then ()
-  else (
-    let packages =
-      Package_name.Set.to_list unneeded_packages_in_lock_dir
-      |> List.map ~f:(Package_name.Map.find_exn packages)
-    in
-    User_error.raise
-      ~hints:lockdir_regenerate_hints
-      [ Pp.text
-          "The lockdir contains packages which are not among the transitive dependencies \
-           of any local package:"
-      ; Pp.enumerate packages ~f:(fun (package : Lock_dir.Pkg.t) ->
-          Pp.textf
-            "%s.%s"
-            (Package_name.to_string package.info.name)
-            (Package_version.to_string package.info.version))
-      ])
 ;;
 
 let dependency_digest local_packages =
@@ -226,88 +180,124 @@ let validate_dependency_hash local_packages ~saved_dependency_hash =
         ]
 ;;
 
-let validate t =
-  validate_dependency_hash
-    t.local_packages
-    ~saved_dependency_hash:t.lock_dir.dependency_hash;
-  all_non_local_dependencies_of_local_packages t
-  |> check_for_unnecessary_packges_in_lock_dir ~platform:t.platform t.lock_dir
+let make ~platform local_packages lock_dir =
+  let lock_packages =
+    Lock_dir.Packages.pkgs_on_platform_by_name ~platform lock_dir.Lock_dir.packages
+  in
+  let version_by_package_name = version_by_package_name local_packages lock_packages in
+  { local_packages; lock_dir; platform; lock_packages; version_by_package_name }
 ;;
 
-let create ~platform local_packages lock_dir =
-  try
-    let version_by_package_name =
-      version_by_package_name ~platform local_packages lock_dir
-    in
-    let t = { local_packages; lock_dir; platform; version_by_package_name } in
-    validate t;
-    Ok t
-  with
-  | User_error.E e -> Error e
-;;
-
-let local_transitive_dependency_closure_without_test =
-  let module Top_closure = Top_closure.Make (Package_name.Set) (Monad.Id) in
-  fun t start ->
-    match
-      Top_closure.top_closure
-        ~deps:(fun a ->
-          concrete_dependencies_of_local_package t a ~with_test:false
-          |> List.filter ~f:(Package_name.Map.mem t.local_packages))
-        ~key:Fun.id
-        start
-    with
-    | Ok s -> Package_name.Set.of_list s
-    | Error _ -> Code_error.raise "cycles aren't allowed because we forbid post deps" []
+(* The immediate dependencies of a node of the combined workspace/lockdir
+   dependency graph. Local packages contribute the concrete dependencies of
+   their formula; lock packages contribute the dependencies declared for the
+   current platform. Names that resolve to neither kind of package are
+   leaves: for valid input they can only be dune or a package disabled on
+   the current platform. *)
+let immediate_build_dependencies (t : t) package_name =
+  match Package_name.Map.find t.local_packages package_name with
+  | Some _ -> concrete_dependencies_of_local_package t package_name ~with_test:false
+  | None ->
+    (match Package_name.Map.find t.lock_packages package_name with
+     | None -> []
+     | Some package ->
+       Lock_dir.Conditional_choice.choose_for_platform
+         package.depends
+         ~platform:t.platform
+       |> Option.value ~default:[]
+       |> List.map ~f:(fun (dependency : Lock_dir.Dependency.t) -> dependency.name))
 ;;
 
 let transitive_dependency_closure_without_test t start =
-  let local_package_names = Package_name.Set.of_keys t.local_packages in
-  let local_transitive_dependency_closure =
-    local_transitive_dependency_closure_without_test
-      t
-      (Package_name.Set.inter local_package_names start |> Package_name.Set.to_list)
+  let rec loop seen = function
+    | [] -> seen
+    | name :: names ->
+      if Package_name.Set.mem seen name
+      then loop seen names
+      else
+        loop (Package_name.Set.add seen name) (immediate_build_dependencies t name @ names)
   in
-  let non_local_transitive_dependency_closure =
-    let non_local_immediate_dependencies_of_local_transitive_dependency_closure =
-      local_transitive_dependency_closure
-      |> Package_name.Set.to_list
-      |> Package_name.Set.union_map ~f:(fun name ->
-        let all_deps =
-          concrete_dependencies_of_local_package t name ~with_test:false
-          |> Package_name.Set.of_list
-        in
-        Package_name.Set.diff all_deps local_package_names)
-    in
-    match
-      Lock_dir.transitive_dependency_closure
-        t.lock_dir
-        ~platform:t.platform
-        Package_name.Set.(
-          union
-            non_local_immediate_dependencies_of_local_transitive_dependency_closure
-            (diff start local_package_names))
-    with
-    | Ok x -> x
-    | Error (`Missing_packages missing_packages) ->
-      Code_error.raise
-        "Attempted to find non-existent packages in lockdir after validation which \
-         should not be possible"
-        (Package_name.Set.to_list missing_packages
-         |> List.map ~f:(fun p -> "missing package", Package_name.to_dyn p))
-  in
-  Package_name.Set.union
-    local_transitive_dependency_closure
-    non_local_transitive_dependency_closure
+  loop Package_name.Set.empty (Package_name.Set.to_list start)
 ;;
 
 let contains_package t package_name =
   let in_local_packages = Package_name.Map.mem t.local_packages package_name in
-  let lock_dir_packages =
-    Lock_dir.Packages.pkgs_on_platform_by_name ~platform:t.platform t.lock_dir.packages
-  in
-  let in_lock_dir = Package_name.Map.mem lock_dir_packages package_name in
+  let in_lock_dir = Package_name.Map.mem t.lock_packages package_name in
   in_local_packages || in_lock_dir
+;;
+
+let check_lock_packages_do_not_depend_on_local_packages t =
+  Package_name.Map.iter
+    t.lock_packages
+    ~f:(fun { Lock_dir.Pkg.depends; info = { name = package_name; _ }; _ } ->
+      Lock_dir.Conditional_choice.choose_for_platform depends ~platform:t.platform
+      |> Option.value ~default:[]
+      |> List.iter ~f:(fun { Lock_dir.Dependency.name = dependency_name; loc } ->
+        if
+          (not (Package_name.equal dependency_name Dune_dep.name))
+          && Package_name.Map.mem t.local_packages dependency_name
+        then
+          User_error.raise
+            ~loc
+            [ Pp.textf
+                "Dune does not support packages outside the workspace depending on \
+                 packages in the workspace. The package %S is not in the workspace but \
+                 it depends on the package %S which is in the workspace."
+                (Package_name.to_string package_name)
+                (Package_name.to_string dependency_name)
+            ]))
+;;
+
+let check_for_unnecessary_packges_in_lock_dir
+      t
+      all_non_local_dependencies_of_local_packages
+  =
+  let unneeded_packages_in_lock_dir =
+    let locked_transitive_closure_of_local_package_dependencies =
+      transitive_dependency_closure_without_test
+        t
+        all_non_local_dependencies_of_local_packages
+    in
+    Package_name.Set.diff
+      (Package_name.Set.of_keys t.lock_packages)
+      locked_transitive_closure_of_local_package_dependencies
+  in
+  if Package_name.Set.is_empty unneeded_packages_in_lock_dir
+  then ()
+  else (
+    let packages =
+      Package_name.Set.to_list unneeded_packages_in_lock_dir
+      |> List.map ~f:(Package_name.Map.find_exn t.lock_packages)
+    in
+    User_error.raise
+      ~hints:lockdir_regenerate_hints
+      [ Pp.text
+          "The lockdir contains packages which are not among the transitive dependencies \
+           of any local package:"
+      ; Pp.enumerate packages ~f:(fun (package : Lock_dir.Pkg.t) ->
+          Pp.textf
+            "%s.%s"
+            (Package_name.to_string package.info.name)
+            (Package_version.to_string package.info.version))
+      ])
+;;
+
+let validate t =
+  validate_dependency_hash
+    t.local_packages
+    ~saved_dependency_hash:t.lock_dir.dependency_hash;
+  check_lock_packages_do_not_depend_on_local_packages t;
+  all_non_local_dependencies_of_local_packages t
+  |> check_for_unnecessary_packges_in_lock_dir t
+;;
+
+let create ~platform local_packages lock_dir =
+  try
+    let t = make ~platform local_packages lock_dir in
+    validate t;
+    Ok t
+  with
+  | User_error.E e -> Error e
 ;;
 
 let check_contains_package t package_name =

--- a/test/blackbox-tests/test-cases/pkg/lockdir-dependency-cycle.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-dependency-cycle.t
@@ -31,7 +31,7 @@ silently tolerates the cycle, deferring the failure to build time:
   $ dune pkg validate-lockdir
 
 Second, a cycle between workspace packages. Validation accepts it, and
-querying the transitive dependencies crashes with an internal error:
+querying the transitive dependencies tolerates it as well:
 
   $ cd ..
   $ mkdir workspace-cycle
@@ -52,10 +52,11 @@ querying the transitive dependencies crashes with an internal error:
   (no dependencies to lock)
 
   $ dune pkg validate-lockdir
-  $ dune describe pkg list-locked-dependencies --transitive 2>&1 | head -5
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
-  providing the file _build/trace.csexp, if possible. This includes build
-  commands, message logs, and file paths.
-  Description:
-    ("cycles aren't allowed because we forbid post deps", {})
-  [1]
+  $ dune describe pkg list-locked-dependencies --transitive
+  Dependencies of local packages locked in dune.lock
+  - Transitive dependencies of local package a.dev
+    - b.dev
+    
+  - Transitive dependencies of local package b.dev
+    - a.dev
+    

--- a/test/blackbox-tests/test-cases/pkg/non-local-package-depends-on-local-package-error.t
+++ b/test/blackbox-tests/test-cases/pkg/non-local-package-depends-on-local-package-error.t
@@ -24,3 +24,63 @@ local package.
   packages in the workspace. The package "remote" is not in the workspace but
   it depends on the package "local_b" which is in the workspace.
   [1]
+
+A hand-written portable lockdir must not bypass this check. A locked package
+with the workspace package's name can be disabled on the current platform, so
+the platform projection contains no name collision. Without an explicit check,
+the combined traversal would interpret the locked dependency as the workspace
+package and follow its non-test dependencies.
+
+  $ mkpkg a
+  $ mkpkg b
+  $ solve_project <<EOF
+  > (lang dune 3.20)
+  > (package
+  >  (name root)
+  >  (allow_empty)
+  >  (depends a))
+  > (package
+  >  (name workspace_dep)
+  >  (allow_empty)
+  >  (depends (b (= :with-test false))))
+  > EOF
+  Solution for dune.lock:
+  - a.0.0.1
+
+Make a depend on the workspace package. Add b and a same-named locked package
+which is disabled on the current platform so the lockdir remains globally
+closed under dependencies.
+
+  $ cat > dune.lock/a.0.0.1.pkg <<EOF
+  > (version 0.0.1)
+  > (depends (all_platforms (workspace_dep)))
+  > EOF
+  $ cat > dune.lock/b.0.0.1.pkg <<EOF
+  > (version 0.0.1)
+  > EOF
+  $ cat > dune.lock/workspace_dep.0.0.1.pkg <<EOF
+  > (version 0.0.1)
+  > (enabled_on_platforms (only ((os never))))
+  > EOF
+
+Validation and dependency queries reject the unsupported dependency before the
+combined traversal can reinterpret it and make b reachable from root.
+
+  $ dune pkg validate-lockdir
+  Lockdir dune.lock does not contain a solution for local packages:
+  File "dune.lock/a.0.0.1.pkg", line 2, characters 25-38:
+  Error: Dune does not support packages outside the workspace depending on
+  packages in the workspace. The package "a" is not in the workspace but it
+  depends on the package "workspace_dep" which is in the workspace.
+  Error: Some lockdirs do not contain solutions for local packages:
+  - dune.lock
+  [1]
+
+  $ dune describe pkg list-locked-dependencies --transitive
+  File "dune.lock/a.0.0.1.pkg", line 2, characters 25-38:
+  2 | (depends (all_platforms (workspace_dep)))
+                               ^^^^^^^^^^^^^
+  Error: Dune does not support packages outside the workspace depending on
+  packages in the workspace. The package "a" is not in the workspace but it
+  depends on the package "workspace_dep" which is in the workspace.
+  [1]


### PR DESCRIPTION
## Description

Dune currently computes dependency reachability separately for workspace
packages and lock-directory packages. This works only because locked packages
are currently forbidden from depending back on workspace packages. It cannot
represent a dependency path such as:

    workspace a → locked b → workspace c

This refactor makes `Package_universe` own a single view of dependencies across
both package sets. Dependency queries and lock-directory reachability checks now
use that view, removing the assumption that dependency traversal ends after
entering the lock directory.

This does not yet permit lock-directory packages to depend on workspace
packages. Follow-up changes use this graph to produce dependency-first build
plans, reject cycles across the combined graph, and ultimately enable those
dependencies.

Existing valid lock directories produce the same dependency closures. The only
observable change is that querying a cycle between workspace packages no longer
raises an internal error; the following PR replaces this temporary tolerance
with a user-facing cycle diagnostic.

## Related Issue and Motivation

This is the dependency-graph foundation for supporting lock-directory packages
that depend on workspace packages in #8652.
