### PR TITLE
docs(changes): add changelog fragment guidance

### DIFF
--- a/doc/changes/AGENTS.md
+++ b/doc/changes/AGENTS.md
@@ -1,0 +1,23 @@
+# Changelog entries
+
+Document every notable user-visible change with a changelog fragment. Do not
+edit `CHANGES.md` directly. Add the fragment under the appropriate directory:
+
+- `added/` for a new user-visible feature or behavior
+- `changed/` for a change to existing user-visible behavior
+- `fixed/` for a bug fix that restores the expected behavior
+- `unreleased/` only in special cases; normally use one of the other categories
+
+Skip implementation-only changes. Also skip non-notable changes even when they
+are user-visible; routine improvements to existing error messages are an
+example.
+
+Name the fragment `<PR-number>.md`. Write a concise bullet from the user's
+perspective, keep it within 80 columns, and end it with a parenthesized
+reference containing the PR number and author, for example:
+
+```markdown
+- Explain the change and its benefit to users (#12345, fixes #12300, @author)
+```
+
+The `fixes` reference is optional.

--- a/doc/changes/forbid-files.sh
+++ b/doc/changes/forbid-files.sh
@@ -1,5 +1,7 @@
-if [[ $# -ne 0 ]]; then
-	echo .md files are not allowed in this directory
-	echo Please categorize your md files according to type of change
-	exit 1
-fi
+for file in "$@"; do
+	if [[ "${file##*/}" != "AGENTS.md" ]]; then
+		echo .md files are not allowed in this directory
+		echo Please categorize your md files according to type of change
+		exit 1
+	fi
+done


### PR DESCRIPTION
Document when to add or skip user-visible changelog entries and how to format
fragments. Allow the scoped AGENTS.md through the root Markdown-file check.