### PR TITLE
test(fs-io): reproduce read_file exception for missing files

### DIFF
--- a/otherlibs/fs-io/test/dune
+++ b/otherlibs/fs-io/test/dune
@@ -1,0 +1,14 @@
+(library
+ (name fs_io_tests)
+ (inline_tests)
+ (libraries
+  fs_io
+  unix
+  ;; This is because of the (implicit_transitive_deps false)
+  ;; in dune-project
+  ppx_expect.config
+  ppx_expect.config_types
+  base
+  ppx_inline_test.config)
+ (preprocess
+  (pps ppx_expect)))

--- a/otherlibs/fs-io/test/fs_io_tests.ml
+++ b/otherlibs/fs-io/test/fs_io_tests.ml
@@ -1,0 +1,10 @@
+open Unix
+
+let%expect_test "read_file with a nonexistent file" =
+  (match Fs_io.read_file (__FILE__ ^ ".does-not-exist") with
+   | Ok _ -> print_endline "Read contents"
+   | Error (Unix_error (ENOENT, _, _)) -> print_endline "Error ENOENT"
+   | Error exn -> raise exn
+   | exception Unix_error (ENOENT, _, _) -> print_endline "Raised ENOENT");
+  [%expect {| Raised ENOENT |}]
+;;


### PR DESCRIPTION
## Description

Add an inline expect test for `Fs_io.read_file` with a nonexistent path. The test documents the current behavior: `Unix_error ENOENT` is raised instead of being returned as an error result.

## Related Issue and Motivation

This isolates the current behavior before a follow-up correction.

## Checklist

- [x] Tests added.
- [x] Change log entry is not applicable to this test-only change.
- [x] Documentation is not applicable to this test-only change.
