### PR TITLE
fix(fs-io): return Unix errors from read_file

### DIFF
--- a/doc/changes/fixed/15641.md
+++ b/doc/changes/fixed/15641.md
@@ -1,0 +1,2 @@
+- Return Unix errors from `Fs_io.read_file` rather than raising them. (#15641,
+  @rgrinberg)

--- a/otherlibs/fs-io/fs_io.ml
+++ b/otherlibs/fs-io/fs_io.ml
@@ -111,12 +111,16 @@ let with_file_in_fd fn ~f =
 ;;
 
 let read_file fn =
-  with_file_in_fd fn ~f:(fun fd ->
-    match read_all_fd fd with
-    | Ok s -> Ok s
-    | Error `Retry -> read_file_chan fn
-    | Error `Too_big -> Error too_big
-    | Error (`Unix (e, s, x)) -> Error (Unix.Unix_error (e, s, x)))
+  match
+    with_file_in_fd fn ~f:(fun fd ->
+      match read_all_fd fd with
+      | Ok s -> Ok s
+      | Error `Retry -> read_file_chan fn
+      | Error `Too_big -> Error too_big
+      | Error (`Unix (e, s, x)) -> Error (Unix.Unix_error (e, s, x)))
+  with
+  | result -> result
+  | exception (Unix.Unix_error _ as exn) -> Error exn
 ;;
 
 let write_file =

--- a/otherlibs/fs-io/test/fs_io_tests.ml
+++ b/otherlibs/fs-io/test/fs_io_tests.ml
@@ -6,5 +6,5 @@ let%expect_test "read_file with a nonexistent file" =
    | Error (Unix_error (ENOENT, _, _)) -> print_endline "Error ENOENT"
    | Error exn -> raise exn
    | exception Unix_error (ENOENT, _, _) -> print_endline "Raised ENOENT");
-  [%expect {| Raised ENOENT |}]
+  [%expect {| Error ENOENT |}]
 ;;


### PR DESCRIPTION
`Fs_io.read_file` returns a result, but opening a nonexistent file currently raises `Unix_error` instead of returning it. Catch Unix errors around descriptor-based file access so callers receive `Error` consistently.

This updates the regression expectation introduced in #15639.