### PR TITLE
build(nix): use shallow melange clone

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,16 +10,17 @@
       "locked": {
         "lastModified": 1783843147,
         "narHash": "sha256-lT+PtjJ6l6eQGhd/2szsj9alpV5tn/0uouC3OkeTeX0=",
-        "owner": "melange-re",
-        "repo": "melange",
+        "ref": "refs/heads/v7-55",
         "rev": "08cd3ca8fcc9ec2a75ebacb5f86f336467cd2e6c",
-        "type": "github"
+        "shallow": true,
+        "type": "git",
+        "url": "https://github.com/melange-re/melange"
       },
       "original": {
-        "owner": "melange-re",
-        "ref": "v7-55",
-        "repo": "melange",
-        "type": "github"
+        "ref": "refs/heads/v7-55",
+        "shallow": true,
+        "type": "git",
+        "url": "https://github.com/melange-re/melange"
       }
     },
     "melange-compiler-libs": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,8 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     melange = {
-      url = "github:melange-re/melange/v7-55";
+      url =
+        "git+https://github.com/melange-re/melange?ref=refs/heads/v7-55&shallow=1";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     ocaml-overlays = {


### PR DESCRIPTION
Fetch the Melange flake input through a shallow Git clone to avoid relying on GitHub-generated source archives.

Related to #15643.