### PR TITLE
build(nix): use `nix-ocaml/nix-overlays` as `nixpkgs` input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,26 +46,8 @@
       }
     },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1785542685,
-        "narHash": "sha256-sjfvXMbG5pCFgpvw2OZAFcZiTvrppCWvnB6cuGrSY08=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "f8e81fc7eb063db454f563cdd596fb96a5ad1497",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "ocaml-overlays": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1785641981,
@@ -78,6 +60,22 @@
       "original": {
         "owner": "nix-ocaml",
         "repo": "nix-overlays",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1785638663,
+        "narHash": "sha256-yt6kjAgY29W8au8gDWX1NYSjkQBSSuedo43n7Mke4Uk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0b9e82138431f31772b103d3957994fb254dd5e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0b9e82138431f31772b103d3957994fb254dd5e8",
         "type": "github"
       }
     },
@@ -107,7 +105,7 @@
           "nixpkgs"
         ],
         "ocaml-overlays": [
-          "ocaml-overlays"
+          "nixpkgs"
         ],
         "ocaml-trunk": [
           "ocaml-trunk"
@@ -134,7 +132,6 @@
       "inputs": {
         "melange": "melange",
         "nixpkgs": "nixpkgs",
-        "ocaml-overlays": "ocaml-overlays",
         "ocaml-trunk": "ocaml-trunk",
         "revdeps-dune": "revdeps-dune"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,8 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:nix-ocaml/nix-overlays";
     melange = {
-      url =
-        "git+https://github.com/melange-re/melange?ref=refs/heads/v7-55&shallow=1";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    ocaml-overlays = {
-      url = "github:nix-ocaml/nix-overlays";
+      url = "git+https://github.com/melange-re/melange?ref=refs/heads/v7-55&shallow=1";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     ocaml-trunk = {
@@ -17,7 +12,7 @@
     revdeps-dune = {
       url = "github:ocaml/dune";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.ocaml-overlays.follows = "ocaml-overlays";
+      inputs.ocaml-overlays.follows = "nixpkgs";
       inputs.melange.follows = "melange";
       inputs.revdeps-dune.follows = "revdeps-dune";
       inputs.ocaml-trunk.follows = "ocaml-trunk";
@@ -34,7 +29,6 @@
       self,
       nixpkgs,
       melange,
-      ocaml-overlays,
       ocaml-trunk,
       revdeps-dune,
     }:
@@ -45,7 +39,6 @@
           system:
           let
             pkgs = nixpkgs.legacyPackages.${system}.appendOverlays [
-              ocaml-overlays.overlays.default
               (self: super: {
                 ocamlPackages = super.ocaml-ng.ocamlPackages_5_5.overrideScope (
                   oself: osuper: {
@@ -109,12 +102,7 @@
       revdeps = forAllSystems (
         pkgs:
         import ./nix/revdeps.nix {
-          inherit
-            nixpkgs
-            ocaml-overlays
-            revdeps-dune
-            pkgs
-            ;
+          inherit nixpkgs revdeps-dune pkgs;
         }
       );
 
@@ -128,8 +116,7 @@
           );
           dune =
             (import ./nix/dune-package.nix {
-              nixpkgs = nixpkgsDarwin;
-              inherit ocaml-overlays;
+              inherit nixpkgs;
               pkgs = nixpkgsDarwin.legacyPackages.x86_64-darwin;
               src = ./.;
             }).default;
@@ -152,11 +139,11 @@
               ocamlPackages = ocamlTrunkPackages;
             };
             dune-package = import ./nix/dune-package.nix {
-              inherit nixpkgs ocaml-overlays pkgs;
+              inherit nixpkgs pkgs;
               src = ./.;
             };
             dune-trunk-package = import ./nix/dune-package.nix {
-              inherit nixpkgs ocaml-overlays;
+              inherit nixpkgs;
               pkgs = trunkPkgs;
               src = ./.;
             };

--- a/nix/dune-package.nix
+++ b/nix/dune-package.nix
@@ -9,7 +9,6 @@
 #   - `dune-static`: alias for `musl-static`
 {
   nixpkgs,
-  ocaml-overlays,
   pkgs,
   src,
 }:
@@ -64,7 +63,6 @@ let
   };
 
   pkgs-static = nixpkgs.legacyPackages.${pkgs.stdenv.hostPlatform.system}.appendOverlays [
-    ocaml-overlays.overlays.default
     dune-static-overlay
   ];
 

--- a/nix/revdeps.nix
+++ b/nix/revdeps.nix
@@ -1,6 +1,5 @@
 {
   nixpkgs,
-  ocaml-overlays,
   revdeps-dune,
   pkgs,
 }:
@@ -137,21 +136,20 @@ let
     );
   };
 
-  # Import nixpkgs with allowBroken so deps of broken pkgs can be evaluated
-  pkgsPermissive = import nixpkgs {
+  # Instantiate nix-overlays with allowBroken so deps of broken pkgs can be
+  # evaluated.
+  pkgsPermissive = nixpkgs.makePkgs {
     inherit (pkgs.stdenv.hostPlatform) system;
     config = {
       allowBroken = true;
       allowUnfree = true;
+      allowUnsupportedSystem = true;
     };
-    overlays = [
-      ocaml-overlays.overlays.default
-      duneOverlay
-    ];
+    extraOverlays = [ duneOverlay ];
   };
 
   # Use the filter from nix-overlays
-  filter = import "${ocaml-overlays}/ci/filter.nix" {
+  filter = import "${nixpkgs}/ci/filter.nix" {
     inherit lib;
     inherit (pkgsPermissive) stdenv;
   };


### PR DESCRIPTION
CI builds regressed in terms of caching after the update to 5.5 in #15446. 

This change aligns nix-overlays and nixpkgs to use cached versions of derivations uploaded to the ocaml overlays cache upstream.