### PR TITLE
build(nix): use released Melange from nixpkgs.ocamlPackages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4,6 +4,7 @@
       "inputs": {
         "melange-compiler-libs": "melange-compiler-libs",
         "nixpkgs": [
+          "revdeps-dune",
           "nixpkgs"
         ]
       },
@@ -26,6 +27,7 @@
     "melange-compiler-libs": {
       "inputs": {
         "nixpkgs": [
+          "revdeps-dune",
           "melange",
           "nixpkgs"
         ]
@@ -98,9 +100,7 @@
     },
     "revdeps-dune": {
       "inputs": {
-        "melange": [
-          "melange"
-        ],
+        "melange": "melange",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -130,7 +130,6 @@
     },
     "root": {
       "inputs": {
-        "melange": "melange",
         "nixpkgs": "nixpkgs",
         "ocaml-trunk": "ocaml-trunk",
         "revdeps-dune": "revdeps-dune"

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,6 @@
 {
   inputs = {
     nixpkgs.url = "github:nix-ocaml/nix-overlays";
-    melange = {
-      url = "git+https://github.com/melange-re/melange?ref=refs/heads/v7-55&shallow=1";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
     ocaml-trunk = {
       url = "github:ocaml/ocaml/trunk";
       flake = false;
@@ -13,7 +9,6 @@
       url = "github:ocaml/dune";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.ocaml-overlays.follows = "nixpkgs";
-      inputs.melange.follows = "melange";
       inputs.revdeps-dune.follows = "revdeps-dune";
       inputs.ocaml-trunk.follows = "ocaml-trunk";
     };
@@ -28,7 +23,6 @@
     {
       self,
       nixpkgs,
-      melange,
       ocaml-trunk,
       revdeps-dune,
     }:
@@ -76,7 +70,6 @@
                   ocamlPackages_5_5 = self.ocamlPackages;
                 };
               })
-              melange.overlays.default
             ];
           in
           f pkgs


### PR DESCRIPTION
fixes yet another cache miss in CI -- Melange changes rarely and will need to be released before Dune (and its CI) can upgrade to new OCaml version, anyway.