### PR TITLE
refactor: remove the useless background actions config

### DIFF
--- a/otherlibs/stdune/src/config.ml
+++ b/otherlibs/stdune/src/config.ml
@@ -92,10 +92,6 @@ let background_default =
   | _ -> `Disabled
 ;;
 
-let background_actions =
-  make ~name:"background_actions" ~of_string:Toggle.of_string ~default:`Disabled
-;;
-
 let background_digests =
   make ~name:"background_digests" ~of_string:Toggle.of_string ~default:background_default
 ;;

--- a/otherlibs/stdune/src/config.mli
+++ b/otherlibs/stdune/src/config.mli
@@ -27,10 +27,6 @@ val global_lock : Toggle.t t
 (** whether dune should optimize file copying on Linux/MacOS *)
 val copy_file : [ `Portable | `Best ] t
 
-(** Execute some actions in background threads. See [Action_exec] for the
-    concrete list of actions *)
-val background_actions : Toggle.t t
-
 (** Compute digests of files in a background thread *)
 val background_digests : Toggle.t t
 

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -4,16 +4,6 @@ open Action_intf.Exec
 open Done_or_more_deps
 module Dependency = Dune_action_plugin.Private.Protocol.Dependency
 
-let maybe_async =
-  let maybe_async =
-    lazy
-      (match Config.(get background_actions) with
-       | `Enabled -> Scheduler.async_exn
-       | `Disabled -> fun f -> Fiber.return (f ()))
-  in
-  fun f -> (Lazy.force maybe_async) f
-;;
-
 module Exec_result = struct
   module Error = struct
     type t =
@@ -126,11 +116,8 @@ let rec exec t ~ectx ~eenv : Done_or_more_deps.t Fiber.t =
     exec t ~ectx ~eenv:{ eenv with env = Env.add eenv.env ~var ~value }
   | Redirect_out (Stdout, fn, perm, Echo s) ->
     let perm = File_perm.to_unix_perm perm in
-    let+ () =
-      maybe_async (fun () ->
-        Io.write_file (Path.build fn) (String.concat s ~sep:" ") ~perm)
-    in
-    Done
+    Io.write_file ~perm (Path.build fn) (String.concat s ~sep:" ");
+    Fiber.return Done
   | Redirect_out (outputs, fn, perm, t) ->
     let fn = Path.build fn in
     redirect_out t ~ectx ~eenv outputs ~perm fn
@@ -146,13 +133,10 @@ let rec exec t ~ectx ~eenv : Done_or_more_deps.t Fiber.t =
     in
     Fiber.return Done
   | Cat xs ->
-    let+ () =
-      maybe_async (fun () ->
-        List.iter xs ~f:(fun fn ->
-          Io.with_file_in fn ~f:(fun ic ->
-            Io.copy_channels ic (Process.Io.out_channel eenv.stdout_to))))
-    in
-    Done
+    List.iter xs ~f:(fun fn ->
+      Io.with_file_in fn ~f:(fun ic ->
+        Io.copy_channels ic (Process.Io.out_channel eenv.stdout_to)));
+    Fiber.return Done
   | Copy (src, dst) ->
     let dst = Path.build dst in
     let copy_file ~src ~dst =
@@ -168,25 +152,24 @@ let rec exec t ~ectx ~eenv : Done_or_more_deps.t Fiber.t =
             (File_kind.to_string_hum kind)
         ]
     in
-    let+ () =
-      maybe_async (fun () ->
-        (* NOTE(anmonteiro): we may reconsider relaxing the directory target
+    let () =
+      (* NOTE(anmonteiro): we may reconsider relaxing the directory target
            constraint (see [test/blackbox-tests/test-cases/pkg/source-with-directory-symlink.t]).
 
            [Copy] stays file-oriented by default. We only use recursive copying
            when [dst] is a directory target. *)
-        match ectx.targets with
-        | Some { dirs; _ } when Filename.Set.mem dirs (Path.basename dst) ->
-          Tree_copy.copy ~src ~dst ~copy_file ~mkdir ~on_unsupported ()
-        | _ -> copy_file ~src ~dst)
+      match ectx.targets with
+      | Some { dirs; _ } when Filename.Set.mem dirs (Path.basename dst) ->
+        Tree_copy.copy ~src ~dst ~copy_file ~mkdir ~on_unsupported ()
+      | _ -> copy_file ~src ~dst
     in
-    Done
+    Fiber.return Done
   | Symlink (src, dst) ->
-    let+ () = maybe_async (fun () -> Io.portable_symlink ~src ~dst:(Path.build dst)) in
-    Done
+    Io.portable_symlink ~src ~dst:(Path.build dst);
+    Fiber.return Done
   | Hardlink (src, dst) ->
-    let+ () = maybe_async (fun () -> Io.portable_hardlink ~src ~dst:(Path.build dst)) in
-    Done
+    Io.portable_hardlink ~src ~dst:(Path.build dst);
+    Fiber.return Done
   | System command ->
     let prog, arg =
       Env_path.system_shell_exn ~needed_to:"interpret (system ...) actions"
@@ -206,10 +189,9 @@ let rec exec t ~ectx ~eenv : Done_or_more_deps.t Fiber.t =
   | Write_file (fn, perm, s) ->
     let start = Time.now () in
     let fn = Path.build fn in
-    let* () =
-      maybe_async (fun () ->
-        let perm = File_perm.to_unix_perm perm in
-        Io.write_file fn s ~perm)
+    let () =
+      let perm = File_perm.to_unix_perm perm in
+      Io.write_file fn s ~perm
     in
     let finish = Time.now () in
     Dune_trace.emit ~buffered:true Action (fun () ->
@@ -218,14 +200,14 @@ let rec exec t ~ectx ~eenv : Done_or_more_deps.t Fiber.t =
   | Rename (src, dst) ->
     let src = Path.Build.to_string src in
     let dst = Path.Build.to_string dst in
-    let+ () = maybe_async (fun () -> Unix.rename src dst) in
-    Done
+    Unix.rename src dst;
+    Fiber.return Done
   | Remove_tree path ->
-    let+ () = maybe_async (fun () -> Path.rm_rf (Path.build path)) in
-    Done
+    Path.rm_rf (Path.build path);
+    Fiber.return Done
   | Mkdir path ->
-    let+ () = maybe_async (fun () -> Path.mkdir_p (Path.build path)) in
-    Done
+    Path.mkdir_p (Path.build path);
+    Fiber.return Done
   | Pipe (outputs, l) -> exec_pipe ~ectx ~eenv outputs l
   | Diff diff ->
     let+ () = Diff_action.exec ~patch_back:None ectx.rule_loc diff in

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -322,15 +322,6 @@ module Internal = struct
         ; attached_to_alias : bool
         }
 
-  let maybe_async_rule_file_op f =
-    (* It would be nice to do this check only once and return a function, but the
-       type of this function would need to be polymorphic which is forbidden by
-       the relaxed value restriction. *)
-    match Config.(get background_file_system_operations_in_rule_execution) with
-    | `Enabled -> Scheduler.async_exn f
-    | `Disabled -> Fiber.return (f ())
-  ;;
-
   module Anonymous_action = struct
     type t =
       { action : Rule.Anonymous_action.t
@@ -447,10 +438,9 @@ module Internal = struct
           then Action.with_stdout_to stamp_file action
           else Action.progn [ action; Action.write_file stamp_file "" ]
       in
-      let* () =
-        maybe_async_rule_file_op (fun () ->
-          Action.chdirs action
-          |> Path.Build.Set.iter ~f:(fun p -> Path.mkdir_p (Path.build p)))
+      let () =
+        Action.chdirs action
+        |> Path.Build.Set.iter ~f:(fun p -> Path.mkdir_p (Path.build p))
       in
       let context = Build_context.of_build_path targets.root in
       let root =
@@ -478,7 +468,7 @@ module Internal = struct
         in
         let* action_exec_result = Action_exec.Exec_result.ok_exn action_exec_result in
         let* () = Action_trace.collect action_trace in
-        let* () =
+        let+ () =
           if not is_sandboxed
           then Fiber.return ()
           else (
@@ -491,10 +481,7 @@ module Internal = struct
             in
             Sandbox.move_targets_to_build_dir sandbox ~should_be_skipped ~targets)
         in
-        let+ produced_targets =
-          maybe_async_rule_file_op (fun () -> Targets.Produced.of_validated targets)
-        in
-        match produced_targets with
+        match Targets.Produced.of_validated targets with
         | Ok produced_targets -> { Exec_result.produced_targets; action_exec_result }
         | Error error -> User_error.raise ~loc (Targets.Produced.Error.message error))
     in
@@ -561,9 +548,7 @@ module Internal = struct
     wrap_fiber (fun () ->
       let open Fiber.O in
       report_evaluated_rule_exn ();
-      let* () =
-        maybe_async_rule_file_op (fun () -> Path.mkdir_p (Path.build targets.root))
-      in
+      Path.mkdir_p (Path.build targets.root);
       let is_action_dynamic = Action.is_dynamic action.action in
       let sandbox_mode =
         select_sandbox_mode
@@ -625,31 +610,27 @@ module Internal = struct
           (* Step II. Remove stale targets both from the digest table and from
              the build directory. *)
           Rule_cache.Workspace_local.remove targets;
-          let* () =
-            maybe_async_rule_file_op (fun () ->
-              let remove_target_dir dir =
-                let () = Rule_cache.Workspace_local.remove_subtree dir in
-                Path.rm_rf (Path.build dir)
-              in
-              let remove_target_file path =
-                match Fpath.unlink (Path.Build.to_string path) with
-                | Success -> ()
-                | Does_not_exist -> ()
-                | Is_a_directory ->
-                  (* If target changed from a directory to a file, delete
+          let () =
+            let remove_target_dir dir =
+              let () = Rule_cache.Workspace_local.remove_subtree dir in
+              Path.rm_rf (Path.build dir)
+            in
+            let remove_target_file path =
+              match Fpath.unlink (Path.Build.to_string path) with
+              | Success -> ()
+              | Does_not_exist -> ()
+              | Is_a_directory ->
+                (* If target changed from a directory to a file, delete
                      in anyway. *)
-                  remove_target_dir path
-                | Error exn ->
-                  Log.warn
-                    "Error while removing target"
-                    [ "path", Dyn.string (Path.Build.to_string path)
-                    ; "error", Dyn.string (Printexc.to_string exn)
-                    ]
-              in
-              Targets.Validated.iter
-                targets
-                ~file:remove_target_file
-                ~dir:remove_target_dir)
+                remove_target_dir path
+              | Error exn ->
+                Log.warn
+                  "Error while removing target"
+                  [ "path", Dyn.string (Path.Build.to_string path)
+                  ; "error", Dyn.string (Printexc.to_string exn)
+                  ]
+            in
+            Targets.Validated.iter targets ~file:remove_target_file ~dir:remove_target_dir
           in
           let* produced_targets, dynamic_deps_stages =
             (* Step III. Try to restore artifacts from the shared cache. *)


### PR DESCRIPTION
This did not speed anything up in practice. There's no use for it