### PR TITLE
refactor(engine): unify workspace cache storage

### DIFF
--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -10,44 +10,26 @@ module Dir_contents = struct
       ; rest : File_kind.t Filename.Array.Map.t
       }
     ]}*)
-  type t = File_kind.t Filename.Array.Map.t
+  type t = Workspace_cache.Dir_contents.t
 
   let iter t ~f = Filename.Array.Map.iteri t ~f
   let to_list = Filename.Array.Map.to_list
 
   (* The names must be unique, so we don't care about comparing file kinds. *)
   let of_list = Filename.Array.Map.of_list_exn
+  let repr = Workspace_cache.Dir_contents.repr
   let equal = Filename.Array.Map.equal ~equal:File_kind.equal
-  let repr = Repr.view (Repr.list (Repr.pair Filename.repr File_kind.repr)) ~to_:to_list
   let to_dyn = Repr.to_dyn repr
 end
 
 module Cached_digest = struct
   module Stats = struct
-    type t =
-      { mtime : Time.t
-      ; ctime : Time.t
-      ; size : int
-      ; perm : Unix.file_perm
-      ; dev : int
-      ; ino : int
-      }
+    type t = Workspace_cache.Fs_memo.Stats.t
 
-    let repr =
-      Repr.record
-        "fs-memo-cached-digest-reduced-stats"
-        [ Repr.field "mtime" Time.repr ~get:(fun t -> t.mtime)
-        ; Repr.field "ctime" Time.repr ~get:(fun t -> t.ctime)
-        ; Repr.field "size" Repr.int ~get:(fun t -> t.size)
-        ; Repr.field "perm" Repr.int ~get:(fun t -> t.perm)
-        ; Repr.field "dev" Repr.int ~get:(fun t -> t.dev)
-        ; Repr.field "ino" Repr.int ~get:(fun t -> t.ino)
-        ]
-    ;;
-
+    let repr = Workspace_cache.Fs_memo.Stats.repr
     let to_dyn = Repr.to_dyn repr
 
-    let of_stat (stat : Stat.t) =
+    let of_stat (stat : Stat.t) : t =
       { mtime = stat.mtime
       ; ctime = stat.ctime
       ; size = stat.size
@@ -64,52 +46,8 @@ module Cached_digest = struct
       end)
   end
 
-  type 'a file =
-    { mutable contents : 'a
-    ; mutable stats : Stats.t
-    ; mutable stats_checked : int
-    }
-
-  type t =
-    { mutable checked_key : int
-    ; mutable max_timestamp : Time.t
-    ; table : Digest.t file Path.Table.t
-    ; dir_contents : Dir_contents.t file Path.Table.t
-    }
-
-  let db_file = Path.relative Path.build_dir ".digest-db"
-  let digest_repr = Repr.view Repr.string ~to_:Digest.to_string
-
-  let file_repr contents_repr =
-    Repr.record
-      "fs-memo-cached-digest-file"
-      [ Repr.field "contents" contents_repr ~get:(fun t -> t.contents)
-      ; Repr.field "stats" Stats.repr ~get:(fun t -> t.stats)
-      ; Repr.field "stats_checked" Repr.int ~get:(fun t -> t.stats_checked)
-      ]
-  ;;
-
-  let repr =
-    let table contents_repr =
-      Repr.abstract (Path.Table.to_dyn (Repr.to_dyn (file_repr contents_repr)))
-    in
-    Repr.record
-      "fs-memo-cached-digest"
-      [ Repr.field "checked_key" Repr.int ~get:(fun t -> t.checked_key)
-      ; Repr.field "max_timestamp" Time.repr ~get:(fun t -> t.max_timestamp)
-      ; Repr.field "table" (table digest_repr) ~get:(fun t -> t.table)
-      ; Repr.field "dir_contents" (table Dir_contents.repr) ~get:(fun t -> t.dir_contents)
-      ]
-  ;;
-
-  module P = Persistent.Make (struct
-      type nonrec t = t
-
-      let name = "DIGEST-DB"
-      let version = 12
-      let sharing = true
-      let repr = repr
-    end)
+  type 'a file = 'a Workspace_cache.Fs_memo.file
+  type t = Workspace_cache.Fs_memo.t
 
   let needs_dumping = ref false
 
@@ -120,16 +58,10 @@ module Cached_digest = struct
      subscribing for file-watching updates. *)
   let cache =
     lazy
-      (match P.load db_file with
-       | None ->
-         { checked_key = 0
-         ; table = Path.Table.create ()
-         ; max_timestamp = Time.of_ns 0
-         ; dir_contents = Path.Table.create ()
-         }
-       | Some cache ->
-         cache.checked_key <- cache.checked_key + 1;
-         cache)
+      (let cache = Workspace_cache.fs_memo () in
+       if Workspace_cache.loaded_from_disk ()
+       then cache.checked_key <- cache.checked_key + 1;
+       cache)
   ;;
 
   let get_current_filesystem_time () =
@@ -142,7 +74,7 @@ module Cached_digest = struct
     let t = get_current_filesystem_time () in
     while get_current_filesystem_time () <= t do
       (* This is a blocking wait but we don't care too much. This code is only
-       used in the test suite. *)
+         used in the test suite. *)
       Unix.sleepf 0.01
     done
   ;;
@@ -187,18 +119,10 @@ module Cached_digest = struct
       cache.max_timestamp <- !max_timestamp
   ;;
 
-  let dump () =
-    if !needs_dumping && Path.build_dir_exists ()
-    then (
-      needs_dumping := false;
-      Console.Status_line.with_overlay
-        (Live (fun () -> Pp.hbox (Pp.text "Saving digest db...")))
-        ~f:(fun () ->
-          delete_very_recent_entries ();
-          P.dump db_file (Lazy.force cache)))
+  let () =
+    At_exit.at_exit_ignore Workspace_cache.at_exit (fun () ->
+      if !needs_dumping && Path.build_dir_exists () then delete_very_recent_entries ())
   ;;
-
-  let () = At_exit.at_exit_ignore Dune_trace.at_exit dump
 
   let invalidate_cached_timestamps () =
     if Lazy.is_val cache
@@ -208,18 +132,20 @@ module Cached_digest = struct
     delete_very_recent_entries ()
   ;;
 
-  let set_max_timestamp cache (stat : Stat.t) =
+  let set_max_timestamp (cache : t) (stat : Stat.t) =
     cache.max_timestamp <- Time.max cache.max_timestamp stat.mtime
   ;;
 
   let set_with_stat ~table path contents stat =
     let cache = Lazy.force cache in
     needs_dumping := true;
+    Workspace_cache.mark_dirty ();
     set_max_timestamp cache stat;
     Path.Table.set
       (table cache)
       path
-      { contents; stats = Stats.of_stat stat; stats_checked = cache.checked_key }
+      ({ contents; stats = Stats.of_stat stat; stats_checked = cache.checked_key }
+       : _ file)
   ;;
 
   let digest_path_with_stats path stats =
@@ -253,7 +179,7 @@ module Cached_digest = struct
     let cache = Lazy.force cache in
     match Path.Table.find (table cache) path with
     | None -> None
-    | Some x ->
+    | Some (x : _ file) ->
       Some
         (if x.stats_checked = cache.checked_key
          then Ok x.contents
@@ -289,6 +215,7 @@ module Cached_digest = struct
                    ~old_stats:x.stats
                    ~new_stats:reduced_stats;
                  needs_dumping := true;
+                 Workspace_cache.mark_dirty ();
                  set_max_timestamp cache stats;
                  x.contents <- contents;
                  x.stats <- reduced_stats;
@@ -322,7 +249,7 @@ module Cached_digest = struct
       let cache = Lazy.force cache in
       match Path.Table.find (table cache) path with
       | None -> ()
-      | Some entry ->
+      | Some (entry : _ file) ->
         (* Make [stats_checked] unequal to [cache.checked_key] so that [peek]
          is forced to re-[stat] the [path]. *)
         entry.stats_checked <- cache.checked_key - 1
@@ -385,9 +312,9 @@ module Cached_digest = struct
     ;;
   end
 
-  let load () = P.load db_file
+  let load () = Workspace_cache.load_fs_memo ()
 
-  let entries { table; _ } =
+  let entries ({ table; _ } : t) =
     let entries = ref [] in
     Path.Table.iteri table ~f:(fun ~key ~data -> entries := (key, data) :: !entries);
     List.sort !entries ~compare:(fun (path_a, _) (path_b, _) ->
@@ -435,15 +362,15 @@ module Debug = struct
       ; Repr.field
           "contents"
           (Repr.abstract Digest.to_dyn)
-          ~get:(fun (_, { Cached_digest.contents; _ }) -> contents)
+          ~get:(fun (_, ({ contents; _ } : _ Cached_digest.file)) -> contents)
       ; Repr.field
           "stats"
           Cached_digest.Stats.repr
-          ~get:(fun (_, { Cached_digest.stats; _ }) -> stats)
+          ~get:(fun (_, ({ stats; _ } : _ Cached_digest.file)) -> stats)
       ; Repr.field
           "stats_checked"
           Repr.int
-          ~get:(fun (_, { Cached_digest.stats_checked; _ }) -> stats_checked)
+          ~get:(fun (_, ({ stats_checked; _ } : _ Cached_digest.file)) -> stats_checked)
       ]
   ;;
 
@@ -456,13 +383,12 @@ module Debug = struct
       User_error.raise
         [ Pp.textf
             "No digest database found at %s"
-            (Path.to_string_maybe_quoted Cached_digest.db_file)
+            (Path.to_string_maybe_quoted Workspace_cache.file)
         ]
   ;;
 
   let dump_digest_db paths =
-    let db = load_exn () in
-    let { Cached_digest.checked_key; max_timestamp; _ } = db in
+    let (({ checked_key; max_timestamp; _ } : Cached_digest.t) as db) = load_exn () in
     let entries =
       selected_entries db paths
       |> List.map ~f:(fun (path, file) -> entry_to_dyn (path, file))
@@ -516,20 +442,25 @@ module Debug = struct
   let check_digest_db paths =
     let db = load_exn () in
     selected_entries db paths
-    |> List.filter_map ~f:(fun (path, file) ->
-      let { Cached_digest.contents = cached_digest; stats; stats_checked = _ } = file in
-      let current_stats, actual = current_digest path in
-      if Digest_result.equal actual (Ok cached_digest)
-      then None
-      else (
-        let status =
-          match current_stats with
-          | Some current_stats when Cached_digest.Stats.equal stats current_stats ->
-            "invalid"
-          | Some _ | None -> "stale"
-        in
-        Some (finding_to_dyn { status; path; cached_digest; actual })))
-    |> fun findings -> Dyn.List findings
+    |> List.filter_map
+         ~f:
+           (fun
+             ( path
+             , ({ contents = cached_digest; stats; stats_checked = _ } :
+                 _ Cached_digest.file) )
+           ->
+           let current_stats, actual = current_digest path in
+           if Digest_result.equal actual (Ok cached_digest)
+           then None
+           else (
+             let status =
+               match current_stats with
+               | Some current_stats when Cached_digest.Stats.equal stats current_stats ->
+                 "invalid"
+               | Some _ | None -> "stale"
+             in
+             Some (finding_to_dyn { status; path; cached_digest; actual })))
+    |> Dyn.list Fun.id
   ;;
 end
 

--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -4,47 +4,11 @@ open Dune_cache.Hit_or_miss
 module Workspace_local = struct
   (* Stores information for deciding if a rule needs to be re-executed. *)
   module Database = struct
-    let digest_repr = Repr.view Repr.string ~to_:Digest.to_string
-
-    module Entry = struct
-      type t =
-        { rule_digest : Digest.t
-        ; dynamic_deps_stages : (Dep.Set.t * Digest.t) list
-        ; targets_digest : Digest.t
-        }
-
-      let repr =
-        Repr.record
-          "rule-cache-workspace-local-entry"
-          [ Repr.field "rule_digest" digest_repr ~get:(fun t -> t.rule_digest)
-          ; Repr.field
-              "dynamic_deps_stages"
-              (Repr.list (Repr.pair (Repr.abstract Dep.Set.to_dyn) digest_repr))
-              ~get:(fun t -> t.dynamic_deps_stages)
-          ; Repr.field "targets_digest" digest_repr ~get:(fun t -> t.targets_digest)
-          ]
-      ;;
-    end
-
-    type digest =
-      { digest : Digest.t
-      ; siblings : Digest.t Targets.Produced.t
-      ; generation : int
-      }
-
-    let digest_repr =
-      Repr.record
-        "rule-cache-workspace-local-digest"
-        [ Repr.field "digest" digest_repr ~get:(fun t -> t.digest)
-        ; Repr.field "siblings" (Repr.abstract Targets.Produced.to_dyn) ~get:(fun t ->
-            t.siblings)
-        ; Repr.field "generation" Repr.int ~get:(fun t -> t.generation)
-        ]
-    ;;
+    type digest = Workspace_cache.Rule_cache.digest
 
     (* Keyed by the first target of the rule. *)
-    type t =
-      { rules : Entry.t Path.Table.t
+    type t = Workspace_cache.Rule_cache.t =
+      { rules : Workspace_cache.Rule_cache.Entry.t Path.Table.t
       ; digests : digest Path.Build.Table.t
       ; invalidated_subtrees : int Path.Build.Table.t
         (* A digest is only valid if its generation is greater or equal to the
@@ -52,68 +16,7 @@ module Workspace_local = struct
       ; mutable generation : int (* The current generation *)
       }
 
-    let file = Path.relative Path.build_dir ".db"
-
-    let repr =
-      Repr.record
-        "rule-cache-workspace-local-database"
-        [ Repr.field
-            "rules"
-            (Repr.abstract (Path.Table.to_dyn (Repr.to_dyn Entry.repr)))
-            ~get:(fun t -> t.rules)
-        ; Repr.field
-            "digests"
-            (Repr.abstract (Path.Build.Table.to_dyn (Repr.to_dyn digest_repr)))
-            ~get:(fun t -> t.digests)
-        ; Repr.field
-            "invalidated_subtrees"
-            (Repr.abstract (Path.Build.Table.to_dyn Dyn.int))
-            ~get:(fun t -> t.invalidated_subtrees)
-        ; Repr.field "generation" Repr.int ~get:(fun t -> t.generation)
-        ]
-    ;;
-
-    module P = Dune_util.Persistent.Make (struct
-        type nonrec t = t
-
-        let name = "INCREMENTAL-DB"
-        let version = 8
-        let sharing = true
-        let repr = repr
-      end)
-
-    let needs_dumping = ref false
-
-    let t =
-      lazy
-        (match P.load file with
-         | Some t -> t
-         (* This mutable table is safe: it's only used by [execute_rule_impl] to
-            decide whether to rebuild a rule or not; [execute_rule_impl] ensures
-            that the targets are produced deterministically. *)
-         | None ->
-           { rules = Path.Table.create ()
-           ; digests = Path.Build.Table.create 128
-           ; invalidated_subtrees = Path.Build.Table.create 16
-           ; generation = 0
-           })
-    ;;
-
-    let dump () =
-      if !needs_dumping && Path.build_dir_exists ()
-      then (
-        needs_dumping := false;
-        Console.Status_line.with_overlay
-          (Live (fun () -> Pp.hbox (Pp.text "Saving build trace db...")))
-          ~f:(fun () -> P.dump file (Lazy.force t)))
-    ;;
-
-    (* CR-someday amokhov: If this happens to be executed after we've cleared
-       the status line and printed some text afterwards, [dump] would overwrite
-       that text by the "Saving..." message. If this hypothetical scenario turns
-       out to be a real problem, we will need to add some synchronisation
-       mechanism to prevent clearing the status line too early. *)
-    let () = At_exit.at_exit_ignore Dune_trace.at_exit dump
+    let t = lazy (Workspace_cache.rule_cache ())
 
     let get path =
       let t = Lazy.force t in
@@ -122,10 +25,10 @@ module Workspace_local = struct
 
     let set path e (targets : _ Targets.Produced.t) =
       let t = Lazy.force t in
-      needs_dumping := true;
+      Workspace_cache.mark_dirty ();
       Path.Table.set t.rules path e;
       let set_digest p digest =
-        let digest = { digest; siblings = targets; generation = t.generation } in
+        let digest : digest = { digest; siblings = targets; generation = t.generation } in
         Path.Build.Table.set t.digests (Path.Build.append_local targets.root p) digest
       in
       Targets.Produced.iteri targets ~f:set_digest ~d:(fun _ -> ())
@@ -133,14 +36,14 @@ module Workspace_local = struct
 
     let remove (targets : Targets.Validated.t) =
       let t = Lazy.force t in
-      needs_dumping := true;
+      Workspace_cache.mark_dirty ();
       let remove = Path.Build.Table.remove t.digests in
       Targets.Validated.iter targets ~file:remove ~dir:remove
     ;;
 
     let remove_target path =
       let t = Lazy.force t in
-      needs_dumping := true;
+      Workspace_cache.mark_dirty ();
       match Path.Build.Table.find t.digests path with
       | None -> ()
       | Some { digest = _; siblings; _ } ->
@@ -181,7 +84,7 @@ module Workspace_local = struct
 
     let remove_subtree root =
       let t = Lazy.force t in
-      needs_dumping := true;
+      Workspace_cache.mark_dirty ();
       t.generation <- t.generation + 1;
       Path.Build.Table.set t.invalidated_subtrees root t.generation
     ;;

--- a/src/dune_engine/rule_cache.mli
+++ b/src/dune_engine/rule_cache.mli
@@ -6,9 +6,10 @@ open Import
 
     - Build artifacts currently available in the build directory.
 
-    - A database [_build/.db] that maps rule digests to their target digests.
+    - The rule records in the workspace cache [_build/.db], which map rule
+      digests to their target digests.
 
-    The database makes it possible to decide if the build directory contains up
+    These records make it possible to decide if the build directory contains up
     to date results for a given rule. *)
 module Workspace_local : sig
   (** Check if the workspace-local cache contains up-to-date results for a rule

--- a/src/dune_engine/workspace_cache.ml
+++ b/src/dune_engine/workspace_cache.ml
@@ -1,0 +1,207 @@
+open Import
+
+let needs_dumping = ref false
+let mark_dirty () = needs_dumping := true
+
+module Dir_contents = struct
+  type t = File_kind.t Filename.Array.Map.t
+
+  let repr =
+    Repr.view
+      (Repr.list (Repr.pair Filename.repr File_kind.repr))
+      ~to_:Filename.Array.Map.to_list
+  ;;
+end
+
+let digest_repr = Repr.view Repr.string ~to_:Digest.to_string
+
+module Fs_memo = struct
+  module Stats = struct
+    type t =
+      { mtime : Time.t
+      ; ctime : Time.t
+      ; size : int
+      ; perm : Unix.file_perm
+      ; dev : int
+      ; ino : int
+      }
+
+    let repr =
+      Repr.record
+        "fs-memo-cached-digest-reduced-stats"
+        [ Repr.field "mtime" Time.repr ~get:(fun t -> t.mtime)
+        ; Repr.field "ctime" Time.repr ~get:(fun t -> t.ctime)
+        ; Repr.field "size" Repr.int ~get:(fun t -> t.size)
+        ; Repr.field "perm" Repr.int ~get:(fun t -> t.perm)
+        ; Repr.field "dev" Repr.int ~get:(fun t -> t.dev)
+        ; Repr.field "ino" Repr.int ~get:(fun t -> t.ino)
+        ]
+    ;;
+  end
+
+  type 'a file =
+    { mutable contents : 'a
+    ; mutable stats : Stats.t
+    ; mutable stats_checked : int
+    }
+
+  type t =
+    { mutable checked_key : int
+    ; mutable max_timestamp : Time.t
+    ; table : Digest.t file Path.Table.t
+    ; dir_contents : Dir_contents.t file Path.Table.t
+    }
+
+  let file_repr contents_repr =
+    Repr.record
+      "fs-memo-cached-digest-file"
+      [ Repr.field "contents" contents_repr ~get:(fun t -> t.contents)
+      ; Repr.field "stats" Stats.repr ~get:(fun t -> t.stats)
+      ; Repr.field "stats_checked" Repr.int ~get:(fun t -> t.stats_checked)
+      ]
+  ;;
+
+  let repr =
+    let table contents_repr =
+      Repr.abstract (Path.Table.to_dyn (Repr.to_dyn (file_repr contents_repr)))
+    in
+    Repr.record
+      "fs-memo-cached-digest"
+      [ Repr.field "checked_key" Repr.int ~get:(fun t -> t.checked_key)
+      ; Repr.field "max_timestamp" Time.repr ~get:(fun t -> t.max_timestamp)
+      ; Repr.field "table" (table digest_repr) ~get:(fun t -> t.table)
+      ; Repr.field "dir_contents" (table Dir_contents.repr) ~get:(fun t -> t.dir_contents)
+      ]
+  ;;
+
+  let create () =
+    { checked_key = 0
+    ; table = Path.Table.create ()
+    ; max_timestamp = Time.of_ns 0
+    ; dir_contents = Path.Table.create ()
+    }
+  ;;
+end
+
+module Rule_cache = struct
+  module Entry = struct
+    type t =
+      { rule_digest : Digest.t
+      ; dynamic_deps_stages : (Dep.Set.t * Digest.t) list
+      ; targets_digest : Digest.t
+      }
+
+    let repr =
+      Repr.record
+        "rule-cache-workspace-local-entry"
+        [ Repr.field "rule_digest" digest_repr ~get:(fun t -> t.rule_digest)
+        ; Repr.field
+            "dynamic_deps_stages"
+            (Repr.list (Repr.pair (Repr.abstract Dep.Set.to_dyn) digest_repr))
+            ~get:(fun t -> t.dynamic_deps_stages)
+        ; Repr.field "targets_digest" digest_repr ~get:(fun t -> t.targets_digest)
+        ]
+    ;;
+  end
+
+  type digest =
+    { digest : Digest.t
+    ; siblings : Digest.t Targets.Produced.t
+    ; generation : int
+    }
+
+  let digest_repr =
+    Repr.record
+      "rule-cache-workspace-local-digest"
+      [ Repr.field "digest" digest_repr ~get:(fun t -> t.digest)
+      ; Repr.field "siblings" (Repr.abstract Targets.Produced.to_dyn) ~get:(fun t ->
+          t.siblings)
+      ; Repr.field "generation" Repr.int ~get:(fun t -> t.generation)
+      ]
+  ;;
+
+  type t =
+    { rules : Entry.t Path.Table.t
+    ; digests : digest Path.Build.Table.t
+    ; invalidated_subtrees : int Path.Build.Table.t
+    ; mutable generation : int
+    }
+
+  let repr =
+    Repr.record
+      "rule-cache-workspace-local-database"
+      [ Repr.field
+          "rules"
+          (Repr.abstract (Path.Table.to_dyn (Repr.to_dyn Entry.repr)))
+          ~get:(fun t -> t.rules)
+      ; Repr.field
+          "digests"
+          (Repr.abstract (Path.Build.Table.to_dyn (Repr.to_dyn digest_repr)))
+          ~get:(fun t -> t.digests)
+      ; Repr.field
+          "invalidated_subtrees"
+          (Repr.abstract (Path.Build.Table.to_dyn Dyn.int))
+          ~get:(fun t -> t.invalidated_subtrees)
+      ; Repr.field "generation" Repr.int ~get:(fun t -> t.generation)
+      ]
+  ;;
+
+  let create () =
+    { rules = Path.Table.create ()
+    ; digests = Path.Build.Table.create 128
+    ; invalidated_subtrees = Path.Build.Table.create 16
+    ; generation = 0
+    }
+  ;;
+end
+
+type t =
+  { fs_memo : Fs_memo.t
+  ; rule_cache : Rule_cache.t
+  }
+
+let file = Path.relative Path.build_dir ".db"
+let old_digest_file = Path.relative Path.build_dir ".digest-db"
+
+let repr =
+  Repr.record
+    "workspace-cache"
+    [ Repr.field "fs_memo" Fs_memo.repr ~get:(fun t -> t.fs_memo)
+    ; Repr.field "rule_cache" Rule_cache.repr ~get:(fun t -> t.rule_cache)
+    ]
+;;
+
+module P = Persistent.Make (struct
+    type nonrec t = t
+
+    let name = "WORKSPACE-CACHE"
+    let version = 1
+    let sharing = true
+    let repr = repr
+  end)
+
+let cache =
+  lazy
+    (match P.load file with
+     | None -> { fs_memo = Fs_memo.create (); rule_cache = Rule_cache.create () }, false
+     | Some t -> t, true)
+;;
+
+let get () = fst (Lazy.force cache)
+let fs_memo () = (get ()).fs_memo
+let rule_cache () = (get ()).rule_cache
+let loaded_from_disk () = snd (Lazy.force cache)
+
+let dump () =
+  if !needs_dumping && Path.build_dir_exists ()
+  then (
+    needs_dumping := false;
+    Console.Status_line.with_overlay
+      (Live (fun () -> Pp.hbox (Pp.text "Saving workspace cache...")))
+      ~f:(fun () ->
+        P.dump file (get ());
+        Fpath.unlink_no_err (Path.to_string old_digest_file)))
+;;
+
+let at_exit = At_exit.at_exit Dune_trace.at_exit dump
+let load_fs_memo () = Option.map (P.load file) ~f:(fun t -> t.fs_memo)

--- a/src/dune_engine/workspace_cache.mli
+++ b/src/dune_engine/workspace_cache.mli
@@ -1,0 +1,74 @@
+(** Storage for persistent workspace-local state. Values used by file-system
+    memoization and the rule cache are serialized together so they can share
+    structure. *)
+
+open Import
+
+val mark_dirty : unit -> unit
+
+module Dir_contents : sig
+  type t = File_kind.t Filename.Array.Map.t
+
+  val repr : t Repr.t
+end
+
+module Fs_memo : sig
+  module Stats : sig
+    type t =
+      { mtime : Time.t
+      ; ctime : Time.t
+      ; size : int
+      ; perm : Unix.file_perm
+      ; dev : int
+      ; ino : int
+      }
+
+    val repr : t Repr.t
+  end
+
+  type 'a file =
+    { mutable contents : 'a
+    ; mutable stats : Stats.t
+    ; mutable stats_checked : int
+    }
+
+  type t =
+    { mutable checked_key : int
+    ; mutable max_timestamp : Time.t
+    ; table : Digest.t file Path.Table.t
+    ; dir_contents : Dir_contents.t file Path.Table.t
+    }
+end
+
+module Rule_cache : sig
+  module Entry : sig
+    type t =
+      { rule_digest : Digest.t
+      ; dynamic_deps_stages : (Dep.Set.t * Digest.t) list
+      ; targets_digest : Digest.t
+      }
+  end
+
+  type digest =
+    { digest : Digest.t
+    ; siblings : Digest.t Targets.Produced.t
+    ; generation : int
+    }
+
+  (* [rules] is keyed by the first target of the rule. *)
+  type t =
+    { rules : Entry.t Path.Table.t
+    ; digests : digest Path.Build.Table.t
+    ; invalidated_subtrees : int Path.Build.Table.t
+      (* A digest is only valid if its generation is greater or equal to the
+         generation of all of its parents. *)
+    ; mutable generation : int
+    }
+end
+
+val file : Path.t
+val fs_memo : unit -> Fs_memo.t
+val rule_cache : unit -> Rule_cache.t
+val loaded_from_disk : unit -> bool
+val at_exit : At_exit.t
+val load_fs_memo : unit -> Fs_memo.t option


### PR DESCRIPTION
Store fs memo digest metadata and workspace-local rule records in a single _build/.db value. Introduce Workspace_cache as the storage API so both caches can share serialized structure while retaining their existing higher-level logic.