### PR TITLE
refactor(engine): compact fs memo directory contents

### DIFF
--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -3,22 +3,52 @@ open Memo.O
 module Digest_result = Dune_digest.Digest_result
 
 module Dir_contents = struct
-  (* CR-soon rgrinberg: turn this into this record:
-    {[
-      { files : Filename.Array.Set.t
-      ; dirs : Filename.Array.Set.t
-      ; rest : File_kind.t Filename.Array.Map.t
-      }
-    ]}*)
-  type t = Workspace_cache.Dir_contents.t
+  type t = Workspace_cache.Dir_contents.t =
+    { files : Filename.Array.Set.t
+    ; dirs : Filename.Array.Set.t
+    ; rest : File_kind.t Filename.Array.Map.t
+    }
 
-  let iter t ~f = Filename.Array.Map.iteri t ~f
-  let to_list = Filename.Array.Map.to_list
+  let to_list { files; dirs; rest } =
+    Filename.Array.Set.to_list_map files ~f:(fun filename -> filename, File_kind.S_REG)
+    @ Filename.Array.Set.to_list_map dirs ~f:(fun filename -> filename, File_kind.S_DIR)
+    @ Filename.Array.Map.to_list rest
+  ;;
 
-  (* The names must be unique, so we don't care about comparing file kinds. *)
-  let of_list = Filename.Array.Map.of_list_exn
-  let repr = Workspace_cache.Dir_contents.repr
-  let equal = Filename.Array.Map.equal ~equal:File_kind.equal
+  let iter { files; dirs; rest } ~f =
+    Filename.Array.Set.iter files ~f:(fun filename -> f filename File_kind.S_REG);
+    Filename.Array.Set.iter dirs ~f:(fun filename -> f filename File_kind.S_DIR);
+    Filename.Array.Map.iteri rest ~f
+  ;;
+
+  let of_list entries =
+    let files, dirs, rest =
+      List.fold_left
+        entries
+        ~init:([], [], [])
+        ~f:(fun (files, dirs, rest) (filename, (kind : File_kind.t)) ->
+          match kind with
+          | S_REG -> filename :: files, dirs, rest
+          | S_DIR -> files, filename :: dirs, rest
+          | _ -> files, dirs, (filename, kind) :: rest)
+    in
+    { Workspace_cache.Dir_contents.files = Filename.Array.Set.of_list files
+    ; dirs = Filename.Array.Set.of_list dirs
+    ; rest = Filename.Array.Map.of_list_exn rest
+    }
+  ;;
+
+  let repr = Repr.view (Repr.list (Repr.pair Filename.repr File_kind.repr)) ~to_:to_list
+
+  let equal
+        { files = files_a; dirs = dirs_a; rest = rest_a }
+        { files = files_b; dirs = dirs_b; rest = rest_b }
+    =
+    Filename.Array.Set.equal files_a files_b
+    && Filename.Array.Set.equal dirs_a dirs_b
+    && Filename.Array.Map.equal rest_a rest_b ~equal:File_kind.equal
+  ;;
+
   let to_dyn = Repr.to_dyn repr
 end
 

--- a/src/dune_engine/fs_memo.mli
+++ b/src/dune_engine/fs_memo.mli
@@ -3,7 +3,7 @@ open Import
 module Dir_contents : sig
   type t
 
-  (** The sorted list of file names with kinds. *)
+  (** The list of file names with kinds. *)
   val to_list : t -> (Filename.t * File_kind.t) list
 
   val iter : t -> f:(Filename.t -> File_kind.t -> unit) -> unit

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -101,7 +101,7 @@ let get_dir_triage ~dir =
           match kind with
           | Unix.S_DIR -> None
           | _ -> Some filename)
-        |> Filename.Array.Set.of_sorted_list
+        |> Filename.Array.Set.of_list
     in
     Dir_triage.Known (External { filenames })
   | Build (Regular Root) ->

--- a/src/dune_engine/workspace_cache.ml
+++ b/src/dune_engine/workspace_cache.ml
@@ -4,12 +4,25 @@ let needs_dumping = ref false
 let mark_dirty () = needs_dumping := true
 
 module Dir_contents = struct
-  type t = File_kind.t Filename.Array.Map.t
+  type t =
+    { files : Filename.Array.Set.t
+    ; dirs : Filename.Array.Set.t
+    ; rest : File_kind.t Filename.Array.Map.t
+    }
 
   let repr =
-    Repr.view
-      (Repr.list (Repr.pair Filename.repr File_kind.repr))
-      ~to_:Filename.Array.Map.to_list
+    let set = Repr.view (Repr.list Filename.repr) ~to_:Filename.Array.Set.to_list in
+    let rest =
+      Repr.view
+        (Repr.list (Repr.pair Filename.repr File_kind.repr))
+        ~to_:Filename.Array.Map.to_list
+    in
+    Repr.record
+      "fs-memo-dir-contents"
+      [ Repr.field "files" set ~get:(fun t -> t.files)
+      ; Repr.field "dirs" set ~get:(fun t -> t.dirs)
+      ; Repr.field "rest" rest ~get:(fun t -> t.rest)
+      ]
   ;;
 end
 
@@ -175,7 +188,7 @@ module P = Persistent.Make (struct
     type nonrec t = t
 
     let name = "WORKSPACE-CACHE"
-    let version = 1
+    let version = 2
     let sharing = true
     let repr = repr
   end)

--- a/src/dune_engine/workspace_cache.mli
+++ b/src/dune_engine/workspace_cache.mli
@@ -7,9 +7,11 @@ open Import
 val mark_dirty : unit -> unit
 
 module Dir_contents : sig
-  type t = File_kind.t Filename.Array.Map.t
-
-  val repr : t Repr.t
+  type t =
+    { files : Filename.Array.Set.t
+    ; dirs : Filename.Array.Set.t
+    ; rest : File_kind.t Filename.Array.Map.t
+    }
 end
 
 module Fs_memo : sig

--- a/src/source/dir_contents.ml
+++ b/src/source/dir_contents.ml
@@ -122,8 +122,8 @@ let of_source_path_impl path =
           if is_directory then List.Right (fn, file) else Left fn)
       >>| List.filter_partition_map ~f:Fun.id
     in
-    let dirs = Filename.Array.Map.of_sorted_list_exn dirs in
-    { files = Filename.Array.Set.of_sorted_list files; dirs } |> Result.ok
+    let dirs = Filename.Array.Map.of_list_exn dirs in
+    { files = Filename.Array.Set.of_list files; dirs } |> Result.ok
 ;;
 
 (* Having a cutoff here speeds up incremental rebuilds quite a bit when a


### PR DESCRIPTION
Represent cached directory contents with separate filename sets for regular files and directories, retaining a map only for uncommon file kinds. This avoids storing the common file kind alongside every entry.

Callers that construct sorted sets and maps now establish their own ordering, and the workspace cache version is bumped for the persistent-format change.

Follow-up to #15655.
