### PR TITLE
[3.24.2] backport #15632 and #15634

### DIFF
--- a/doc/changes/fixed/15634.md
+++ b/doc/changes/fixed/15634.md
@@ -1,0 +1,3 @@
+- Rescan the RPC registry when its directory mtime changes, allowing clients
+  that poll before Dune registers to discover the new instance (#15634, fixes
+  #15630, @rgrinberg)

--- a/otherlibs/dune-rpc/registry.ml
+++ b/otherlibs/dune-rpc/registry.ml
@@ -169,11 +169,10 @@ struct
     let** (`Mtime mtime) = IO.stat dir in
     let skip =
       match t.last_mtime with
-      | Some last_mtime -> last_mtime <> mtime
-      | None ->
-        t.last_mtime <- Some mtime;
-        false
+      | Some last_mtime -> last_mtime = mtime
+      | None -> false
     in
+    t.last_mtime <- Some mtime;
     if skip
     then Fiber.return (Ok Refresh.empty)
     else

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
@@ -105,8 +105,8 @@ let%expect_test "poll skips scans after the registry mtime changes" =
   [%expect
     {|
     initial: scans=1 added=0 current=0
-    after change: scans=1 added=0 current=0
-    subsequent poll: scans=1 added=0 current=0 |}]
+    after change: scans=2 added=1 current=1
+    subsequent poll: scans=2 added=0 current=1 |}]
 ;;
 
 let%expect_test "turn on dune watch and wait until the connection is listed" =

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
@@ -45,6 +45,70 @@ let run =
           ()))
 ;;
 
+let%expect_test "poll skips scans after the registry mtime changes" =
+  let module IO = struct
+    let mtime = ref 0.0
+    let file : Registry.File.t option ref = ref None
+    let scans = ref 0
+    let stat _ = Fiber.return (Ok (`Mtime !mtime))
+
+    let scandir _ =
+      incr scans;
+      let files =
+        match !file with
+        | None -> []
+        | Some { Registry.File.path; _ } -> [ Filename.basename path ]
+      in
+      Fiber.return (Ok files)
+    ;;
+
+    let read_file path =
+      match !file with
+      | Some { Registry.File.path = registered_path; contents }
+        when String.equal path registered_path -> Fiber.return (Ok contents)
+      | None | Some _ -> Fiber.return (Error (Failure path))
+    ;;
+  end
+  in
+  let module Poll = Registry.Poll (Fiber) (IO) in
+  let case () =
+    let config =
+      Registry.Config.create
+        (Xdg.create
+           ~env:(function
+             | "XDG_RUNTIME_DIR" -> Some "."
+             | _ -> None)
+           ())
+    in
+    let registry = Registry.create config in
+    let poll description =
+      let+ result = Poll.poll registry in
+      match result with
+      | Error exn -> raise exn
+      | Ok refresh ->
+        printfn
+          "%s: scans=%d added=%d current=%d"
+          description
+          !IO.scans
+          (List.length (Registry.Refresh.added refresh))
+          (List.length (Registry.current registry))
+    in
+    let* () = poll "initial" in
+    let dune = Registry.Dune.create ~where:(`Unix "rpc") ~root:"." ~pid:1 in
+    let (`Caller_should_write file) = Registry.Config.register config dune in
+    IO.file := Some file;
+    IO.mtime := 1.0;
+    let* () = poll "after change" in
+    poll "subsequent poll"
+  in
+  run case;
+  [%expect
+    {|
+    initial: scans=1 added=0 current=0
+    after change: scans=1 added=0 current=0
+    subsequent poll: scans=1 added=0 current=0 |}]
+;;
+
 let%expect_test "turn on dune watch and wait until the connection is listed" =
   let case () =
     let runtime_dir = "_runtime_dir" in


### PR DESCRIPTION
Backport the RPC registry regression test from #15632 and its fix from #15634 onto `3.24.2-rc`.

The commits remain separate and in test-before-fix order.

Fixes #15630 for Dune 3.24.2.
