### PR TITLE
[3.24.2] backport #15592

### DIFF
--- a/doc/changes/fixed/15592.md
+++ b/doc/changes/fixed/15592.md
@@ -1,0 +1,2 @@
+- Add the implicit `unix` dependency required by MDX 2.6 and later to
+  generated MDX test executables (#15592, @avsm)

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -476,7 +476,7 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~mdx_prog =
         (`Exe Nonempty_list.[ t.loc, name ])
         ~allow_overlaps:false
         ~forbidden_libraries:[]
-        (lib "mdx.test" :: lib "mdx.top" :: t.libraries)
+        (lib "mdx.test" :: lib "mdx.top" :: lib "unix" :: t.libraries)
         ~allow_unused_libraries:[]
         ~pps:[]
         ~dune_version


### PR DESCRIPTION
Backport #15592 onto `3.24.2-rc` so generated MDX test executables include the implicit `unix` dependency required by MDX 2.6 and later.

This also adds the changelog fragment missing from the original PR.
