### PR TITLE
change: Pull anon. action data out of action builder context

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -323,7 +323,7 @@ module Internal = struct
 
   module Anonymous_action = struct
     type t =
-      { action : Rule.Anonymous_action.t
+      { action : Rule.Anonymous_action.Evaluated.t
       ; deps : Dep.Set.t
       ; capture_stdout : bool
       ; digest : Digest.t
@@ -333,7 +333,7 @@ module Internal = struct
     let hash t = Digest.hash t.digest
 
     let to_dyn t : Dyn.t =
-      Record [ "digest", Digest.to_dyn t.digest; "loc", Loc.to_dyn t.action.loc ]
+      Record [ "digest", Digest.to_dyn t.digest; "loc", Loc.to_dyn t.action.anon.loc ]
     ;;
   end
 
@@ -705,20 +705,22 @@ module Internal = struct
 
   (* Returns the action's stdout or the empty string if [capture_stdout = false]. *)
   and execute_action_generic_stage2_impl
-        { Anonymous_action.action = { dir; loc; action }; deps; capture_stdout; digest }
+        { Anonymous_action.action = { anon; action; _ }; deps; capture_stdout; digest }
     =
     let target =
       let dir =
-        Path.Build.append_local Dpath.Build.anonymous_actions_dir (Path.Build.local dir)
+        Path.Build.append_local
+          Dpath.Build.anonymous_actions_dir
+          (Path.Build.local anon.dir)
       in
       Path.Build.relative dir (Digest.to_string digest)
     in
     let rule =
-      Rule.make
-        ~info:(if Loc.is_none loc then Internal else From_dune_file loc)
+      Rule.Anonymous_action.to_rule
         ~targets:(Targets.File.create target)
         ~mode:Standard
-        (Action_builder.record action deps ~f:build_dep)
+        anon
+      |> Fun.flip Rule.set_action (Action_builder.record action deps ~f:build_dep)
     in
     let+ { facts = _; targets = _ } =
       execute_rule_impl
@@ -727,11 +729,7 @@ module Internal = struct
     in
     if capture_stdout then Io.read_file (Path.build target) else ""
 
-  and execute_action_generic
-        ~observing_facts
-        (act : Rule.Anonymous_action.t)
-        ~capture_stdout
-    =
+  and execute_action_generic (anon : Rule.Anonymous_action.Evaluated.t) ~capture_stdout =
     (* We memoize the execution of anonymous actions, both via the persistent
        mechanism for not re-running build rules between invocations of [dune
        build] and via [Memo]. The former is done by producing a normal build
@@ -747,6 +745,13 @@ module Internal = struct
        only depend on the action. If the two execution could run concurrently,
        then they would both try to create the same file. So in this regard, we
        use [Memo] mostly for synchronisation purposes. *)
+    let { Rule.Anonymous_action.Evaluated.anon = { dir; _ }
+        ; facts = observing_facts
+        ; action = { action; env; locks; can_go_in_shared_cache; sandbox; corrections }
+        }
+      =
+      anon
+    in
     (* Here we "forget" the facts about the world. We do that to make the input
        of the memoized function smaller. If we passed the whole [original_facts]
        as input, then we would end up memoizing one entry per set of facts. This
@@ -758,14 +763,6 @@ module Internal = struct
     let observing_facts = () in
     ignore observing_facts;
     let digest =
-      let { Rule.Anonymous_action.action =
-              { action; env; locks; can_go_in_shared_cache; sandbox; corrections }
-          ; loc = _
-          ; dir
-          }
-        =
-        act
-      in
       let digest =
         let d = Digest.Manual.create () in
         Digest.Manual.int d rule_digest_version;
@@ -798,17 +795,16 @@ module Internal = struct
        the execution and avoid such a race condition. *)
     Memo.exec
       (Lazy.force execute_action_generic_stage2_memo)
-      { Anonymous_action.action = act; deps; capture_stdout; digest }
+      { Anonymous_action.action = anon; deps; capture_stdout; digest }
 
-  and execute_action ~observing_facts act =
-    let+ (_empty_string : string) =
-      execute_action_generic ~observing_facts act ~capture_stdout:false
-    in
+  and execute_action anon =
+    let+ (_empty_string : string) = execute_action_generic anon ~capture_stdout:false in
     ()
 
-  and execute_action_stdout action =
-    let* action, observing_facts = Action_builder.evaluate_and_collect_facts action in
-    execute_action_generic ~observing_facts action ~capture_stdout:true
+  and execute_action_stdout (anon : Rule.Anonymous_action.t) =
+    let* action, facts = Action_builder.evaluate_and_collect_facts anon.action in
+    let anon = Rule.Anonymous_action.Evaluated.make ~action ~facts anon in
+    execute_action_generic anon ~capture_stdout:true
 
   (* A rule can have multiple targets but calls to [execute_rule] are memoized,
      so the rule will be executed only once. *)
@@ -874,14 +870,13 @@ module Internal = struct
                target
            ])
 
-  and execute_anonymous_action action =
-    let* action, facts = Action_builder.evaluate_and_collect_facts action in
-    execute_action action ~observing_facts:facts
+  and execute_anonymous_action (anon : Rule.Anonymous_action.t) =
+    let* action, facts = Action_builder.evaluate_and_collect_facts anon.action in
+    let anon = Rule.Anonymous_action.Evaluated.make ~action ~facts anon in
+    execute_action anon
 
-  and dep_on_anonymous_action (action : Rule.Anonymous_action.t Action_builder.t)
-    : unit Action_builder.t
-    =
-    Action_builder.record_success (Memo.of_thunk_apply execute_anonymous_action action)
+  and dep_on_anonymous_action (anon : Rule.Anonymous_action.t) : unit Action_builder.t =
+    Action_builder.record_success (Memo.of_thunk_apply execute_anonymous_action anon)
 
   and dep_on_alias_definition (definition : Rules.Dir_rules.Alias_spec.item) =
     match definition with
@@ -1014,7 +1009,8 @@ module Internal = struct
                frame
                ~of_:(Memo.Table.spec (Lazy.force execute_action_generic_stage2_memo)))
             ~f:(fun (x : Anonymous_action.t) ->
-              Option.some_if (not @@ Loc.is_none x.action.loc) x.action.loc)))
+              let loc = x.action.anon.loc in
+              Option.some_if (not @@ Loc.is_none loc) loc)))
   ;;
 end
 

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -790,6 +790,13 @@ module Internal = struct
        only depend on the action. If the two execution could run concurrently,
        then they would both try to create the same file. So in this regard, we
        use [Memo] mostly for synchronisation purposes. *)
+    let { Rule.Anonymous_action.Evaluated.anon = { dir; _ }
+        ; facts = observing_facts
+        ; action = { action; props }
+        }
+      =
+      anon
+    in
     (* Here we "forget" the facts about the world. We do that to make the input
        of the memoized function smaller. If we passed the whole [original_facts]
        as input, then we would end up memoizing one entry per set of facts. This
@@ -801,13 +808,6 @@ module Internal = struct
     let observing_facts = () in
     ignore observing_facts;
     let digest =
-      let { Rule.Anonymous_action.Evaluated.anon = { dir; _ }
-          ; facts = observing_facts
-          ; action = { action; props }
-          }
-        =
-        anon
-      in
       let { Action.Full.Props.env
           ; locks
           ; can_go_in_shared_cache

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -338,7 +338,7 @@ module Internal = struct
 
   module Anonymous_action = struct
     type t =
-      { action : Rule.Anonymous_action.t
+      { action : Rule.Anonymous_action.Evaluated.t
       ; deps : Dep.Set.t
       ; capture_stdout : bool
       ; digest : Digest.t
@@ -348,7 +348,7 @@ module Internal = struct
     let hash t = Digest.hash t.digest
 
     let to_dyn t : Dyn.t =
-      Record [ "digest", Digest.to_dyn t.digest; "loc", Loc.to_dyn t.action.loc ]
+      Record [ "digest", Digest.to_dyn t.digest; "loc", Loc.to_dyn t.action.anon.loc ]
     ;;
   end
 
@@ -750,20 +750,22 @@ module Internal = struct
 
   (* Returns the action's stdout or the empty string if [capture_stdout = false]. *)
   and execute_action_generic_stage2_impl
-        { Anonymous_action.action = { dir; loc; action }; deps; capture_stdout; digest }
+        { Anonymous_action.action = { anon; action; _ }; deps; capture_stdout; digest }
     =
     let target =
       let dir =
-        Path.Build.append_local Dpath.Build.anonymous_actions_dir (Path.Build.local dir)
+        Path.Build.append_local
+          Dpath.Build.anonymous_actions_dir
+          (Path.Build.local anon.dir)
       in
       Path.Build.relative dir (Digest.to_string digest)
     in
     let rule =
-      Rule.make
-        ~info:(if Loc.is_none loc then Internal else From_dune_file loc)
+      Rule.Anonymous_action.to_rule
         ~targets:(Targets.File.create target)
         ~mode:Standard
-        (Action_builder.record action deps ~f:build_dep)
+        anon
+      |> Fun.flip Rule.set_action (Action_builder.record action deps ~f:build_dep)
     in
     let+ { facts = _; targets = _ } =
       execute_rule_impl
@@ -772,11 +774,7 @@ module Internal = struct
     in
     if capture_stdout then Io.read_file (Path.build target) else ""
 
-  and execute_action_generic
-        ~observing_facts
-        (act : Rule.Anonymous_action.t)
-        ~capture_stdout
-    =
+  and execute_action_generic (anon : Rule.Anonymous_action.Evaluated.t) ~capture_stdout =
     (* We memoize the execution of anonymous actions, both via the persistent
        mechanism for not re-running build rules between invocations of [dune
        build] and via [Memo]. The former is done by producing a normal build
@@ -803,8 +801,13 @@ module Internal = struct
     let observing_facts = () in
     ignore observing_facts;
     let digest =
-      let { Rule.Anonymous_action.action = full_action; loc = _; dir } = act in
-      let { Action.Full.action; props } = full_action in
+      let { Rule.Anonymous_action.Evaluated.anon = { dir; _ }
+          ; facts = observing_facts
+          ; action = { action; props }
+          }
+        =
+        anon
+      in
       let { Action.Full.Props.env
           ; locks
           ; can_go_in_shared_cache
@@ -848,17 +851,16 @@ module Internal = struct
        the execution and avoid such a race condition. *)
     Memo.exec
       (Lazy.force execute_action_generic_stage2_memo)
-      { Anonymous_action.action = act; deps; capture_stdout; digest }
+      { Anonymous_action.action = anon; deps; capture_stdout; digest }
 
-  and execute_action ~observing_facts act =
-    let+ (_empty_string : string) =
-      execute_action_generic ~observing_facts act ~capture_stdout:false
-    in
+  and execute_action anon =
+    let+ (_empty_string : string) = execute_action_generic anon ~capture_stdout:false in
     ()
 
-  and execute_action_stdout action =
-    let* action, observing_facts = Action_builder.evaluate_and_collect_facts action in
-    execute_action_generic ~observing_facts action ~capture_stdout:true
+  and execute_action_stdout (anon : Rule.Anonymous_action.t) =
+    let* action, facts = Action_builder.evaluate_and_collect_facts anon.action in
+    let anon = Rule.Anonymous_action.Evaluated.make ~action ~facts anon in
+    execute_action_generic anon ~capture_stdout:true
 
   (* A rule can have multiple targets but calls to [execute_rule] are memoized,
      so the rule will be executed only once. *)
@@ -924,14 +926,13 @@ module Internal = struct
                target
            ])
 
-  and execute_anonymous_action action =
-    let* action, facts = Action_builder.evaluate_and_collect_facts action in
-    execute_action action ~observing_facts:facts
+  and execute_anonymous_action (anon : Rule.Anonymous_action.t) =
+    let* action, facts = Action_builder.evaluate_and_collect_facts anon.action in
+    let anon = Rule.Anonymous_action.Evaluated.make ~action ~facts anon in
+    execute_action anon
 
-  and dep_on_anonymous_action (action : Rule.Anonymous_action.t Action_builder.t)
-    : unit Action_builder.t
-    =
-    Action_builder.record_success (Memo.of_thunk_apply execute_anonymous_action action)
+  and dep_on_anonymous_action (anon : Rule.Anonymous_action.t) : unit Action_builder.t =
+    Action_builder.record_success (Memo.of_thunk_apply execute_anonymous_action anon)
 
   and dep_on_alias_definition (definition : Rules.Dir_rules.Alias_spec.item) =
     match definition with
@@ -1067,7 +1068,8 @@ module Internal = struct
                frame
                ~of_:(Memo.Table.spec (Lazy.force execute_action_generic_stage2_memo)))
             ~f:(fun (x : Anonymous_action.t) ->
-              Option.some_if (not @@ Loc.is_none x.action.loc) x.action.loc)))
+              let loc = x.action.anon.loc in
+              Option.some_if (not @@ Loc.is_none loc) loc)))
   ;;
 end
 

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -36,10 +36,10 @@ val eval_pred : File_selector.t -> Filename_set.t Memo.t
 val files_of : dir:Path.t -> Filename_set.t Memo.t
 
 (** Execute an action. The execution is cached. *)
-val execute_action : observing_facts:Dep.Facts.t -> Rule.Anonymous_action.t -> unit Memo.t
+val execute_action : Rule.Anonymous_action.Evaluated.t -> unit Memo.t
 
 (** Execute an action and capture its stdout. The execution is cached. *)
-val execute_action_stdout : Rule.Anonymous_action.t Action_builder.t -> string Memo.t
+val execute_action_stdout : Rule.Anonymous_action.t -> string Memo.t
 
 type rule_execution_result =
   { facts : Dep.Fact.t Dep.Map.t

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -36,7 +36,7 @@ val eval_pred : File_selector.t -> Filename_set.t Memo.t
 val files_of : dir:Path.t -> Filename_set.t Memo.t
 
 (** Execute an action and capture its stdout. The execution is cached. *)
-val execute_action_stdout : Rule.Anonymous_action.t Action_builder.t -> string Memo.t
+val execute_action_stdout : Rule.Anonymous_action.t -> string Memo.t
 
 type rule_execution_result =
   { facts : Dep.Fact.t Dep.Map.t

--- a/src/dune_engine/rule.ml
+++ b/src/dune_engine/rule.ml
@@ -89,8 +89,7 @@ end
 include T
 include Comparable.Make (T)
 
-let make ?(mode = Mode.Standard) ?(info = Info.Internal) ~targets action =
-  let action = Action_builder.memoize "Rule.make" action in
+let validate_targets ~(info : Info.t) targets =
   let report_error ?(extra_pp = []) message =
     match info with
     | From_dune_file loc ->
@@ -101,22 +100,24 @@ let make ?(mode = Mode.Standard) ?(info = Info.Internal) ~targets action =
         message
         [ "info", Info.to_dyn info; "targets", Targets.to_dyn targets ]
   in
-  let targets =
-    match Targets.validate targets with
-    | Valid targets -> targets
-    | No_targets -> report_error "Rule has no targets specified"
-    | Inconsistent_parent_dir ->
-      (* user written actions have their own validation step that also works
+  match Targets.validate targets with
+  | Valid targets -> targets
+  | No_targets -> report_error "Rule has no targets specified"
+  | Inconsistent_parent_dir ->
+    (* user written actions have their own validation step that also works
          with the target inference mechanism *)
-      Code_error.raise
-        "Rule has targets in different directories."
-        [ "targets", Targets.to_dyn targets ]
-    | File_and_directory_target_with_the_same_name path ->
-      report_error
-        (sprintf
-           "%S is declared as both a file and a directory target."
-           (Dpath.describe_target path))
-  in
+    Code_error.raise
+      "Rule has targets in different directories."
+      [ "targets", Targets.to_dyn targets ]
+  | File_and_directory_target_with_the_same_name path ->
+    report_error
+      (sprintf
+         "%S is declared as both a file and a directory target."
+         (Dpath.describe_target path))
+;;
+
+let make ?(mode = Mode.Standard) ?(info = Info.Internal) ~targets action =
+  let targets = validate_targets ~info targets in
   let loc =
     match info with
     | From_dune_file loc -> loc
@@ -135,9 +136,58 @@ let set_action t action =
 ;;
 
 module Anonymous_action = struct
-  type t =
-    { action : Action.Full.t
-    ; loc : Loc.t
-    ; dir : Path.Build.t
+  module Rule = T
+
+  module T = struct
+    type t =
+      { id : Id.t
+      ; action : Action.Full.t Action_builder.t
+      ; info : Info.t
+      ; loc : Loc.t
+      ; dir : Path.Build.t
+      }
+
+    let compare a b = Id.compare a.id b.id
+    let equal a b = Id.equal a.id b.id
+    let hash t = Id.hash t.id
+    let loc t = t.loc
+
+    let repr =
+      Repr.record
+        "anonymous_action"
+        [ Repr.field "id" (Repr.abstract Id.to_dyn) ~get:(fun t -> t.id) ]
+    ;;
+
+    let to_dyn = Repr.to_dyn repr
+  end
+
+  include T
+  include Comparable.Make (T)
+
+  let make ?(loc = Loc.none) ~dir action =
+    { id = Id.gen ()
+    ; action
+    ; info = (if Loc.is_none loc then Internal else From_dune_file loc)
+    ; loc
+    ; dir
     }
+  ;;
+
+  let to_rule ~targets ?(mode = Mode.Standard) { id; action; info; loc; dir = _ } =
+    let targets = validate_targets ~info targets in
+    { Rule.id; targets; action; mode; info; loc }
+  ;;
+
+  module Map = Import.Map.Make (T)
+  module Set = Import.Set.Make (T) (Map)
+
+  module Evaluated = struct
+    type t =
+      { anon : T.t
+      ; action : Action.Full.t
+      ; facts : Dep.Facts.t
+      }
+
+    let make ~action ~facts anon = { anon; action; facts }
+  end
 end

--- a/src/dune_engine/rule.ml
+++ b/src/dune_engine/rule.ml
@@ -97,7 +97,7 @@ end
 include T
 include Comparable.Make (T)
 
-let make ?(mode = Mode.Standard) ?(info = Info.Internal) ~targets action =
+let validate_targets ~(info : Info.t) targets =
   let report_error ?(extra_pp = []) message =
     match info with
     | From_dune_file loc ->
@@ -108,31 +108,76 @@ let make ?(mode = Mode.Standard) ?(info = Info.Internal) ~targets action =
         message
         [ "info", Info.to_dyn info; "targets", Targets.to_dyn targets ]
   in
-  let targets =
-    match Targets.validate targets with
-    | Valid targets -> targets
-    | No_targets -> report_error "Rule has no targets specified"
-    | Inconsistent_parent_dir ->
-      (* user written actions have their own validation step that also works
+  match Targets.validate targets with
+  | Valid targets -> targets
+  | No_targets -> report_error "Rule has no targets specified"
+  | Inconsistent_parent_dir ->
+    (* user written actions have their own validation step that also works
          with the target inference mechanism *)
-      Code_error.raise
-        "Rule has targets in different directories."
-        [ "targets", Targets.to_dyn targets ]
-    | File_and_directory_target_with_the_same_name path ->
-      report_error
-        (sprintf
-           "%S is declared as both a file and a directory target."
-           (Dpath.describe_target path))
-  in
+    Code_error.raise
+      "Rule has targets in different directories."
+      [ "targets", Targets.to_dyn targets ]
+  | File_and_directory_target_with_the_same_name path ->
+    report_error
+      (sprintf
+         "%S is declared as both a file and a directory target."
+         (Dpath.describe_target path))
+;;
+
+let make ?(mode = Mode.Standard) ?(info = Info.Internal) ~targets action =
+  let targets = validate_targets ~info targets in
   { id = Id.gen (); targets; action; mode; info }
 ;;
 
 let set_action t action = { t with action }
 
 module Anonymous_action = struct
-  type t =
-    { action : Action.Full.t
-    ; loc : Loc.t
-    ; dir : Path.Build.t
-    }
+  module Rule = T
+
+  module T = struct
+    type t =
+      { id : Id.t
+      ; action : Action.Full.t Action_builder.t
+      ; loc : Loc.t
+      ; dir : Path.Build.t
+      }
+
+    let compare a b = Id.compare a.id b.id
+    let equal a b = Id.equal a.id b.id
+    let hash t = Id.hash t.id
+    let loc t = t.loc
+
+    let repr =
+      Repr.record
+        "anonymous_action"
+        [ Repr.field "id" (Repr.abstract Id.to_dyn) ~get:(fun t -> t.id) ]
+    ;;
+
+    let to_dyn = Repr.to_dyn repr
+  end
+
+  include T
+  include Comparable.Make (T)
+
+  let make ?(loc = Loc.none) ~dir action = { id = Id.gen (); action; loc; dir }
+  let info { loc; _ } = if Loc.is_none loc then Info.Internal else From_dune_file loc
+
+  let to_rule ~targets ?(mode = Mode.Standard) ({ id; action; loc = _; dir = _ } as anon) =
+    let info = info anon in
+    let targets = validate_targets ~info targets in
+    { Rule.id; targets; action; mode; info }
+  ;;
+
+  module Map = Import.Map.Make (T)
+  module Set = Import.Set.Make (T) (Map)
+
+  module Evaluated = struct
+    type t =
+      { anon : T.t
+      ; action : Action.Full.t
+      ; facts : Dep.Facts.t
+      }
+
+    let make ~action ~facts anon = { anon; action; facts }
+  end
 end

--- a/src/dune_engine/rule.ml
+++ b/src/dune_engine/rule.ml
@@ -97,7 +97,7 @@ end
 include T
 include Comparable.Make (T)
 
-let validate_targets ~(info : Info.t) targets =
+let make ?(mode = Mode.Standard) ?(info = Info.Internal) ~targets action =
   let report_error ?(extra_pp = []) message =
     match info with
     | From_dune_file loc ->
@@ -108,72 +108,49 @@ let validate_targets ~(info : Info.t) targets =
         message
         [ "info", Info.to_dyn info; "targets", Targets.to_dyn targets ]
   in
-  match Targets.validate targets with
-  | Valid targets -> targets
-  | No_targets -> report_error "Rule has no targets specified"
-  | Inconsistent_parent_dir ->
-    (* user written actions have their own validation step that also works
+  let targets =
+    match Targets.validate targets with
+    | Valid targets -> targets
+    | No_targets -> report_error "Rule has no targets specified"
+    | Inconsistent_parent_dir ->
+      (* user written actions have their own validation step that also works
          with the target inference mechanism *)
-    Code_error.raise
-      "Rule has targets in different directories."
-      [ "targets", Targets.to_dyn targets ]
-  | File_and_directory_target_with_the_same_name path ->
-    report_error
-      (sprintf
-         "%S is declared as both a file and a directory target."
-         (Dpath.describe_target path))
-;;
-
-let make ?(mode = Mode.Standard) ?(info = Info.Internal) ~targets action =
-  let targets = validate_targets ~info targets in
+      Code_error.raise
+        "Rule has targets in different directories."
+        [ "targets", Targets.to_dyn targets ]
+    | File_and_directory_target_with_the_same_name path ->
+      report_error
+        (sprintf
+           "%S is declared as both a file and a directory target."
+           (Dpath.describe_target path))
+  in
   { id = Id.gen (); targets; action; mode; info }
 ;;
 
 let set_action t action = { t with action }
 
 module Anonymous_action = struct
-  module Rule = T
+  type t =
+    { action : Action.Full.t Action_builder.t
+    ; loc : Loc.t
+    ; dir : Path.Build.t
+    }
 
-  module T = struct
-    type t =
-      { id : Id.t
-      ; action : Action.Full.t Action_builder.t
-      ; loc : Loc.t
-      ; dir : Path.Build.t
-      }
-
-    let compare a b = Id.compare a.id b.id
-    let equal a b = Id.equal a.id b.id
-    let hash t = Id.hash t.id
-    let loc t = t.loc
-
-    let repr =
-      Repr.record
-        "anonymous_action"
-        [ Repr.field "id" (Repr.abstract Id.to_dyn) ~get:(fun t -> t.id) ]
-    ;;
-
-    let to_dyn = Repr.to_dyn repr
-  end
-
-  include T
-  include Comparable.Make (T)
-
-  let make ?(loc = Loc.none) ~dir action = { id = Id.gen (); action; loc; dir }
+  let loc t = t.loc
   let info { loc; _ } = if Loc.is_none loc then Info.Internal else From_dune_file loc
 
-  let to_rule ~targets ?(mode = Mode.Standard) ({ id; action; loc = _; dir = _ } as anon) =
+  let to_rule ~targets ?mode ({ action; loc = _; dir = _ } as anon) =
     let info = info anon in
-    let targets = validate_targets ~info targets in
-    { Rule.id; targets; action; mode; info }
+    make ?mode ~info ~targets action
   ;;
 
-  module Map = Import.Map.Make (T)
-  module Set = Import.Set.Make (T) (Map)
+  let make ?(loc = Loc.none) ~dir action = { action; loc; dir }
 
   module Evaluated = struct
+    type anon = t
+
     type t =
-      { anon : T.t
+      { anon : anon
       ; action : Action.Full.t
       ; facts : Dep.Facts.t
       }

--- a/src/dune_engine/rule.mli
+++ b/src/dune_engine/rule.mli
@@ -80,13 +80,40 @@ val set_action : t -> Action.Full.t Action_builder.t -> t
 val loc : t -> Loc.t
 
 module Anonymous_action : sig
+  type rule := t
+
   (* jeremiedimino: this type correspond to a subset of [Rule.t]. We should
      eventually share the code. *)
   type t =
-    { action : Action.Full.t
+    { id : Id.t
+    ; action : Action.Full.t Action_builder.t
+    ; info : Info.t
     ; loc : Loc.t
     ; dir : Path.Build.t
       (** Directory the action is attached to. This is the directory where
         the outcome of the action will be cached. *)
     }
+
+  include Comparable_intf.S with type key := t
+
+  val equal : t -> t -> bool
+  val hash : t -> int
+  val to_dyn : t -> Dyn.t
+  val loc : t -> Loc.t
+  val make : ?loc:Loc.t -> dir:Path.Build.t -> Action.Full.t Action_builder.t -> t
+  val to_rule : targets:Targets.t -> ?mode:Mode.t -> t -> rule
+
+  module Set : Import.Set.S with type elt = t
+
+  module Evaluated : sig
+    type anon := t
+
+    type t =
+      { anon : anon
+      ; action : Action.Full.t
+      ; facts : Dep.Facts.t
+      }
+
+    val make : action:Action.Full.t -> facts:Dep.Facts.t -> anon -> t
+  end
 end

--- a/src/dune_engine/rule.mli
+++ b/src/dune_engine/rule.mli
@@ -84,25 +84,17 @@ module Anonymous_action : sig
   (* jeremiedimino: this type correspond to a subset of [Rule.t]. We should
      eventually share the code. *)
   type t =
-    { id : Id.t
-    ; action : Action.Full.t Action_builder.t
+    { action : Action.Full.t Action_builder.t
     ; loc : Loc.t
     ; dir : Path.Build.t
       (** Directory the action is attached to. This is the directory where
         the outcome of the action will be cached. *)
     }
 
-  include Comparable_intf.S with type key := t
-
-  val equal : t -> t -> bool
-  val hash : t -> int
-  val to_dyn : t -> Dyn.t
   val loc : t -> Loc.t
   val make : ?loc:Loc.t -> dir:Path.Build.t -> Action.Full.t Action_builder.t -> t
   val info : t -> Info.t
   val to_rule : targets:Targets.t -> ?mode:Mode.t -> t -> rule
-
-  module Set : Import.Set.S with type elt = t
 
   module Evaluated : sig
     type anon := t

--- a/src/dune_engine/rule.mli
+++ b/src/dune_engine/rule.mli
@@ -79,13 +79,40 @@ val set_action : t -> Action.Full.t Action_builder.t -> t
 val loc : t -> Loc.t
 
 module Anonymous_action : sig
+  type rule := t
+
   (* jeremiedimino: this type correspond to a subset of [Rule.t]. We should
      eventually share the code. *)
   type t =
-    { action : Action.Full.t
+    { id : Id.t
+    ; action : Action.Full.t Action_builder.t
     ; loc : Loc.t
     ; dir : Path.Build.t
       (** Directory the action is attached to. This is the directory where
         the outcome of the action will be cached. *)
     }
+
+  include Comparable_intf.S with type key := t
+
+  val equal : t -> t -> bool
+  val hash : t -> int
+  val to_dyn : t -> Dyn.t
+  val loc : t -> Loc.t
+  val make : ?loc:Loc.t -> dir:Path.Build.t -> Action.Full.t Action_builder.t -> t
+  val info : t -> Info.t
+  val to_rule : targets:Targets.t -> ?mode:Mode.t -> t -> rule
+
+  module Set : Import.Set.S with type elt = t
+
+  module Evaluated : sig
+    type anon := t
+
+    type t =
+      { anon : anon
+      ; action : Action.Full.t
+      ; facts : Dep.Facts.t
+      }
+
+    val make : action:Action.Full.t -> facts:Dep.Facts.t -> anon -> t
+  end
 end

--- a/src/dune_engine/rules.ml
+++ b/src/dune_engine/rules.ml
@@ -5,7 +5,7 @@ module Dir_rules = struct
   module Alias_spec = struct
     type item =
       | Deps of unit Action_builder.t
-      | Action of Rule.Anonymous_action.t Action_builder.t
+      | Action of Rule.Anonymous_action.t
 
     type t = { expansions : (Loc.t * item) Appendable_list.t } [@@unboxed]
 
@@ -158,16 +158,11 @@ module Produce = struct
         | [] -> Code_error.raise "Rules.Produce.Alias.add_action: empty list" []
         | r :: _ -> r
       in
-      let action =
-        let open Action_builder.O in
-        let+ action in
-        { Rule.Anonymous_action.action; loc; dir = Alias.dir representative }
-      in
+      let anon = Rule.Anonymous_action.make ~loc ~dir:(Alias.dir representative) action in
       Memo.parallel_iter ts ~f:(fun t ->
         alias
           t
-          { expansions =
-              Appendable_list.singleton (loc, Dir_rules.Alias_spec.Action action)
+          { expansions = Appendable_list.singleton (loc, Dir_rules.Alias_spec.Action anon)
           })
     ;;
   end

--- a/src/dune_engine/rules.ml
+++ b/src/dune_engine/rules.ml
@@ -5,7 +5,7 @@ module Dir_rules = struct
   module Alias_spec = struct
     type item =
       | Deps of unit Action_builder.t
-      | Action of Rule.Anonymous_action.t Action_builder.t
+      | Action of Rule.Anonymous_action.t
 
     type t = { expansions : (Loc.t * item) Appendable_list.t } [@@unboxed]
 
@@ -160,16 +160,11 @@ module Produce = struct
         | [] -> Code_error.raise "Rules.Produce.Alias.add_action: empty list" []
         | r :: _ -> r
       in
-      let action =
-        let open Action_builder.O in
-        let+ action in
-        { Rule.Anonymous_action.action; loc; dir = Alias.dir representative }
-      in
+      let anon = Rule.Anonymous_action.make ~loc ~dir:(Alias.dir representative) action in
       Memo.parallel_iter ts ~f:(fun t ->
         alias
           t
-          { expansions =
-              Appendable_list.singleton (loc, Dir_rules.Alias_spec.Action action)
+          { expansions = Appendable_list.singleton (loc, Dir_rules.Alias_spec.Action anon)
           })
     ;;
   end

--- a/src/dune_engine/rules.mli
+++ b/src/dune_engine/rules.mli
@@ -25,7 +25,7 @@ module Dir_rules : sig
 
            When passing [--force] to Dune, these are exactly the actions that
            will be re-executed. *)
-        Action of Rule.Anonymous_action.t Action_builder.t
+        Action of Rule.Anonymous_action.t
 
     type t = { expansions : (Loc.t * item) Appendable_list.t } [@@unboxed]
   end

--- a/src/dune_rules/cc_flags.ml
+++ b/src/dune_rules/cc_flags.ml
@@ -147,29 +147,27 @@ let resolve_c_compiler context ~dir program =
 ;;
 
 let cc_vendor_action (ctx : Build_context.t) =
-  let open Action_builder.O in
-  let* context = Action_builder.of_memo (Context.DB.get ctx.name) in
+  let open Memo.O in
+  let* context = Context.DB.get ctx.name in
   let* ocaml_config =
-    Action_builder.of_memo
-      (let open Memo.O in
-       let+ ocaml = Context.ocaml context in
-       ocaml.ocaml_config)
+    let+ ocaml = Context.ocaml context in
+    ocaml.ocaml_config
   in
-  Ocaml_config.c_compiler ocaml_config
-  |> resolve_c_compiler context ~dir:ctx.build_dir
-  |> Action_builder.of_memo
-  >>= function
-  | Error e -> Action_builder.fail { fail = (fun () -> Action.Prog.Not_found.raise e) }
-  | Ok c_compiler ->
-    let+ action =
+  let+ action =
+    Ocaml_config.c_compiler ocaml_config
+    |> resolve_c_compiler context ~dir:ctx.build_dir
+    >>| function
+    | Error e -> Action.Prog.Not_found.raise e
+    | Ok c_compiler ->
+      let open Action_builder.O in
       let+ () = Action_builder.path c_compiler
       and+ env = Action_builder.of_memo (Context.installed_env context) in
       Detect.action { c_compiler; ccomp_type = Ocaml_config.ccomp_type ocaml_config }
       |> Action.chdir (Path.build ctx.build_dir)
       |> Action.Full.make
       |> Action.Full.add_env env
-    in
-    { Rule.Anonymous_action.action; loc = Loc.none; dir = ctx.build_dir }
+  in
+  Rule.Anonymous_action.make ~dir:ctx.build_dir action
 ;;
 
 let check_warn = function
@@ -186,9 +184,10 @@ let check_warn = function
 let cc_vendor (ctx : Build_context.t) =
   let open Action_builder.O in
   let+ cc_vendor =
+    let open Memo.O in
     cc_vendor_action ctx
-    |> Build_system.execute_action_stdout
-    |> Memo.map ~f:parse_cc_vendor
+    >>= Build_system.execute_action_stdout
+    >>| parse_cc_vendor
     |> Action_builder.of_memo
   in
   check_warn cc_vendor;

--- a/src/dune_rules/cc_flags.ml
+++ b/src/dune_rules/cc_flags.ml
@@ -148,29 +148,27 @@ let resolve_c_compiler context ~dir program =
 ;;
 
 let cc_vendor_action (ctx : Build_context.t) =
-  let open Action_builder.O in
-  let* context = Action_builder.of_memo (Context.DB.get ctx.name) in
+  let open Memo.O in
+  let* context = Context.DB.get ctx.name in
   let* ocaml_config =
-    Action_builder.of_memo
-      (let open Memo.O in
-       let+ ocaml = Context.ocaml context in
-       ocaml.ocaml_config)
+    let+ ocaml = Context.ocaml context in
+    ocaml.ocaml_config
   in
-  Ocaml_config.c_compiler ocaml_config
-  |> resolve_c_compiler context ~dir:ctx.build_dir
-  |> Action_builder.of_memo
-  >>= function
-  | Error e -> Action_builder.fail { fail = (fun () -> Action.Prog.Not_found.raise e) }
-  | Ok c_compiler ->
-    let+ action =
+  let+ action =
+    Ocaml_config.c_compiler ocaml_config
+    |> resolve_c_compiler context ~dir:ctx.build_dir
+    >>| function
+    | Error e -> Action.Prog.Not_found.raise e
+    | Ok c_compiler ->
+      let open Action_builder.O in
       let+ () = Action_builder.path c_compiler
       and+ env = Action_builder.of_memo (Context.installed_env context) in
       Detect.action { c_compiler; ccomp_type = Ocaml_config.ccomp_type ocaml_config }
       |> Action.chdir (Path.build ctx.build_dir)
       |> Action.Full.make
       |> Action.Full.add_env env
-    in
-    { Rule.Anonymous_action.action; loc = Loc.none; dir = ctx.build_dir }
+  in
+  Rule.Anonymous_action.make ~dir:ctx.build_dir action
 ;;
 
 let check_warn = function
@@ -187,9 +185,10 @@ let check_warn = function
 let cc_vendor (ctx : Build_context.t) =
   let open Action_builder.O in
   let+ cc_vendor =
+    let open Memo.O in
     cc_vendor_action ctx
-    |> Build_system.execute_action_stdout
-    |> Memo.map ~f:parse_cc_vendor
+    >>= Build_system.execute_action_stdout
+    >>| parse_cc_vendor
     |> Action_builder.of_memo
   in
   check_warn cc_vendor;

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -93,14 +93,12 @@ let merge_deps ~dir ~transitive ~immediate =
   let open Action_builder.O in
   let action =
     let+ transitive = Action_builder.all transitive in
-    { Rule.Anonymous_action.action =
-        Merge_dep_output.action ~transitive ~immediate
-        |> Action.Full.make ~sandbox:Sandbox_config.no_sandboxing
-    ; loc = Loc.none
-    ; dir
-    }
+    Merge_dep_output.action ~transitive ~immediate
+    |> Action.Full.make ~sandbox:Sandbox_config.no_sandboxing
   in
-  Build_system.execute_action_stdout action |> Action_builder.of_memo
+  Rule.Anonymous_action.make ~dir action
+  |> Build_system.execute_action_stdout
+  |> Action_builder.of_memo
 ;;
 
 let transitive_dep m =

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -102,16 +102,15 @@ end = struct
 
   let merge ~dir ~transitive ~immediate =
     let open Action_builder.O in
-    let action =
-      let+ transitive = Action_builder.all transitive in
-      { Rule.Anonymous_action.action =
-          Merge.action ~transitive ~immediate
-          |> Action.Full.make ~sandbox:Sandbox_config.no_sandboxing
-      ; loc = Loc.none
-      ; dir
-      }
+    let anon =
+      let action =
+        let+ transitive = Action_builder.all transitive in
+        Merge.action ~transitive ~immediate
+        |> Action.Full.make ~sandbox:Sandbox_config.no_sandboxing
+      in
+      Rule.Anonymous_action.make ~dir action
     in
-    Build_system.execute_action_stdout action |> Action_builder.of_memo
+    Build_system.execute_action_stdout anon |> Action_builder.of_memo
   ;;
 end
 

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -15,12 +15,8 @@ let depend_on_files ~named dir =
 
 let formatter_diff_action =
   let dep_on_alias_action alias ~loc action =
-    let action =
-      let open Action_builder.O in
-      let+ action = action in
-      { Rule.Anonymous_action.action; loc; dir = Alias.dir alias }
-    in
-    Build_system.dep_on_alias_definition (Rules.Dir_rules.Alias_spec.Action action)
+    let anon = Rule.Anonymous_action.make ~loc ~dir:(Alias.dir alias) action in
+    Build_system.dep_on_alias_definition (Rules.Dir_rules.Alias_spec.Action anon)
   in
   let formatter_stdout sctx ~loc alias action =
     Super_context.execute_action_stdout sctx ~loc ~dir:(Alias.dir alias) action

--- a/src/dune_rules/ocamldep.ml
+++ b/src/dune_rules/ocamldep.ml
@@ -53,12 +53,12 @@ let ocamldep_action ~sandbox ~sctx ~dir ~ml_kind unit =
     | None -> Action_builder.return [], sandbox, true
     | Some (flags, sandbox) -> flags, sandbox, false
   in
-  let open Action_builder.O in
-  let* ocamldep =
-    let+ ocaml = Action_builder.of_memo (Context.ocaml context) in
-    ocaml.ocamldep
-  in
-  let+ action =
+  let action =
+    let open Action_builder.O in
+    let* ocamldep =
+      let+ ocaml = Action_builder.of_memo (Context.ocaml context) in
+      ocaml.ocamldep
+    in
     let source = Option.value_exn (Module.source unit ~ml_kind) in
     let env =
       (* CR-someday rgrinberg: consider getting rid of this *)
@@ -78,7 +78,7 @@ let ocamldep_action ~sandbox ~sctx ~dir ~ml_kind unit =
       ; Dep (Module.File.path source)
       ]
   in
-  { Rule.Anonymous_action.action; loc = Loc.none; dir }
+  Rule.Anonymous_action.make ~loc:Loc.none ~dir action
 ;;
 
 (* Top-level cache per (source path, ml_kind). Without it, each caller's

--- a/src/dune_rules/ocamldep.ml
+++ b/src/dune_rules/ocamldep.ml
@@ -52,12 +52,12 @@ let ocamldep_action ~sandbox ~sctx ~dir ~ml_kind unit =
     | None -> Action_builder.return [], sandbox, true
     | Some (flags, sandbox) -> flags, sandbox, false
   in
-  let open Action_builder.O in
-  let* ocamldep =
-    let+ ocaml = Action_builder.of_memo (Context.ocaml context) in
-    ocaml.ocamldep
-  in
-  let+ action =
+  let action =
+    let open Action_builder.O in
+    let* ocamldep =
+      let+ ocaml = Action_builder.of_memo (Context.ocaml context) in
+      ocaml.ocamldep
+    in
     let source = Option.value_exn (Module.source unit ~ml_kind) in
     let env =
       (* CR-someday rgrinberg: consider getting rid of this *)
@@ -77,7 +77,7 @@ let ocamldep_action ~sandbox ~sctx ~dir ~ml_kind unit =
       ; Dep (Module.File.path source)
       ]
   in
-  { Rule.Anonymous_action.action; loc = Loc.none; dir }
+  Rule.Anonymous_action.make ~loc:Loc.none ~dir action
 ;;
 
 (* Top-level cache per (source path, ml_kind). Without it, each caller's

--- a/src/dune_rules/ocamlobjinfo.mll
+++ b/src/dune_rules/ocamlobjinfo.mll
@@ -64,41 +64,29 @@ let rules (ocaml : Ocaml_toolchain.t) ~dir ~sandbox ~units =
     else
       []
   in
-  let open Action_builder.O in
-  let action =
-    let+ action =
-      Command.run' ?sandbox
-        ~dir:(Path.build dir) ocaml.ocamlobjinfo
-        (List.concat
-           [ no_approx
-           ; no_code
-           ; [ Deps units ]
-           ])
-    in
-    { Rule.Anonymous_action.action
-    ; loc = Loc.none
-    ; dir
-    }
+  let anon =
+    Command.run' ?sandbox
+      ~dir:(Path.build dir) ocaml.ocamlobjinfo
+      (List.concat
+         [ no_approx
+         ; no_code
+         ; [ Deps units ]
+         ])
+    |> Rule.Anonymous_action.make ~dir
   in
-  Dune_engine.Build_system.execute_action_stdout action
+  Dune_engine.Build_system.execute_action_stdout anon
   |> Memo.map ~f:parse
   |> Action_builder.of_memo
 ;;
 
 let archive_rules (ocaml : Ocaml_toolchain.t) ~dir ~sandbox ~archive =
-  let action =
-    let open Action_builder.O in
-    let+ action =
-      Command.run' ?sandbox
-        ~dir:(Path.build dir) ocaml.ocamlobjinfo
-        [ Dep archive ]
-    in
-    { Rule.Anonymous_action.action
-    ; loc = Loc.none
-    ; dir
-    }
+  let anon =
+    Command.run' ?sandbox
+      ~dir:(Path.build dir) ocaml.ocamlobjinfo
+      [ Dep archive ]
+    |> Rule.Anonymous_action.make ~dir
   in
-  Dune_engine.Build_system.execute_action_stdout action
+  Dune_engine.Build_system.execute_action_stdout anon
   |> Memo.map ~f:parse_archive
   |> Action_builder.of_memo
 }

--- a/src/dune_rules/ocamlobjinfo.mll
+++ b/src/dune_rules/ocamlobjinfo.mll
@@ -65,41 +65,29 @@ let rules (ocaml : Ocaml_toolchain.t) ~dir ~sandbox ~units =
     else
       []
   in
-  let open Action_builder.O in
-  let action =
-    let+ action =
-      Command.run' ?sandbox
-        ~dir:(Path.build dir) ocaml.ocamlobjinfo
-        (List.concat
-           [ no_approx
-           ; no_code
-           ; [ Deps units ]
-           ])
-    in
-    { Rule.Anonymous_action.action
-    ; loc = Loc.none
-    ; dir
-    }
+  let anon =
+    Command.run' ?sandbox
+      ~dir:(Path.build dir) ocaml.ocamlobjinfo
+      (List.concat
+         [ no_approx
+         ; no_code
+         ; [ Deps units ]
+         ])
+    |> Rule.Anonymous_action.make ~dir
   in
-  Dune_engine.Build_system.execute_action_stdout action
+  Dune_engine.Build_system.execute_action_stdout anon
   |> Memo.map ~f:parse
   |> Action_builder.of_memo
 ;;
 
 let archive_rules (ocaml : Ocaml_toolchain.t) ~dir ~sandbox ~archive =
-  let action =
-    let open Action_builder.O in
-    let+ action =
-      Command.run' ?sandbox
-        ~dir:(Path.build dir) ocaml.ocamlobjinfo
-        [ Dep archive ]
-    in
-    { Rule.Anonymous_action.action
-    ; loc = Loc.none
-    ; dir
-    }
+  let anon =
+    Command.run' ?sandbox
+      ~dir:(Path.build dir) ocaml.ocamlobjinfo
+      [ Dep archive ]
+    |> Rule.Anonymous_action.make ~dir
   in
-  Dune_engine.Build_system.execute_action_stdout action
+  Dune_engine.Build_system.execute_action_stdout anon
   |> Memo.map ~f:parse_archive
   |> Action_builder.of_memo
 }

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -158,10 +158,8 @@ let extend_action_env t ~dir action =
 ;;
 
 let execute_action_stdout t ~loc ~dir action =
-  let open Action_builder.O in
-  (let+ action = extend_action_env t ~dir action in
-   { Rule.Anonymous_action.action; loc; dir })
-  |> Build_system.execute_action_stdout
+  let action = extend_action_env t ~dir action in
+  Rule.Anonymous_action.make ~loc ~dir action |> Build_system.execute_action_stdout
 ;;
 
 let extend_action t ~dir action =

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -171,10 +171,8 @@ let extend_action_env t ~dir action =
 ;;
 
 let execute_action_stdout t ~loc ~dir action =
-  let open Action_builder.O in
-  (let+ action = extend_action_env t ~dir action in
-   { Rule.Anonymous_action.action; loc; dir })
-  |> Build_system.execute_action_stdout
+  let action = extend_action_env t ~dir action in
+  Rule.Anonymous_action.make ~loc ~dir action |> Build_system.execute_action_stdout
 ;;
 
 let extend_action t ~dir action =


### PR DESCRIPTION
Change `Anonymous_action.t`'s `action` from `Action_builder.t` to `Action.Full.t Action_builder.t`, removing the need to wrap anonymous actions in action builders.

This brings anonymous actions one step closer to parity with `Rule.t`. There *shouldn't* be any observable behavioural differences.

Needed for #15586, which will fix #11505 & #11564.

## Checklist

- [x] Tests added, if applicable.
- [x] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [x] Documentation added for any user-facing changes.
