### PR TITLE
refactor(engine): abstract cached file stats

### DIFF
--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -57,16 +57,17 @@ module Cached_digest = struct
     type t = Workspace_cache.Fs_memo.Stats.t
 
     let repr = Workspace_cache.Fs_memo.Stats.repr
+    let mtime = Workspace_cache.Fs_memo.Stats.mtime
     let to_dyn = Repr.to_dyn repr
 
     let of_stat (stat : Stat.t) : t =
-      { mtime = stat.mtime
-      ; ctime = stat.ctime
-      ; size = stat.size
-      ; perm = stat.perm
-      ; dev = stat.dev
-      ; ino = stat.ino
-      }
+      Workspace_cache.Fs_memo.Stats.create
+        ~mtime:stat.mtime
+        ~ctime:stat.ctime
+        ~size:stat.size
+        ~perm:stat.perm
+        ~dev:stat.dev
+        ~ino:stat.ino
     ;;
 
     include Repr.Poly (struct
@@ -121,9 +122,10 @@ module Cached_digest = struct
     | Eq | Gt ->
       let max_timestamp = ref (Time.of_ns 0) in
       let filter (data : _ file) =
-        match Time.compare data.stats.mtime now with
+        let mtime = Stats.mtime data.stats in
+        match Time.compare mtime now with
         | Lt ->
-          max_timestamp := Time.max !max_timestamp data.stats.mtime;
+          max_timestamp := Time.max !max_timestamp mtime;
           true
         | Gt | Eq -> false
       in

--- a/src/dune_engine/workspace_cache.ml
+++ b/src/dune_engine/workspace_cache.ml
@@ -39,15 +39,26 @@ module Fs_memo = struct
       ; ino : int
       }
 
+    let create ~mtime ~ctime ~size ~perm ~dev ~ino =
+      { mtime; ctime; size; perm; dev; ino }
+    ;;
+
+    let mtime t = t.mtime
+    let ctime t = t.ctime
+    let size t = t.size
+    let perm t = t.perm
+    let dev t = t.dev
+    let ino t = t.ino
+
     let repr =
       Repr.record
         "fs-memo-cached-digest-reduced-stats"
-        [ Repr.field "mtime" Time.repr ~get:(fun t -> t.mtime)
-        ; Repr.field "ctime" Time.repr ~get:(fun t -> t.ctime)
-        ; Repr.field "size" Repr.int ~get:(fun t -> t.size)
-        ; Repr.field "perm" Repr.int ~get:(fun t -> t.perm)
-        ; Repr.field "dev" Repr.int ~get:(fun t -> t.dev)
-        ; Repr.field "ino" Repr.int ~get:(fun t -> t.ino)
+        [ Repr.field "mtime" Time.repr ~get:mtime
+        ; Repr.field "ctime" Time.repr ~get:ctime
+        ; Repr.field "size" Repr.int ~get:size
+        ; Repr.field "perm" Repr.int ~get:perm
+        ; Repr.field "dev" Repr.int ~get:dev
+        ; Repr.field "ino" Repr.int ~get:ino
         ]
     ;;
   end

--- a/src/dune_engine/workspace_cache.mli
+++ b/src/dune_engine/workspace_cache.mli
@@ -16,15 +16,23 @@ end
 
 module Fs_memo : sig
   module Stats : sig
-    type t =
-      { mtime : Time.t
-      ; ctime : Time.t
-      ; size : int
-      ; perm : Unix.file_perm
-      ; dev : int
-      ; ino : int
-      }
+    type t
 
+    val create
+      :  mtime:Time.t
+      -> ctime:Time.t
+      -> size:int
+      -> perm:Unix.file_perm
+      -> dev:int
+      -> ino:int
+      -> t
+
+    val mtime : t -> Time.t
+    val ctime : t -> Time.t
+    val size : t -> int
+    val perm : t -> Unix.file_perm
+    val dev : t -> int
+    val ino : t -> int
     val repr : t Repr.t
   end
 


### PR DESCRIPTION
Hide workspace-cache file stats behind constructor and accessor functions so
their storage representation can change independently.