### PR TITLE
perf(persistent): avoid buffered string concatenation

### DIFF
--- a/src/dune_util/persistent.ml
+++ b/src/dune_util/persistent.ml
@@ -51,9 +51,7 @@ module Make (D : Desc) = struct
       end : Desc_with_data)
   ;;
 
-  let to_string (v : D.t) =
-    Printf.sprintf "%s%s" magic (Marshal.to_string v ~sharing:D.sharing)
-  ;;
+  let to_string (v : D.t) = magic ^ Marshal.to_string v ~sharing:D.sharing
 
   let with_record what ~file ~f =
     let start = Time.now () in


### PR DESCRIPTION
Prefix marshaled persistent values with direct string concatenation instead of
`Printf` formatting. This preserves the serialized representation while
avoiding the intermediate formatting buffer.

In a no-op Dune self-build allocation profile, the `Persistent.to_string`
stacks dropped from 2.73M to 1.60M major words, saving approximately 8.6 MiB.
