### PR TITLE
perf(engine): track pending targets in hash tables

### DIFF
--- a/otherlibs/stdune/src/hashtbl.ml
+++ b/otherlibs/stdune/src/hashtbl.ml
@@ -84,5 +84,6 @@ struct
       | false -> None)
   ;;
 
-  let iter t ~f = iter t ~f:(fun ~key:_ ~data -> f data)
+  let iteri t ~f = iter t ~f:(fun ~key ~data -> f key data)
+  let iter t ~f = iteri t ~f:(fun _ data -> f data)
 end

--- a/otherlibs/stdune/src/hashtbl_intf.ml
+++ b/otherlibs/stdune/src/hashtbl_intf.ml
@@ -8,6 +8,7 @@ module type S = sig
   val remove : 'a t -> key -> unit
   val to_seq_values : 'a t -> 'a Seq.t
   val iter : 'a t -> f:('a -> unit) -> unit
+  val iteri : 'a t -> f:(key -> 'a -> unit) -> unit
   val set : 'a t -> key -> 'a -> unit
   val add_exn : 'a t -> key -> 'a -> unit
   val add : 'a t -> key -> 'a -> (unit, 'a) Result.t

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -11,17 +11,32 @@ module Pending_targets = struct
      being executed. On exit, we need to delete them as they might contain
      garbage. *)
 
-  let t = ref Targets.empty
-  let remove targets = t := Targets.diff !t (Targets.Validated.unvalidate targets)
-  let add targets = t := Targets.combine !t (Targets.Validated.unvalidate targets)
+  let files = Path.Build.Table.create 128
+  let dirs = Path.Build.Table.create 128
+
+  let remove targets =
+    Targets.Validated.iter
+      targets
+      ~file:(Path.Build.Table.remove files)
+      ~dir:(Path.Build.Table.remove dirs)
+  ;;
+
+  let add targets =
+    Targets.Validated.iter
+      targets
+      ~file:(fun path -> Path.Build.Table.set files path ())
+      ~dir:(fun path -> Path.Build.Table.set dirs path ())
+  ;;
 
   let cleanup () =
-    let targets = !t in
-    t := Targets.empty;
-    Targets.iter
-      targets
-      ~file:(fun p -> p |> Path.Build.to_string |> Fpath.unlink_no_err)
-      ~dir:(fun p -> Path.rm_rf (Path.build p))
+    Exn.protect
+      ~f:(fun () ->
+        Path.Build.Table.iteri files ~f:(fun path () ->
+          Path.Build.to_string path |> Fpath.unlink_no_err);
+        Path.Build.Table.iteri dirs ~f:(fun path () -> Path.rm_rf (Path.build path)))
+      ~finally:(fun () ->
+        Path.Build.Table.clear files;
+        Path.Build.Table.clear dirs)
   ;;
 end
 


### PR DESCRIPTION
Tracking targets of running unsandboxed actions previously converted validated
targets and rebuilt sorted arrays whenever an action started or finished.

Use separate mutable path tables for file and directory targets, iterate
validated targets directly, and add key-aware hash-table iteration for cleanup.
The cleanup tables are cleared even if removing a pending target raises.

In a cold Dune self-build allocation profile, the pending-target stacks
accounted for at least 6.8M minor words and 1.33M major words (about 62 MiB).
Those stacks disappeared after this change.
