### PR TITLE
feature(watch): show build run in status line

### DIFF
--- a/doc/changes/added/15673.md
+++ b/doc/changes/added/15673.md
@@ -1,0 +1,2 @@
+- Display the current build run at the end of watch-mode status lines.
+  (#15673, @rgrinberg)

--- a/src/dune_engine/build_loop.ml
+++ b/src/dune_engine/build_loop.ml
@@ -81,6 +81,12 @@ let set_build_duration_section t message =
   t.build_duration_section <- Some (Console.Status_line.add_section message)
 ;;
 
+let build_timing_status (run_id : Run_id.t) timing =
+  match run_id with
+  | Batch -> Pp.text timing
+  | Watch run -> Pp.textf "%s [%d]" timing run
+;;
+
 let build_finish t (build_result : Build_outcome.t) =
   let message =
     match build_result with
@@ -317,7 +323,8 @@ let run_current_build
   clear_status_overlay t;
   set_build_duration_section
     t
-    (Live (fun () -> Pp.text (Build_timing.format_now build_started_at)));
+    (Live
+       (fun () -> build_timing_status run_id (Build_timing.format_now build_started_at)));
   t.current_request <- Some request;
   let* outcome =
     Fiber.finalize
@@ -358,7 +365,8 @@ let run_current_build
    | `Done ->
      set_build_duration_section
        t
-       (Constant (Pp.text (Build_timing.format ~build_duration ~process_time))));
+       (Constant
+          (build_timing_status run_id (Build_timing.format ~build_duration ~process_time))));
   outcome, next, build_start_input_change_generation, build_start_wakeup_generation
 ;;
 

--- a/test/blackbox-tests/test-cases/watching/rpc-build-status-line.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-status-line.t
@@ -1,4 +1,5 @@
-Forwarded builds display a rich status line once connected over RPC.
+Forwarded watch builds display a rich status line with the current run once
+connected over RPC.
 
   $ setup_xdg_runtime_dir
 
@@ -20,6 +21,22 @@ Forwarded builds display a rich status line once connected over RPC.
   Connected to RPC server
   $ tr '\r' '\n' < .#dune-output | grep -a -m 1 "\[rpc 1\]"
   [rpc 1]
+  $ tr '\r' '\n' < .#dune-output \
+  > | grep -a -E -m 1 -o "\[[0-9]+\.[0-9]s\] \[[0-9]+\.[0-9]x\] \[1\]" \
+  > | sed -E 's/\[[0-9]+\.[0-9]s\]/[BUILD DURATION]/; s/\[[0-9]+\.[0-9]x\]/[PARALLELISM]/'
+  [BUILD DURATION] [PARALLELISM] [1]
+
+The run number increments with the next watch build.
+
+  $ : > .#dune-output
+  $ INSIDE_EMACS=1 DUNE_CONFIG__THREADED_CONSOLE=disabled \
+  >   with_timeout dune build --display progress x > output 2>&1
+  $ tr '\r' '\n' < output | grep -m 1 "Connected to RPC server"
+  Connected to RPC server
+  $ tr '\r' '\n' < .#dune-output \
+  > | grep -a -E -m 1 -o "\[[0-9]+\.[0-9]s\] \[[0-9]+\.[0-9]x\] \[2\]" \
+  > | sed -E 's/\[[0-9]+\.[0-9]s\]/[BUILD DURATION]/; s/\[[0-9]+\.[0-9]x\]/[PARALLELISM]/'
+  [BUILD DURATION] [PARALLELISM] [2]
 
   $ stop_dune_quiet
 
@@ -58,6 +75,13 @@ count while their temporary RPC server is running.
   > | grep -a -E -m 1 -o "\[[0-9]+\.[0-9]s\] \[[0-9]+\.[0-9]x\]" \
   > | sed -E 's/\[[0-9]+\.[0-9]s\]/[BUILD DURATION]/; s/\[[0-9]+\.[0-9]x\]/[PARALLELISM]/'
   [BUILD DURATION] [PARALLELISM]
+  $ if tr '\r' '\n' < batch-output \
+  > | grep -a -E -q "\[[0-9]+\.[0-9]s\] \[[0-9]+\.[0-9]x\] \[[0-9]+\]"; then
+  >   echo "batch timing unexpectedly included a watch run"
+  > else
+  >   echo "batch timing has no watch run"
+  > fi
+  batch timing has no watch run
 
   $ touch "$RELEASE"
   $ if wait_for_pid_to_exit_with_timeout "$BATCH_PID" 200; then


### PR DESCRIPTION
Show the current watch-mode build run at the end of the status line as `[N]`. The number increments for each watch build, while batch status output remains unchanged.