### PR TITLE
test: expose spurious binary layout cache miss

### DIFF
--- a/test/blackbox-tests/test-cases/bin-pform/run-action.t
+++ b/test/blackbox-tests/test-cases/bin-pform/run-action.t
@@ -29,3 +29,21 @@ symlink:
   >   | grep mybin | censor
   "_build/default/mybin.exe"
   "_build/install/default/.binaries/$DIGEST/mybin"
+
+Building the same target again pointlessly invalidates and rebuilds the
+.binaries symlink:
+
+  $ DUNE_TRACE=cache dune build path-output
+  $ dune trace cat \
+  >   | jq_dune -s 'cacheMissesMatching("\\.binaries")' \
+  >   | censor
+  {
+    "name": "workspace_local_miss",
+    "target": "_build/install/default/.binaries/$DIGEST/mybin",
+    "reason": "target missing from build dir"
+  }
+  {
+    "name": "miss",
+    "target": "_build/install/default/.binaries/$DIGEST/mybin",
+    "reason": "can't go in shared cache"
+  }


### PR DESCRIPTION
## Description

Add a cram reproduction showing that rebuilding an unchanged target with a
`%{bin:...}` dependency pointlessly invalidates and rebuilds its generated
`.binaries` symlink. The cache trace records both the workspace-local miss
(`target missing from build dir`) and the resulting shared-cache miss.