### PR TITLE
test(rpc): cover connecting to a killed watch server

### DIFF
--- a/test/blackbox-tests/test-cases/watching/dune
+++ b/test/blackbox-tests/test-cases/watching/dune
@@ -19,7 +19,7 @@
  (applies_to path-pwd))
 
 (cram
- (applies_to rpc-bind-failure)
+ (applies_to rpc-bind-failure rpc-connect-after-server-killed)
  (enabled_if
   (<> %{ocaml-config:system} win)))
 

--- a/test/blackbox-tests/test-cases/watching/rpc-connect-after-server-killed.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-connect-after-server-killed.t
@@ -1,0 +1,21 @@
+A client connecting to a watch server that was killed without cleaning up its
+RPC socket reports the connection failure with a backtrace.
+
+  $ make_simple_rpc_watch_project
+
+  $ start_dune 2>/dev/null
+
+  $ SERVER_PID=$(cat _build/.lock)
+  $ kill -9 "$SERVER_PID"
+  $ wait_for_pid_to_exit_with_timeout "$SERVER_PID" 200
+  $ wait_for_dune_exit_with_timeout
+
+  $ with_timeout dune rpc ping > client.output 2>&1
+  [1]
+  $ head -n 3 client.output
+  Error: failed to connect to RPC server unix:path=_build/.rpc/dune
+  Unix.Unix_error(Unix.ECONNREFUSED, "connect", "")
+  backtrace:
+  $ grep -m1 '^Raised by primitive operation' client.output \
+  > | sed 's/ in file.*//'
+  Raised by primitive operation at Rpc__Csexp_rpc.Client.connect


### PR DESCRIPTION
## Description

Add a Unix-only cram test for an RPC client connecting after a passive watch server is killed with `SIGKILL`. The test verifies that the stale socket reports `ECONNREFUSED` together with a backtrace.

## Related Issue and Motivation

Reproduces #15676.