### PR TITLE
fix: preserve internal install layouts across builds

### DIFF
--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -798,10 +798,30 @@ let gen_rules ctx ~dir components =
       Bin_layout.gen_rules (Context_name.of_string ctx) ~dir rest |> Memo.return
     | ctx :: ".packages" :: rest ->
       Install_layout.gen_rules (Context_name.of_string ctx) ~dir rest
-    | ctx :: _ ->
+    | ctx :: rest ->
       let ctx = Context_name.of_string ctx in
       with_context ctx ~f:(fun sctx ->
         let+ subdirs, rules = Install_rules.symlink_rules sctx ~dir in
+        let subdirs =
+          match rest with
+          | [] ->
+            (* Here we retain the extra subdirectories that we dispatched
+               above. *)
+            Subdir_set.union
+              subdirs
+              (* CR-someday Alizter: Sharing these directory names with the
+                 dispatch cases above would avoid duplicate strings, but
+                 dispatch and retention could still get out of sync.
+
+                 It would be better to have a structured [Gen_rules] API where
+                 registering a generated child dispatcher automatically retains
+                 that child. *)
+              (Subdir_set.of_list
+                 [ Filename.of_string_exn ".binaries"
+                 ; Filename.of_string_exn ".packages"
+                 ])
+          | _ :: _ -> subdirs
+        in
         let directory_targets = Rules.directory_targets rules in
         Gen_rules.make
           ~build_dir_only_sub_dirs:(Gen_rules.Build_only_sub_dirs.singleton ~dir subdirs)

--- a/test/blackbox-tests/test-cases/bin-pform/run-action.t
+++ b/test/blackbox-tests/test-cases/bin-pform/run-action.t
@@ -30,20 +30,11 @@ symlink:
   "_build/default/mybin.exe"
   "_build/install/default/.binaries/$DIGEST/mybin"
 
-Building the same target again pointlessly invalidates and rebuilds the
-.binaries symlink:
+Building the same target again does not invalidate or rebuild the .binaries
+symlink:
 
   $ DUNE_TRACE=cache dune build path-output
   $ dune trace cat \
   >   | jq_dune -s 'cacheMissesMatching("\\.binaries")' \
   >   | censor
-  {
-    "name": "workspace_local_miss",
-    "target": "_build/install/default/.binaries/$DIGEST/mybin",
-    "reason": "target missing from build dir"
-  }
-  {
-    "name": "miss",
-    "target": "_build/install/default/.binaries/$DIGEST/mybin",
-    "reason": "can't go in shared cache"
-  }
+  

--- a/test/blackbox-tests/test-cases/package-materialization/single-package.t
+++ b/test/blackbox-tests/test-cases/package-materialization/single-package.t
@@ -42,23 +42,14 @@ install layout under _build/install/<context>/.packages/<digest>/.
 
   $ dune build out1 out2 out_rev out3
 
-Building the same target again pointlessly invalidates and rebuilds its
-.packages layout:
+Building the same target again does not invalidate or rebuild its .packages
+layout:
 
   $ DUNE_TRACE=cache dune build out1
   $ dune trace cat \
   >   | jq_dune -s 'cacheMissesMatching("\\.packages/.*/dune-package")' \
   >   | censor
-  {
-    "name": "workspace_local_miss",
-    "target": "_build/install/default/.packages/$DIGEST/lib/foo/dune-package",
-    "reason": "target missing from build dir"
-  }
-  {
-    "name": "miss",
-    "target": "_build/install/default/.packages/$DIGEST/lib/foo/dune-package",
-    "reason": "can't go in shared cache"
-  }
+  
 
 Single package dep only includes that package:
 


### PR DESCRIPTION
## Description

Preserve the engine-owned `.binaries` and `.packages` directories when loading
`_build/install/<context>`. Without this declaration, stale-artifact cleanup
deletes both layouts before their child rule generators run, causing pointless
cache misses, symlink recreation, and persistent rule-cache rewrites on null
builds.

The two cram reproductions now expect no cache misses on an unchanged second
build.

Depends on:

- #15674
- #15677