### PR TITLE
perf(stdune): cache signal number lookup

### DIFF
--- a/otherlibs/stdune/src/signal.ml
+++ b/otherlibs/stdune/src/signal.ml
@@ -122,9 +122,10 @@ let to_int =
   | t -> Map.find_exn table t
 ;;
 
-let of_int i =
+let of_int =
   let table = Int.Map.of_list_exn (List.map all ~f:(fun (t, i) -> i, t)) in
-  match Int.Map.find table i with
-  | None -> Unknown i
-  | Some s -> s
+  fun i ->
+    match Int.Map.find table i with
+    | None -> Unknown i
+    | Some s -> s
 ;;


### PR DESCRIPTION
`Signal.of_int` rebuilt an `Int.Map` from the platform signal list on every
call. The signal watcher invokes it for every `SIGCHLD`, so builds with many
subprocesses repeatedly constructed the same map.

Build the inverse map once in the closure, matching `Signal.to_int`. In a cold
Dune self-build with 5,750 subprocesses, this reduced minor allocation by 7.53M
words, or about 57 MiB.
