### PR TITLE
perf(stdune): avoid allocations in nonempty-list comparison

### DIFF
--- a/otherlibs/stdune/src/nonempty_list.ml
+++ b/otherlibs/stdune/src/nonempty_list.ml
@@ -38,10 +38,10 @@ let to_list (x :: xs) = List.cons x xs
 let to_list_map (x :: xs) ~f = List.map (x :: xs) ~f
 let map (x :: xs) ~f = f x :: List.map xs ~f
 
-let compare xs ys ~compare =
-  let (x :: xs) = xs
-  and (y :: ys) = ys in
-  List.compare ~compare (x :: xs) (y :: ys)
+let compare (x :: xs) (y :: ys) ~compare =
+  match compare x y with
+  | Ordering.Eq -> List.compare xs ys ~compare
+  | ordering -> ordering
 ;;
 
 let concat xs (t :: ts : _ t) =


### PR DESCRIPTION
`Nonempty_list.compare` destructured its arguments and then rebuilt both list
heads before calling `List.compare`, allocating two temporary list cells for
every comparison.

Compare the heads directly and delegate only the tails to `List.compare`. This
reduced minor allocation by 1.72M words (13 MiB) in a cold Dune self-build and
by 1.33M words (10 MiB) in a no-op build.
