### PR TITLE
change(status): calculate parallelism from CPU time

### DIFF
--- a/doc/changes/changed/15685.md
+++ b/doc/changes/changed/15685.md
@@ -1,0 +1,3 @@
+- Calculate status-line build parallelism from process CPU time rather than
+  wall-clock action time; Windows continues to use wall-clock time.
+  (#15685, @rgrinberg)

--- a/otherlibs/stdune/src/metrics.ml
+++ b/otherlibs/stdune/src/metrics.ml
@@ -1,12 +1,24 @@
 module Build = struct
   let count = Counter.create ()
   let process_wall_clock = Counter.Timer.create ()
+  let action_duration_counter = Counter.Timer.create ()
   let user = Counter.Timer.create ()
   let system = Counter.Timer.create ()
 
   let add_process_times ~elapsed_time ~user_cpu_time ~system_cpu_time =
     Counter.incr count;
     Counter.Timer.add process_wall_clock elapsed_time;
+    Counter.Timer.add
+      action_duration_counter
+      (match user_cpu_time, system_cpu_time with
+       | Some user_cpu_time, Some system_cpu_time ->
+         Time.Span.add user_cpu_time system_cpu_time
+       | _ ->
+         (* CR-someday rgrinberg:
+            Resource usage isn't available on Windows. Wall-clock time is the
+            best approximation until we have better Windows process bindings.
+         *)
+         elapsed_time);
     (match user_cpu_time with
      | None -> ()
      | Some user_cpu_time -> Counter.Timer.add user user_cpu_time);
@@ -19,10 +31,12 @@ module Build = struct
   let process_time () = Counter.Timer.read process_wall_clock
   let process_user_cpu_time () = Counter.Timer.read user
   let process_system_cpu_time () = Counter.Timer.read system
+  let action_duration () = Counter.Timer.read action_duration_counter
 
   let reset () =
     Counter.reset count;
     Counter.Timer.reset process_wall_clock;
+    Counter.Timer.reset action_duration_counter;
     Counter.Timer.reset user;
     Counter.Timer.reset system
   ;;

--- a/otherlibs/stdune/src/metrics.mli
+++ b/otherlibs/stdune/src/metrics.mli
@@ -14,6 +14,12 @@ module Build : sig
   val process_time : unit -> Time.Span.t
   val process_user_cpu_time : unit -> Time.Span.t
   val process_system_cpu_time : unit -> Time.Span.t
+
+  (** Total action duration used to calculate build parallelism. This is user
+      plus system CPU time when resource usage is available, and wall-clock time
+      otherwise. *)
+  val action_duration : unit -> Time.Span.t
+
   val reset : unit -> unit
 end
 

--- a/otherlibs/stdune/test/proc_tests.ml
+++ b/otherlibs/stdune/test/proc_tests.ml
@@ -95,3 +95,30 @@ let%expect_test "Proc.Resource_usage.get_self returns sane data" =
     values_do_not_go_backwards: true
   |}]
 ;;
+
+let%expect_test "Metrics.Build.action_duration selects CPU time" =
+  let equals duration expected =
+    Time.Span.compare duration (Time.Span.of_secs expected) = Eq
+  in
+  Metrics.Build.reset ();
+  Metrics.Build.add_process_times
+    ~elapsed_time:(Time.Span.of_secs 10.)
+    ~user_cpu_time:(Some (Time.Span.of_secs 2.))
+    ~system_cpu_time:(Some (Time.Span.of_secs 3.));
+  print_bool "uses_cpu_time" (equals (Metrics.Build.action_duration ()) 5.);
+  print_bool "retains_wall_clock" (equals (Metrics.Build.process_time ()) 10.);
+  Metrics.Build.reset ();
+  Metrics.Build.add_process_times
+    ~elapsed_time:(Time.Span.of_secs 10.)
+    ~user_cpu_time:None
+    ~system_cpu_time:None;
+  let action_duration = Metrics.Build.action_duration () in
+  print_bool "falls_back_to_wall_clock" (equals action_duration 10.);
+  Metrics.Build.reset ();
+  [%expect
+    {|
+    uses_cpu_time: true
+    retains_wall_clock: true
+    falls_back_to_wall_clock: true
+  |}]
+;;

--- a/src/dune_engine/build_loop.ml
+++ b/src/dune_engine/build_loop.ml
@@ -346,7 +346,7 @@ let run_current_build
   in
   let+ () = Scheduler.cleanup_subreaper_child_processes () in
   let build_duration = Time.diff (Time.now ()) build_started_at in
-  let process_time = Metrics.Build.process_time () in
+  let action_duration = Metrics.Build.action_duration () in
   let next =
     match t.status with
     | Restarting_build _
@@ -366,7 +366,9 @@ let run_current_build
      set_build_duration_section
        t
        (Constant
-          (build_timing_status run_id (Build_timing.format ~build_duration ~process_time))));
+          (build_timing_status
+             run_id
+             (Build_timing.format ~build_duration ~action_duration))));
   outcome, next, build_start_input_change_generation, build_start_wakeup_generation
 ;;
 

--- a/src/dune_engine/build_timing.ml
+++ b/src/dune_engine/build_timing.ml
@@ -1,11 +1,13 @@
 open Import
 
-let parallelism ~build_duration ~process_time =
+let parallelism ~build_duration ~action_duration =
   match
     match Time.Span.compare build_duration Time.Span.zero with
     | Eq | Lt -> None
     | Gt ->
-      (try Some (Time.Span.to_secs process_time /. Time.Span.to_secs build_duration) with
+      (try
+         Some (Time.Span.to_secs action_duration /. Time.Span.to_secs build_duration)
+       with
        | _ -> None)
   with
   | None -> ""
@@ -17,8 +19,8 @@ let format =
     | "" -> ""
     | s -> "[" ^ s ^ "]"
   in
-  fun ~build_duration ~process_time ->
-    let parallelism = parallelism ~build_duration ~process_time in
+  fun ~build_duration ~action_duration ->
+    let parallelism = parallelism ~build_duration ~action_duration in
     let duration = sprintf "%.1fs" (Time.Span.to_secs build_duration) in
     [ section duration; section parallelism ]
     |> List.filter ~f:(function
@@ -30,5 +32,5 @@ let format =
 let format_now started_at =
   format
     ~build_duration:(Time.diff (Time.now ()) started_at)
-    ~process_time:(Metrics.Build.process_time ())
+    ~action_duration:(Metrics.Build.action_duration ())
 ;;

--- a/src/dune_engine/build_timing.mli
+++ b/src/dune_engine/build_timing.mli
@@ -1,4 +1,4 @@
 open Import
 
-val format : build_duration:Time.Span.t -> process_time:Time.Span.t -> string
+val format : build_duration:Time.Span.t -> action_duration:Time.Span.t -> string
 val format_now : Time.t -> string


### PR DESCRIPTION
Calculate status-line parallelism from accumulated user and system CPU time instead of action wall time. Preserve wall-clock process metrics for tracing and fall back to wall time when resource usage is unavailable, including on Windows.