### PR TITLE
fix(stdune): correct filesystem metric accounting

### DIFF
--- a/doc/changes/fixed/15686.md
+++ b/doc/changes/fixed/15686.md
@@ -1,0 +1,2 @@
+- Correct filesystem trace metrics for file writes and directory scans.
+  (#15686, @rgrinberg)

--- a/otherlibs/stdune/src/io.ml
+++ b/otherlibs/stdune/src/io.ml
@@ -326,7 +326,7 @@ struct
         |> Result.ok_exn
       else with_file_out ~binary ?perm fn ~f:(fun oc -> output_string oc data)
     in
-    Counter.Timer.stop Metrics.File_read.time start;
+    Counter.Timer.stop Metrics.File_write.time start;
     res
   ;;
 
@@ -342,7 +342,7 @@ struct
             output_string oc "\n")
           lines)
     in
-    Counter.Timer.stop Metrics.Directory_read.time start;
+    Counter.Timer.stop Metrics.File_write.time start;
     res
   ;;
 

--- a/otherlibs/stdune/src/readdir.ml
+++ b/otherlibs/stdune/src/readdir.ml
@@ -53,17 +53,26 @@ let readdir_with_kind_if_available_win32 : Unix.dir_handle -> Readdir_result.t =
   | entry -> Entry (entry, File_kind.Option.UNKNOWN)
 ;;
 
-let readdir_with_kind_if_available : Unix.dir_handle -> Readdir_result.t =
-  Counter.incr Metrics.Directory_read.count;
+let readdir_with_kind_if_available =
   if Stdlib.Sys.win32
   then readdir_with_kind_if_available_win32
   else readdir_with_kind_if_available_unix
 ;;
 
 let read_directory_with_kinds_exn dir_path =
-  let dir = Unix.opendir dir_path in
+  let start = Counter.Timer.start () in
+  Counter.incr Metrics.Directory_read.count;
+  let dir =
+    match Unix.opendir dir_path with
+    | dir -> dir
+    | exception exn ->
+      Counter.Timer.stop Metrics.Directory_read.time start;
+      raise exn
+  in
   Fun.protect
-    ~finally:(fun () -> Unix.closedir dir)
+    ~finally:(fun () ->
+      Unix.closedir dir;
+      Counter.Timer.stop Metrics.Directory_read.time start)
     (fun () ->
        let rec loop acc =
          match readdir_with_kind_if_available dir with
@@ -91,9 +100,19 @@ let read_directory_with_kinds dir_path =
 ;;
 
 let read_directory_exn dir_path =
-  let dir = Unix.opendir dir_path in
+  let start = Counter.Timer.start () in
+  Counter.incr Metrics.Directory_read.count;
+  let dir =
+    match Unix.opendir dir_path with
+    | dir -> dir
+    | exception exn ->
+      Counter.Timer.stop Metrics.Directory_read.time start;
+      raise exn
+  in
   Fun.protect
-    ~finally:(fun () -> Unix.closedir dir)
+    ~finally:(fun () ->
+      Unix.closedir dir;
+      Counter.Timer.stop Metrics.Directory_read.time start)
     (fun () ->
        let rec loop acc =
          match readdir_with_kind_if_available dir with

--- a/otherlibs/stdune/test/io_metrics_tests.ml
+++ b/otherlibs/stdune/test/io_metrics_tests.ml
@@ -1,0 +1,88 @@
+open Stdune
+
+let ok_exn = function
+  | Ok value -> value
+  | Error error -> Unix_error.Detailed.raise error
+;;
+
+let timer_changed timer before =
+  match Time.Span.compare (Counter.Timer.read timer) before with
+  | Gt -> true
+  | Eq | Lt -> false
+;;
+
+let%expect_test "IO metrics are attributed to the operation being measured" =
+  let dir = Temp.create Dir ~prefix:"io-metrics" ~suffix:"test" in
+  let file = Path.relative dir "file" in
+  let file_read_before = Counter.Timer.read Metrics.File_read.time in
+  let file_write_count_before = Counter.read Metrics.File_write.count in
+  let file_write_before = Counter.Timer.read Metrics.File_write.time in
+  let directory_read_before = Counter.Timer.read Metrics.Directory_read.time in
+  Io.write_file file "contents";
+  Dune_tests_common.print_dyn
+    (Dyn.record
+       [ ( "file_write_count"
+         , Dyn.int (Counter.read Metrics.File_write.count - file_write_count_before) )
+       ; ( "file_write_time_changed"
+         , Dyn.bool (timer_changed Metrics.File_write.time file_write_before) )
+       ; ( "file_read_time_changed"
+         , Dyn.bool (timer_changed Metrics.File_read.time file_read_before) )
+       ; ( "directory_read_time_changed"
+         , Dyn.bool (timer_changed Metrics.Directory_read.time directory_read_before) )
+       ]);
+  [%expect
+    {|
+    { file_write_count = 1
+    ; file_write_time_changed = true
+    ; file_read_time_changed = false
+    ; directory_read_time_changed = false
+    }
+    |}];
+  let file_read_before = Counter.Timer.read Metrics.File_read.time in
+  let file_write_count_before = Counter.read Metrics.File_write.count in
+  let file_write_before = Counter.Timer.read Metrics.File_write.time in
+  let directory_read_before = Counter.Timer.read Metrics.Directory_read.time in
+  Io.write_lines file [ "one"; "two" ];
+  Dune_tests_common.print_dyn
+    (Dyn.record
+       [ ( "file_write_count"
+         , Dyn.int (Counter.read Metrics.File_write.count - file_write_count_before) )
+       ; ( "file_write_time_changed"
+         , Dyn.bool (timer_changed Metrics.File_write.time file_write_before) )
+       ; ( "file_read_time_changed"
+         , Dyn.bool (timer_changed Metrics.File_read.time file_read_before) )
+       ; ( "directory_read_time_changed"
+         , Dyn.bool (timer_changed Metrics.Directory_read.time directory_read_before) )
+       ]);
+  [%expect
+    {|
+    { file_write_count = 1
+    ; file_write_time_changed = true
+    ; file_read_time_changed = false
+    ; directory_read_time_changed = false
+    }
+    |}]
+;;
+
+let%expect_test "directory metrics count directory scans" =
+  let dir = Temp.create Dir ~prefix:"directory-metrics" ~suffix:"test" in
+  let first = Path.relative dir "first" in
+  let second = Path.relative dir "second" in
+  Path.mkdir_p first;
+  Path.mkdir_p second;
+  let count_before = Counter.read Metrics.Directory_read.count in
+  let time_before = Counter.Timer.read Metrics.Directory_read.time in
+  ignore (Readdir.read_directory (Path.to_string first) |> ok_exn : string list);
+  ignore
+    (Readdir.read_directory_with_kinds (Path.to_string second) |> ok_exn
+     : (string * Unix.file_kind) list);
+  Dune_tests_common.print_dyn
+    (Dyn.record
+       [ "count", Dyn.int (Counter.read Metrics.Directory_read.count - count_before)
+       ; "time_changed", Dyn.bool (timer_changed Metrics.Directory_read.time time_before)
+       ]);
+  [%expect
+    {|
+    { count = 2; time_changed = true }
+    |}]
+;;


### PR DESCRIPTION
Filesystem metrics currently charge file-write time to unrelated read metrics, while the directory counter is incremented only once when its module is initialized.

Correct the write attribution, count and time complete directory scans, and add regression tests for both behaviors.
