### PR TITLE
fix(trace): preserve runtime event ring IDs

### DIFF
--- a/doc/changes/fixed/15687.md
+++ b/doc/changes/fixed/15687.md
@@ -1,0 +1,2 @@
+- Preserve runtime-event ring IDs in Dune traces so consumers can distinguish
+  interleaved event streams. (#15687, @rgrinberg)

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -983,9 +983,10 @@ let sandbox name ~start ~stop ~queued loc ~dir =
   Event.complete ~args ~name ~start ~dur Sandbox
 ;;
 
-let runtime time what phase =
+let runtime ring_id time what phase =
   let args =
-    [ "phase", Arg.string (Runtime.runtime_phase_name phase)
+    [ "ring_id", Arg.int ring_id
+    ; "phase", Arg.string (Runtime.runtime_phase_name phase)
     ; ( "what"
       , Arg.string
           (match what with
@@ -996,9 +997,12 @@ let runtime time what phase =
   Event.instant ~args ~name:"event" time Runtime
 ;;
 
-let runtime_counter time name value =
+let runtime_counter ring_id time name value =
   let args =
-    [ "name", Arg.string (Runtime.runtime_counter_name name); "value", Arg.int value ]
+    [ "ring_id", Arg.int ring_id
+    ; "name", Arg.string (Runtime.runtime_counter_name name)
+    ; "value", Arg.int value
+    ]
   in
   Event.instant ~args ~name:"counter" time Runtime
 ;;

--- a/src/dune_trace/out.ml
+++ b/src/dune_trace/out.ml
@@ -170,12 +170,12 @@ let runtime_callbacks =
     let emit event = emit (Lazy.force t) ~buffered:true event in
     let time timestamp = time_of_runtime_timestamp clock timestamp in
     Runtime.Callbacks.create
-      ~runtime_begin:(fun _ timestamp phase ->
-        emit (Event.runtime (time timestamp) `Begin phase))
-      ~runtime_end:(fun _ timestamp phase ->
-        emit (Event.runtime (time timestamp) `End phase))
-      ~runtime_counter:(fun _ timestamp name value ->
-        emit (Event.runtime_counter (time timestamp) name value))
+      ~runtime_begin:(fun ring_id timestamp phase ->
+        emit (Event.runtime ring_id (time timestamp) `Begin phase))
+      ~runtime_end:(fun ring_id timestamp phase ->
+        emit (Event.runtime ring_id (time timestamp) `End phase))
+      ~runtime_counter:(fun ring_id timestamp name value ->
+        emit (Event.runtime_counter ring_id (time timestamp) name value))
       ()
 ;;
 

--- a/test/blackbox-tests/test-cases/trace/runtime-events.t
+++ b/test/blackbox-tests/test-cases/trace/runtime-events.t
@@ -29,10 +29,12 @@ exact event counts or counter values.
   >   , valid_shape:
   >       all(.[];
   >         if .name == "event" then
-  >           ((.args.phase | type) == "string"
+  >           ((.args.ring_id | type) == "number"
+  >            and (.args.phase | type) == "string"
   >            and (.args.what == "begin" or .args.what == "end"))
   >         elif .name == "counter" then
-  >           ((.args.name | type) == "string"
+  >           ((.args.ring_id | type) == "number"
+  >            and (.args.name | type) == "string"
   >            and (.args.value | type) == "number")
   >         else
   >           false


### PR DESCRIPTION
OCaml runtime-event callbacks identify the ring buffer that produced each event, but Dune currently discards that information while serializing its trace. Events from different streams are therefore indistinguishable, making begin/end pairing unreliable when streams interleave.

Preserve the ring ID on runtime phase and counter events, and verify both serialized event shapes.
