### PR TITLE
perf(fiber): reuse variable maps for unchanged values

### DIFF
--- a/src/fiber/src/var_map.ml
+++ b/src/fiber/src/var_map.ml
@@ -37,11 +37,16 @@ let get (type a) (t : t) key : a =
 ;;
 
 let set (type a) (t : t) (key : a Key.t) (x : a) : t =
-  let copy =
-    if key < Array.length t then Array.copy t else Array.init (key + 1) (fun i -> get t i)
-  in
-  copy.(key) <- Obj.repr x;
-  copy
+  if Obj.repr (get t key) == Obj.repr x
+  then t
+  else (
+    let copy =
+      if key < Array.length t
+      then Array.copy t
+      else Array.init (key + 1) (fun i -> get t i)
+    in
+    copy.(key) <- Obj.repr x;
+    copy)
 ;;
 
 let update (type a) (t : t) (key : a Key.t) ~(f : a -> a) : t =


### PR DESCRIPTION
About 13% of fiber-variable writes in a self-build store the same physical value already present. Return the existing map in that case, avoiding an array copy while preserving the dynamic-scope context.

This saved about 0.23M words (1.8 MiB) in a cold self-build and 0.90M words (6.9 MiB) in a no-op build.
