### PR TITLE
bench: optionally count instructions with perf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,9 +171,10 @@ ifeq (dune,$(firstword $(MAKECMDGOALS)))
   $(eval $(RUN_ARGS):;@:)
 endif
 
+# Set PERF to collect user-space instruction counts with perf stat.
 .PHONY: bench
 bench: $(BIN)
-	@$(BIN) exec -- ./bench/bench.exe $(BIN)
+	@$(BIN) exec -- ./bench/bench.exe $(BIN) $(PERF)
 
 .PHONY: dune
 dune: $(BIN)

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -43,16 +43,68 @@ module Output = struct
   ;;
 end
 
-let git =
-  lazy
-    (let path = Env.get Env.initial "PATH" |> Option.value_exn |> Bin.parse_path in
-     Bin.which ~path "git" |> Option.value_exn)
+let bin_path = lazy (Env.get Env.initial "PATH" |> Option.value_exn |> Bin.parse_path)
+let git = lazy (Bin.which ~path:(Lazy.force bin_path) "git" |> Option.value_exn)
+let true_program = lazy (Bin.which ~path:(Lazy.force bin_path) "true" |> Option.value_exn)
+
+let path_of_argument argument =
+  if Filename.is_relative argument
+  then Path.of_string (Filename.concat Fpath.initial_cwd argument)
+  else Path.of_string argument
 ;;
 
-let dune = Path.of_string (Filename.concat Fpath.initial_cwd Sys.argv.(1))
+let executable_of_argument argument =
+  if Filename.is_relative argument && String.equal (Filename.dirname argument) "."
+  then Bin.which ~path:(Lazy.force bin_path) argument |> Option.value_exn
+  else path_of_argument argument
+;;
+
+let dune = path_of_argument Sys.argv.(1)
+
+let perf =
+  if Array.length Sys.argv >= 3 then Some (executable_of_argument Sys.argv.(2)) else None
+;;
+
 let output_limit = Dune_engine.Execution_parameters.Action_output_limit.default
 let make_stdout () = Process.Io.make_stdout ~output_on_success:Swallow ~output_limit
 let make_stderr () = Process.Io.make_stderr ~output_on_success:Swallow ~output_limit
+
+let perf_arguments ~output ~program args =
+  [ "stat"
+  ; "--no-big-num"
+  ; "--field-separator"
+  ; ";"
+  ; "--event"
+  ; "instructions:u"
+  ; "--output"
+  ; Path.to_absolute_filename output
+  ; "--"
+  ; Path.to_absolute_filename program
+  ]
+  @ args
+;;
+
+let check_perf () =
+  match perf with
+  | None -> Fiber.return ()
+  | Some perf ->
+    let output = Temp.create File ~prefix:"perf" ~suffix:"check" in
+    let stdout_to = make_stdout () in
+    let stderr_to = make_stderr () in
+    let stdin_from = Process.Io.(null In) in
+    let open Fiber.O in
+    let+ () =
+      Process.run
+        Strict
+        perf
+        ~display:Quiet
+        ~stdin_from
+        ~stdout_to
+        ~stderr_to
+        (perf_arguments ~output ~program:(Lazy.force true_program) [])
+    in
+    ignore (Perf_counter.read_instructions output : int)
+;;
 
 module Package = struct
   type t =
@@ -89,41 +141,58 @@ let prepare_workspace () =
         Fiber.return @@ Console.printf "finished cloning %s/%s" pkg.org pkg.name))
 ;;
 
+type run =
+  { metrics : (float, int) Metrics.t
+  ; instructions : int option
+  }
+
 let dune_build ~name ~sandbox =
   let stdin_from = Process.(Io.null In) in
   let stdout_to = make_stdout () in
   let stderr_to = make_stderr () in
   let gc_dump = Temp.create File ~prefix:"gc_stat" ~suffix:name in
+  let dune_args =
+    [ "build"
+    ; "@install"
+    ; "--release"
+    ; "--cache" (* explicitly disable cache *)
+    ; "disabled"
+    ; "--dump-gc-stats"
+    ; Path.to_string gc_dump
+    ]
+    @
+    match sandbox with
+    | `Yes -> [ "--sandbox"; "hardlink" ]
+    | `No -> []
+  in
+  let program, args, perf_output =
+    match perf with
+    | None -> dune, dune_args, None
+    | Some perf ->
+      let output = Temp.create File ~prefix:"perf" ~suffix:name in
+      perf, perf_arguments ~output ~program:dune dune_args, Some output
+  in
   let open Fiber.O in
-  (* Build with timings and gc stats *)
   let+ times =
     Process.run_with_times
       Strict
-      dune
+      program
       ~display:Quiet
       ~stdin_from
       ~stdout_to
       ~stderr_to
-      ([ "build"
-       ; "@install"
-       ; "--release"
-       ; "--cache" (* explicitly disable cache *)
-       ; "disabled"
-       ; "--dump-gc-stats"
-       ; Path.to_string gc_dump
-       ]
-       @
-       match sandbox with
-       | `Yes -> [ "--sandbox"; "hardlink" ]
-       | `No -> [])
+      args
   in
-  (* Read the gc stats from the dump file *)
-  Dune_lang.Parser.parse_string
-    ~mode:Single
-    ~fname:(Path.to_string gc_dump)
-    (Io.read_file gc_dump)
-  |> Dune_lang.Decoder.parse Dune_util.Gc.decode Univ_map.empty
-  |> Metrics.make times
+  let gc =
+    Dune_lang.Parser.parse_string
+      ~mode:Single
+      ~fname:(Path.to_string gc_dump)
+      (Io.read_file gc_dump)
+    |> Dune_lang.Decoder.parse Dune_util.Gc.decode Univ_map.empty
+  in
+  { metrics = Metrics.make times gc
+  ; instructions = Option.map perf_output ~f:Perf_counter.read_instructions
+  }
 ;;
 
 let run_bench ~sandbox =
@@ -142,10 +211,10 @@ let run_bench ~sandbox =
   clean, zero
 ;;
 
-type ('float, 'int) bench_results =
+type bench_results =
   { size : int
-  ; clean : ('float, 'int) Metrics.t
-  ; zero : ('float, 'int) Metrics.t list
+  ; clean : run
+  ; zero : run list
   }
 
 let tag_results { size; clean; zero } =
@@ -153,7 +222,7 @@ let tag_results { size; clean; zero } =
   let list_tag data =
     List.map data ~f:tag |> Metrics.unzip |> Metrics.map ~f:Json.list ~g:Json.list
   in
-  Json.int size, tag clean, list_tag zero
+  Json.int size, tag clean.metrics, list_tag (List.map zero ~f:(fun run -> run.metrics))
 ;;
 
 (** Display all clean and null builds with a few exceptions:
@@ -210,12 +279,25 @@ let display_clean_and_zero_with_sandboxing
   ]
 ;;
 
+let instruction_results ({ clean; zero; _ } : bench_results) =
+  match clean.instructions with
+  | None -> []
+  | Some clean ->
+    let zero = List.map zero ~f:(fun run -> Option.value_exn run.instructions) in
+    [ { Output.name = "Instructions"
+      ; metrics =
+          [ "[Clean] Instructions", Json.int clean, "Instructions"
+          ; "[Null] Instructions", Json.list (List.map zero ~f:Json.int), "Instructions"
+          ]
+      }
+    ]
+;;
+
 let format_results bench_results =
-  (* tagging data for json conversion *)
   let size, clean, zero = tag_results bench_results in
-  (* bench results *)
   [ { Output.name = "Misc"; metrics = [ "Size of _boot/dune.exe", size, "Bytes" ] } ]
   @ display_clean_and_zero_with_sandboxing clean zero
+  @ instruction_results bench_results
 ;;
 
 let () =
@@ -239,6 +321,7 @@ let () =
     Scheduler.Run.go config
     @@ fun () ->
     let open Fiber.O in
+    let* () = check_perf () in
     (* Prepare the workspace *)
     let* () = prepare_workspace () in
     (* Build the clean and null builds *)
@@ -249,7 +332,12 @@ let () =
     format_results { size; clean; zero }
   in
   let version = 4 in
-  let output = { Output.config = []; version; results } in
+  let config =
+    match perf with
+    | None -> []
+    | Some perf -> [ "perf", Json.string (Path.to_string perf) ]
+  in
+  let output = { Output.config; version; results } in
   print_string (Json.to_string (Output.to_json output));
   flush stdout
 ;;

--- a/bench/dune
+++ b/bench/dune
@@ -1,7 +1,14 @@
+(library
+ (name build_bench_perf)
+ (wrapped false)
+ (modules perf_counter)
+ (libraries stdune))
+
 (executable
  (name bench)
  (modules bench metrics)
  (libraries
+  build_bench_perf
   dune_trace
   dune_scheduler
   stdune
@@ -10,6 +17,11 @@
   dune_engine
   dune_util
   unix))
+
+(test
+ (name perf_counter_tests)
+ (modules perf_counter_tests)
+ (libraries build_bench_perf stdune))
 
 (rule
  (alias bench)

--- a/bench/perf_counter.ml
+++ b/bench/perf_counter.ml
@@ -1,0 +1,18 @@
+open Stdune
+
+let read_instructions path =
+  let instructions =
+    Io.lines_of_file path
+    |> List.find_map ~f:(fun line ->
+      match String.split line ~on:';' with
+      | count :: _unit :: event :: _
+        when Option.is_some (String.drop_prefix event ~prefix:"instructions") ->
+        Int.of_string count
+      | _ -> None)
+  in
+  match instructions with
+  | Some instructions -> instructions
+  | None ->
+    User_error.raise
+      [ Pp.textf "Unable to read the instruction count from %s" (Path.to_string path) ]
+;;

--- a/bench/perf_counter.mli
+++ b/bench/perf_counter.mli
@@ -1,0 +1,3 @@
+open Stdune
+
+val read_instructions : Path.t -> int

--- a/bench/perf_counter_tests.ml
+++ b/bench/perf_counter_tests.ml
@@ -1,0 +1,12 @@
+open Stdune
+
+let () =
+  let path = Temp.create File ~prefix:"perf" ~suffix:"stat" in
+  Io.write_file path "# started on ...\n\n123456;;instructions:u;100.00;100.00;;\n";
+  let instructions = Perf_counter.read_instructions path in
+  if instructions <> 123_456
+  then
+    Code_error.raise
+      "incorrect perf instruction count"
+      [ "actual", Dyn.int instructions; "expected", Dyn.int 123_456 ]
+;;


### PR DESCRIPTION
Allow the benchmark harness to optionally wrap clean and null builds with
`perf stat` and report user-space instruction counts for Dune and its child
processes.

Set `PERF=perf` when invoking `make bench` to enable collection. The harness
checks that the event is available before cloning the benchmark workspace, and
continues to behave as before when `PERF` is unset.
