### PR TITLE
test(watching): avoid SIGPIPE in status line test

### DIFF
--- a/test/blackbox-tests/test-cases/watching/rpc-build-status-line.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-status-line.t
@@ -11,19 +11,20 @@ connected over RPC.
   $ start_dune --display progress
   $ : > .#dune-output
   $ with_timeout_quiet dune rpc ping
-  $ tr '\r' '\n' < .#dune-output | grep -a -m 1 "\[rpc 0\]"
+  $ tr '\r' '\n' < .#dune-output | grep -a "\[rpc 0\]" | awk 'NR == 1'
   [1]
 
   $ : > .#dune-output
   $ INSIDE_EMACS=1 DUNE_CONFIG__THREADED_CONSOLE=disabled \
   >   with_timeout dune build --display progress x > output 2>&1
-  $ tr '\r' '\n' < output | grep -m 1 "Connected to RPC server"
+  $ tr '\r' '\n' < output | grep "Connected to RPC server" | awk 'NR == 1'
   Connected to RPC server
-  $ tr '\r' '\n' < .#dune-output | grep -a -m 1 "\[rpc 1\]"
+  $ tr '\r' '\n' < .#dune-output | grep -a "\[rpc 1\]" | awk 'NR == 1'
   [rpc 1]
   $ tr '\r' '\n' < .#dune-output \
-  > | grep -a -E -m 1 -o "\[[0-9]+\.[0-9]s\] \[[0-9]+\.[0-9]x\] \[1\]" \
-  > | sed -E 's/\[[0-9]+\.[0-9]s\]/[BUILD DURATION]/; s/\[[0-9]+\.[0-9]x\]/[PARALLELISM]/'
+  > | grep -a -E -o "\[[0-9]+\.[0-9]s\] \[[0-9]+\.[0-9]x\] \[1\]" \
+  > | sed -E 's/\[[0-9]+\.[0-9]s\]/[BUILD DURATION]/; s/\[[0-9]+\.[0-9]x\]/[PARALLELISM]/' \
+  > | awk 'NR == 1'
   [BUILD DURATION] [PARALLELISM] [1]
 
 The run number increments with the next watch build.
@@ -31,11 +32,12 @@ The run number increments with the next watch build.
   $ : > .#dune-output
   $ INSIDE_EMACS=1 DUNE_CONFIG__THREADED_CONSOLE=disabled \
   >   with_timeout dune build --display progress x > output 2>&1
-  $ tr '\r' '\n' < output | grep -m 1 "Connected to RPC server"
+  $ tr '\r' '\n' < output | grep "Connected to RPC server" | awk 'NR == 1'
   Connected to RPC server
   $ tr '\r' '\n' < .#dune-output \
-  > | grep -a -E -m 1 -o "\[[0-9]+\.[0-9]s\] \[[0-9]+\.[0-9]x\] \[2\]" \
-  > | sed -E 's/\[[0-9]+\.[0-9]s\]/[BUILD DURATION]/; s/\[[0-9]+\.[0-9]x\]/[PARALLELISM]/'
+  > | grep -a -E -o "\[[0-9]+\.[0-9]s\] \[[0-9]+\.[0-9]x\] \[2\]" \
+  > | sed -E 's/\[[0-9]+\.[0-9]s\]/[BUILD DURATION]/; s/\[[0-9]+\.[0-9]x\]/[PARALLELISM]/' \
+  > | awk 'NR == 1'
   [BUILD DURATION] [PARALLELISM] [2]
 
   $ stop_dune_quiet
@@ -65,18 +67,19 @@ count while their temporary RPC server is running.
   $ with_timeout dune_cmd wait-for-file-to-appear "$CLIENT_CONNECTED"
   $ i=200
   $ while [ "$i" != 0 ]; do
-  >   tr '\r' '\n' < batch-output | grep -a -q "\[rpc 1\]" && break
+  >   tr '\r' '\n' < batch-output | grep -a "\[rpc 1\]" >/dev/null && break
   >   i=$((i - 1))
   >   sleep 0.01
   > done
-  $ tr '\r' '\n' < batch-output | grep -a -m 1 -o "\[rpc 1\]"
+  $ tr '\r' '\n' < batch-output | grep -a -o "\[rpc 1\]" | awk 'NR == 1'
   [rpc 1]
   $ tr '\r' '\n' < batch-output \
-  > | grep -a -E -m 1 -o "\[[0-9]+\.[0-9]s\] \[[0-9]+\.[0-9]x\]" \
-  > | sed -E 's/\[[0-9]+\.[0-9]s\]/[BUILD DURATION]/; s/\[[0-9]+\.[0-9]x\]/[PARALLELISM]/'
+  > | grep -a -E -o "\[[0-9]+\.[0-9]s\] \[[0-9]+\.[0-9]x\]" \
+  > | sed -E 's/\[[0-9]+\.[0-9]s\]/[BUILD DURATION]/; s/\[[0-9]+\.[0-9]x\]/[PARALLELISM]/' \
+  > | awk 'NR == 1'
   [BUILD DURATION] [PARALLELISM]
   $ if tr '\r' '\n' < batch-output \
-  > | grep -a -E -q "\[[0-9]+\.[0-9]s\] \[[0-9]+\.[0-9]x\] \[[0-9]+\]"; then
+  > | grep -a -E "\[[0-9]+\.[0-9]s\] \[[0-9]+\.[0-9]x\] \[[0-9]+\]" >/dev/null; then
   >   echo "batch timing unexpectedly included a watch run"
   > else
   >   echo "batch timing has no watch run"


### PR DESCRIPTION
Cram tests run with `pipefail`, and `grep -m 1` or `grep -q` could exit while `tr` was still writing. Depending on output size and scheduling, `tr` then exited with SIGPIPE (141), making `rpc-build-status-line.t` flaky.

Let the affected `grep` processes consume their entire streams and select the first output afterward. This preserves the assertions while avoiding SIGPIPE.