### PR TITLE
refactor(engine): cache anonymous actions without target files

### DIFF
--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -47,6 +47,7 @@ let rec encode_action : Action.For_shell.t -> Dune_lang.t =
   let path = Encoder.string in
   let target = Encoder.string in
   function
+  | Anonymous _ -> Code_error.raise "cannot print an internal anonymous action" []
   | Run { prog; args; can_run_in_action_runner = _ } ->
     List (atom "run" :: program prog :: List.map (Appendable_list.to_list args) ~f:string)
   | With_accepted_exit_codes (pred, t) ->

--- a/src/dune_digest/digest.ml
+++ b/src/dune_digest/digest.ml
@@ -6,6 +6,8 @@ module T = struct
   let to_string = Blake3_mini.Digest.to_hex
   let to_dyn s = Dyn.variant "digest" [ String (to_string s) ]
   let compare x y = Ordering.of_int (Blake3_mini.Digest.compare x y)
+  let equal = Blake3_mini.Digest.equal
+  let hash = Blake3_mini.Digest.hash
 end
 
 include T
@@ -116,8 +118,6 @@ let file_async =
       digest)
 ;;
 
-let equal = Blake3_mini.Digest.equal
-let hash = Blake3_mini.Digest.hash
 let file p = file (Path.to_string p)
 let file_async p = file_async (Path.to_string p)
 let from_hex s = Blake3_mini.Digest.of_hex s
@@ -523,3 +523,5 @@ let file_with_executable_bit ~executable path =
   let+ content_digest = file_async path in
   path_with_executable_bit ~content_digest ~executable
 ;;
+
+module Table = Hashtbl.Make (T)

--- a/src/dune_digest/digest.mli
+++ b/src/dune_digest/digest.mli
@@ -74,6 +74,8 @@ module Stats_for_digest : sig
   val of_time_stat : Stat.t -> t
 end
 
+module Table : Hashtbl.S with type key = t
+
 module Path_digest_error : sig
   type nonrec t =
     | Unexpected_kind

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -59,6 +59,7 @@ struct
   let rename a b = Rename (a, b)
   let remove_tree path = Remove_tree path
   let mkdir path = Mkdir path
+  let anonymous action digest ~capture_stdout = Anonymous (action, digest, capture_stdout)
 
   let diff
         ?(optional = false)
@@ -308,12 +309,18 @@ let digest =
     | System command ->
       int d 22;
       string d command
+    | Anonymous (t, digest, capture_stdout) ->
+      int d 23;
+      string d (Digest.to_string_raw digest);
+      bool d capture_stdout;
+      loop d t ~dir
   in
   fun d t -> loop d t ~dir:Path.root
 ;;
 
 let fold_one_step t ~init:acc ~f =
   match t with
+  | Anonymous (t, _, _)
   | Chdir (_, t)
   | Setenv (_, _, t)
   | Redirect_out (_, _, _, t)
@@ -360,6 +367,7 @@ let chdirs =
 let empty = Progn []
 
 let rec is_dynamic = function
+  | Anonymous (t, _, _)
   | Chdir (_, t)
   | Setenv (_, _, t)
   | Redirect_out (_, _, _, t)
@@ -384,6 +392,7 @@ let rec is_dynamic = function
 ;;
 
 let rec runs_process = function
+  | Anonymous (t, _, _)
   | Chdir (_, t)
   | Setenv (_, _, t)
   | Redirect_out (_, _, _, t)
@@ -435,7 +444,7 @@ type is_useful =
 let is_useful_to memoize =
   let rec loop t =
     match t with
-    | Chdir (_, t) -> loop t
+    | Anonymous (t, _, _) | Chdir (_, t) -> loop t
     | Setenv (_, _, t) -> loop t
     | Redirect_out (_, _, _, t) -> memoize || loop t
     | Redirect_in (_, _, t) -> loop t

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -96,6 +96,26 @@ let zero = Predicate_lang.element 0
 
 let rec exec t ~ectx ~eenv : Done_or_more_deps.t Fiber.t =
   match (t : Action.t) with
+  | Anonymous (t, digest, capture_stdout) ->
+    let* result, contents =
+      if capture_stdout
+      then (
+        let stdout_to, read = Process.Io.capture () in
+        let execute () =
+          Fiber.finalize
+            (fun () -> exec t ~ectx ~eenv:{ eenv with stdout_to })
+            ~finally:(fun () ->
+              Process.Io.release stdout_to;
+              Fiber.return ())
+        in
+        let+ contents, result = Fiber.fork_and_join read execute in
+        result, contents)
+      else
+        let+ result = exec t ~ectx ~eenv in
+        result, ""
+    in
+    Workspace_cache.Anonymous.write digest contents;
+    Fiber.return result
   | Run { prog = Error e; args = _; can_run_in_action_runner = _ } ->
     Action.Prog.Not_found.raise e
   | Run { prog = Ok prog; args; can_run_in_action_runner } ->
@@ -344,9 +364,14 @@ let exec
       ~build_deps
   =
   let ectx =
-    let metadata =
-      Process_metadata.create ~purpose:(Process_metadata.Build_job targets) ()
+    let purpose =
+      match t with
+      | Anonymous _ ->
+        let context = Option.value_exn context in
+        Process_metadata.Anonymous_job context.name
+      | _ -> Process_metadata.Build_job targets
     in
+    let metadata = Process_metadata.create ~purpose () in
     { targets; metadata; context; rule_loc; build_deps }
   and eenv =
     let env =

--- a/src/dune_engine/action_intf.ml
+++ b/src/dune_engine/action_intf.ml
@@ -62,6 +62,7 @@ module type Ast = sig
     | Mkdir of target
     | Pipe of Outputs.t * t list
     | Diff of (path, target) Diff.t
+    | Anonymous of t * Digest.t * bool
     | Extension of ext
 end
 
@@ -94,6 +95,7 @@ module type Helpers = sig
   val rename : target -> target -> t
   val remove_tree : target -> t
   val mkdir : target -> t
+  val anonymous : t -> Digest.t -> capture_stdout:bool -> t
 
   val diff
     :  ?optional:bool

--- a/src/dune_engine/action_mapper.ml
+++ b/src/dune_engine/action_mapper.ml
@@ -28,6 +28,7 @@ module Make (Src : Action_intf.Ast) (Dst : Action_intf.Ast) = struct
     | Redirect_out (outputs, fn, perm, t) ->
       Redirect_out (outputs, f_target ~dir fn, perm, f t ~dir)
     | Redirect_in (inputs, fn, t) -> Redirect_in (inputs, f_path ~dir fn, f t ~dir)
+    | Anonymous (t, digest, capture_stdout) -> Anonymous (f t ~dir, digest, capture_stdout)
     | Ignore (outputs, t) -> Ignore (outputs, f t ~dir)
     | Progn l -> Progn (List.map l ~f:(fun t -> f t ~dir))
     | Concurrent l -> Concurrent (List.map l ~f:(fun t -> f t ~dir))

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -317,7 +317,7 @@ module Internal = struct
   type rule_kind =
     | Normal_rule
     | Anonymous_action of
-        { stamp_file : Path.Build.t
+        { digest : Digest.t
         ; capture_stdout : bool
         }
 
@@ -426,16 +426,12 @@ module Internal = struct
       let is_sandboxed = Sandbox.is_sandboxed sandbox in
       let action = if is_sandboxed then Action.sandbox action sandbox else action in
       let action =
-        (* We must add the creation of the stamp file after sandboxing it, as
-           otherwise the stamp file would end up inside the sandbox. This is
-           especially a problem for the [Patch_back_source_tree] sandboxing
-           mode. *)
+        (* The wrapper records the anonymous action's result in the workspace cache,
+           rather than producing a target in the sandbox. *)
         match rule_kind with
         | Normal_rule -> action
-        | Anonymous_action { stamp_file; capture_stdout; _ } ->
-          if capture_stdout
-          then Action.with_stdout_to stamp_file action
-          else Action.progn [ action; Action.write_file stamp_file "" ]
+        | Anonymous_action { digest; capture_stdout } ->
+          Action.anonymous action digest ~capture_stdout
       in
       let () =
         Action.chdirs action
@@ -448,6 +444,11 @@ module Internal = struct
         | Some context -> context.build_dir
       in
       let root = Path.build (Sandbox.map_path sandbox root) in
+      let exec_targets =
+        match rule_kind with
+        | Normal_rule -> Some targets
+        | Anonymous_action _ -> None
+      in
       let action_trace = Action_trace.create rule_digest in
       with_locks locks ~f:(fun () ->
         let* action_exec_result =
@@ -456,7 +457,7 @@ module Internal = struct
             { Action_exec.root
             ; context (* can be derived from the root *)
             ; env
-            ; targets = Some targets
+            ; targets = exec_targets
             ; rule_loc = loc
             ; execution_parameters
             ; action
@@ -468,17 +469,9 @@ module Internal = struct
         let* action_exec_result = Action_exec.Exec_result.ok_exn action_exec_result in
         let* () = Action_trace.collect action_trace in
         let+ () =
-          if not is_sandboxed
-          then Fiber.return ()
-          else (
-            (* The stamp file for anonymous actions is always created outside
-               the sandbox, so we can't move it. *)
-            let should_be_skipped =
-              match rule_kind with
-              | Normal_rule -> fun (_ : Path.Build.t) -> false
-              | Anonymous_action { stamp_file; _ } -> Path.Build.equal stamp_file
-            in
-            Sandbox.move_targets_to_build_dir sandbox ~should_be_skipped ~targets)
+          if is_sandboxed
+          then Sandbox.move_targets_to_build_dir sandbox ~targets
+          else Fiber.return ()
         in
         match Targets.Produced.of_validated targets with
         | Ok produced_targets -> { Exec_result.produced_targets; action_exec_result }
@@ -514,7 +507,6 @@ module Internal = struct
 
   and execute_rule_impl ~rule_kind rule =
     let { Rule.id = _; targets; mode; action; info } = rule in
-    let head_target = Targets.Validated.head targets in
     let* execution_parameters =
       match Dpath.Target_dir.of_target targets.root with
       | Regular (With_context (context, _)) | Anonymous_action (With_context (context, _))
@@ -582,115 +574,141 @@ module Internal = struct
       let rule_digest =
         compute_rule_digest rule ~facts ~action ~sandbox_mode ~execution_parameters
       in
-      let can_go_in_shared_cache =
-        action.can_go_in_shared_cache
-        && (not
-              (always_rerun
-               || is_action_dynamic
-               || Action.is_useful_to_memoize action.action = Clearly_not))
-        &&
-        match sandbox_mode with
-        | Some Patch_back_source_tree ->
-          (* Action in this mode cannot go in the shared cache *)
-          false
-        | _ -> true
-      in
-      let* (produced_targets : Digest.t Targets.Produced.t) =
-        (* Step I. Check if the workspace-local cache is up to date. *)
-        Rule_cache.Workspace_local.lookup
-          ~always_rerun
+      let execute_action ~loc =
+        execute_action_for_rule
+          ~rule_kind
           ~rule_digest
+          ~action
+          ~facts
+          ~loc
+          ~execution_parameters
+          ~sandbox_mode
           ~targets
-          ~env:action.env
-          ~build_deps
-        >>= function
-        | Some produced_targets -> Fiber.return produced_targets
-        | None ->
-          (* Step II. Remove stale targets both from the digest table and from
-             the build directory. *)
-          Rule_cache.Workspace_local.remove targets;
-          let () =
-            let remove_target_dir dir =
-              let () = Rule_cache.Workspace_local.remove_subtree dir in
-              Path.rm_rf (Path.build dir)
-            in
-            let remove_target_file path =
-              match Fpath.unlink (Path.Build.to_string path) with
-              | Success -> ()
-              | Does_not_exist -> ()
-              | Is_a_directory ->
-                (* If target changed from a directory to a file, delete
-                     in anyway. *)
-                remove_target_dir path
-              | Error exn ->
-                Log.warn
-                  "Error while removing target"
-                  [ "path", Dyn.string (Path.Build.to_string path)
-                  ; "error", Dyn.string (Printexc.to_string exn)
-                  ]
-            in
-            Targets.Validated.iter targets ~file:remove_target_file ~dir:remove_target_dir
+      in
+      let dynamic_deps_stages (exec_result : Exec_result.t) =
+        List.map
+          exec_result.action_exec_result.dynamic_deps_stages
+          ~f:(fun (deps, fact_map) ->
+            ( deps
+            , let digest = Digest.Manual.create () in
+              Dep.Facts.digest fact_map digest ~env:action.env;
+              Digest.Manual.get digest ))
+      in
+      let empty_targets () : Digest.t Targets.Produced.t =
+        Targets.Produced.of_files targets.root Path.Local.Map.empty
+      in
+      let* produced_targets =
+        match rule_kind with
+        | Anonymous_action { digest; capture_stdout = _ } ->
+          let* hit =
+            Rule_cache.Anonymous.lookup
+              ~always_rerun
+              ~digest
+              ~rule_digest
+              ~env:action.env
+              ~build_deps
           in
-          let* produced_targets, dynamic_deps_stages =
-            (* Step III. Try to restore artifacts from the shared cache. *)
-            Dune_cache.Shared.lookup ~can_go_in_shared_cache ~rule_digest ~targets
-            >>= function
-            | Some produced_targets ->
-              (* Rules with dynamic deps can't be stored to the shared cache
-                 (see the [is_action_dynamic] check above), so we know this is
-                 not a dynamic action, so returning an empty list is correct.
-                 The lack of information to fill in [dynamic_deps_stages] here
-                 is precisely the reason why we don't store dynamic actions in
-                 the shared cache. *)
-              let dynamic_deps_stages = [] in
-              Fiber.return (produced_targets, dynamic_deps_stages)
-            | None ->
-              (* Step IV. Execute the build action. *)
-              let loc = Rule.loc rule in
-              let* exec_result =
-                execute_action_for_rule
-                  ~rule_kind
-                  ~rule_digest
-                  ~action
-                  ~facts
-                  ~loc
-                  ~execution_parameters
-                  ~sandbox_mode
-                  ~targets
-              in
-              (* Step V. Examine produced targets and store them to the shared
-                 cache if needed. *)
-              let* produced_targets =
-                Dune_cache.Shared.examine_targets_and_store
-                  ~can_go_in_shared_cache
-                  ~loc
-                  ~rule_digest
-                  ~should_remove_write_permissions_on_generated_files:
-                    (Execution_parameters
-                     .should_remove_write_permissions_on_generated_files
-                       execution_parameters)
-                  ~produced_targets:exec_result.produced_targets
-              in
-              let dynamic_deps_stages =
-                List.map
-                  exec_result.action_exec_result.dynamic_deps_stages
-                  ~f:(fun (deps, fact_map) ->
-                    ( deps
-                    , let d = Digest.Manual.create () in
-                      Dep.Facts.digest fact_map d ~env:action.env;
-                      Digest.Manual.get d ))
-              in
-              Fiber.return (produced_targets, dynamic_deps_stages)
+          if hit
+          then Fiber.return (empty_targets ())
+          else (
+            let loc = Rule.loc rule in
+            let* exec_result = execute_action ~loc in
+            let dynamic_deps_stages = dynamic_deps_stages exec_result in
+            Rule_cache.Anonymous.store ~digest ~rule_digest ~dynamic_deps_stages;
+            Fiber.return (empty_targets ()))
+        | Normal_rule ->
+          let head_target = Targets.Validated.head targets in
+          let can_go_in_shared_cache =
+            action.can_go_in_shared_cache
+            && (not
+                  (always_rerun
+                   || is_action_dynamic
+                   || Action.is_useful_to_memoize action.action = Clearly_not))
+            &&
+            match sandbox_mode with
+            | Some Patch_back_source_tree ->
+              (* Action in this mode cannot go in the shared cache *)
+              false
+            | _ -> true
           in
-          (* We do not include target names into [targets_digest] because they
-             are already included into the rule digest. *)
-          Rule_cache.Workspace_local.store
-            ~targets:produced_targets
-            ~head_target
+          (* Step I. Check if the workspace-local cache is up to date. *)
+          Rule_cache.Workspace_local.lookup
+            ~always_rerun
             ~rule_digest
-            ~dynamic_deps_stages
-            ~targets_digest:(Targets.Produced.digest produced_targets);
-          Fiber.return produced_targets
+            ~targets
+            ~env:action.env
+            ~build_deps
+          >>= (function
+           | Some produced_targets -> Fiber.return produced_targets
+           | None ->
+             (* Step II. Remove stale targets both from the digest table and from
+                the build directory. *)
+             Rule_cache.Workspace_local.remove targets;
+             let () =
+               let remove_target_dir dir =
+                 let () = Rule_cache.Workspace_local.remove_subtree dir in
+                 Path.rm_rf (Path.build dir)
+               in
+               let remove_target_file path =
+                 match Fpath.unlink (Path.Build.to_string path) with
+                 | Success -> ()
+                 | Does_not_exist -> ()
+                 | Is_a_directory ->
+                   (* If target changed from a directory to a file, delete
+                        in anyway. *)
+                   remove_target_dir path
+                 | Error exn ->
+                   Log.warn
+                     "Error while removing target"
+                     [ "path", Dyn.string (Path.Build.to_string path)
+                     ; "error", Dyn.string (Printexc.to_string exn)
+                     ]
+               in
+               Targets.Validated.iter
+                 targets
+                 ~file:remove_target_file
+                 ~dir:remove_target_dir
+             in
+             let* produced_targets, dynamic_deps_stages =
+               (* Step III. Try to restore artifacts from the shared cache. *)
+               Dune_cache.Shared.lookup ~can_go_in_shared_cache ~rule_digest ~targets
+               >>= function
+               | Some produced_targets ->
+                 (* Rules with dynamic deps can't be stored to the shared cache
+                    (see the [is_action_dynamic] check above), so we know this is
+                    not a dynamic action, so returning an empty list is correct.
+                    The lack of information to fill in [dynamic_deps_stages] here
+                    is precisely the reason why we don't store dynamic actions in
+                    the shared cache. *)
+                 Fiber.return (produced_targets, [])
+               | None ->
+                 (* Step IV. Execute the build action. *)
+                 let loc = Rule.loc rule in
+                 let* exec_result = execute_action ~loc in
+                 (* Step V. Examine produced targets and store them to the shared
+                    cache if needed. *)
+                 let* produced_targets =
+                   Dune_cache.Shared.examine_targets_and_store
+                     ~can_go_in_shared_cache
+                     ~loc
+                     ~rule_digest
+                     ~should_remove_write_permissions_on_generated_files:
+                       (Execution_parameters
+                        .should_remove_write_permissions_on_generated_files
+                          execution_parameters)
+                     ~produced_targets:exec_result.produced_targets
+                 in
+                 Fiber.return (produced_targets, dynamic_deps_stages exec_result)
+             in
+             (* We do not include target names into [targets_digest] because they
+                are already included into the rule digest. *)
+             Rule_cache.Workspace_local.store
+               ~targets:produced_targets
+               ~head_target
+               ~rule_digest
+               ~dynamic_deps_stages
+               ~targets_digest:(Targets.Produced.digest produced_targets);
+             Fiber.return produced_targets)
       in
       let+ () =
         promote_targets
@@ -708,25 +726,16 @@ module Internal = struct
   and execute_action_generic_stage2_impl
         { Anonymous_action.action = { dir; loc; action }; deps; capture_stdout; digest }
     =
-    let target =
-      let dir =
-        Path.Build.append_local Dpath.Build.anonymous_actions_dir (Path.Build.local dir)
-      in
-      Path.Build.relative dir (Digest.to_string digest)
-    in
     let rule =
-      Rule.make
+      Rule.anonymous
         ~info:(if Loc.is_none loc then Internal else From_dune_file loc)
-        ~targets:(Targets.File.create target)
-        ~mode:Standard
+        ~dir
         (Action_builder.record action deps ~f:build_dep)
     in
     let+ { facts = _; targets = _ } =
-      execute_rule_impl
-        rule
-        ~rule_kind:(Anonymous_action { capture_stdout; stamp_file = target })
+      execute_rule_impl rule ~rule_kind:(Anonymous_action { capture_stdout; digest })
     in
-    if capture_stdout then Io.read_file (Path.build target) else ""
+    Workspace_cache.Anonymous.read digest
 
   and execute_action_generic
         ~observing_facts
@@ -735,19 +744,17 @@ module Internal = struct
     =
     (* We memoize the execution of anonymous actions, both via the persistent
        mechanism for not re-running build rules between invocations of [dune
-       build] and via [Memo]. The former is done by producing a normal build
-       rule on the fly for the anonymous action.
+       build] and via [Memo]. The former stores the action result directly in
+       the workspace cache.
 
        Memoizing such actions via [Memo] doesn't feel super useful given that we
        expect a given anonymous action to be executed only once in a given
-       build. And so persistent mechanism should be enough.
+       build. And so the persistent mechanism should be enough.
 
        However, if it does happen that two code paths try to execute the same
-       anonymous action, then we need to be sure it is not executed twice. This
-       is because the build rule we produce on the fly creates a file whose name
-       only depend on the action. If the two execution could run concurrently,
-       then they would both try to create the same file. So in this regard, we
-       use [Memo] mostly for synchronisation purposes. *)
+       anonymous action, then we need to be sure it is not executed twice and
+       that they share the same cache entry. In this regard, we use [Memo]
+       mostly for synchronisation purposes. *)
     (* Here we "forget" the facts about the world. We do that to make the input
        of the memoized function smaller. If we passed the whole [original_facts]
        as input, then we would end up memoizing one entry per set of facts. This
@@ -794,9 +801,9 @@ module Internal = struct
     (* It might seem superfluous to memoize the execution here, given that a
        given anonymous action will typically only appear once during a given
        build. However, it is possible that two code paths try to execute the
-       exact same anonymous action, and so would end up trying to create the
-       same file. Using [Memo.create] serves as a synchronisation point to share
-       the execution and avoid such a race condition. *)
+       exact same anonymous action. Using [Memo.create] serves as a
+       synchronisation point to share the execution and avoid such a race
+       condition. *)
     Memo.exec
       (Lazy.force execute_action_generic_stage2_memo)
       { Anonymous_action.action = act; deps; capture_stdout; digest }

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -82,6 +82,7 @@ module Io = struct
         { path : Path.t
         ; perm : Permissions.Mode.t
         }
+    | Capture
     | Null
       (* This argument make no sense for inputs, but it seems annoying to
          change, especially as this code is meant to change again in #4435. *)
@@ -183,6 +184,26 @@ module Io = struct
     { kind = File { path = fn; perm }; fd; channel; status = Close_after_exec }
   ;;
 
+  let capture () =
+    let input_fd, output_fd = Unix.pipe ~cloexec:true () in
+    let output_fd = Fd.unsafe_of_unix_file_descr output_fd in
+    let output =
+      { kind = Capture
+      ; fd = lazy output_fd
+      ; channel = lazy (channel_of_descr output_fd Out)
+      ; status = Close_after_exec
+      }
+    in
+    let read () =
+      Scheduler.async_exn (fun () ->
+        let input_channel = Unix.in_channel_of_descr input_fd in
+        Exn.protect
+          ~f:(fun () -> In_channel.input_all input_channel)
+          ~finally:(fun () -> close_in input_channel))
+    in
+    output, read
+  ;;
+
   let flush : type a. a t -> unit =
     fun t ->
     if Lazy.is_val t.channel
@@ -264,7 +285,7 @@ let io_to_redirection_path (kind : Io.kind) =
   | Terminal _ -> None
   | Null -> Some (Path.to_string Dev_null.path)
   | File { path; _ } -> Some (Path.to_string path)
-  | External -> None
+  | Capture | External -> None
 ;;
 
 let command_line_enclosers
@@ -281,7 +302,7 @@ let command_line_enclosers
   in
   let suffix =
     match stdin_from.kind with
-    | Null | Terminal _ | External -> suffix
+    | Null | Terminal _ | Capture | External -> suffix
     | File { path; _ } -> suffix ^ " < " ^ quote path
   in
   let suffix =
@@ -397,6 +418,17 @@ module Exit_status = Dune_trace.Event.Exit_status
 module Short_display = struct
   let pp_purpose = function
     | Process_metadata.Internal_job -> Pp.verbatim "(internal)"
+    | Process_metadata.Anonymous_job context ->
+      let pp = Pp.verbatim "(anonymous)" in
+      if Context_name.is_default context
+      then pp
+      else
+        let open Pp.O in
+        pp
+        ++ Pp.char ' '
+        ++ Pp.tag
+             User_message.Style.Details
+             (Pp.char '[' ++ Pp.verbatim (Context_name.to_string context) ++ Pp.char ']')
     | Process_metadata.Build_job targets ->
       let rec split_paths targets_acc ctxs_acc = function
         | [] -> List.rev targets_acc, Context_name.Set.to_list ctxs_acc
@@ -653,7 +685,7 @@ module Handle_exit_status = struct
       in
       let paragraphs =
         match verbosity, purpose, output with
-        | Short, Process_metadata.Build_job _, _
+        | Short, (Process_metadata.Build_job _ | Anonymous_job _), _
         | Short, Process_metadata.Internal_job, Has_output _ ->
           Short_display.pp_ok ~prog ~purpose :: paragraphs
         | _ -> paragraphs
@@ -819,8 +851,7 @@ end
 
 let targets_of_purpose (purpose : Process_metadata.purpose) =
   match purpose with
-  | Process_metadata.Internal_job -> None
-  | Build_job None -> None
+  | Process_metadata.Internal_job | Anonymous_job _ | Build_job None -> None
   | Build_job (Some { dirs; files; root }) -> Some { Dune_trace.Event.root; dirs; files }
 ;;
 
@@ -1039,13 +1070,14 @@ let runner_input_of_io (io : Io.input Io.t) =
   | Null -> Some Process_runner.Input.Null
   | Terminal _ -> Some Process_runner.Input.Terminal
   | File { path; _ } -> Some (Process_runner.Input.File path)
-  | External -> None
+  | Capture | External -> None
 ;;
 
 let runner_output_of_io (io : Io.output Io.t) =
   match io.kind with
   | Null -> Some Process_runner.Output.Null
   | Terminal _ -> Some Process_runner.Output.Terminal
+  | Capture -> Some Process_runner.Output.Capture
   | File { path; perm } -> Some (Process_runner.Output.File { path; perm })
   | External -> None
 ;;
@@ -1127,22 +1159,22 @@ let exec_locally
     | Terminal -> Io.stdin
     | File path -> Io.file path Io.In
   in
-  let stdout =
-    match stdout_to with
-    | Null -> Io.null Io.Out
-    | Terminal -> Io.stdout
-    | File { path; perm } -> Io.file path Io.Out ~perm
+  let make_output (output : Process_runner.Output.t) ~terminal =
+    match output with
+    | Null -> Io.null Io.Out, None
+    | Terminal -> terminal, None
+    | Capture ->
+      let output, read = Io.capture () in
+      output, Some read
+    | File { path; perm } -> Io.file path Io.Out ~perm, None
   in
-  let stderr =
+  let stdout, read_stdout = make_output stdout_to ~terminal:Io.stdout in
+  let stderr, read_stderr =
     let stderr_to : Process_runner.Stderr.t = stderr_to in
     let open Process_runner.Stderr in
     match stderr_to with
-    | Same_as_stdout -> stdout
-    | Output (out : Process_runner.Output.t) ->
-      (match out with
-       | Null -> Io.null Io.Out
-       | Terminal -> Io.stderr
-       | File { path; perm } -> Io.file path Io.Out ~perm)
+    | Same_as_stdout -> stdout, None
+    | Output output -> make_output output ~terminal:Io.stderr
   in
   let prepared_outputs =
     { stdout_on_success = Io.output_on_success stdout
@@ -1155,40 +1187,60 @@ let exec_locally
     ; stderr
     }
   in
-  Fiber.finalize
-    (fun () ->
-       let t =
-         spawn
-           ?dir
-           ~env
-           ~emit_trace:false
-           ~prepared_outputs
-           ~stdin
-           ~queued
-           ~setpgid:
-             (if create_process_group then Some Spawn.Pgid.new_process_group else None)
-           ~prog
-           ~args
-           ~metadata
-           ~timeout
-           ()
-       in
-       let { Build.cancellation; _ } = build in
-       let+ process_info, termination_reason = await ~cancellation ~timeout t in
-       let times =
-         { Proc.Times.elapsed_time = Time.diff process_info.end_time t.started_at
-         ; resource_usage = process_info.resource_usage
-         }
-       in
-       { Process_runner.started_at = t.started_at
-       ; process_info
-       ; termination_reason
-       ; times
-       ; trace_args = []
-       })
-    ~finally:(fun () ->
-      Io.release stdin;
-      Fiber.return ())
+  let execute () =
+    Fiber.finalize
+      (fun () ->
+         let t =
+           spawn
+             ?dir
+             ~env
+             ~emit_trace:false
+             ~prepared_outputs
+             ~stdin
+             ~queued
+             ~setpgid:
+               (if create_process_group then Some Spawn.Pgid.new_process_group else None)
+             ~prog
+             ~args
+             ~metadata
+             ~timeout
+             ()
+         in
+         let { Build.cancellation; _ } = build in
+         let+ process_info, termination_reason = await ~cancellation ~timeout t in
+         let times =
+           { Proc.Times.elapsed_time = Time.diff process_info.end_time t.started_at
+           ; resource_usage = process_info.resource_usage
+           }
+         in
+         t.started_at, process_info, termination_reason, times)
+      ~finally:(fun () ->
+        Io.release stdin;
+        Io.release stdout;
+        Io.release stderr;
+        Fiber.return ())
+  in
+  let read = function
+    | None -> Fiber.return None
+    | Some read ->
+      let+ output = read () in
+      Some output
+  in
+  let* (stdout, stderr), (started_at, process_info, termination_reason, times) =
+    Fiber.fork_and_join
+      (fun () ->
+         Fiber.fork_and_join (fun () -> read read_stdout) (fun () -> read read_stderr))
+      execute
+  in
+  Fiber.return
+    { Process_runner.started_at
+    ; process_info
+    ; termination_reason
+    ; times
+    ; stdout
+    ; stderr
+    ; trace_args = []
+    }
 ;;
 
 let run_internal
@@ -1265,6 +1317,7 @@ let run_internal
         let description =
           match metadata.Process_metadata.purpose with
           | Process_metadata.Internal_job -> Pp.text "(internal)"
+          | Process_metadata.Anonymous_job _ -> Pp.text "(anonymous)"
           | Process_metadata.Build_job None -> Pp.text "(no targets)"
           | Process_metadata.Build_job (Some target) ->
             Targets.Validated.head target
@@ -1303,20 +1356,42 @@ let run_internal
            (match Build.action_runner build with
             | None -> local ()
             | Some action_runner ->
-              Io.release prepared_outputs.stdout;
-              Io.release prepared_outputs.stderr;
-              let+ { Process_runner.started_at
+              let release_before_runner (output : Io.output Io.t) =
+                match output.kind with
+                | Capture -> ()
+                | File _ | Null | Terminal _ | External -> Io.release output
+              in
+              release_before_runner prepared_outputs.stdout;
+              release_before_runner prepared_outputs.stderr;
+              let execute () =
+                let+ response =
+                  Action_runner.exec_process
+                    action_runner
+                    ~run_id:(Build.run_id build)
+                    ~cancellation:(Build.cancellation build)
+                    request
+                in
+                let write output = function
+                  | None -> ()
+                  | Some contents -> output_string (Io.out_channel output) contents
+                in
+                write prepared_outputs.stdout response.stdout;
+                write prepared_outputs.stderr response.stderr;
+                response
+              in
+              let* { Process_runner.started_at
                    ; process_info
                    ; termination_reason
                    ; times
+                   ; stdout = _
+                   ; stderr = _
                    ; trace_args
                    }
                 =
-                Action_runner.exec_process
-                  action_runner
-                  ~run_id:(Build.run_id build)
-                  ~cancellation:(Build.cancellation build)
-                  request
+                Fiber.finalize execute ~finally:(fun () ->
+                  Io.release prepared_outputs.stdout;
+                  Io.release prepared_outputs.stderr;
+                  Fiber.return ())
               in
               let dummy_process =
                 { started_at
@@ -1331,12 +1406,13 @@ let run_internal
                 ; stderr_limit = prepared_outputs.stderr_limit
                 }
               in
-              ( dummy_process
-              , process_info
-              , termination_reason
-              , times
-              , Some started_at
-              , trace_args ))
+              Fiber.return
+                ( dummy_process
+                , process_info
+                , termination_reason
+                , times
+                , Some started_at
+                , trace_args ))
          | None -> local ())
       | None -> local ()
     in

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -58,6 +58,10 @@ module Io : sig
       [clone]. *)
   val file : Path.t -> ?perm:Permissions.Mode.t -> 'a mode -> 'a t
 
+  (** Capture output in memory. The reader must run concurrently with any writer to avoid
+      filling the underlying pipe. *)
+  val capture : unit -> output t * (unit -> string Fiber.t)
+
   (** Call this when you no longer need this redirection *)
   val release : 'a t -> unit
 

--- a/src/dune_engine/process_metadata.ml
+++ b/src/dune_engine/process_metadata.ml
@@ -3,6 +3,7 @@ open Import
 type purpose =
   | Internal_job
   | Build_job of Targets.Validated.t option
+  | Anonymous_job of Context_name.t
 
 type t =
   { loc : Loc.t option

--- a/src/dune_engine/process_metadata.mli
+++ b/src/dune_engine/process_metadata.mli
@@ -3,6 +3,7 @@ open Import
 type purpose =
   | Internal_job
   | Build_job of Targets.Validated.t option
+  | Anonymous_job of Context_name.t
 
 type t =
   { loc : Loc.t option

--- a/src/dune_engine/process_runner.ml
+++ b/src/dune_engine/process_runner.ml
@@ -11,6 +11,7 @@ module Output = struct
   type t =
     | Null
     | Terminal
+    | Capture
     | File of
         { path : Path.t
         ; perm : Permissions.Mode.t
@@ -42,5 +43,7 @@ type response =
   ; process_info : Proc.Process_info.t
   ; termination_reason : Scheduler.termination_reason
   ; times : Proc.Times.t
+  ; stdout : string option
+  ; stderr : string option
   ; trace_args : (string * Sexp.t) list
   }

--- a/src/dune_engine/process_runner.mli
+++ b/src/dune_engine/process_runner.mli
@@ -11,6 +11,7 @@ module Output : sig
   type t =
     | Null
     | Terminal
+    | Capture
     | File of
         { path : Path.t
         ; perm : Permissions.Mode.t
@@ -45,6 +46,8 @@ type response =
   ; process_info : Proc.Process_info.t
   ; termination_reason : Scheduler.termination_reason
   ; times : Proc.Times.t
+  ; stdout : string option
+  ; stderr : string option
   ; trace_args : (string * Sexp.t) list
     (** Extra fields to append to the parent-owned process trace events. *)
   }

--- a/src/dune_engine/rule.ml
+++ b/src/dune_engine/rule.ml
@@ -128,6 +128,12 @@ let make ?(mode = Mode.Standard) ?(info = Info.Internal) ~targets action =
   { id = Id.gen (); targets; action; mode; info }
 ;;
 
+let anonymous ?(info = Info.Internal) ~dir action =
+  let action = Action_builder.memoize "Rule.anonymous" action in
+  let targets = Targets.Validated.empty ~root:dir in
+  { id = Id.gen (); targets; action; mode = Mode.Standard; info }
+;;
+
 let set_action t action =
   let action = Action_builder.memoize "Rule.set_action" action in
   { t with action }

--- a/src/dune_engine/rule.mli
+++ b/src/dune_engine/rule.mli
@@ -75,6 +75,9 @@ val make
   -> Action.Full.t Action_builder.t
   -> t
 
+(** Construct a targetless rule for an anonymous action. *)
+val anonymous : ?info:Info.t -> dir:Path.Build.t -> Action.Full.t Action_builder.t -> t
+
 val set_action : t -> Action.Full.t Action_builder.t -> t
 val loc : t -> Loc.t
 

--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -1,6 +1,22 @@
 open Import
 open Dune_cache.Hit_or_miss
 
+let rec dynamic_deps_unchanged stages ~env ~build_deps =
+  match stages with
+  | [] -> Fiber.return true
+  | (deps, old_digest) :: rest ->
+    let open Fiber.O in
+    let* deps = Memo.run (build_deps deps) in
+    let new_digest =
+      let digest = Digest.Manual.create () in
+      Dep.Facts.digest deps digest ~env;
+      Digest.Manual.get digest
+    in
+    if Digest.equal old_digest new_digest
+    then dynamic_deps_unchanged rest ~env ~build_deps
+    else Fiber.return false
+;;
+
 module Workspace_local = struct
   (* Stores information for deciding if a rule needs to be re-executed. *)
   module Database = struct
@@ -173,22 +189,11 @@ module Workspace_local = struct
          we still re-run all the previous stages, which is a bit of a waste. We
          could remember what stage needs re-running and only re-run that (and
          later stages). *)
-      let rec loop stages =
-        match stages with
-        | [] -> Fiber.return (Hit produced_targets)
-        | (deps, old_digest) :: rest ->
-          let open Fiber.O in
-          let* deps = Memo.run (build_deps deps) in
-          let new_digest =
-            let d = Digest.Manual.create () in
-            Dep.Facts.digest deps d ~env;
-            Digest.Manual.get d
-          in
-          if Digest.equal old_digest new_digest
-          then loop rest
-          else Fiber.return (Miss Miss_reason.Dynamic_deps_changed)
+      let open Fiber.O in
+      let+ unchanged =
+        dynamic_deps_unchanged prev_trace.dynamic_deps_stages ~env ~build_deps
       in
-      loop prev_trace.dynamic_deps_stages
+      if unchanged then Hit produced_targets else Miss Miss_reason.Dynamic_deps_changed
   ;;
 
   let lookup ~always_rerun ~rule_digest ~targets ~env ~build_deps
@@ -220,4 +225,26 @@ module Workspace_local = struct
   let remove targets = Database.remove targets
   let remove_target = Database.remove_target
   let remove_subtree = Database.remove_subtree
+end
+
+module Anonymous = struct
+  let lookup ~always_rerun ~digest ~rule_digest ~env ~build_deps =
+    if always_rerun
+    then Fiber.return false
+    else (
+      match Workspace_cache.Anonymous.find_entry digest with
+      | None -> Fiber.return false
+      | Some entry ->
+        if
+          (not (Digest.equal entry.rule_digest rule_digest))
+          || not (Workspace_cache.Anonymous.has_result digest)
+        then Fiber.return false
+        else dynamic_deps_unchanged entry.dynamic_deps_stages ~env ~build_deps)
+  ;;
+
+  let store ~digest ~rule_digest ~dynamic_deps_stages =
+    Workspace_cache.Anonymous.set_entry
+      digest
+      { Workspace_cache.Anonymous.Entry.rule_digest; dynamic_deps_stages }
+  ;;
 end

--- a/src/dune_engine/rule_cache.mli
+++ b/src/dune_engine/rule_cache.mli
@@ -35,3 +35,19 @@ module Workspace_local : sig
   val remove_target : Path.Build.t -> unit
   val remove_subtree : Path.Build.t -> unit
 end
+
+module Anonymous : sig
+  val lookup
+    :  always_rerun:bool
+    -> digest:Digest.t
+    -> rule_digest:Digest.t
+    -> env:Env.t
+    -> build_deps:(Dep.Set.t -> Dep.Facts.t Memo.t)
+    -> bool Fiber.t
+
+  val store
+    :  digest:Digest.t
+    -> rule_digest:Digest.t
+    -> dynamic_deps_stages:(Dep.Set.t * Digest.t) list
+    -> unit
+end

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -428,9 +428,7 @@ let hint_delete_dir =
   ]
 ;;
 
-let move_real_targets_to_build_dir t ~should_be_skipped ~(targets : Targets.Validated.t)
-  : unit Fiber.t
-  =
+let move_real_targets_to_build_dir t ~(targets : Targets.Validated.t) : unit Fiber.t =
   let open Fiber.O in
   let start = Time.now () in
   let* () =
@@ -448,9 +446,7 @@ let move_real_targets_to_build_dir t ~should_be_skipped ~(targets : Targets.Vali
   let () =
     Targets.Validated.iter
       targets
-      ~file:(fun target ->
-        if not (should_be_skipped target)
-        then rename_optional_file ~src:(map_real_path t target) ~dst:target)
+      ~file:(fun target -> rename_optional_file ~src:(map_real_path t target) ~dst:target)
       ~dir:(fun target ->
         let src_dir = map_real_path t target in
         (match Path.Untracked.stat (Path.build target) with
@@ -481,10 +477,10 @@ let move_real_targets_to_build_dir t ~should_be_skipped ~(targets : Targets.Vali
     Dune_trace.Event.sandbox `Extract ~start ~stop ~queued:None t.loc ~dir:t.dir)
 ;;
 
-let move_targets_to_build_dir t ~should_be_skipped ~(targets : Targets.Validated.t) =
+let move_targets_to_build_dir t ~(targets : Targets.Validated.t) =
   match t with
   | No_sandbox _ -> Fiber.return ()
-  | Sandboxed t -> move_real_targets_to_build_dir t ~should_be_skipped ~targets
+  | Sandboxed t -> move_real_targets_to_build_dir t ~targets
 ;;
 
 let failed_to_delete_sandbox dir reason =

--- a/src/dune_engine/sandbox.mli
+++ b/src/dune_engine/sandbox.mli
@@ -30,12 +30,7 @@ val with_
   -> f:(t -> 'a Fiber.t)
   -> 'a Fiber.t
 
-(** Move all targets created by the action from the sandbox to the build
-    directory, skipping the files for which [should_be_skipped] returns [true].
+(** Move all targets created by the action from the sandbox to the build directory.
 
     Expands [targets] with the set of files discovered in directory targets. *)
-val move_targets_to_build_dir
-  :  t
-  -> should_be_skipped:(Path.Build.t -> bool)
-  -> targets:Targets.Validated.t
-  -> unit Fiber.t
+val move_targets_to_build_dir : t -> targets:Targets.Validated.t -> unit Fiber.t

--- a/src/dune_engine/workspace_cache.ml
+++ b/src/dune_engine/workspace_cache.ml
@@ -230,9 +230,51 @@ module Rule_cache = struct
   ;;
 end
 
+module Anonymous_cache = struct
+  module Entry = struct
+    type t =
+      { rule_digest : Digest.t
+      ; dynamic_deps_stages : (Dep.Set.t * Digest.t) list
+      }
+
+    let repr =
+      Repr.record
+        "anonymous-action-cache-entry"
+        [ Repr.field "rule_digest" digest_repr ~get:(fun t -> t.rule_digest)
+        ; Repr.field
+            "dynamic_deps_stages"
+            (Repr.list (Repr.pair (Repr.abstract Dep.Set.to_dyn) digest_repr))
+            ~get:(fun t -> t.dynamic_deps_stages)
+        ]
+    ;;
+  end
+
+  type t =
+    { entries : Entry.t Digest.Table.t
+    ; results : string Digest.Table.t
+    }
+
+  let repr =
+    Repr.record
+      "anonymous-action-cache"
+      [ Repr.field
+          "entries"
+          (Repr.abstract (Digest.Table.to_dyn (Repr.to_dyn Entry.repr)))
+          ~get:(fun t -> t.entries)
+      ; Repr.field
+          "results"
+          (Repr.abstract (Digest.Table.to_dyn Dyn.string))
+          ~get:(fun t -> t.results)
+      ]
+  ;;
+
+  let create () = { entries = Digest.Table.create 128; results = Digest.Table.create 128 }
+end
+
 type t =
   { fs_memo : Fs_memo.t
   ; rule_cache : Rule_cache.t
+  ; anonymous : Anonymous_cache.t
   }
 
 let file = Path.relative Path.build_dir ".db"
@@ -243,6 +285,7 @@ let repr =
     "workspace-cache"
     [ Repr.field "fs_memo" Fs_memo.repr ~get:(fun t -> t.fs_memo)
     ; Repr.field "rule_cache" Rule_cache.repr ~get:(fun t -> t.rule_cache)
+    ; Repr.field "anonymous" Anonymous_cache.repr ~get:(fun t -> t.anonymous)
     ]
 ;;
 
@@ -258,7 +301,12 @@ module P = Persistent.Make (struct
 let cache =
   lazy
     (match P.load file with
-     | None -> { fs_memo = Fs_memo.create (); rule_cache = Rule_cache.create () }, false
+     | None ->
+       ( { fs_memo = Fs_memo.create ()
+         ; rule_cache = Rule_cache.create ()
+         ; anonymous = Anonymous_cache.create ()
+         }
+       , false )
      | Some t -> t, true)
 ;;
 
@@ -277,6 +325,25 @@ let dump () =
         P.dump file (get ());
         Fpath.unlink_no_err (Path.to_string old_digest_file)))
 ;;
+
+module Anonymous = struct
+  module Entry = Anonymous_cache.Entry
+
+  let find_entry digest = Digest.Table.find (get ()).anonymous.entries digest
+
+  let set_entry digest entry =
+    mark_dirty ();
+    Digest.Table.set (get ()).anonymous.entries digest entry
+  ;;
+
+  let read digest = Digest.Table.find_exn (get ()).anonymous.results digest
+  let has_result digest = Digest.Table.mem (get ()).anonymous.results digest
+
+  let write digest result =
+    mark_dirty ();
+    Digest.Table.set (get ()).anonymous.results digest result
+  ;;
+end
 
 let at_exit = At_exit.at_exit Dune_trace.at_exit dump
 let load_fs_memo () = Option.map (P.load file) ~f:(fun t -> t.fs_memo)

--- a/src/dune_engine/workspace_cache.mli
+++ b/src/dune_engine/workspace_cache.mli
@@ -14,6 +14,21 @@ module Dir_contents : sig
     }
 end
 
+module Anonymous : sig
+  module Entry : sig
+    type t =
+      { rule_digest : Digest.t
+      ; dynamic_deps_stages : (Dep.Set.t * Digest.t) list
+      }
+  end
+
+  val find_entry : Digest.t -> Entry.t option
+  val set_entry : Digest.t -> Entry.t -> unit
+  val has_result : Digest.t -> bool
+  val write : Digest.t -> string -> unit
+  val read : Digest.t -> string
+end
+
 module Fs_memo : sig
   module Stats : sig
     type t

--- a/src/dune_targets/dune_targets.ml
+++ b/src/dune_targets/dune_targets.ml
@@ -83,6 +83,8 @@ module Validated = struct
     ; dirs : Filename.Set.t
     }
 
+  let empty ~root = { root; files = Filename.Set.empty; dirs = Filename.Set.empty }
+
   let iter { root; files; dirs } ~file ~dir =
     Filename.Set.iter files ~f:(fun fn -> file (Path.Build.relative_fname root fn));
     Filename.Set.iter dirs ~f:(fun dn -> dir (Path.Build.relative_fname root dn))

--- a/src/dune_targets/dune_targets.mli
+++ b/src/dune_targets/dune_targets.mli
@@ -3,9 +3,9 @@ open Import
 (** A non-validated set of targets of a build rule. *)
 type t
 
-(** The empty set of targets. Note that rules are not allowed to have the empty
-    set of targets, but it is convenient to construct [t] by aggregating several
-    sources of information, for some of which it's OK to be empty. *)
+(** The empty set of targets. Ordinary build rules are not allowed to have an
+    empty target set, but internal anonymous rules are targetless. It is also
+    convenient to construct [t] by aggregating sources that may be empty. *)
 val empty : t
 
 val is_empty : t -> bool
@@ -39,6 +39,9 @@ module Validated : sig
     ; files : Filename.Set.t
     ; dirs : Filename.Set.t
     }
+
+  (** An empty target set for internal actions. *)
+  val empty : root:Path.Build.t -> t
 
   val iter : t -> file:(Path.Build.t -> unit) -> dir:(Path.Build.t -> unit) -> unit
 

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation-ocamlfind.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation-ocamlfind.t
@@ -67,9 +67,6 @@ Dune should be able to find it too
     "prog": "$TESTCASE_ROOT/notocamldep-foo",
     "dir": "_build/default.foo",
     "exit": 0,
-    "target_files": [
-      "_build/.actions/default.foo/$ACTION"
-    ],
     "rusage": [
       "inblock",
       "majflt",
@@ -82,6 +79,10 @@ Dune should be able to find it too
       "user_cpu_time"
     ]
   }
+
+The anonymous action has no target in the trace or on disk.
+
+  $ if [ -d app/_build/.actions ]; then find app/_build/.actions -type f; fi
 
 Library is built in the target context
 

--- a/test/blackbox-tests/test-cases/foreign-stubs/foreign-stubs-caml-headers.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/foreign-stubs-caml-headers.t
@@ -24,12 +24,6 @@ We compile a first time...
   $ dune build _build/default/cstub.o
   $ dune trace cat | jq 'include "dune"; traceTargetFilesRedacted'
   [
-    "_build/.actions/default/<action>"
-  ]
-  [
-    "_build/.actions/default/<action>"
-  ]
-  [
     "_build/default/cstub.o"
   ]
   [

--- a/test/blackbox-tests/test-cases/lib-available.t/run.t
+++ b/test/blackbox-tests/test-cases/lib-available.t/run.t
@@ -3,3 +3,9 @@ Evaluates `%{lib-available:...}` forms in actions.
   $ dune build @runtest --display short --debug-dependency-path 2>&1 | sed "s/ cmd /  sh /"
             sh (anonymous)
             sh (anonymous)
+
+Anonymous actions are cached without creating target files.
+
+  $ if [ -d _build/.actions ]; then find _build/.actions -type f; fi
+
+  $ dune build @runtest

--- a/test/blackbox-tests/test-cases/sandbox/patch-back-source-tree.t
+++ b/test/blackbox-tests/test-cases/sandbox/patch-back-source-tree.t
@@ -301,11 +301,10 @@ inside the source tree:
   $ if test -w x; then echo writable; else echo non-writable; fi
   writable
 
-Reproduction case for copying the action stamp file
----------------------------------------------------
+Anonymous actions with patch-back sandboxing
+--------------------------------------------
 
-There used to be a bug causing the internal action stamp file to be
-produced in the sandbox and copied back:
+Anonymous actions must not add an internal cache target to the source tree:
 
   $ cat >dune<<EOF
   > (rule
@@ -318,15 +317,10 @@ produced in the sandbox and copied back:
   $ dune build @blah
   Hello, world!
 
-The stamp file is kept internal to the build directory: it must not be patched
-back into the source tree, so there is nothing to promote.
+There is nothing to promote, and the anonymous action has no target file.
 
   $ dune promotion list
-
-The stamp itself lives under the build directory, named after its digest:
-
-  $ ls _build/.actions/default/ | dune_cmd subst '[0-9a-f]{32}' 'REDACTED'
-  REDACTED
+  $ if [ -d _build/.actions ]; then find _build/.actions -type f; fi
 
 Patch-back sandboxing with directory targets
 --------------------------------------------

--- a/test/blackbox-tests/test-cases/trace/commands.t
+++ b/test/blackbox-tests/test-cases/trace/commands.t
@@ -31,7 +31,7 @@ Now test the basic trace commands output - it should show commands in shell form
 
 Verify the format is executable by checking it contains cd && pattern:
 
-  $ dune trace commands | grep "cd.*&&.*sh" | dune_cmd subst '[^ ]*/bin/' '' | head -1
+  $ dune trace commands | grep -E 'cd.*&& ([^ ]*/)?sh ' | dune_cmd subst '[^ ]*/bin/' '' | head -1
   (cd _build/default && sh -c "echo 'Hello World' > success.txt")
 
 Test with a failing command to verify stderr output:

--- a/test/blackbox-tests/test-cases/trace/trace-file.t/run.t
+++ b/test/blackbox-tests/test-cases/trace/trace-file.t/run.t
@@ -40,9 +40,6 @@ This captures the commands that are being run:
     "prog": "ocamldep.opt",
     "dir": "_build/default",
     "exit": 0,
-    "target_files": [
-      "_build/.actions/default/$DIGEST"
-    ],
     "rusage": [
       "inblock",
       "majflt",


### PR DESCRIPTION
Anonymous actions previously wrote stamp files and captured stdout under `_build/.actions` solely to participate in caching. This change makes anonymous rules targetless, captures stdout through a pipe, and stores results in a digest-keyed workspace cache.

Captured output is returned through the action-runner protocol, preserving worker execution. Regression coverage checks persistence, sandboxing, process metadata, and the absence of physical anonymous-action targets.