### PR TITLE
fix dune version bound for dune-project's (warnings (duplicate_deps ..))

### DIFF
--- a/doc/changes/fixed/15696.md
+++ b/doc/changes/fixed/15696.md
@@ -1,0 +1,2 @@
+- BREAKING CHANGE: in dune-project, (warnings (duplicate_deps ..)) requires
+  a dune lang version of 3.22, instead of 3.18 (#15696, @v-gb).

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -385,7 +385,7 @@ let missing_project_name =
 
 (* Warn about duplicate dependencies in package definitions *)
 let duplicate_deps =
-  Warning.make ~default:(fun _ -> `Enabled) ~name:"duplicate_deps" ~since:(3, 18)
+  Warning.make ~default:(fun _ -> `Enabled) ~name:"duplicate_deps" ~since:(3, 22)
 ;;
 
 (* To be called once per project, when we are generating the rules for the root

--- a/test/blackbox-tests/test-cases/dune-project-meta/duplicate-dependencies.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/duplicate-dependencies.t
@@ -229,7 +229,7 @@ Disabling the warning
 The warning can be disabled using the (warnings ...) field in dune-project.
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.18)
+  > (lang dune 3.22)
   > (name test-pkg)
   > (warnings (duplicate_deps disabled))
   > (package


### PR DESCRIPTION
This warning requires a dune >= 3.18, but it was introduced in 17e049088d21c9b3ee12768d9a93b044b726accd, which landed in 3.22:

```
$ jj log -r 'roots(17e049088d21c9b3ee12768d9a93b044b726accd:: & tags())' -T 'tags ++ "\n"' -G
3.22.0_alpha0
3.22.0_alpha1
```

This results in dune generating overly permissive opam version bounds, which then fail in opam ci.

No idea if it's ok to just bump the version like this (I assume existing dune-project files that make use of this will cause failure until their dune-lang version is bumped, at which point the generated opam files will change as well).

## Checklist

- [ ] Tests added, if applicable.
- [X] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [ ] Documentation added for any user-facing changes.
