### PR TITLE
perf(rules): flatten command argument action builders

### DIFF
--- a/src/dune_rules/command.ml
+++ b/src/dune_rules/command.ml
@@ -102,11 +102,10 @@ and expand_list
   fun ~dir ts ->
   match ts with
   | [] -> Appendable_list.empty |> Action_builder.With_targets.return
-  | t :: ts ->
-    let open Action_builder.With_targets.O in
-    let+ t = expand ~dir t
-    and+ ts = expand_list ~dir ts in
-    Appendable_list.(t @ ts)
+  | ts ->
+    List.map ts ~f:(expand ~dir)
+    |> Action_builder.With_targets.all
+    |> Action_builder.With_targets.map ~f:Appendable_list.concat
 
 and expand_no_targets ~dir (t : without_targets t) =
   let { Action_builder.With_targets.build; targets } = expand ~dir t in


### PR DESCRIPTION
`Command.expand_list` currently builds a right-nested action-builder tree with one `Both` and one `Map` node per command argument. Evaluating that tree repeatedly forks Memo computations and combines dependency maps.

Build the argument expansions with `With_targets.all` instead, then concatenate their appendable lists once. This preserves argument order and parallel evaluation while using a flat action-builder node.

Controlled self-build profiles showed:

- cold minor allocations: 492.0M → 457.0M words, saving 266.9 MiB (7.1%)
- no-op minor allocations: 380.9M → 342.9M words, saving 289.9 MiB (10.0%)
- no-op promoted allocations: 57.6M → 52.7M words, saving 37.6 MiB (8.5%)
- 20-run no-op mean: 1.713s → 1.608s, approximately 6.2% faster
