### PR TITLE
feature(trace): record per-build Memo metrics

### DIFF
--- a/doc/changes/added/15698.md
+++ b/doc/changes/added/15698.md
@@ -1,0 +1,2 @@
+- Record per-build Memo compute, restore, and cycle-detection metrics in Dune
+  traces. (#15698, @rgrinberg)

--- a/src/dune_engine/build_loop.ml
+++ b/src/dune_engine/build_loop.ml
@@ -480,7 +480,7 @@ let rpc_poll_iter t ~action_runner ~sticky_goal ~sticky_built_at =
         let run_id = next_watch_run_id t in
         let () =
           match t.pending_reset with
-          | None -> Memo.Metrics.reset ()
+          | None -> ()
           | Some invalidation ->
             t.pending_reset <- None;
             if not (Memo.Invalidation.is_empty invalidation)

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1126,6 +1126,7 @@ let run_with_error_collection ?restart_started_at ~build_started_at ~build colle
         ~run_id:(Run_id.to_int run_id)
         ~restart:(Option.is_some restart_started_at)
         ~start:build_started_at);
+    Memo.Metrics.reset ();
     Dune_trace.reset_alloc_profile ();
     (* CR-someday amokhov: Currently we invalidate cached timestamps on every
        incremental rebuild. This conservative approach helps us to work around
@@ -1179,6 +1180,17 @@ let run_with_error_collection ?restart_started_at ~build_started_at ~build colle
              Option.map restart_started_at ~f:(fun restart_started_at ->
                Time.diff stop restart_started_at)
            in
+           let memo : Dune_trace.Event.memo_metrics =
+             { Dune_trace.Event.restore_nodes = Counter.read Memo.Metrics.Restore.nodes
+             ; restore_edges = Counter.read Memo.Metrics.Restore.edges
+             ; restore_blocked = Counter.read Memo.Metrics.Restore.blocked
+             ; compute_nodes = Counter.read Memo.Metrics.Compute.nodes
+             ; compute_edges = Counter.read Memo.Metrics.Compute.edges
+             ; compute_blocked = Counter.read Memo.Metrics.Compute.blocked
+             ; cycle_detection_nodes = Counter.read Memo.Metrics.Cycle_detection.nodes
+             ; cycle_detection_edges = Counter.read Memo.Metrics.Cycle_detection.edges
+             }
+           in
            Dune_trace.Event.watch_build_finish
              ~run_id:(Run_id.to_int run_id)
              ~outcome:
@@ -1187,7 +1199,8 @@ let run_with_error_collection ?restart_started_at ~build_started_at ~build colle
                 | Error `Already_reported -> `Failure)
              ~start:build_started_at
              ~stop
-             ~restart_duration);
+             ~restart_duration
+             ~memo);
          Dune_trace.capture_alloc_profile (`Build (Run_id.to_int run_id))
          |> Option.iter ~f:Dune_trace.always_emit;
          outcome)

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -137,12 +137,24 @@ module Event : sig
   val watch_build_start : run_id:int -> restart:bool -> start:Time.t -> t
   val watch_build_restart : run_id:int -> reasons:string list -> at:Time.t -> t
 
+  type memo_metrics =
+    { restore_nodes : int
+    ; restore_edges : int
+    ; restore_blocked : int
+    ; compute_nodes : int
+    ; compute_edges : int
+    ; compute_blocked : int
+    ; cycle_detection_nodes : int
+    ; cycle_detection_edges : int
+    }
+
   val watch_build_finish
     :  run_id:int
     -> outcome:[ `Success | `Failure ]
     -> start:Time.t
     -> stop:Time.t
     -> restart_duration:Time.Span.t option
+    -> memo:memo_metrics
     -> t
 
   val init : version:string option -> t

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -315,7 +315,34 @@ let watch_build_restart ~run_id ~reasons ~at =
   Event.instant ~name:"build-restart" ~args at Build
 ;;
 
-let watch_build_finish ~run_id ~outcome ~start ~stop ~restart_duration =
+type memo_metrics =
+  { restore_nodes : int
+  ; restore_edges : int
+  ; restore_blocked : int
+  ; compute_nodes : int
+  ; compute_edges : int
+  ; compute_blocked : int
+  ; cycle_detection_nodes : int
+  ; cycle_detection_edges : int
+  }
+
+let watch_build_finish
+      ~run_id
+      ~outcome
+      ~start
+      ~stop
+      ~restart_duration
+      ~memo:
+        { restore_nodes
+        ; restore_edges
+        ; restore_blocked
+        ; compute_nodes
+        ; compute_edges
+        ; compute_blocked
+        ; cycle_detection_nodes
+        ; cycle_detection_edges
+        }
+  =
   let dur = Time.diff stop start in
   let outcome =
     match outcome with
@@ -328,6 +355,31 @@ let watch_build_finish ~run_id ~outcome ~start ~stop ~restart_duration =
        | None -> []
        | Some restart_duration -> [ "restart_duration", Arg.span restart_duration ])
     @ make_process_times_args ()
+    @ [ ( "memo"
+        , Arg.record
+            [ ( "restore"
+              , Arg.record
+                  [ "nodes", Arg.int restore_nodes
+                  ; "edges", Arg.int restore_edges
+                  ; "blocked", Arg.int restore_blocked
+                  ]
+                |> Arg.list )
+            ; ( "compute"
+              , Arg.record
+                  [ "nodes", Arg.int compute_nodes
+                  ; "edges", Arg.int compute_edges
+                  ; "blocked", Arg.int compute_blocked
+                  ]
+                |> Arg.list )
+            ; ( "cycle_detection"
+              , Arg.record
+                  [ "nodes", Arg.int cycle_detection_nodes
+                  ; "edges", Arg.int cycle_detection_edges
+                  ]
+                |> Arg.list )
+            ]
+          |> Arg.list )
+      ]
     @ make_rusage_args (Proc.Resource_usage.get_self ())
   in
   Event.complete ~name:"build-finish" ~args ~start ~dur Build

--- a/test/blackbox-tests/dune.jq
+++ b/test/blackbox-tests/dune.jq
@@ -264,6 +264,10 @@ def buildEvents:
     then .args.process_times |= keys
     else .
     end
+  | if .args.memo? != null
+    then .args.memo |= with_entries(.value |= keys)
+    else .
+    end
   | if .args.rusage? != null
     then .args.rusage |= keys
     else .

--- a/test/blackbox-tests/test-cases/trace/interrupted-watch-build-events.t
+++ b/test/blackbox-tests/test-cases/trace/interrupted-watch-build-events.t
@@ -45,7 +45,8 @@ own source invalidation.
   $ stop_dune > /dev/null
 
   $ dune trace cat | jq_dune -s '
-  > [ .[] | buildEvents | del(.args.process_times, .args.rusage) ] | .[-5:]'
+  > [ .[] | buildEvents | del(.args.process_times, .args.rusage, .args.memo) ]
+  > | .[-5:]'
   [
     {
       "args": {

--- a/test/blackbox-tests/test-cases/trace/watch-build-events.t
+++ b/test/blackbox-tests/test-cases/trace/watch-build-events.t
@@ -49,6 +49,22 @@ rusage snapshots on build trace events.
         "system_cpu_time",
         "user_cpu_time"
       ],
+      "memo": {
+        "restore": [
+          "blocked",
+          "edges",
+          "nodes"
+        ],
+        "compute": [
+          "blocked",
+          "edges",
+          "nodes"
+        ],
+        "cycle_detection": [
+          "edges",
+          "nodes"
+        ]
+      },
       "rusage": [
         "inblock",
         "majflt",
@@ -111,6 +127,22 @@ active build is interrupted.
         "system_cpu_time",
         "user_cpu_time"
       ],
+      "memo": {
+        "restore": [
+          "blocked",
+          "edges",
+          "nodes"
+        ],
+        "compute": [
+          "blocked",
+          "edges",
+          "nodes"
+        ],
+        "cycle_detection": [
+          "edges",
+          "nodes"
+        ]
+      },
       "rusage": [
         "inblock",
         "majflt",
@@ -154,6 +186,22 @@ active build is interrupted.
         "system_cpu_time",
         "user_cpu_time"
       ],
+      "memo": {
+        "restore": [
+          "blocked",
+          "edges",
+          "nodes"
+        ],
+        "compute": [
+          "blocked",
+          "edges",
+          "nodes"
+        ],
+        "cycle_detection": [
+          "edges",
+          "nodes"
+        ]
+      },
       "rusage": [
         "inblock",
         "majflt",


### PR DESCRIPTION
Memo already maintains counters for compute, restore, and cycle-detection work, but Dune traces do not expose them and their process-wide values are difficult to interpret across watch builds.

Reset the existing counters at each build boundary and include their snapshot in the `build-finish` event. This provides per-build Memo statistics for batch and watch builds without adding new instrumentation to Memo's hot paths.
