### PR TITLE
fix(rpc): report connection failures without a backtrace

### DIFF
--- a/src/rpc/client.ml
+++ b/src/rpc/client.ml
@@ -40,11 +40,17 @@ module Connection = struct
       connect_sock sock
       >>| (function
        | Ok s -> Ok s
-       | Error exn ->
+       | Error ({ Exn_with_backtrace.exn; _ } as exn_with_backtrace) ->
+         let details =
+           match exn with
+           | Unix.Unix_error (error, syscall, arg) ->
+             Unix_error.Detailed.pp_reason (error, syscall, arg)
+           | _ -> Exn_with_backtrace.pp exn_with_backtrace
+         in
          Error
            (User_error.make
               [ Pp.textf "failed to connect to RPC server %s" (Where.to_string where)
-              ; Exn_with_backtrace.pp exn
+              ; details
               ]))
   ;;
 

--- a/test/blackbox-tests/test-cases/watching/rpc-connect-after-server-killed.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-connect-after-server-killed.t
@@ -1,5 +1,5 @@
 A client connecting to a watch server that was killed without cleaning up its
-RPC socket reports the connection failure with a backtrace.
+RPC socket reports the connection failure without a backtrace.
 
   $ make_simple_rpc_watch_project
 
@@ -10,12 +10,7 @@ RPC socket reports the connection failure with a backtrace.
   $ wait_for_pid_to_exit_with_timeout "$SERVER_PID" 200
   $ wait_for_dune_exit_with_timeout
 
-  $ with_timeout dune rpc ping > client.output 2>&1
-  [1]
-  $ head -n 3 client.output
+  $ dune rpc ping
   Error: failed to connect to RPC server unix:path=_build/.rpc/dune
-  Unix.Unix_error(Unix.ECONNREFUSED, "connect", "")
-  backtrace:
-  $ grep -m1 '^Raised by primitive operation' client.output \
-  > | sed 's/ in file.*//'
-  Raised by primitive operation at Rpc__Csexp_rpc.Client.connect
+  Reason: connect(): Connection refused
+  [1]


### PR DESCRIPTION
## Description

Format Unix errors returned while connecting an RPC client as user-facing
reasons instead of embedding their captured backtraces. Unexpected non-Unix
exceptions continue to include their backtraces.

A connection to a stale socket now reports:

```text
Error: failed to connect to RPC server unix:path=_build/.rpc/dune
Reason: connect(): Connection refused
```

## Related Issue and Motivation

A watch server killed with `SIGKILL` cannot remove `_build/.rpc/dune`.
Connecting to the abandoned socket returns `ECONNREFUSED`, which is an expected
user-facing failure but was previously printed with an internal backtrace.

Fixes #15676.

## Testing

- Updated the regression test introduced in #15675.
- `./dune.exe runtest test/blackbox-tests/test-cases/watching/rpc-connect-after-server-killed.t`
- `./dune.exe runtest test/expect-tests/dune_rpc`
- `./dune.exe build @check @fmt`
- Manually reproduced the failure through both `dune rpc ping` and
  `dune monitor`, and verified that restarting the watch server still works.

No changelog or documentation update is needed for this routine error-message
improvement.
