### PR TITLE
feature(trace): record rule progress metrics

### DIFF
--- a/doc/changes/added/15701.md
+++ b/doc/changes/added/15701.md
@@ -1,0 +1,2 @@
+- Record discovered, validated, and failed rule counts in Dune traces.
+  (#15701, @rgrinberg)

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1149,6 +1149,14 @@ let run_with_error_collection ?restart_started_at ~build_started_at ~build colle
       (fun () ->
          let* () = State.reset_errors () in
          let* outcome = collect_errors () in
+         let progress =
+           match !State.t with
+           | Building progress -> progress
+           | state ->
+             Code_error.raise
+               "Build progress is unavailable at the end of a build"
+               [ "state", State.to_dyn state ]
+         in
          Dtemp.clear ();
          Sandbox.cleanup_pending_targets ();
          Target_promotion.save ();
@@ -1180,6 +1188,16 @@ let run_with_error_collection ?restart_started_at ~build_started_at ~build colle
              Option.map restart_started_at ~f:(fun restart_started_at ->
                Time.diff stop restart_started_at)
            in
+           let { Progress.number_of_rules_discovered = discovered
+               ; number_of_rules_validated = validated
+               ; number_of_rules_failed = failed
+               }
+             =
+             progress
+           in
+           let rules : Dune_trace.Event.build_rules =
+             { Dune_trace.Event.discovered; validated; failed }
+           in
            let memo : Dune_trace.Event.memo_metrics =
              { Dune_trace.Event.restore_nodes = Counter.read Memo.Metrics.Restore.nodes
              ; restore_edges = Counter.read Memo.Metrics.Restore.edges
@@ -1200,6 +1218,7 @@ let run_with_error_collection ?restart_started_at ~build_started_at ~build colle
              ~start:build_started_at
              ~stop
              ~restart_duration
+             ~rules
              ~memo);
          Dune_trace.capture_alloc_profile (`Build (Run_id.to_int run_id))
          |> Option.iter ~f:Dune_trace.always_emit;

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -137,6 +137,12 @@ module Event : sig
   val watch_build_start : run_id:int -> restart:bool -> start:Time.t -> t
   val watch_build_restart : run_id:int -> reasons:string list -> at:Time.t -> t
 
+  type build_rules =
+    { discovered : int
+    ; validated : int
+    ; failed : int
+    }
+
   type memo_metrics =
     { restore_nodes : int
     ; restore_edges : int
@@ -154,6 +160,7 @@ module Event : sig
     -> start:Time.t
     -> stop:Time.t
     -> restart_duration:Time.Span.t option
+    -> rules:build_rules
     -> memo:memo_metrics
     -> t
 

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -315,6 +315,12 @@ let watch_build_restart ~run_id ~reasons ~at =
   Event.instant ~name:"build-restart" ~args at Build
 ;;
 
+type build_rules =
+  { discovered : int
+  ; validated : int
+  ; failed : int
+  }
+
 type memo_metrics =
   { restore_nodes : int
   ; restore_edges : int
@@ -332,6 +338,7 @@ let watch_build_finish
       ~start
       ~stop
       ~restart_duration
+      ~rules:{ discovered; validated; failed }
       ~memo:
         { restore_nodes
         ; restore_edges
@@ -355,7 +362,14 @@ let watch_build_finish
        | None -> []
        | Some restart_duration -> [ "restart_duration", Arg.span restart_duration ])
     @ make_process_times_args ()
-    @ [ ( "memo"
+    @ [ ( "rules"
+        , Arg.record
+            [ "discovered", Arg.int discovered
+            ; "validated", Arg.int validated
+            ; "failed", Arg.int failed
+            ]
+          |> Arg.list )
+      ; ( "memo"
         , Arg.record
             [ ( "restore"
               , Arg.record

--- a/test/blackbox-tests/dune.jq
+++ b/test/blackbox-tests/dune.jq
@@ -268,6 +268,10 @@ def buildEvents:
     then .args.memo |= with_entries(.value |= keys)
     else .
     end
+  | if .args.rules? != null
+    then .args.rules |= keys
+    else .
+    end
   | if .args.rusage? != null
     then .args.rusage |= keys
     else .

--- a/test/blackbox-tests/test-cases/trace/interrupted-watch-build-events.t
+++ b/test/blackbox-tests/test-cases/trace/interrupted-watch-build-events.t
@@ -45,7 +45,7 @@ own source invalidation.
   $ stop_dune > /dev/null
 
   $ dune trace cat | jq_dune -s '
-  > [ .[] | buildEvents | del(.args.process_times, .args.rusage, .args.memo) ]
+  > [ .[] | buildEvents | del(.args.process_times, .args.rusage, .args.rules, .args.memo) ]
   > | .[-5:]'
   [
     {

--- a/test/blackbox-tests/test-cases/trace/watch-build-events.t
+++ b/test/blackbox-tests/test-cases/trace/watch-build-events.t
@@ -49,6 +49,11 @@ rusage snapshots on build trace events.
         "system_cpu_time",
         "user_cpu_time"
       ],
+      "rules": [
+        "discovered",
+        "failed",
+        "validated"
+      ],
       "memo": {
         "restore": [
           "blocked",
@@ -127,6 +132,11 @@ active build is interrupted.
         "system_cpu_time",
         "user_cpu_time"
       ],
+      "rules": [
+        "discovered",
+        "failed",
+        "validated"
+      ],
       "memo": {
         "restore": [
           "blocked",
@@ -185,6 +195,11 @@ active build is interrupted.
         "elapsed_time",
         "system_cpu_time",
         "user_cpu_time"
+      ],
+      "rules": [
+        "discovered",
+        "failed",
+        "validated"
       ],
       "memo": {
         "restore": [


### PR DESCRIPTION
Dune already maintains discovered, validated, and failed rule counters for build progress reporting, but these values are lost once a build finishes and are not available in traces.

Snapshot the existing counters before leaving the building state and include them in the `build-finish` event. This makes rule progress available for batch and watch-build analysis without adding instrumentation to rule evaluation.
