### PR TITLE
perf(memo): skip dependency storage for batch builds

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1241,6 +1241,10 @@ let action_runner t =
 ;;
 
 let init_with_root_and_rpc ~(root : Workspace_root.t) ~rpc_build (builder : Builder.t) =
+  Memo.set_incremental
+    (match builder.watch with
+     | No -> false
+     | Yes _ -> true);
   let c = build root builder in
   No_build.set c.builder.no_build;
   if c.root.dir <> Filename.current_dir_name then Sys.chdir c.root.dir;

--- a/src/memo/deps_collector.ml
+++ b/src/memo/deps_collector.ml
@@ -7,18 +7,26 @@ open Fiber.O
      can each collect into their own sub-collector. *)
 type t = Dep_node.packed Deps.Dynamic.t ref
 
+let enabled = ref true
+let set_enabled value = enabled := value
+let disabled = ref Deps.Dynamic.empty
+let is_disabled t = Stdlib.( == ) t disabled
 let var : t option Fiber.Var.t = Fiber.Var.create None
-let create () : t = ref Deps.Dynamic.empty
-let run_apply (t : t) ~f x = Fiber.Var.set_apply var (Some t) f x
-let get (t : t) : Dep_node.packed Deps.t = Deps.Dynamic.to_static !t
-let add (t : t) dep_node = t := Deps.Dynamic.append_seq !t ~node:(Dep_node.T dep_node)
+let create () : t = if !enabled then ref Deps.Dynamic.empty else disabled
+let run_apply t ~f x = Fiber.Var.set_apply var (Some t) f x
+
+let get t : Dep_node.packed Deps.t =
+  if is_disabled t then Deps.empty else Deps.Dynamic.to_static !t
+;;
+
+let add t dep_node = t := Deps.Dynamic.append_seq !t ~node:(Dep_node.T dep_node)
 
 (* Add a dependency on [dep_node] to [collector], if there is an active one. Defined at
    the top level so it is hoisted (closure-free) when passed to [get_apply_map]. *)
 let add_dep_to_collector collector dep_node =
   match collector with
   | None -> ()
-  | Some t -> add t dep_node
+  | Some t -> if is_disabled t then Counter.incr Metrics.Compute.edges else add t dep_node
 ;;
 
 (* Add a dependency on [dep_node] to the currently running computation, if there is one. *)
@@ -124,12 +132,13 @@ end
 
 (* Run [num_threads] parallel threads, collecting each thread's dependencies into its own
      sub-collector (via fiber-local storage) and recording them as a single parallel section
-     in the caller's collector. [k] is called with [None] when [num_threads < 2] or when
-     there is no active collector, in which case dependencies are collected sequentially as
-     usual.
+     in the caller's collector. [k] is called with [None] when dependency collection is
+     disabled, [num_threads < 2], or there is no active collector.
 
-     Dependencies are recorded even when a thread raises, because some errors are cached; we
-     reraise after recording. *)
+     The error-collection boundary is preserved when dependency collection is disabled.
+     Otherwise errors raised by parallel branches can bypass Memo continuations that add
+     stack frames. When dependency collection is enabled, the boundary also lets us record
+     dependencies before reraising errors, since some errors are cached. *)
 let run_parallel ~num_threads k =
   if num_threads < 2
   then k None
@@ -137,6 +146,11 @@ let run_parallel ~num_threads k =
     Fiber.Var.get var
     >>= function
     | None -> k None
+    | Some t when is_disabled t ->
+      Fiber.collect_errors (fun () -> k None)
+      >>= (function
+       | Ok result -> Fiber.return result
+       | Error exns -> Fiber.reraise_all exns)
     | Some t ->
       let threads = Pool.acquire num_threads in
       let thread_index = ref 0 in

--- a/src/memo/deps_collector.mli
+++ b/src/memo/deps_collector.mli
@@ -5,6 +5,10 @@ open Node
     storage so that parallel branches can each collect into their own sub-collector. *)
 type t
 
+(** Enable or disable dependency collection globally. Disabling collection preserves the
+    error boundaries around parallel evaluation. *)
+val set_enabled : bool -> unit
+
 val create : unit -> t
 
 (** Run [f x] with [t] as the active collector. *)

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -167,6 +167,7 @@ let dep_node (t : (_, _) Table.t) input =
 ;;
 
 let check_point = Exec.check_point
+let set_incremental = Deps_collector.set_enabled
 let exec (type i o) (t : (i, o) Table.t) i = Exec.exec_dep_node (dep_node t i)
 
 let create_rec

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -265,6 +265,12 @@ module Invalidation : sig
   val changed_paths : t -> Path.t list
 end
 
+(** Configure whether Memo will reuse cached nodes in future build runs. When disabled,
+    Memo does not record dependencies between nodes, but still preserves error propagation
+    and Memo stack construction. This must be called before evaluating any Memo
+    computations. *)
+val set_incremental : bool -> unit
+
 (** Notify the memoization system that the build system has restarted. This
     removes the values specified by [Invalidation.t] from the memoization cache,
     and advances the current run. *)

--- a/test/expect-tests/memo/incremental_mode.ml
+++ b/test/expect-tests/memo/incremental_mode.ml
@@ -1,0 +1,70 @@
+open! Stdune
+open Test_helpers.Make ()
+
+let in_non_incremental_mode ~f =
+  Memo.Metrics.reset ();
+  Memo.set_incremental false;
+  Exn.protect ~f ~finally:(fun () ->
+    Memo.Metrics.reset ();
+    Memo.set_incremental true)
+;;
+
+let%expect_test "non-incremental mode discards dependencies but counts them" =
+  in_non_incremental_mode ~f:(fun () ->
+    let dependency =
+      Memo.lazy_node ~name:"dependency" (fun () ->
+        Scheduler.yield () |> Memo.of_reproducible_fiber)
+    in
+    let node =
+      Memo.lazy_node ~name:"node" (fun () ->
+        Memo.parallel_iter [ dependency; dependency ] ~f:Memo.Node.read)
+    in
+    let () = run (Memo.Node.read node) in
+    let deps =
+      Memo.For_tests.get_deps_structured node |> Option.value_exn |> Dyn.to_string
+    in
+    printfn "dependencies: %s" deps;
+    printfn "edges: %d" (Counter.read Memo.Metrics.Compute.edges);
+    printfn "cycle detection edges: %d" (Counter.read Memo.Metrics.Cycle_detection.edges);
+    Memo.Metrics.assert_invariants ());
+  [%expect
+    {|
+    dependencies: Empty
+    edges: 2
+    cycle detection edges: 1
+    |}]
+;;
+
+let%expect_test "non-incremental mode preserves early errors outside Memo nodes" =
+  in_non_incremental_mode ~f:(fun () ->
+    let trace = ref [] in
+    let log event = trace := event :: !trace in
+    let (_ : (unit, unit) result) =
+      Scheduler.run
+        (Fiber.map_reduce_errors
+           (module Monoid.Unit)
+           ~on_error:(fun _exn ->
+             log "late";
+             Fiber.return ())
+           (fun () ->
+              Memo.run_with_error_handler
+                (fun () ->
+                   Memo.fork_and_join_unit
+                     (fun () ->
+                        Fiber.map (Scheduler.yield ()) ~f:(fun () -> failwith "error")
+                        |> Memo.of_reproducible_fiber)
+                     (fun () ->
+                        Fiber.map (Scheduler.yield ()) ~f:(fun () -> log "other branch")
+                        |> Memo.of_reproducible_fiber))
+                ~handle_error_no_raise:(fun _exn ->
+                  log "early";
+                  Fiber.return ())))
+    in
+    List.rev !trace |> List.iter ~f:(fun event -> printfn "%s" event));
+  [%expect
+    {|
+    early
+    other branch
+    late
+    |}]
+;;


### PR DESCRIPTION
Batch builds currently allocate and retain Memo dependency graphs even though they do not restore cached nodes in a later build run.

This configures Memo from Dune's watch mode. Batch builds count discovered edges for metrics and retain the parallel error boundaries needed for Memo stack construction, but discard the graph instead of storing it. Watch mode continues to collect dependencies as before.

Null builds of the Dune repository improve by approximately 10% for `@check`, `@install`, and `@runtest`. Focused tests cover discarded dependencies, metrics and cycle-detection invariants, and early parallel error reporting.
