### PR TITLE
refactor(stdune): use compiler list implementations

### DIFF
--- a/otherlibs/stdune/src/list.ml
+++ b/otherlibs/stdune/src/list.ml
@@ -2,8 +2,6 @@ include ListLabels
 
 type 'a t = 'a list
 
-let map ~f t = rev (rev_map ~f t)
-
 let is_empty = function
   | [] -> true
   | _ -> false
@@ -25,7 +23,7 @@ let rev_filter_map l ~f =
   loop [] l
 ;;
 
-let filter_map l ~f = rev (rev_filter_map l ~f)
+let filter_map l ~f = ListLabels.filter_map ~f l
 let filter_opt l = filter_map ~f:Fun.id l
 
 let filteri l ~f =


### PR DESCRIPTION
Stdune currently overrides the compiler's `List.map` and `List.filter_map` with implementations that construct reversed temporary lists and then reverse them. Remove the `map` override and delegate `filter_map` to `ListLabels`, retaining only a thin wrapper for Stdune's list-first API.

This avoids maintaining duplicate implementations and lets their allocation and stack behavior follow the OCaml compiler used to build Dune. OCaml 5.5 uses Tail-Modulo-Cons for both functions. On older supported compilers behavior follows their standard library instead; notably, OCaml 4.14's `map` is not stack-safe for extremely large lists and its `filter_map` still uses a reversed temporary list.

With OCaml 5.5, real no-op `@install` and `@check` self-builds allocated 1.1% to 1.2% fewer minor words, while native runtime remained neutral. A generated 100,000-argument action benefits more substantially, but the primary motivation is relying on the compiler implementation rather than maintaining our own.
