### PR TITLE
perf(engine): pass process arguments as arrays

### DIFF
--- a/bin/action_runner.ml
+++ b/bin/action_runner.ml
@@ -75,8 +75,13 @@ let create ~config ~sandbox_actions =
             prog, argv)
           else Path.to_string dune_prog, worker_argv
         in
-        let argv =
-          argv
+        let argv0, args =
+          match argv with
+          | argv0 :: args -> argv0, args
+          | [] -> Code_error.raise "empty action runner command line" []
+        in
+        let args =
+          args
           @ [ "--rpc-fd"; Int.to_string (Fd.unsafe_to_int worker_fd) ]
           @
           match trace_fd with
@@ -88,7 +93,8 @@ let create ~config ~sandbox_actions =
           ~f:(fun () ->
             (* Use SIGTERM because the action runner knows how to clean up
                its children. *)
-            Spawn.spawn ~env ~prog ~argv ~pdeathsig:Term ())
+            let args = Array.Immutable.of_list args in
+            Spawn.spawn ~env ~prog ~argv0 ~args ~pdeathsig:Term ())
       in
       let action_runner =
         Dune_engine.Action_runner.create name pid ~connection_fd:parent_fd

--- a/otherlibs/stdune/src/array.ml
+++ b/otherlibs/stdune/src/array.ml
@@ -62,6 +62,8 @@ module Immutable = struct
   let of_array a = copy a
   let to_list_map t ~f = to_list_map t ~f
   let of_list_map t ~f = of_list_map t ~f
+  let fold_left t ~f ~init = fold_left t ~f ~init
+  let iter t ~f = iter t ~f
 end
 
 module Sorted = struct

--- a/otherlibs/stdune/src/array.mli
+++ b/otherlibs/stdune/src/array.mli
@@ -24,6 +24,8 @@ module Immutable : sig
   val map : 'a t -> f:('a -> 'b) -> 'b t
   val to_dyn : ('a -> Dyn.t) -> 'a t -> Dyn.t
   val fold_right : 'a t -> f:('a -> 'acc -> 'acc) -> init:'acc -> 'acc
+  val fold_left : 'a t -> f:('acc -> 'a -> 'acc) -> init:'acc -> 'acc
+  val iter : 'a t -> f:('a -> unit) -> unit
   val exists : 'a t -> f:('a -> bool) -> bool
   val length : _ t -> int
   val to_list_map : 'a t -> f:('a -> 'b) -> 'b list

--- a/otherlibs/stdune/src/spawn.ml
+++ b/otherlibs/stdune/src/spawn.ml
@@ -1,5 +1,3 @@
-open StdLabels
-
 external is_osx : unit -> bool = "dune_spawn_is_osx" [@@noalloc]
 
 let is_osx = is_osx ()
@@ -95,7 +93,8 @@ external spawn_unix
   :  env:Env.t option
   -> cwd:Working_dir.t
   -> prog:string
-  -> argv:string list
+  -> argv0:string
+  -> args:string Array.Immutable.t
   -> stdin:Unix.file_descr
   -> stdout:Unix.file_descr
   -> stderr:Unix.file_descr
@@ -110,7 +109,8 @@ let spawn_unix
       ~env
       ~cwd
       ~prog
-      ~argv
+      ~argv0
+      ~args
       ~stdin
       ~stdout
       ~stderr
@@ -125,7 +125,8 @@ let spawn_unix
     ~env
     ~cwd
     ~prog
-    ~argv
+    ~argv0
+    ~args
     ~stdin
     ~stdout
     ~stderr
@@ -157,7 +158,8 @@ let spawn_windows
       ~env
       ~cwd
       ~prog
-      ~argv
+      ~argv0
+      ~args
       ~stdin
       ~stdout
       ~stderr
@@ -172,7 +174,8 @@ let spawn_windows
     | Fd _ -> invalid_arg "Spawn.spawn: [cwd=Fd _] is not supported on Windows"
     | Inherit -> None
   in
-  let cmdline = String.concat (List.map argv ~f:maybe_quote) ~sep:" " in
+  let argv = maybe_quote argv0 :: Array.Immutable.to_list_map args ~f:maybe_quote in
+  let cmdline = String.concat argv ~sep:" " in
   let prog =
     match Filename.is_relative prog, cwd with
     | true, Some p -> Filename.concat p prog
@@ -194,7 +197,8 @@ let spawn
       ?env
       ?(cwd = Working_dir.Inherit)
       ~prog
-      ~argv
+      ~argv0
+      ~args
       ?(stdin = Unix.stdin)
       ?(stdout = Unix.stdout)
       ?(stderr = Unix.stderr)
@@ -208,25 +212,42 @@ let spawn
    | Path s -> no_null s
    | Fd _ | Inherit -> ());
   no_null prog;
-  List.iter argv ~f:no_null;
-  let backend = if Sys.win32 then spawn_windows else spawn_unix in
+  no_null argv0;
+  Array.Immutable.iter args ~f:no_null;
   let use_vfork =
     match unix_backend with
     | Vfork -> true
     | Fork -> false
   in
-  backend
-    ~env
-    ~cwd
-    ~prog
-    ~argv
-    ~stdin
-    ~stdout
-    ~stderr
-    ~use_vfork
-    ~setpgid
-    ~sigprocmask
-    ~pdeathsig
+  if Sys.win32
+  then
+    spawn_windows
+      ~env
+      ~cwd
+      ~prog
+      ~argv0
+      ~args
+      ~stdin
+      ~stdout
+      ~stderr
+      ~use_vfork
+      ~setpgid
+      ~sigprocmask
+      ~pdeathsig
+  else
+    spawn_unix
+      ~env
+      ~cwd
+      ~prog
+      ~argv0
+      ~args
+      ~stdin
+      ~stdout
+      ~stderr
+      ~use_vfork
+      ~setpgid
+      ~sigprocmask
+      ~pdeathsig
 ;;
 
 external safe_pipe : unit -> Unix.file_descr * Unix.file_descr = "dune_spawn_pipe"

--- a/otherlibs/stdune/src/spawn.mli
+++ b/otherlibs/stdune/src/spawn.mli
@@ -65,10 +65,9 @@ end
 
     {b Command line arguments}
 
-    [argv] is the full command line. The first element should be the program
-    name and subsequent elements the command line arguments. Note that the head
-    of [argv] doesn't necessarily have to be equal to [prog]. For instance it
-    might be [foo] while [prog] might be [/usr/bin/foo].
+    [argv0] and [args] form the command line. [argv0] is the program name seen
+    by the child and may differ from [prog]. [args] contains the remaining
+    command line arguments.
 
     {b Environment}
 
@@ -118,7 +117,8 @@ val spawn
   :  ?env:Env.t
   -> ?cwd:Working_dir.t (* default: [Inherit] *)
   -> prog:string
-  -> argv:string list
+  -> argv0:string
+  -> args:string Array.Immutable.t
   -> ?stdin:Unix.file_descr
   -> ?stdout:Unix.file_descr
   -> ?stderr:Unix.file_descr

--- a/otherlibs/stdune/src/spawn_stubs.c
+++ b/otherlibs/stdune/src/spawn_stubs.c
@@ -442,6 +442,41 @@ static char **alloc_string_vect(value v)
   return result;
 }
 
+/* Convert an [argv0] and a [string array] into a NULL terminated array of C
+   strings. */
+static char **alloc_string_array(value v_argv0, value v_args)
+{
+  mlsize_t count = Wosize_val(v_args);
+  mlsize_t full_size =
+    (sizeof(char*) * (count + 2)) + caml_string_length(v_argv0) + 1;
+  mlsize_t i;
+  mlsize_t len;
+  char **result;
+  char *ptr;
+
+  for (i = 0; i < count; i++)
+    full_size += caml_string_length(Field(v_args, i)) + 1;
+
+  result = (char**)malloc(full_size);
+  if (result == NULL) caml_raise_out_of_memory();
+
+  ptr = ((char*)result) + (sizeof(char*) * (count + 2));
+  len = caml_string_length(v_argv0) + 1;
+  memcpy(ptr, String_val(v_argv0), len);
+  result[0] = ptr;
+  ptr += len;
+  for (i = 0; i < count; i++) {
+    value v_str = Field(v_args, i);
+    len = caml_string_length(v_str) + 1;
+    memcpy(ptr, String_val(v_str), len);
+    result[i + 1] = ptr;
+    ptr += len;
+  }
+  result[count + 1] = NULL;
+
+  return result;
+}
+
 static char **copy_c_string_array(char ** strings)
 {
   char **result;
@@ -490,7 +525,8 @@ static void init_spawn_info(struct spawn_info *info,
                             value v_env,
                             value v_cwd,
                             value v_prog,
-                            value v_argv,
+                            value v_argv0,
+                            value v_args,
                             value v_stdin,
                             value v_stdout,
                             value v_stderr,
@@ -527,7 +563,7 @@ static void init_spawn_info(struct spawn_info *info,
 
   info->prog = strdup(String_val(v_prog));
   if (info->prog == NULL) caml_raise_out_of_memory();
-  info->argv = alloc_string_vect(v_argv);
+  info->argv = alloc_string_array(v_argv0, v_args);
   info->env =
     Is_block(v_env) ?
     alloc_string_vect(Field(v_env, 0)) : copy_c_string_array(environ);
@@ -593,7 +629,8 @@ static void init_spawn_info(struct spawn_info *info,
 CAMLprim value dune_spawn_unix(value v_env,
                                value v_cwd,
                                value v_prog,
-                               value v_argv,
+                               value v_argv0,
+                               value v_args,
                                value v_stdin,
                                value v_stdout,
                                value v_stderr,
@@ -602,7 +639,7 @@ CAMLprim value dune_spawn_unix(value v_env,
                                value v_sigprocmask,
                                value v_pdeathsig)
 {
-  CAMLparam4(v_env, v_cwd, v_prog, v_argv);
+  CAMLparam5(v_env, v_cwd, v_prog, v_argv0, v_args);
   CAMLlocal1(e_arg);
   e_arg = Nothing;
 
@@ -625,7 +662,7 @@ CAMLprim value dune_spawn_unix(value v_env,
   }
 
   struct spawn_info info;
-  init_spawn_info(&info, v_env, v_cwd, v_prog, v_argv,
+  init_spawn_info(&info, v_env, v_cwd, v_prog, v_argv0, v_args,
                   v_stdin, v_stdout, v_stderr, v_setpgid, v_sigprocmask,
                   v_pdeathsig);
 
@@ -725,7 +762,8 @@ CAMLprim value dune_spawn_unix(value v_env,
 CAMLprim value dune_spawn_unix(value v_env,
                                value v_cwd,
                                value v_prog,
-                               value v_argv,
+                               value v_argv0,
+                               value v_args,
                                value v_stdin,
                                value v_stdout,
                                value v_stderr,
@@ -734,7 +772,7 @@ CAMLprim value dune_spawn_unix(value v_env,
                                value v_sigprocmask,
                                value v_pdeathsig)
 {
-  CAMLparam4(v_env, v_cwd, v_prog, v_argv);
+  CAMLparam5(v_env, v_cwd, v_prog, v_argv0, v_args);
   pid_t ret;
   struct spawn_info info;
   int result_pipe[2];
@@ -746,7 +784,7 @@ CAMLprim value dune_spawn_unix(value v_env,
   int errno_after_forking = 0;
   int status;
 
-  init_spawn_info(&info, v_env, v_cwd, v_prog, v_argv,
+  init_spawn_info(&info, v_env, v_cwd, v_prog, v_argv0, v_args,
                   v_stdin, v_stdout, v_stderr, v_setpgid, v_sigprocmask,
                   v_pdeathsig);
 
@@ -866,7 +904,8 @@ CAMLprim value dune_spawn_windows(value v_env,
 CAMLprim value dune_spawn_unix(value v_env,
                                value v_cwd,
                                value v_prog,
-                               value v_argv,
+                               value v_argv0,
+                               value v_args,
                                value v_stdin,
                                value v_stdout,
                                value v_stderr,
@@ -878,7 +917,8 @@ CAMLprim value dune_spawn_unix(value v_env,
   (void)v_env;
   (void)v_cwd;
   (void)v_prog;
-  (void)v_argv;
+  (void)v_argv0;
+  (void)v_args;
   (void)v_stdin;
   (void)v_stdout;
   (void)v_stderr;
@@ -989,7 +1029,8 @@ CAMLprim value dune_spawn_unix_byte(value * argv)
                     argv[7],
                     argv[8],
                     argv[9],
-                    argv[10]);
+                    argv[10],
+                    argv[11]);
 }
 
 CAMLprim value dune_spawn_windows_byte(value * argv)

--- a/otherlibs/stdune/test/spawn/exe/print_env.ml
+++ b/otherlibs/stdune/test/spawn/exe/print_env.ml
@@ -33,6 +33,7 @@ let () =
     pdeathsig_child ready_file marker_file
   | _ :: "pdeathsig-default-child" :: ready_file :: marker_file :: _ ->
     pdeathsig_default_child ready_file marker_file
+  | argv0 :: "print-args" :: args -> List.iter print_endline (argv0 :: args)
   | _ ->
     (match Sys.getenv "FOO" with
      | exception _ -> print_endline "None"

--- a/otherlibs/stdune/test/spawn/tests.ml
+++ b/otherlibs/stdune/test/spawn/tests.ml
@@ -1,10 +1,6 @@
-module Int = Stdune.Int
-module Exn = Stdune.Exn
-module Pid = Stdune.Pid
-module Proc = Stdune.Proc
-module Platform = Stdune.Platform
-module Signal = Stdune.Signal
-module Spawn = Stdune.Spawn
+open Stdune
+
+let no_args = Array.Immutable.of_list []
 
 let show_raise f =
   try ignore (f ()) with
@@ -20,7 +16,7 @@ let show_raise f =
 ;;
 
 let%expect_test "non-existing program" =
-  show_raise (fun () -> Spawn.spawn () ~prog:"/doesnt-exist" ~argv:[ "blah" ]);
+  show_raise (fun () -> Spawn.spawn () ~prog:"/doesnt-exist" ~argv0:"blah" ~args:no_args);
   [%expect
     {|
     raised Unix.Unix_error _
@@ -32,7 +28,8 @@ let%expect_test "non-existing dir" =
     Spawn.spawn
       ()
       ~prog:"/bin/true"
-      ~argv:[ "true" ]
+      ~argv0:"true"
+      ~args:no_args
       ~cwd:(Spawn.Working_dir.Path "/doesnt-exist"));
   [%expect
     {|
@@ -58,12 +55,24 @@ let () =
   close_out (open_out "sub/bar")
 ;;
 
+let%expect_test "array arguments" =
+  let args = Array.Immutable.of_list [ "print-args"; "one"; "two" ] in
+  wait (Spawn.spawn () ~prog:print_env ~argv0:"custom-argv0" ~args);
+  [%expect
+    {|
+    custom-argv0
+    one
+    two
+  |}]
+;;
+
 let%expect_test "cwd:Path" =
   wait
     (Spawn.spawn
        ()
        ~prog:list_files
-       ~argv:[ "list_files.exe" ]
+       ~argv0:"list_files.exe"
+       ~args:no_args
        ~cwd:(Spawn.Working_dir.Path "sub"));
   [%expect
     {|
@@ -81,7 +90,8 @@ let%expect_test "cwd:Fd" =
       (Spawn.spawn
          ()
          ~prog:list_files
-         ~argv:[ "list_files.exe" ]
+         ~argv0:"list_files.exe"
+         ~args:no_args
          ~cwd:(Spawn.Working_dir.Fd fd));
     Unix.close fd);
   [%expect
@@ -99,7 +109,8 @@ let%expect_test "cwd:Fd (invalid)" =
       Spawn.spawn
         ()
         ~prog:"/bin/pwd"
-        ~argv:[ "pwd" ]
+        ~argv0:"pwd"
+        ~args:no_args
         ~cwd:(Spawn.Working_dir.Fd Unix.stdin));
   [%expect
     {|
@@ -114,9 +125,9 @@ module Program_lookup = struct
   let split_path s =
     let rec loop i j =
       if j = String.length s
-      then [ String.sub s i (j - i) ]
+      then [ String.sub s ~pos:i ~len:(j - i) ]
       else if s.[j] = path_sep
-      then String.sub s i (j - i) :: loop (j + 1) (j + 1)
+      then String.sub s ~pos:i ~len:(j - i) :: loop (j + 1) (j + 1)
       else loop i (j + 1)
     in
     loop 0 0
@@ -148,7 +159,8 @@ let%expect_test "inheriting stdout with close-on-exec set" =
     Unix.set_close_on_exec Unix.stdout;
     let shell, arg = if Sys.win32 then "cmd", "/c" else "sh", "-c" in
     let prog = Program_lookup.find_prog shell in
-    wait (Spawn.spawn () ~prog ~argv:[ shell; arg; {|echo "hello world"|} ]));
+    let args = Array.Immutable.of_list [ arg; {|echo "hello world"|} ] in
+    wait (Spawn.spawn () ~prog ~argv0:shell ~args));
   [%expect {| hello world |}]
 ;;
 
@@ -160,7 +172,8 @@ let%expect_test "prog relative to cwd" =
       (Spawn.spawn
          ()
          ~prog:"./hello.exe"
-         ~argv:[ "hello" ]
+         ~argv0:"hello"
+         ~args:no_args
          ~cwd:(Spawn.Working_dir.Path "exe"));
   [%expect {| Hello, world! |}]
 ;;
@@ -177,7 +190,8 @@ let%expect_test "env" =
          ()
          ~env
          ~prog:"./print_env.exe"
-         ~argv:[ "print_env" ]
+         ~argv0:"print_env"
+         ~args:no_args
          ~cwd:(Spawn.Working_dir.Path "exe"))
   in
   tst (Some "foo");
@@ -194,7 +208,8 @@ let%expect_test "pgid tests" =
        ~setpgid:Spawn.Pgid.new_process_group
        ()
        ~prog:"pgid_test/checkpgid.exe"
-       ~argv:[]);
+       ~argv0:"checkpgid.exe"
+       ~args:no_args);
   [%expect {||}]
 ;;
 
@@ -249,9 +264,8 @@ let with_pdeathsig_child mode ~spawn ~f =
   let pid_file = temp_name "pid" in
   let cleanup () =
     kill_child pid_file;
-    List.iter
-      (fun fn -> if Sys.file_exists fn then Unix.unlink fn)
-      [ ready_file; marker_file; pid_file ]
+    List.iter [ ready_file; marker_file; pid_file ] ~f:(fun fn ->
+      if Sys.file_exists fn then Unix.unlink fn)
   in
   Exn.protect ~finally:cleanup ~f:(fun () ->
     cleanup ();
@@ -259,8 +273,8 @@ let with_pdeathsig_child mode ~spawn ~f =
     | 0 ->
       let exit_code =
         try
-          let argv = "print_env" :: mode :: [ ready_file; marker_file ] in
-          let child = spawn argv in
+          let args = mode :: [ ready_file; marker_file ] in
+          let child = spawn args in
           Stdune.Io.String_path.write_file
             pid_file
             (Printf.sprintf "%d\n" (Pid.to_int child));
@@ -281,7 +295,12 @@ let%expect_test "pdeathsig defaults to kill" =
      with_pdeathsig_child
        "pdeathsig-default-child"
        ~f:(fun ~marker_file -> wait_for_no_file marker_file)
-       ~spawn:(fun argv -> Spawn.spawn () ~prog:print_env ~argv)
+       ~spawn:(fun args ->
+         Spawn.spawn
+           ()
+           ~prog:print_env
+           ~argv0:"print_env"
+           ~args:(Array.Immutable.of_list args))
    | _ -> ());
   [%expect {||}]
 ;;
@@ -292,7 +311,13 @@ let%expect_test "pdeathsig explicit signal" =
      with_pdeathsig_child
        "pdeathsig-child"
        ~f:(fun ~marker_file -> wait_for_file marker_file)
-       ~spawn:(fun argv -> Spawn.spawn ~pdeathsig:Usr1 () ~prog:print_env ~argv)
+       ~spawn:(fun args ->
+         Spawn.spawn
+           ~pdeathsig:Usr1
+           ()
+           ~prog:print_env
+           ~argv0:"print_env"
+           ~args:(Array.Immutable.of_list args))
    | _ -> ());
   [%expect {||}]
 ;;
@@ -302,7 +327,8 @@ let%expect_test "sigprocmask" =
   then (
     let run ?sigprocmask expected_signal =
       let prog = Program_lookup.find_prog "sleep" in
-      let pid = Spawn.spawn ?sigprocmask ~prog ~argv:[ "sleep"; "60" ] () in
+      let args = Array.Immutable.of_list [ "60" ] in
+      let pid = Spawn.spawn ?sigprocmask ~prog ~argv0:"sleep" ~args () in
       let pid_int = Pid.to_int pid in
       Unix.kill pid_int Sys.sigusr1;
       Unix.kill pid_int Sys.sigkill;

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -727,7 +727,8 @@ module Dune_config = struct
                 (match
                    Stdune.Spawn.spawn
                      ~prog
-                     ~argv:(prog :: args)
+                     ~argv0:prog
+                     ~args:(Stdune.Array.Immutable.of_list args)
                      ~stdin:(Fd.unsafe_to_unix_file_descr (Lazy.force Dev_null.in_))
                      ~stdout:fdw
                      ~stderr:(Fd.unsafe_to_unix_file_descr (Lazy.force Dev_null.out))

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -66,7 +66,7 @@ open Fiber.O
 let exec_run ~(ectx : context) ~(eenv : env) ~can_run_in_action_runner prog args =
   let metadata = { ectx.metadata with can_run_in_action_runner } in
   let+ (_ : (unit, int) result) =
-    Process.run
+    Process.run_with_array_args
       ~display:!Clflags.display
       (Accept eenv.exit_codes)
       ~dir:eenv.working_dir
@@ -100,7 +100,8 @@ let rec exec t ~ectx ~eenv : Done_or_more_deps.t Fiber.t =
     Action.Prog.Not_found.raise e
   | Run { prog = Ok prog; args; can_run_in_action_runner } ->
     let+ () =
-      exec_run ~ectx ~eenv ~can_run_in_action_runner prog (Appendable_list.to_list args)
+      let args = Appendable_list.to_immutable_array args in
+      exec_run ~ectx ~eenv ~can_run_in_action_runner prog args
     in
     Done
   | With_accepted_exit_codes (exit_codes, t) ->
@@ -171,10 +172,17 @@ let rec exec t ~ectx ~eenv : Done_or_more_deps.t Fiber.t =
     Io.portable_hardlink ~src ~dst:(Path.build dst);
     Fiber.return Done
   | System command ->
-    let prog, arg =
-      Env_path.system_shell_exn ~needed_to:"interpret (system ...) actions"
+    let+ () =
+      let prog, arg =
+        Env_path.system_shell_exn ~needed_to:"interpret (system ...) actions"
+      in
+      exec_run
+        ~ectx
+        ~eenv
+        ~can_run_in_action_runner:true
+        prog
+        (Array.Immutable.of_list [ arg; command ])
     in
-    let+ () = exec_run ~ectx ~eenv ~can_run_in_action_runner:true prog [ arg; command ] in
     Done
   | Bash { script; can_run_in_action_runner } ->
     let+ () =
@@ -183,7 +191,7 @@ let rec exec t ~ectx ~eenv : Done_or_more_deps.t Fiber.t =
         ~eenv
         ~can_run_in_action_runner
         (bash_exn ~loc:ectx.rule_loc ~needed_to:"interpret (bash ...) actions")
-        [ "-e"; "-u"; "-o"; "pipefail"; "-c"; script ]
+        (Array.Immutable.of_list [ "-e"; "-u"; "-o"; "pipefail"; "-c"; script ])
     in
     Done
   | Write_file (fn, perm, s) ->

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -501,7 +501,7 @@ module Short_display = struct
 end
 
 let cmdline_approximate_length prog args =
-  List.fold_left args ~init:(String.length prog) ~f:(fun acc arg ->
+  Array.Immutable.fold_left args ~init:(String.length prog) ~f:(fun acc arg ->
     acc + String.length arg)
 ;;
 
@@ -970,10 +970,10 @@ let spawn
       | Zero_terminated_strings arg ->
         let fn = Temp.create File ~prefix:"responsefile" ~suffix:"data" in
         Stdune.Io.with_file_out fn ~f:(fun oc ->
-          List.iter args ~f:(fun arg ->
+          Array.Immutable.iter args ~f:(fun arg ->
             output_string oc arg;
             output_char oc '\000'));
-        [ arg; Path.to_string fn ], Some fn)
+        Array.Immutable.of_list [ arg; Path.to_string fn ], Some fn)
     else args, None
   in
   let started_at =
@@ -989,20 +989,22 @@ let spawn
     let stdout = Io.fd stdout |> Fd.unsafe_to_unix_file_descr in
     let stderr = Io.fd stderr |> Fd.unsafe_to_unix_file_descr in
     let stdin = Io.fd stdin |> Fd.unsafe_to_unix_file_descr in
-    let argv = prog_str :: args in
+    let cwd =
+      match dir with
+      | None -> Spawn.Working_dir.Inherit
+      | Some dir -> Spawn.Working_dir.Path (Path.to_string dir)
+    in
     Spawn.spawn
       ()
       ~prog:prog_str
-      ~argv
+      ~argv0:prog_str
+      ~args
       ~env
       ~stdout
       ~stderr
       ~stdin
       ?setpgid
-      ~cwd:
-        (match dir with
-         | None -> Inherit
-         | Some dir -> Path (Path.to_string dir))
+      ~cwd
   in
   if emit_trace
   then
@@ -1066,27 +1068,18 @@ let runner_request
   if not metadata.Process_metadata.can_run_in_action_runner
   then None
   else (
-    match
-      ( runner_input_of_io stdin_from
-      , runner_output_of_io stdout_to
-      , Stdlib.( == ) stdout_to stderr_to )
-    with
-    | Some stdin_from, Some stdout_to, true ->
-      Some
-        { Process_runner.dir
-        ; env
-        ; metadata
-        ; prog
-        ; args
-        ; stdin_from
-        ; stdout_to
-        ; stderr_to = Process_runner.Stderr.Same_as_stdout
-        ; create_process_group = Option.is_some setpgid
-        ; timeout
-        ; queued
-        }
-    | Some stdin_from, Some stdout_to, false ->
-      (match runner_output_of_io stderr_to with
+    let same_output = Stdlib.( == ) stdout_to stderr_to in
+    match runner_input_of_io stdin_from, runner_output_of_io stdout_to with
+    | Some stdin_from, Some stdout_to ->
+      let stderr_to =
+        if same_output
+        then Some Process_runner.Stderr.Same_as_stdout
+        else (
+          match runner_output_of_io stderr_to with
+          | None -> None
+          | Some stderr_to -> Some (Process_runner.Stderr.Output stderr_to))
+      in
+      (match stderr_to with
        | None -> None
        | Some stderr_to ->
          Some
@@ -1097,12 +1090,12 @@ let runner_request
            ; args
            ; stdin_from
            ; stdout_to
-           ; stderr_to = Process_runner.Stderr.Output stderr_to
+           ; stderr_to
            ; create_process_group = Option.is_some setpgid
            ; timeout
            ; queued
            })
-    | None, _, _ | _, None, _ -> None)
+    | None, _ | _, None -> None)
 ;;
 
 let exec_locally
@@ -1224,14 +1217,27 @@ let run_internal
     let id = Running_jobs.Id.gen () in
     let prog_str = Path.reach_for_running ?from:dir prog in
     let command_line =
-      lazy (command_line ~prog:prog_str ~args ~dir ~stdout_to ~stderr_to ~stdin_from)
+      lazy
+        (command_line
+           ~prog:prog_str
+           ~args:(Array.Immutable.to_list args)
+           ~dir
+           ~stdout_to
+           ~stderr_to
+           ~stdin_from)
     in
     let fancy_command_line =
       match display with
       | Verbose ->
         let open Pp.O in
         let cmdline =
-          Fancy.command_line ~prog:prog_str ~args ~dir ~stdout_to ~stderr_to ~stdin_from
+          Fancy.command_line
+            ~prog:prog_str
+            ~args:(Array.Immutable.to_list args)
+            ~dir
+            ~stdout_to
+            ~stderr_to
+            ~stdin_from
         in
         Console.print_user_message
           (User_message.make
@@ -1283,26 +1289,28 @@ let run_internal
       t, process_info, termination_reason, times, None, []
     in
     let* t, process_info, termination_reason, times, remote_started_at, trace_args =
-      match
-        runner_request
-          ~dir
-          ~env
-          ~metadata
-          ~prog
-          ~args
-          ~stdin_from
-          ~stdout_to:prepared_outputs.stdout
-          ~stderr_to:prepared_outputs.stderr
-          ~setpgid
-          ~timeout
-          ~queued
-      with
-      | Some request ->
-        (match build with
-         | Some build ->
-           (match Build.action_runner build with
+      match build with
+      | None -> local ()
+      | Some build ->
+        (match Build.action_runner build with
+         | None -> local ()
+         | Some action_runner ->
+           (match
+              runner_request
+                ~dir
+                ~env
+                ~metadata
+                ~prog
+                ~args
+                ~stdin_from
+                ~stdout_to:prepared_outputs.stdout
+                ~stderr_to:prepared_outputs.stderr
+                ~setpgid
+                ~timeout
+                ~queued
+            with
             | None -> local ()
-            | Some action_runner ->
+            | Some request ->
               Io.release prepared_outputs.stdout;
               Io.release prepared_outputs.stderr;
               let+ { Process_runner.started_at
@@ -1336,9 +1344,7 @@ let run_internal
               , termination_reason
               , times
               , Some started_at
-              , trace_args ))
-         | None -> local ())
-      | None -> local ()
+              , trace_args )))
     in
     Option.iter build ~f:(fun (_ : Build.t) ->
       let user_cpu_time, system_cpu_time =
@@ -1458,6 +1464,36 @@ let run
       ?build
       fail_mode
       prog
+      (Array.Immutable.of_list args)
+  in
+  Failure_mode.map_result fail_mode run ~f:ignore
+;;
+
+let run_with_array_args
+      ?dir
+      ~display
+      ?stdout_to
+      ?stderr_to
+      ?stdin_from
+      ?env
+      ?metadata
+      ?build
+      fail_mode
+      prog
+      args
+  =
+  let+ run, _ =
+    run_internal
+      ?dir
+      ~display
+      ?stdout_to
+      ?stderr_to
+      ?stdin_from
+      ?env
+      ?metadata
+      ?build
+      fail_mode
+      prog
       args
   in
   Failure_mode.map_result fail_mode run ~f:ignore
@@ -1488,7 +1524,7 @@ let run_with_times
       ?build
       fail_mode
       prog
-      args
+      (Array.Immutable.of_list args)
   in
   Failure_mode.map_result fail_mode code ~f:(fun () -> times)
 ;;
@@ -1519,7 +1555,7 @@ let run_capture_gen
       ?build
       fail_mode
       prog
-      args
+      (Array.Immutable.of_list args)
   in
   Failure_mode.map_result fail_mode run ~f:(fun () ->
     let x = f fn in
@@ -1601,7 +1637,7 @@ let run_inherit_std_in_out =
       ~setpgid:None
       Return
       prog
-      args
+      (Array.Immutable.of_list args)
     >>| fst
     >>| Failure_mode.exit_code_of_result
 ;;

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -106,6 +106,20 @@ val run
   -> string list
   -> 'a Fiber.t
 
+val run_with_array_args
+  :  ?dir:Path.t
+  -> display:Display.t
+  -> ?stdout_to:Io.output Io.t
+  -> ?stderr_to:Io.output Io.t
+  -> ?stdin_from:Io.input Io.t
+  -> ?env:Env.t
+  -> ?metadata:Process_metadata.t
+  -> ?build:Build.t
+  -> (unit, 'a) Failure_mode.t
+  -> Path.t
+  -> string Array.Immutable.t
+  -> 'a Fiber.t
+
 val run_with_times
   :  ?dir:Path.t
   -> display:Display.t

--- a/src/dune_engine/process_runner.ml
+++ b/src/dune_engine/process_runner.ml
@@ -28,7 +28,7 @@ type request =
   ; env : Env.t
   ; metadata : Process_metadata.t
   ; prog : Path.t
-  ; args : string list
+  ; args : string Array.Immutable.t
   ; stdin_from : Input.t
   ; stdout_to : Output.t
   ; stderr_to : Stderr.t

--- a/src/dune_engine/process_runner.mli
+++ b/src/dune_engine/process_runner.mli
@@ -31,7 +31,7 @@ type request =
   ; env : Env.t
   ; metadata : Process_metadata.t
   ; prog : Path.t
-  ; args : string list
+  ; args : string Array.Immutable.t
   ; stdin_from : Input.t
   ; stdout_to : Output.t
   ; stderr_to : Stderr.t

--- a/src/dune_scheduler/file_watcher.ml
+++ b/src/dune_scheduler/file_watcher.ml
@@ -544,9 +544,9 @@ let spawn_external_watcher ~backend ~watch_exclusions =
   let r_stdout, w_stdout = Unix.pipe () in
   let pid =
     let prog = Path.to_absolute_filename prog in
-    let argv = prog :: args in
+    let args = Array.Immutable.of_list args in
     (* CR-someday rgrinberg: we sohuldn't let this program write anything to our stderr *)
-    Spawn.spawn () ~prog ~argv ~stdout:w_stdout
+    Spawn.spawn () ~prog ~argv0:prog ~args ~stdout:w_stdout
   in
   Unix.close w_stdout;
   Unix.in_channel_of_descr r_stdout, pid

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -70,7 +70,7 @@ module Event : sig
     -> pid:Pid.t
     -> dir:Path.t option
     -> prog:string
-    -> args:string list
+    -> args:string Array.Immutable.t
     -> timeout:Time.Span.t option
     -> started_at:Time.t
     -> name:string option
@@ -88,7 +88,7 @@ module Event : sig
     -> pid:Pid.t
     -> exit:Exit_status.t
     -> prog:string
-    -> process_args:string list
+    -> process_args:string Array.Immutable.t
     -> dir:Path.t option
     -> stdout:string
     -> stderr:string

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -11,6 +11,7 @@ module Arg = struct
   let build_path p = string (Path.Build.to_string p)
   let float x = string (string_of_float x)
   let list xs = Sexp.List xs
+  let array xs ~f = Sexp.List (Array.Immutable.to_list_map xs ~f)
   let int x = Sexp.Atom (string_of_int x)
   let bool x = Sexp.Atom (string_of_bool x)
   let record xs = List.map xs ~f:(fun (k, v) -> list [ string k; v ])
@@ -550,7 +551,7 @@ let process_start
   =
   let args =
     let always =
-      [ "process_args", Arg.list (List.map args ~f:Arg.string)
+      [ "process_args", Arg.array args ~f:Arg.string
       ; "pid", Arg.int (Pid.to_int pid)
       ; "categories", Arg.list (List.map categories ~f:Arg.string)
       ; "queued", Arg.span queued
@@ -594,7 +595,7 @@ let process
   =
   let args =
     let always =
-      [ "process_args", Arg.list (List.map process_args ~f:Arg.string)
+      [ "process_args", Arg.array process_args ~f:Arg.string
       ; "pid", Arg.int (Pid.to_int pid)
       ; "categories", Arg.list (List.map categories ~f:Arg.string)
       ]

--- a/src/lev/test/lev_tests_unix.ml
+++ b/src/lev/test/lev_tests_unix.ml
@@ -14,8 +14,8 @@ let%expect_test "child" =
     Bin.which ~path:(Env_path.path Env.initial) "sh" |> Option.value_exn |> Path.to_string
   in
   let pid =
-    Spawn.spawn ~prog ~argv:[ "sh"; "-c"; "exit 42" ] ~stdin ~stdout ~stderr ()
-    |> Pid.to_int
+    let args = Array.Immutable.of_list [ "-c"; "exit 42" ] in
+    Spawn.spawn ~prog ~argv0:"sh" ~args ~stdin ~stdout ~stderr () |> Pid.to_int
   in
   let child =
     match Child.create with

--- a/test/blackbox-tests/utils/dune_cmd.ml
+++ b/test/blackbox-tests/utils/dune_cmd.ml
@@ -74,7 +74,8 @@ module NativePath = struct
         | None -> User_error.raise [ Pp.text "Unable to find cygpath in PATH" ]
         | Some cygpath ->
           let cygpath = Path.to_string cygpath in
-          ignore (Spawn.spawn ~prog:cygpath ~argv:[ cygpath; "-wl"; fn ] ())
+          let args = Array.Immutable.of_list [ "-wl"; fn ] in
+          ignore (Spawn.spawn ~prog:cygpath ~argv0:cygpath ~args ())
   ;;
 
   let of_args = function

--- a/test/expect-tests/dune_pkg/rev_store_fetch_depth/rev_store_fetch_depth_test.ml
+++ b/test/expect-tests/dune_pkg/rev_store_fetch_depth/rev_store_fetch_depth_test.ml
@@ -22,17 +22,18 @@ let with_git_daemon ~parent_dir ~port ~repo_dir ~unrelated_repo_dir ~f =
   let daemon_pid =
     Spawn.spawn
       ~prog:git_prog_str
-      ~argv:
-        [ git_prog_str
-        ; "daemon"
-        ; "--export-all"
-        ; sprintf "--base-path=%s" (Path.to_string parent_dir)
-        ; "--listen=127.0.0.1"
-        ; sprintf "--port=%d" port
-        ; "--reuseaddr"
-        ; Path.to_string repo_dir
-        ; Path.to_string unrelated_repo_dir
-        ]
+      ~argv0:git_prog_str
+      ~args:
+        (Array.Immutable.of_list
+           [ "daemon"
+           ; "--export-all"
+           ; sprintf "--base-path=%s" (Path.to_string parent_dir)
+           ; "--listen=127.0.0.1"
+           ; sprintf "--port=%d" port
+           ; "--reuseaddr"
+           ; Path.to_string repo_dir
+           ; Path.to_string unrelated_repo_dir
+           ])
       ~stdin:(Fd.unsafe_to_unix_file_descr (Lazy.force Dev_null.in_))
       ~stdout:(Fd.unsafe_to_unix_file_descr (Lazy.force Dev_null.out))
       ~stderr:(Fd.unsafe_to_unix_file_descr (Lazy.force Dev_null.out))

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -93,11 +93,12 @@ let run ?env ~prog ~argv () =
   let stdout_i, stdout_w = Unix.pipe ~cloexec:true () in
   let stderr_i, stderr_w = Unix.pipe ~cloexec:true () in
   let pid =
-    let argv = prog :: argv in
+    let args = Array.Immutable.of_list argv in
     let env = Option.map ~f:Spawn.Env.of_list env in
     Spawn.spawn
       ~prog
-      ~argv
+      ~argv0:prog
+      ~args
       ~stdout:stdout_w
       ~stderr:stderr_w
       ~stdin:(Fd.unsafe_to_unix_file_descr (Lazy.force Dev_null.in_))

--- a/test/expect-tests/foreign_stubs/archive_creation_behavior.ml
+++ b/test/expect-tests/foreign_stubs/archive_creation_behavior.ml
@@ -54,7 +54,8 @@ let spawn_and_capture ?env ~prog ~argv ~cwd () =
             let env = Option.map env ~f:Spawn.Env.of_list in
             Spawn.spawn
               ~prog
-              ~argv:(prog :: argv)
+              ~argv0:prog
+              ~args:(Array.Immutable.of_list argv)
               ~stdout:stdout_fd
               ~stderr:stderr_fd
               ?env

--- a/test/expect-tests/inotify_tests/inotify_tests.ml
+++ b/test/expect-tests/inotify_tests/inotify_tests.ml
@@ -351,12 +351,18 @@ let%expect_test "Check that FS events are reported chronologically 2" =
 ;;
 
 let run cmd =
+  let argv0, args =
+    match cmd with
+    | argv0 :: args -> argv0, args
+    | [] -> Code_error.raise "empty command line" []
+  in
   let prog =
-    Bin.which ~path:(Env_path.path Env.initial) (List.hd cmd)
+    Bin.which ~path:(Env_path.path Env.initial) argv0
     |> Option.value_exn
     |> Path.to_string
   in
-  let pid = Spawn.spawn ~prog ~argv:cmd () in
+  let args = Array.Immutable.of_list args in
+  let pid = Spawn.spawn ~prog ~argv0 ~args () in
   match Proc.wait (Pid pid) [] with
   | Some { status = WEXITED 0; _ } -> ()
   | _ -> assert false

--- a/test/expect-tests/timer_tests.ml
+++ b/test/expect-tests/timer_tests.ml
@@ -57,7 +57,7 @@ let%expect_test "run process with timeout" =
         let path = Env.get Env.initial "PATH" |> Option.value_exn |> Bin.parse_path in
         Bin.which ~path "sleep" |> Option.value_exn |> Path.to_string
       in
-      Spawn.spawn ~prog ~argv:[ prog; "100000" ] ()
+      Spawn.spawn ~prog ~argv0:prog ~args:(Array.Immutable.of_list [ "100000" ]) ()
     in
     let+ (_ : Proc.Process_info.t) =
       Scheduler.wait_for_process

--- a/test/unit-tests/fswatch_win/fswatch_win_tests.ml
+++ b/test/unit-tests/fswatch_win/fswatch_win_tests.ml
@@ -257,12 +257,18 @@ let _ =
 ;;
 
 let run cmd =
+  let argv0, args =
+    match cmd with
+    | argv0 :: args -> argv0, args
+    | [] -> Code_error.raise "empty command line" []
+  in
   let prog =
-    Bin.which ~path:(Env_path.path Env.initial) (List.hd cmd)
+    Bin.which ~path:(Env_path.path Env.initial) argv0
     |> Option.value_exn
     |> Path.to_string
   in
-  let pid = Spawn.spawn ~prog ~argv:cmd () in
+  let args = Array.Immutable.of_list args in
+  let pid = Spawn.spawn ~prog ~argv0 ~args () in
   match Proc.wait (Pid pid) [] with
   | Some { status = WEXITED 0; _ } -> ()
   | _ -> assert false


### PR DESCRIPTION
Expanded action arguments are currently flattened into a list, retaining one list cell per argument while the subprocess runs and allocating a temporary reversed list during flattening.

Flatten action arguments directly into an immutable array and use arrays as the canonical representation in the process core. Existing list-based `Process` entry points convert at their boundary, while command rendering converts only when needed. Trace events consume arrays directly without changing the serialized format, and process runner requests retain arrays across marshalling.

`Spawn.spawn` accepts the executable, `argv[0]`, and the remaining immutable argument array separately. This preserves caller control over `argv[0]` while allowing the Unix stub to construct the C argument vector without first materializing either an OCaml argument list or a second full `argv` array.

Across six alternating cold `@check` build pairs with eight jobs and the cache disabled, median minor allocation fell from 295.99M to 295.57M words (-0.14%), promoted allocation fell from 45.30M to 44.34M words (-2.12%), and major allocation fell from 102.13M to 101.27M words (-0.84%). In a separate six-pair `--action-runner` comparison, retaining arrays in runner requests saved another 0.42M parent-process minor words. Runtime measurements remained noisy.
