### PR TITLE
feat(trace): fall back to symbolized allocation frames

### DIFF
--- a/doc/advanced/profiling-dune.rst
+++ b/doc/advanced/profiling-dune.rst
@@ -30,10 +30,11 @@ recorded call-stack depth, and ``top`` is the maximum number of entries kept in
 each ranking. Their defaults are ``0.0001``, ``10``, and ``10``. This
 configuration is experimental and may change without notice.
 
-Each sampled heap is ranked by exact call stack, immediate allocation site, and
-inclusive stack frame. The allocation-site view combines allocations at the
-same source location that have different callers. The inclusive-frame view
-identifies subsystems responsible for allocations below them in the call
+Each sampled heap is ranked by exact call stack, allocation site, and inclusive
+stack frame. The allocation-site view combines allocations at the same source
+location that have different callers. If the youngest sampled frame has no
+symbol, it uses the nearest symbolized frame in the stack. The inclusive-frame
+view identifies subsystems responsible for allocations below them in the call
 stack. Summing the samples in a truncated exact-stack or allocation-site
 ranking and dividing by ``total_samples`` gives its displayed coverage.
 

--- a/src/dune_trace/alloc.ml
+++ b/src/dune_trace/alloc.ml
@@ -157,6 +157,18 @@ module Frame = struct
     Table.find_or_add cache slot ~f:(fun slot ->
       Printexc.convert_raw_backtrace_slot slot |> of_slot)
   ;;
+
+  let nearest_known cache slots =
+    let rec loop index =
+      if index = Array.length slots
+      then Unknown
+      else (
+        match of_slot cache (Array.get slots index) with
+        | Unknown -> loop (index + 1)
+        | Known _ as frame -> frame)
+    in
+    loop 0
+  ;;
 end
 
 module Trace = struct
@@ -406,7 +418,7 @@ let site_entries by_key ~frame_cache ~sampling_rate ~top_entry_count =
     let frame =
       match trace with
       | Trace.Unknown -> Frame.Unknown
-      | Trace slots -> Frame.of_slot frame_cache (Array.get slots 0)
+      | Trace slots -> Frame.nearest_known frame_cache slots
     in
     add_samples by_site { Frame_key.source; frame } samples);
   ranked_frames by_site ~sampling_rate ~top_entry_count


### PR DESCRIPTION
Allocation-site rankings currently use the youngest captured frame even when it has neither a name nor source location. This can collapse otherwise actionable samples into a large `<unknown>` bucket.

Walk each sampled stack from youngest to oldest and attribute the site to the nearest symbolized frame. The lookup reuses the existing frame cache, leaves all-unknown stacks as `<unknown>`, and preserves exact stacks unchanged.

In a no-op Dune self-build, this split a 67.4M-word `<unknown>` site into symbolized callers, led by `Fiber__Scheduler.exec` at 32.9M words.
