### PR TITLE
Fix command-from-user-path to avoid shadowing

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/command-from-user-path.t
+++ b/test/blackbox-tests/test-cases/pkg/command-from-user-path.t
@@ -7,7 +7,7 @@ Create a directory containing a shell script and add the directory to PATH.
   > echo "Hello, World!"
   > EOF
   $ chmod a+x bin/hello
-  $ export PATH=$PATH:$PWD/bin
+  $ export PATH=$PWD/bin:$PATH
 
 Create a lockdir with a lockfile that runs the shell script in a build command.
   $ make_lockdir


### PR DESCRIPTION
## Description

If a dev had a program called `hello` on their path that emitted different output, then this test would fail, since the path to the bin was _suffixed_ to the `PATH`.

This was affecting me due to an a long forgotten install of `hello` thru a nix tutorial.

## Checklist

- [x] Tests added, if applicable.
- [x] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [x] Documentation added for any user-facing changes.
