### PR TITLE
perf(rules): flatten nested command argument groups

### DIFF
--- a/src/dune_rules/command.ml
+++ b/src/dune_rules/command.ml
@@ -103,7 +103,16 @@ and expand_list
   match ts with
   | [] -> Appendable_list.empty |> Action_builder.With_targets.return
   | ts ->
-    List.map ts ~f:(expand ~dir)
+    let rec flatten ts stack =
+      match ts with
+      | [] ->
+        (match stack with
+         | [] -> []
+         | ts :: stack -> flatten ts stack)
+      | S nested :: ts -> flatten nested (ts :: stack)
+      | t :: ts -> t :: flatten ts stack
+    in
+    List.map (flatten ts []) ~f:(expand ~dir)
     |> Action_builder.With_targets.all
     |> Action_builder.With_targets.map ~f:Appendable_list.concat
 


### PR DESCRIPTION
Nested `Command.Args.S` groups currently recurse through `expand_list`, creating
an Action Builder collection and appendable-list node for every group. Flatten
those groups before expansion using an explicit list stack. Argument order and
parallel Action Builder evaluation are preserved.

On warmed no-op `@check` builds, five alternating allocation runs measured:

- minor words: 248.02M -> 243.58M (-1.79%)
- promoted words: 39.26M -> 38.81M (-1.14%)
- live words: 19.99M -> 19.73M (-1.29%)
- Cachegrind instructions: 12.445B -> 12.352B (-0.75%)

Across 40 alternating native `@check` runs, mean wall time improved from 1.512s
to 1.499s (-0.92%).
