### PR TITLE
fix(trace): avoid allocation while swapping profiles

### DIFF
--- a/src/dune_trace/alloc.ml
+++ b/src/dune_trace/alloc.ml
@@ -462,25 +462,33 @@ let swap t =
   let fresh_minor = Table.create (module Key) 64 in
   let fresh_major = Table.create (module Key) 64 in
   let fresh_promoted = Table.create (module Key) 64 in
+  let minor_total_samples = ref 0 in
+  let minor_by_key = ref fresh_minor in
+  let major_total_samples = ref 0 in
+  let major_by_key = ref fresh_major in
+  let promoted_total_samples = ref 0 in
+  let promoted_by_key = ref fresh_promoted in
   Mutex.protect t.mutex (fun () ->
-    let minor_total_samples = t.minor.total_samples in
-    let minor_by_key = t.minor.by_key in
-    let major_total_samples = t.major.total_samples in
-    let major_by_key = t.major.by_key in
-    let promoted_total_samples = t.promoted.total_samples in
-    let promoted_by_key = t.promoted.by_key in
+    minor_total_samples := t.minor.total_samples;
+    minor_by_key := t.minor.by_key;
+    major_total_samples := t.major.total_samples;
+    major_by_key := t.major.by_key;
+    promoted_total_samples := t.promoted.total_samples;
+    promoted_by_key := t.promoted.by_key;
     t.minor.total_samples <- 0;
     t.minor.by_key <- fresh_minor;
     t.major.total_samples <- 0;
     t.major.by_key <- fresh_major;
     t.promoted.total_samples <- 0;
-    t.promoted.by_key <- fresh_promoted;
-    ( minor_total_samples
-    , minor_by_key
-    , major_total_samples
-    , major_by_key
-    , promoted_total_samples
-    , promoted_by_key ))
+    t.promoted.by_key <- fresh_promoted);
+  (* Constructing this tuple can allocate and trigger a Memprof callback, which
+     attempts to acquire [t.mutex], so it must happen after releasing the mutex. *)
+  ( !minor_total_samples
+  , !minor_by_key
+  , !major_total_samples
+  , !major_by_key
+  , !promoted_total_samples
+  , !promoted_by_key )
 ;;
 
 type snapshot =


### PR DESCRIPTION
`Alloc.swap` currently constructs its result tuple while holding the allocation profiler's sample mutex. At sufficiently high sampling rates, that allocation can invoke a Memprof callback which attempts to acquire the same mutex, terminating Dune with `Mutex.lock: Resource deadlock avoided`.

Capture the sampled heap fields in references allocated before taking the mutex, and construct the returned tuple only after releasing it. This keeps the critical section allocation-free without changing the snapshot contents.
