### PR TITLE
test(watching): stabilize shutdown test

### DIFF
--- a/test/blackbox-tests/test-cases/watching/shutdown.t
+++ b/test/blackbox-tests/test-cases/watching/shutdown.t
@@ -13,9 +13,12 @@ a client.
   >   $ echo 'took too long'
   > EOF
 
-  $ dune build -w &
-  Success, waiting for filesystem changes...
+  $ dune build -w > .#dune-output 2>&1 &
   $ DUNE_PID=$!
+  $ wait_for_line_with_timeout .#dune-output \
+  >   "Success, waiting for filesystem changes..." 200
+  $ cat .#dune-output
+  Success, waiting for filesystem changes...
 
   $ dune rpc ping --wait
   Server appears to be responding normally


### PR DESCRIPTION
Capture the watch server output and wait for its initial build to finish before issuing RPC requests. This prevents the background status line from racing with cram output capture and intermittently disappearing from the expected output.

This is a test-only stabilization; no changelog entry or documentation update is needed.