### PR TITLE
refactor: batch qualified dependency lookup

### DIFF
--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -1166,6 +1166,17 @@ module With_vlib = struct
       | Parent_cycle -> Error `Parent_cycle
   ;;
 
+  let find_deps =
+    let rec loop t ~of_ acc = function
+      | [] -> Ok (List.rev acc)
+      | name :: names ->
+        (match find_dep t ~of_ name with
+         | Ok modules -> loop t ~of_ (List.rev_append modules acc) names
+         | Error `Parent_cycle -> Error (`Parent_cycle name))
+    in
+    fun t ~of_ names -> loop t ~of_ [] names
+  ;;
+
   let implicit_deps t ~of_ =
     match t with
     | Impl _ -> []

--- a/src/dune_rules/modules.mli
+++ b/src/dune_rules/modules.mli
@@ -74,11 +74,13 @@ module With_vlib : sig
   val encode : t -> src_dir:Path.t -> Dune_lang.t
   val impl : modules -> vlib:modules -> t
 
-  val find_dep
+  (** Resolve a batch of dependencies in order. The error carries the dependency
+      name that closes a parent cycle. *)
+  val find_deps
     :  t
     -> of_:Module.t
-    -> Module_name.t
-    -> (Module.t list, [ `Parent_cycle ]) result
+    -> Module_name.t list
+    -> (Module.t list, [ `Parent_cycle of Module_name.t ]) result
 
   (** Additional dependencies that aren't always reported by [ocamldep], such
       as `(modules_before_stdlib ..)` in `(stdlib ..)` libraries. *)

--- a/src/dune_rules/ocamldep.ml
+++ b/src/dune_rules/ocamldep.ml
@@ -1,25 +1,24 @@
 open Import
 
 let parse_module_names ~dir ~(unit : Module.t) ~modules words =
-  List.concat_map words ~f:(fun m ->
-    let m = Module_name.of_checked_string m in
-    match Modules.With_vlib.find_dep modules ~of_:unit m with
-    | Ok s -> s
-    | Error `Parent_cycle ->
-      User_error.raise
-        [ Pp.textf
-            "Module %s in directory %s depends on %s."
-            (Module_name.to_string (Module.name unit))
-            (Path.to_string_maybe_quoted (Path.build dir))
-            (Module_name.to_string m)
-        ; Pp.textf "This doesn't make sense to me."
-        ; Pp.nop
-        ; Pp.textf
-            "%s is the main module of the library and is the only module exposed outside \
-             of the library. Consequently, it should be the one depending on all the \
-             other modules in the library."
-            (Module_name.to_string m)
-        ])
+  let names = List.map words ~f:Module_name.of_checked_string in
+  match Modules.With_vlib.find_deps modules ~of_:unit names with
+  | Ok modules -> modules
+  | Error (`Parent_cycle m) ->
+    User_error.raise
+      [ Pp.textf
+          "Module %s in directory %s depends on %s."
+          (Module_name.to_string (Module.name unit))
+          (Path.to_string_maybe_quoted (Path.build dir))
+          (Module_name.to_string m)
+      ; Pp.textf "This doesn't make sense to me."
+      ; Pp.nop
+      ; Pp.textf
+          "%s is the main module of the library and is the only module exposed outside \
+           of the library. Consequently, it should be the one depending on all the other \
+           modules in the library."
+          (Module_name.to_string m)
+      ]
 ;;
 
 let invalid_ocamldep_output file lines =

--- a/test/expect-tests/module_tests.ml
+++ b/test/expect-tests/module_tests.ml
@@ -101,17 +101,10 @@ let module_summary module_ =
 ;;
 
 let find_deps_exn modules ~of_ names =
-  let rec loop acc = function
-    | [] -> List.rev acc
-    | name :: names ->
-      (match Modules.With_vlib.find_dep modules ~of_ name with
-       | Ok modules -> loop (List.rev_append modules acc) names
-       | Error `Parent_cycle ->
-         Code_error.raise
-           "unexpected parent cycle"
-           [ "dependency", Module_name.to_dyn name ])
-  in
-  loop [] names
+  match Modules.With_vlib.find_deps modules ~of_ names with
+  | Ok modules -> modules
+  | Error (`Parent_cycle name) ->
+    Code_error.raise "unexpected parent cycle" [ "dependency", Module_name.to_dyn name ]
 ;;
 
 let check_deps label modules ~of_ names ~expected =


### PR DESCRIPTION
Introduce a behavior-preserving batch dependency lookup API for qualified modules.

Builds on the independent coverage in #15754 and #15759; #15752 adds the optimization.