### PR TITLE
perf(targets): digest produced targets without lists

### DIFF
--- a/otherlibs/stdune/src/array.ml
+++ b/otherlibs/stdune/src/array.ml
@@ -259,6 +259,8 @@ module Sorted = struct
         | _ -> true
       ;;
 
+      let iter { values; _ } ~f = Stdlib.Array.iter f values
+
       let iteri { keys; values } ~f =
         for i = 0 to Array.length keys - 1 do
           f keys.(i) values.(i)
@@ -334,14 +336,13 @@ module Sorted = struct
       ;;
 
       let keys t = t.keys
+      let values t = Stdlib.Array.to_list t.values
 
       let of_set set ~f =
         { keys = set
         ; values = Array.init (Array.length set) (fun i -> f (Array.get set i))
         }
       ;;
-
-      let values t = Stdlib.Array.to_list t.values
 
       let exists t ~f =
         let rec loop i =

--- a/otherlibs/stdune/src/array_intf.ml
+++ b/otherlibs/stdune/src/array_intf.ml
@@ -37,8 +37,8 @@ module type S = sig
     val of_sorted_list_exn : (key * 'a) list -> 'a t
     val union_left_biased : 'a t -> 'a t -> 'a t
     val keys : _ t -> Set.t
-    val of_set : Set.t -> f:(key -> 'a) -> 'a t
     val values : 'a t -> 'a list
+    val of_set : Set.t -> f:(key -> 'a) -> 'a t
     val exists : 'a t -> f:('a -> bool) -> bool
     val foldi : 'a t -> init:'acc -> f:(key -> 'a -> 'acc -> 'acc) -> 'acc
     val filter_mapi : 'a t -> f:(key -> 'a -> 'b option) -> 'b t
@@ -48,6 +48,7 @@ module type S = sig
     val to_list_map : 'a t -> f:(key -> 'a -> 'b) -> 'b list
     val to_dyn : ('a -> Dyn.t) -> 'a t -> Dyn.t
     val equal : 'a t -> 'a t -> equal:('a -> 'a -> bool) -> bool
+    val iter : 'a t -> f:('a -> unit) -> unit
     val iteri : 'a t -> f:(key -> 'a -> unit) -> unit
   end
 end

--- a/otherlibs/stdune/test/array_tests.ml
+++ b/otherlibs/stdune/test/array_tests.ml
@@ -63,6 +63,7 @@ let%expect_test "array-backed map" =
   print_map (Map.filter_mapi map ~f:(fun _ _ -> None));
   print_set (Map.keys map);
   Map.to_list_map map ~f:(fun key value -> sprintf "%s:%d" key value) |> print_string_list;
+  Map.values map |> list int |> print_dyn;
   let bindings = ref [] in
   Map.iteri map ~f:(fun key value -> bindings := sprintf "%s=%d" key value :: !bindings);
   List.rev !bindings |> print_string_list;
@@ -93,6 +94,7 @@ true
 []
 [ "a"; "b" ]
 [ "a:1"; "b:2" ]
+[ 1; 2 ]
 [ "a=1"; "b=2" ]
 true
 false

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -256,7 +256,7 @@ module Internal = struct
 
   (* The current version of the rule digest scheme. We should increment it when
      making any changes to the scheme, to avoid collisions. *)
-  let rule_digest_version = 30
+  let rule_digest_version = 31
 
   let compute_rule_digest
         (rule : Rule.t)

--- a/src/dune_targets/dune_targets.ml
+++ b/src/dune_targets/dune_targets.ml
@@ -552,14 +552,12 @@ module Produced = struct
   ;;
 
   let digest { contents; root = _ } =
-    let rec all_digests { files; subdirs } =
-      let ffiles = Filename.Array.Map.values files in
-      List.concat
-        (ffiles
-         :: Filename.Array.Map.to_list_map subdirs ~f:(fun _ dir -> all_digests dir))
-    in
     let d = Digest.Manual.create () in
-    Digest.Manual.list d (all_digests contents) ~f:Digest.Manual.digest;
+    let rec loop { files; subdirs } =
+      Filename.Array.Map.iter files ~f:(Digest.Manual.digest d);
+      Filename.Array.Map.iter subdirs ~f:loop
+    in
+    loop contents;
     Digest.Manual.get d
   ;;
 

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t
@@ -80,7 +80,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune_build_sorted_actions --config-file config reproducible non-reproducible
-  Warning: cache store error [ea7bca3be6a3429be396d0bc3b7a2d16]: ((in_cache
+  Warning: cache store error [542059eb7b9f78e6cebedf4dd1de4e91]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   action at dune:6
@@ -136,7 +136,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune_build_sorted_actions --cache=enabled reproducible non-reproducible
-  Warning: cache store error [ea7bca3be6a3429be396d0bc3b7a2d16]: ((in_cache
+  Warning: cache store error [542059eb7b9f78e6cebedf4dd1de4e91]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   action at dune:6
@@ -148,7 +148,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune_build_sorted_actions --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [ea7bca3be6a3429be396d0bc3b7a2d16]: ((in_cache
+  Warning: cache store error [542059eb7b9f78e6cebedf4dd1de4e91]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   action at dune:6

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -82,8 +82,8 @@ entries uniformly.
   $ metadata_dir="$PWD/.xdg-cache/dune/db/meta/v5"
   $ (cd "$metadata_dir"; find . -mindepth 2 -maxdepth 2 -type f | sort) > metadata-paths
   $ cat metadata-paths | censor
-  ./18/$DIGEST1
-  ./4c/$DIGEST2
+  ./bf/$DIGEST1
+  ./c9/$DIGEST2
 
   $ while read path; do dune internal cache-metadata "$metadata_dir/$path"; done < metadata-paths \
   > | jq_dune -S -s 'sortCacheMetadataByFirstPath' \


### PR DESCRIPTION
Feed produced-target digests directly from compact map values instead of allocating one list per directory and flattening those lists before hashing. Replace the list-producing map operation with direct value iteration, and bump the rule digest scheme with its affected fixtures.

On no-op self-builds, minor allocation fell by 0.18M words (0.08%) for `@check` and 0.17M words (0.09%) for `@install`. Promoted and live allocation remained neutral; wall time stayed within measurement noise.
