### PR TITLE
perf(engine): derive rule locations on demand

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -173,7 +173,7 @@ module Internal = struct
     Pp.concat [ Pp.text (File_selector.to_dyn file_selector |> Dyn.to_string) ]
   ;;
 
-  let select_sandbox_mode (config : Sandbox_config.t) ~loc ~sandboxing_preference =
+  let select_sandbox_mode (config : Sandbox_config.t) ~rule ~sandboxing_preference =
     (* Rules with (mode patch-back-source-tree) are special and are not affected
        by sandboxing preferences. *)
     match Sandbox_mode.Set.is_patch_back_source_tree_only config with
@@ -186,7 +186,7 @@ module Internal = struct
           if Sys.win32 && preference = Some Sandbox_mode.Symlink
           then
             User_error.raise
-              ~loc
+              ~loc:(Rule.loc rule)
               [ Pp.text
                   "Sandboxing mode symlink is not supported on Windows. Use copy or \
                    hardlink instead."
@@ -201,7 +201,7 @@ module Internal = struct
             modes. However, it can still be reached if multiple sandbox config
             specs are combined into an unsatisfiable one. *)
          User_error.raise
-           ~loc
+           ~loc:(Rule.loc rule)
            [ Pp.text
                "This rule forbids all sandboxing modes (but it also requires sandboxing)"
            ])
@@ -513,7 +513,7 @@ module Internal = struct
       Target_promotion.promote ~targets ~promote ~promote_source
 
   and execute_rule_impl ~rule_kind rule =
-    let { Rule.id = _; targets; mode; action; info = _; loc } = rule in
+    let { Rule.id = _; targets; mode; action; info } = rule in
     let head_target = Targets.Validated.head targets in
     let* execution_parameters =
       match Dpath.Target_dir.of_target targets.root with
@@ -533,13 +533,13 @@ module Internal = struct
     let* action, facts = Action_builder.evaluate_and_collect_facts action in
     let wrap_fiber f =
       Memo.of_reproducible_fiber
-        (if Loc.is_none loc
-         then f ()
-         else
+        (match info with
+         | From_dune_file loc when Loc.is_none loc -> f ()
+         | From_dune_file _ | Internal | Source_file_copy _ ->
            Fiber.with_error_handler f ~on_error:(fun exn ->
              match exn.exn with
              | User_error.E msg when not (User_message.has_location msg) ->
-               let msg = { msg with loc = Some loc } in
+               let msg = { msg with loc = Some (Rule.loc rule) } in
                Exn_with_backtrace.reraise { exn with exn = User_error.E msg }
              | _ -> Exn_with_backtrace.reraise exn))
     in
@@ -551,7 +551,7 @@ module Internal = struct
       let is_action_dynamic = Action.is_dynamic action.action in
       let sandbox_mode =
         select_sandbox_mode
-          ~loc
+          ~rule
           action.sandbox
           ~sandboxing_preference:config.sandboxing_preference
       in
@@ -646,6 +646,7 @@ module Internal = struct
               Fiber.return (produced_targets, dynamic_deps_stages)
             | None ->
               (* Step IV. Execute the build action. *)
+              let loc = Rule.loc rule in
               let* exec_result =
                 execute_action_for_rule
                   ~rule_kind
@@ -865,7 +866,7 @@ module Internal = struct
                [ "targets", Targets.Validated.to_dyn rule.targets ]
          in
          User_error.raise
-           ~loc:rule.loc
+           ~loc:(Rule.loc rule)
            ~needs_stack_trace:true
            [ Pp.textf
                "This rule defines a directory target %S that matches the requested path \

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -657,7 +657,8 @@ end = struct
       match rules with
       | [] ->
         { filenames = of_filename_set filenames; dirnames = of_filename_set dirnames }
-      | { Rule.targets; mode; loc; _ } :: rules when Path.Build.equal dir targets.root ->
+      | ({ Rule.targets; mode; _ } as rule) :: rules
+        when Path.Build.equal dir targets.root ->
         let target_filenames = targets.files in
         let target_dirnames = targets.dirs in
         (* Check if this rule defines any file targets that conflict with internal Dune
@@ -667,7 +668,8 @@ end = struct
            Filename.Set.find target_filenames ~f:(Subdir_set.mem build_dir_only_sub_dirs)
          with
          | None -> ()
-         | Some target_name -> report_rule_internal_dir_conflict target_name loc);
+         | Some target_name ->
+           report_rule_internal_dir_conflict target_name (Rule.loc rule));
         (match mode with
          | Standard | Fallback -> iter ~filenames ~dirnames rules
          | Ignore_source_files ->

--- a/src/dune_engine/rule.ml
+++ b/src/dune_engine/rule.ml
@@ -67,13 +67,21 @@ module T = struct
     ; action : Action.Full.t Action_builder.t
     ; mode : Mode.t
     ; info : Info.t
-    ; loc : Loc.t
     }
 
   let compare a b = Id.compare a.id b.id
   let equal a b = Id.equal a.id b.id
   let hash t = Id.hash t.id
-  let loc t = t.loc
+
+  let loc { info; targets; _ } =
+    match info with
+    | From_dune_file loc -> loc
+    | Internal ->
+      Loc.in_file
+        (Path.drop_optional_build_context
+           (Path.build (Path.Build.relative targets.root "_unknown_")))
+    | Source_file_copy p -> Loc.in_file (Path.source p)
+  ;;
 
   let repr =
     Repr.record
@@ -117,16 +125,7 @@ let make ?(mode = Mode.Standard) ?(info = Info.Internal) ~targets action =
            "%S is declared as both a file and a directory target."
            (Dpath.describe_target path))
   in
-  let loc =
-    match info with
-    | From_dune_file loc -> loc
-    | Internal ->
-      Loc.in_file
-        (Path.drop_optional_build_context
-           (Path.build (Path.Build.relative targets.root "_unknown_")))
-    | Source_file_copy p -> Loc.in_file (Path.source p)
-  in
-  { id = Id.gen (); targets; action; mode; info; loc }
+  { id = Id.gen (); targets; action; mode; info }
 ;;
 
 let set_action t action =

--- a/src/dune_engine/rule.mli
+++ b/src/dune_engine/rule.mli
@@ -58,7 +58,6 @@ type t = private
   ; action : Action.Full.t Action_builder.t
   ; mode : Mode.t
   ; info : Info.t
-  ; loc : Loc.t
   }
 
 include Comparable_intf.S with type key := t

--- a/src/dune_engine/rules.ml
+++ b/src/dune_engine/rules.ml
@@ -199,7 +199,7 @@ let directory_targets (rules : t) =
           Filename.Set.fold ~init:acc rule.targets.dirs ~f:(fun target acc ->
             let target = Path.Build.relative_fname rule.targets.root target in
             Path.Build.Map.update acc target ~f:(function
-              | None -> Some rule.loc
+              | None -> Some (Rule.loc rule)
               | Some loc -> Some loc))))
 ;;
 


### PR DESCRIPTION
Each `Rule.t` currently retains both its provenance in `Rule.Info.t` and a
`Loc.t` derived from that provenance. The location is only needed for errors,
but the extra field remains live for every rule throughout a build.

Remove the redundant field and derive it from `Rule.Info.t` and the rule target
root when diagnostics need it. Locations from dune files are returned directly;
locations for internal and source-copy rules are reconstructed using the same
logic previously used by `Rule.make`.

A generated 20,000-rule workload improved task-clock by about 2.2% and wall
time by about 2.5%. Self-build measurements also showed approximately 0.5--0.9%
less live heap.