### PR TITLE
perf(trace): sort allocation rankings once

### DIFF
--- a/src/dune_trace/alloc.ml
+++ b/src/dune_trace/alloc.ml
@@ -382,19 +382,10 @@ let take_top_entries entries ~top_entry_count =
   take [] top_entry_count entries
 ;;
 
-let insert_top_entry entry entries ~top_entry_count =
-  let _, samples = entry in
-  let rec insert = function
-    | [] -> [ entry ]
-    | ((_, samples') as entry') :: entries ->
-      if samples > samples' then entry :: entry' :: entries else entry' :: insert entries
-  in
-  insert entries |> take_top_entries ~top_entry_count
-;;
-
 let ranked_entries table ~top_entry_count =
-  Table.foldi table ~init:[] ~f:(fun key samples entries ->
-    insert_top_entry (key, samples) entries ~top_entry_count)
+  Table.to_list table
+  |> List.sort ~compare:(fun (_, samples) (_, samples') -> Int.compare samples' samples)
+  |> take_top_entries ~top_entry_count
 ;;
 
 let top_entries by_key ~frame_cache ~sampling_rate ~top_entry_count =

--- a/test/blackbox-tests/test-cases/trace/alloc.t
+++ b/test/blackbox-tests/test-cases/trace/alloc.t
@@ -49,6 +49,11 @@ The alloc sampler is only enabled when the alloc trace category is requested:
   >             ((keys | sort) == ["estimated_words", "frame", "samples", "source"]
   >              and (.source | type == "string")
   >              and (.frame | type == "string"))))
+  >     , rankings_are_sorted:
+  >         all($heaps[];
+  >           all([.top, .by_site, .by_frame][];
+  >             [.[].samples] as $samples
+  >             | $samples == ($samples | sort | reverse)))
   >     }
   >   ]'
   [
@@ -88,7 +93,8 @@ The alloc sampler is only enabled when the alloc trace category is requested:
         ]
       },
       "entries_have_sources_and_traces": true,
-      "frame_entries_have_sources_and_locations": true
+      "frame_entries_have_sources_and_locations": true,
+      "rankings_are_sorted": true
     },
     {
       "name": "summary",
@@ -126,7 +132,8 @@ The alloc sampler is only enabled when the alloc trace category is requested:
         ]
       },
       "entries_have_sources_and_traces": true,
-      "frame_entries_have_sources_and_locations": true
+      "frame_entries_have_sources_and_locations": true,
+      "rankings_are_sorted": true
     }
   ]
 


### PR DESCRIPTION
Allocation-profile rankings currently insert every candidate into a bounded immutable list and immediately truncate it. With `top=100`, rebuilding those lists dominates snapshot allocation.

Sort each aggregated table once and take the requested prefix instead. Add a trace assertion that exact-stack, allocation-site, and inclusive-frame rankings remain ordered by descending sample count.

In controlled cold `@check` profiles with `top=100`, exit-summary allocation fell from 54.5M to 12.8M words, while process-wide fresh allocation fell from 508.5M to 455.4M words.
