### PR TITLE
perf: increase Dune's default minor heap

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -42,7 +42,10 @@
   source
   xdg
   re)
- (bootstrap_info bootstrap-info))
+ (bootstrap_info bootstrap-info)
+ (foreign_stubs
+  (language c)
+  (names runtime_stubs)))
 
 ; Installing the dune binary depends on the kind of build:
 ; - for bootstrap builds, dune.exe is copied from ../dune.exe

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,5 +1,9 @@
 open Import
 
+external restore_runtime_environment : unit -> unit = "dune_restore_runtime_environment"
+
+let () = restore_runtime_environment ()
+
 let () =
   if
     Option.is_none (Sys.getenv_opt "OCAMLRUNPARAM")

--- a/bin/runtime_stubs.c
+++ b/bin/runtime_stubs.c
@@ -1,0 +1,48 @@
+#include <stdlib.h>
+
+#include <caml/mlvalues.h>
+
+#define DUNE_RUNTIME_DEFAULTS_MARKER "DUNE_INTERNAL__RUNTIME_DEFAULTS"
+
+static int runtime_defaults_set = 0;
+
+/* OCaml reads its runtime parameters after native constructors have run. */
+static void dune_set_ocaml_runtime_defaults(void) {
+  /* Any runtime setting is treated as an explicit user choice. */
+  if (getenv("OCAMLRUNPARAM") != NULL || getenv("CAMLRUNPARAM") != NULL) {
+    return;
+  }
+#ifdef _WIN32
+  _putenv_s("OCAMLRUNPARAM", "s=512k");
+  _putenv_s(DUNE_RUNTIME_DEFAULTS_MARKER, "1");
+#else
+  setenv("OCAMLRUNPARAM", "s=512k", 0);
+  setenv(DUNE_RUNTIME_DEFAULTS_MARKER, "1", 0);
+#endif
+  runtime_defaults_set = 1;
+}
+
+CAMLprim value dune_restore_runtime_environment(value unit) {
+  (void)unit;
+  if (runtime_defaults_set) {
+#ifdef _WIN32
+    _putenv_s("OCAMLRUNPARAM", "");
+    _putenv_s(DUNE_RUNTIME_DEFAULTS_MARKER, "");
+#else
+    unsetenv("OCAMLRUNPARAM");
+    unsetenv(DUNE_RUNTIME_DEFAULTS_MARKER);
+#endif
+  }
+  return Val_unit;
+}
+
+#ifdef _MSC_VER
+typedef void(__cdecl *dune_initializer)(void);
+#pragma section(".CRT$XCU", read)
+__declspec(allocate(".CRT$XCU")) static dune_initializer
+    dune_runtime_defaults = dune_set_ocaml_runtime_defaults;
+#else
+__attribute__((constructor)) static void dune_runtime_defaults(void) {
+  dune_set_ocaml_runtime_defaults();
+}
+#endif

--- a/otherlibs/stdune/src/env.ml
+++ b/otherlibs/stdune/src/env.ml
@@ -119,7 +119,18 @@ let map_of_unix arr =
     | x :: _ -> x)
 ;;
 
-let initial = of_map (map_of_unix (Unix.environment ()))
+let initial =
+  let vars = map_of_unix (Unix.environment ()) in
+  (* The native Dune executable temporarily sets these before OCaml starts. *)
+  let runtime_defaults_marker = "DUNE_INTERNAL__RUNTIME_DEFAULTS" in
+  let vars =
+    if Map.mem vars runtime_defaults_marker
+    then Map.remove (Map.remove vars runtime_defaults_marker) "OCAMLRUNPARAM"
+    else vars
+  in
+  of_map vars
+;;
+
 let of_unix u = of_map (map_of_unix u)
 
 let add t ~var ~value =


### PR DESCRIPTION
Dune's no-op self-builds allocate enough short-lived data to collect the
standard 256K-word minor heap almost a thousand times. A 512K-word heap reduces
that GC work and lowers promotion.

Set the default before the native OCaml runtime starts, while treating either
`OCAMLRUNPARAM` or `CAMLRUNPARAM` as an explicit user choice. The temporary
environment setting is removed after startup and filtered from `Env.initial`,
so commands run by Dune do not inherit it.

Across 40 alternating warmed pairs, task-clock improved by 1.4% on `@install`
and 2.8% on `@check`; minor collections fell by about 48% and promoted words by
about 1.9%. Maximum RSS increased by approximately 2%. This is internal runtime
tuning and does not require a changelog entry.
