### PR TITLE
perf: reduce major GC frequency

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,5 +1,14 @@
 open Import
 
+let () =
+  if
+    Option.is_none (Sys.getenv_opt "OCAMLRUNPARAM")
+    && Option.is_none (Sys.getenv_opt "CAMLRUNPARAM")
+  then (
+    let control = Gc.get () in
+    Gc.set { control with space_overhead = 500 })
+;;
+
 let all : _ Cmdliner.Cmd.t list =
   let terms =
     Runtest.commands


### PR DESCRIPTION
Major collections account for a substantial fraction of Dune's warmed no-op
build time. Increase the default OCaml major-heap space overhead from 120 to 500
at CLI startup, while leaving explicit `OCAMLRUNPARAM` and `CAMLRUNPARAM`
settings untouched.

Across 30 alternating warmed pairs, task-clock improved by about 13.0% on
`@install` and 11.0% on `@check`. Major collections fell from 18 to 15 and from
19 to 16 respectively. The tradeoff is memory: maximum RSS on `@check`
increased by approximately 8%.

This changes only Dune's internal GC policy and does not require a changelog
entry.
