### PR TITLE
perf(ordering): inline integer conversion

### DIFF
--- a/otherlibs/ordering/ordering.ml
+++ b/otherlibs/ordering/ordering.ml
@@ -3,7 +3,7 @@ type t =
   | Eq
   | Gt
 
-let of_int n = if n < 0 then Lt else if n = 0 then Eq else Gt
+let[@inline always] of_int n = if n < 0 then Lt else if n = 0 then Eq else Gt
 
 let to_int = function
   | Lt -> -1


### PR DESCRIPTION
Low-level comparators frequently convert an integer comparison result to `Ordering.t`. Keeping the small conversion out of line adds avoidable calls in these paths.

Mark `Ordering.of_int` as always-inline so callers can perform the two comparisons directly. Repeated instruction-only Cachegrind profiles reduced warmed `@install` null-build instructions by about 0.14%, while `@check` remained effectively unchanged.
