### PR TITLE
perf(lang): avoid rebuilding unchecked path comparators

### DIFF
--- a/src/dune_lang/module_name.ml
+++ b/src/dune_lang/module_name.ml
@@ -52,7 +52,7 @@ module Unchecked = struct
       type nonrec t = t Nonempty_list.t
 
       let to_dyn t = Dyn.list to_dyn (Nonempty_list.to_list t)
-      let compare = Nonempty_list.compare ~compare
+      let compare x y = Nonempty_list.compare x y ~compare
 
       let to_string t =
         Nonempty_list.to_list_map ~f:(fun x -> x.name) t |> String.concat ~sep:"."


### PR DESCRIPTION
`Module_name.Unchecked.Path.compare` is a partial application of `Nonempty_list.compare`, so its comparator closure is reconstructed at call sites.

Eta-expand it to pass both paths directly. Repeated instruction-only Cachegrind profiles of warmed `@install` and `@check` null builds improved by approximately 0.02% on each target.

This is an internal implementation change and does not require a changelog entry.
