### PR TITLE
revert: drop dev-only inlining optimizations

### DIFF
--- a/otherlibs/ordering/ordering.ml
+++ b/otherlibs/ordering/ordering.ml
@@ -3,7 +3,7 @@ type t =
   | Eq
   | Gt
 
-let[@inline always] of_int n = if n < 0 then Lt else if n = 0 then Eq else Gt
+let of_int n = if n < 0 then Lt else if n = 0 then Eq else Gt
 
 let to_int = function
   | Lt -> -1

--- a/src/dune_lang/module_name.ml
+++ b/src/dune_lang/module_name.ml
@@ -52,7 +52,7 @@ module Unchecked = struct
       type nonrec t = t Nonempty_list.t
 
       let to_dyn t = Dyn.list to_dyn (Nonempty_list.to_list t)
-      let compare x y = Nonempty_list.compare x y ~compare
+      let compare = Nonempty_list.compare ~compare
 
       let to_string t =
         Nonempty_list.to_list_map ~f:(fun x -> x.name) t |> String.concat ~sep:"."


### PR DESCRIPTION
#15734 and #15735 were selected using Cachegrind measurements of dev-profile executables. That profile enables `-opaque` for local libraries and does not represent the generated code in release builds.

With release-built executables, always-inlining `Ordering.of_int` increased instruction counts by about 0.049% on `@install` and 0.019% on `@check`. Eta-expanding the unchecked module-path comparator increased them by about 0.026% and 0.008%, while changing minor allocation by less than 0.01%. Revert both changes; the independently effective filename and checked module-path changes remain.

This is an internal implementation correction and does not require a changelog entry.
