### PR TITLE
feat(trace): record exact allocation totals in profiles

### DIFF
--- a/doc/advanced/profiling-dune.rst
+++ b/doc/advanced/profiling-dune.rst
@@ -30,6 +30,10 @@ recorded call-stack depth, and ``top`` is the maximum number of entries kept in
 each ranking. Their defaults are ``0.0001``, ``10``, and ``10``. This
 configuration is experimental and may change without notice.
 
+Each summary records exact GC counter deltas for minor allocation, direct major
+allocation, and promotion. The sampled heaps attribute those totals
+approximately to code locations and include their sample counts.
+
 Each sampled heap is ranked by exact call stack, allocation site, and inclusive
 stack frame. The allocation-site view combines allocations at the same source
 location that have different callers. If the youngest sampled frame has no

--- a/src/dune_trace/alloc.ml
+++ b/src/dune_trace/alloc.ml
@@ -287,12 +287,27 @@ type heap =
   ; mutable by_key : heap_table
   }
 
+type gc_counters =
+  { minor_words : float
+  ; major_words : float
+  ; promoted_words : float
+  }
+
+let gc_counters () =
+  let stat = Gc.quick_stat () in
+  { minor_words = stat.minor_words
+  ; major_words = stat.major_words
+  ; promoted_words = stat.promoted_words
+  }
+;;
+
 type t =
   { config : Config.t
   ; mutex : Mutex.t
   ; minor : heap
   ; major : heap
   ; promoted : heap
+  ; mutable gc_baseline : gc_counters
   ; mutable profile : Memprof.t option
   }
 
@@ -304,6 +319,7 @@ let create config =
   ; minor = create_heap ()
   ; major = create_heap ()
   ; promoted = create_heap ()
+  ; gc_baseline = gc_counters ()
   ; profile = None
   }
 ;;
@@ -351,6 +367,7 @@ let start () =
   let { Config.sampling_rate; callstack_size; _ } = config in
   let profile = Memprof.start ~sampling_rate ~callstack_size (tracker t) in
   t.profile <- Some profile;
+  t.gc_baseline <- gc_counters ();
   t
 ;;
 
@@ -458,6 +475,17 @@ let summary_of_heap total_samples by_key (config : Config.t) ~frame_cache =
   }
 ;;
 
+type swap_result =
+  { previous_gc : gc_counters
+  ; current_gc : gc_counters
+  ; minor_total_samples : int
+  ; minor_by_key : heap_table
+  ; major_total_samples : int
+  ; major_by_key : heap_table
+  ; promoted_total_samples : int
+  ; promoted_by_key : heap_table
+  }
+
 let swap t =
   let fresh_minor = Table.create (module Key) 64 in
   let fresh_major = Table.create (module Key) 64 in
@@ -468,46 +496,75 @@ let swap t =
   let major_by_key = ref fresh_major in
   let promoted_total_samples = ref 0 in
   let promoted_by_key = ref fresh_promoted in
-  Mutex.protect t.mutex (fun () ->
+  let previous_gc = ref t.gc_baseline in
+  let current_gc = ref t.gc_baseline in
+  let swap_under_mutex () =
+    previous_gc := t.gc_baseline;
     minor_total_samples := t.minor.total_samples;
     minor_by_key := t.minor.by_key;
     major_total_samples := t.major.total_samples;
     major_by_key := t.major.by_key;
     promoted_total_samples := t.promoted.total_samples;
     promoted_by_key := t.promoted.by_key;
+    t.gc_baseline <- !current_gc;
     t.minor.total_samples <- 0;
     t.minor.by_key <- fresh_minor;
     t.major.total_samples <- 0;
     t.major.by_key <- fresh_major;
     t.promoted.total_samples <- 0;
-    t.promoted.by_key <- fresh_promoted);
-  (* Constructing this tuple can allocate and trigger a Memprof callback, which
+    t.promoted.by_key <- fresh_promoted
+  in
+  (* [gc_counters] allocates and can trigger a Memprof callback, so it must run
+     before taking [t.mutex]. *)
+  current_gc := gc_counters ();
+  Mutex.protect t.mutex swap_under_mutex;
+  (* Constructing this record can allocate and trigger a Memprof callback, which
      attempts to acquire [t.mutex], so it must happen after releasing the mutex. *)
-  ( !minor_total_samples
-  , !minor_by_key
-  , !major_total_samples
-  , !major_by_key
-  , !promoted_total_samples
-  , !promoted_by_key )
+  { previous_gc = !previous_gc
+  ; current_gc = !current_gc
+  ; minor_total_samples = !minor_total_samples
+  ; minor_by_key = !minor_by_key
+  ; major_total_samples = !major_total_samples
+  ; major_by_key = !major_by_key
+  ; promoted_total_samples = !promoted_total_samples
+  ; promoted_by_key = !promoted_by_key
+  }
 ;;
 
 type snapshot =
   { config : Event.alloc_config
+  ; exact : Event.alloc_exact
   ; minor : Event.alloc_heap
   ; major : Event.alloc_heap
   ; promoted : Event.alloc_heap
   }
 
+let exact_gc_delta ~previous ~current =
+  let promoted_words = current.promoted_words -. previous.promoted_words in
+  let major_words =
+    current.major_words -. previous.major_words -. promoted_words |> Stdlib.max 0.0
+  in
+  let round words = int_of_float (words +. 0.5) in
+  { Event.minor_words = round (current.minor_words -. previous.minor_words)
+  ; major_words = round major_words
+  ; promoted_words = round promoted_words
+  }
+;;
+
 let snapshot t =
-  let ( minor_total_samples
-      , minor_by_key
-      , major_total_samples
-      , major_by_key
-      , promoted_total_samples
-      , promoted_by_key )
+  let { previous_gc
+      ; current_gc
+      ; minor_total_samples
+      ; minor_by_key
+      ; major_total_samples
+      ; major_by_key
+      ; promoted_total_samples
+      ; promoted_by_key
+      }
     =
     swap t
   in
+  let exact = exact_gc_delta ~previous:previous_gc ~current:current_gc in
   let { Config.sampling_rate; callstack_size; top_entry_count } = t.config in
   let config = { Event.sampling_rate; callstack_size; top_entry_count } in
   let frame_cache = Table.create (module Raw_backtrace_slot) 64 in
@@ -516,9 +573,7 @@ let snapshot t =
   let promoted =
     summary_of_heap promoted_total_samples promoted_by_key t.config ~frame_cache
   in
-  { config; minor; major; promoted }
+  { config; exact; minor; major; promoted }
 ;;
-
-type swap_result = int * heap_table * int * heap_table * int * heap_table
 
 let reset t = ignore (swap t : swap_result)

--- a/src/dune_trace/alloc.mli
+++ b/src/dune_trace/alloc.mli
@@ -2,6 +2,7 @@ type t
 
 type snapshot =
   { config : Event.alloc_config
+  ; exact : Event.alloc_exact
   ; minor : Event.alloc_heap
   ; major : Event.alloc_heap
   ; promoted : Event.alloc_heap

--- a/src/dune_trace/dune_trace.ml
+++ b/src/dune_trace/dune_trace.ml
@@ -27,13 +27,13 @@ let capture_alloc_profile kind =
   with
   | None -> None
   | Some alloc ->
-    let { Alloc.config; minor; major; promoted } = Alloc.snapshot alloc in
+    let { Alloc.config; exact; minor; major; promoted } = Alloc.snapshot alloc in
     let phase, run_id =
       match kind with
       | `Build run_id -> `Build, Some run_id
       | `Exit -> `Exit, None
     in
-    Some (Event.alloc_summary ~phase ~run_id ~config ~minor ~major ~promoted)
+    Some (Event.alloc_summary ~phase ~run_id ~config ~exact ~minor ~major ~promoted)
 ;;
 
 let at_exit =

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -149,6 +149,12 @@ type alloc_heap =
   ; top : alloc_entry list
   }
 
+type alloc_exact =
+  { minor_words : int
+  ; major_words : int
+  ; promoted_words : int
+  }
+
 let scan_source ~name ~start ~stop ~dir =
   let dur = Time.diff stop start in
   let args = [ "dir", Arg.source_path dir ] in
@@ -414,7 +420,7 @@ let watch_build_finish
   Event.complete ~name:"build-finish" ~args ~start ~dur Build
 ;;
 
-let alloc_summary ~phase ~run_id ~config ~minor ~major ~promoted =
+let alloc_summary ~phase ~run_id ~config ~exact ~minor ~major ~promoted =
   let now = Time.now () in
   let encode_config { sampling_rate; callstack_size; top_entry_count } =
     Arg.record
@@ -461,6 +467,14 @@ let alloc_summary ~phase ~run_id ~config ~minor ~major ~promoted =
       ]
     |> Arg.list
   in
+  let encode_exact { minor_words; major_words; promoted_words } =
+    Arg.record
+      [ "minor_words", Arg.int minor_words
+      ; "major_words", Arg.int major_words
+      ; "promoted_words", Arg.int promoted_words
+      ]
+    |> Arg.list
+  in
   let args =
     [ ( "phase"
       , Arg.string
@@ -468,6 +482,7 @@ let alloc_summary ~phase ~run_id ~config ~minor ~major ~promoted =
            | `Build -> "build"
            | `Exit -> "exit") )
     ; "config", encode_config config
+    ; "exact", encode_exact exact
     ; "minor", heap minor
     ; "major", heap major
     ; "promoted", heap promoted

--- a/test/blackbox-tests/test-cases/trace/alloc.t
+++ b/test/blackbox-tests/test-cases/trace/alloc.t
@@ -22,6 +22,15 @@ The alloc sampler is only enabled when the alloc trace category is requested:
   >     , phase: .args.phase
   >     , has_run_id: (.args.run_id != null)
   >     , config: .args.config
+  >     , exact_allocation_counters:
+  >         ((.args.exact | type) == "object"
+  >          and ((.args.exact | keys | sort)
+  >               == ["major_words", "minor_words", "promoted_words"])
+  >          and all(.args.exact[]; type == "number" and . >= 0)
+  >          and (if .args.phase == "build"
+  >               then .args.exact.minor_words > 0
+  >               else true
+  >               end))
   >     , heaps:
   >         { minor: (.args.minor | keys)
   >         , major: (.args.major | keys)
@@ -66,6 +75,7 @@ The alloc sampler is only enabled when the alloc trace category is requested:
         "callstack_size": 3,
         "top_entry_count": 2
       },
+      "exact_allocation_counters": true,
       "heaps": {
         "minor": [
           "by_frame",
@@ -105,6 +115,7 @@ The alloc sampler is only enabled when the alloc trace category is requested:
         "callstack_size": 3,
         "top_entry_count": 2
       },
+      "exact_allocation_counters": true,
       "heaps": {
         "minor": [
           "by_frame",


### PR DESCRIPTION
Allocation profiles currently estimate total words from the sampling rate. This provides attribution, but the reported total retains sampling error.

Record GC counter deltas at each allocation-profile table swap and expose exact minor allocation, direct major allocation, and promotion totals alongside the sampled views. Direct major allocation subtracts promoted words from OCaml's major-allocation counter so fresh allocation is not counted twice.

The GC baseline advances with the sampled tables. Summary construction therefore belongs to the following interval in both the sampled and exact views, and each boundary requires only one GC-counter read. Counter reads and result construction remain outside the sample mutex because they allocate and may invoke a Memprof callback.

Document the counters and cover their trace schema and basic invariants in the allocation-profile cram test.
