### PR TITLE
perf(stdune): skip canonical path bounds checks

### DIFF
--- a/otherlibs/stdune/src/path0.ml
+++ b/otherlibs/stdune/src/path0.ml
@@ -137,7 +137,7 @@ module Local_gen = struct
       if i < 0
       then false
       else (
-        match s.[i] with
+        match String.unsafe_get s i with
         | '/' -> false
         | '.' -> before_dot_slash s (i - 1)
         | '\\' when Sys.win32 -> false
@@ -146,7 +146,7 @@ module Local_gen = struct
       if i < 0
       then false
       else (
-        match s.[i] with
+        match String.unsafe_get s i with
         | '/' -> false
         | '.' -> before_dot_dot_slash s (i - 1)
         | '\\' when Sys.win32 -> false
@@ -155,7 +155,7 @@ module Local_gen = struct
       if i < 0
       then false
       else (
-        match s.[i] with
+        match String.unsafe_get s i with
         | '/' -> false
         | '\\' when Sys.win32 -> false
         | _ -> in_component s (i - 1))
@@ -163,7 +163,7 @@ module Local_gen = struct
       if i < 0
       then true
       else (
-        match s.[i] with
+        match String.unsafe_get s i with
         | '/' -> before_slash s (i - 1)
         | '\\' when Sys.win32 -> false
         | _ -> in_component s (i - 1))


### PR DESCRIPTION
Canonical-path detection starts scanning at `String.length s - 1` and only decrements the index after checking that it remains non-negative. The string accesses nevertheless perform redundant bounds checks on every scanned character.

Use `String.unsafe_get` inside these bounded loops. With release-built Dune executables, instruction-only Cachegrind counts on warmed null builds fell by 0.299% on `@install` and 0.293% on `@check`.

This is an internal implementation change and does not require a changelog entry.
