### PR TITLE
perf(stdune): test local path roots with equality

### DIFF
--- a/otherlibs/stdune/src/path0.ml
+++ b/otherlibs/stdune/src/path0.ml
@@ -56,7 +56,7 @@ module Local_gen = struct
   let compare = String.compare
   let equal = String.equal
   let root = "."
-  let is_root t = Ordering.is_eq (compare t root)
+  let is_root t = equal t root
 
   let parent t =
     if is_root t


### PR DESCRIPTION
Local paths represent their root with `"."`, but `Path.Local.is_root` currently performs a three-way string comparison and then converts the result to equality.

Use direct string equality instead. With release-built Dune executables, instruction-only Cachegrind counts on warmed null builds fell by 0.818% on `@install` and 0.823% on `@check`.

This is an internal implementation change and does not require a changelog entry.
