### PR TITLE
perf(digest): skip redundant buffered blit checks

### DIFF
--- a/src/dune_digest/digest.ml
+++ b/src/dune_digest/digest.ml
@@ -40,7 +40,7 @@ module Hasher = struct
     else (
       if !Scratch.pos + length > Scratch.len then Scratch.flush ();
       let pos = !Scratch.pos in
-      Bytes.blit_string ~src:s ~src_pos:0 ~dst:Scratch.buf ~dst_pos:pos ~len:length;
+      Bytes.unsafe_blit_string ~src:s ~src_pos:0 ~dst:Scratch.buf ~dst_pos:pos ~len:length;
       Scratch.pos := pos + length)
   ;;
 


### PR DESCRIPTION
The buffered manual digest path checks the source length and ensures sufficient destination capacity before copying a short string into its 4KB scratch buffer. `Bytes.blit_string` then repeats those bounds checks for every buffered string.

Use `Bytes.unsafe_blit_string` after the existing explicit checks. With release-built Dune executables, instruction-only Cachegrind counts on warmed null builds fell by 0.395% on `@install` and 0.426% on `@check`.

This is an internal implementation change and does not require a changelog entry.
