### PR TITLE
perf: reduce null-build instruction overhead

### DIFF
--- a/otherlibs/stdune/src/array.ml
+++ b/otherlibs/stdune/src/array.ml
@@ -72,7 +72,7 @@ module Sorted = struct
         then -1
         else (
           let mid = (low + high) / 2 in
-          match Key.compare key keys.(mid) with
+          match Key.compare key (Stdlib.Array.unsafe_get keys mid) with
           | Eq -> mid
           | Lt -> loop low (mid - 1)
           | Gt -> loop (mid + 1) high)

--- a/otherlibs/stdune/src/filename.ml
+++ b/otherlibs/stdune/src/filename.ml
@@ -2,6 +2,10 @@ include Stdlib.Filename
 
 type t = string
 
+let rec contains_slash s i =
+  i >= 0 && (Char.equal (String.unsafe_get s i) '/' || contains_slash s (i - 1))
+;;
+
 let is_valid s =
   let len = String.length s in
   len > 0
@@ -10,7 +14,7 @@ let is_valid s =
       || not
            (Char.equal (String.unsafe_get s 0) '.'
             && Char.equal (String.unsafe_get s 1) '.'))
-  && not (String.contains s '/')
+  && not (contains_slash s (len - 1))
 ;;
 
 let of_string s = Option.some_if (is_valid s) s
@@ -78,7 +82,8 @@ module Extension = struct
   let json = ".json"
 
   let is_valid s =
-    (not (String.is_empty s)) && Char.equal s.[0] '.' && not (String.contains s '/')
+    let len = String.length s in
+    len > 0 && Char.equal (String.unsafe_get s 0) '.' && not (contains_slash s (len - 1))
   ;;
 
   let of_string s = Option.some_if (is_valid s) s
@@ -214,7 +219,9 @@ type program_name_kind =
 let analyze_program_name fn =
   if not (is_relative fn)
   then Absolute
-  else if String.contains fn '/' || (Stdlib.Sys.win32 && String.contains fn '\\')
+  else if
+    contains_slash fn (String.length fn - 1)
+    || (Stdlib.Sys.win32 && String.contains fn '\\')
   then Relative_to_current_dir
   else In_path
 ;;

--- a/otherlibs/stdune/src/path0.ml
+++ b/otherlibs/stdune/src/path0.ml
@@ -6,9 +6,9 @@ let append_with_slash x y =
   let len_x = String.length x in
   let len_y = String.length y in
   let dst = Bytes.create (len_x + 1 + len_y) in
-  Bytes.blit_string ~src:x ~src_pos:0 ~dst ~dst_pos:0 ~len:len_x;
-  Bytes.set dst len_x '/';
-  Bytes.blit_string ~src:y ~src_pos:0 ~dst ~dst_pos:(len_x + 1) ~len:len_y;
+  Bytes.unsafe_blit_string ~src:x ~src_pos:0 ~dst ~dst_pos:0 ~len:len_x;
+  Bytes.unsafe_set dst len_x '/';
+  Bytes.unsafe_blit_string ~src:y ~src_pos:0 ~dst ~dst_pos:(len_x + 1) ~len:len_y;
   Bytes.unsafe_to_string dst
 ;;
 
@@ -263,7 +263,9 @@ module Local_gen = struct
     ;;
 
     (* the size of the "../.." string we need to generate *)
-    let go_up_components_buffer_size times = (times * 2) + max 0 (times - 1)
+    let go_up_components_buffer_size times =
+      (times * 2) + if times > 0 then times - 1 else 0
+    ;;
 
     let reach_root ~from pos =
       let go_up_this_many_times = parent_remaining_components pos from in

--- a/otherlibs/stdune/src/string.ml
+++ b/otherlibs/stdune/src/string.ml
@@ -10,12 +10,14 @@ struct
 
   let rec check_prefix s ~prefix len i =
     i = len
-    || (X.normalize s.[i] = X.normalize prefix.[i] && check_prefix s ~prefix len (i + 1))
+    || (X.normalize (String.unsafe_get s i) = X.normalize (String.unsafe_get prefix i)
+        && check_prefix s ~prefix len (i + 1))
   ;;
 
   let rec check_suffix s ~suffix suffix_len offset i =
     i = suffix_len
-    || (X.normalize s.[offset + i] = X.normalize suffix.[i]
+    || (X.normalize (String.unsafe_get s (offset + i))
+        = X.normalize (String.unsafe_get suffix i)
         && check_suffix s ~suffix suffix_len offset (i + 1))
   ;;
 
@@ -179,7 +181,9 @@ let longest_prefix = function
   | [ x ] -> x
   | x :: xs ->
     let rec loop len i =
-      if i < len && List.for_all xs ~f:(fun s -> s.[i] = x.[i])
+      if
+        i < len
+        && List.for_all xs ~f:(fun s -> String.unsafe_get s i = String.unsafe_get x i)
       then loop len (i + 1)
       else i
     in
@@ -218,16 +222,20 @@ let enumerate_one_of = function
   | s -> "One of " ^ enumerate_or s
 ;;
 
-let take s len = sub s ~pos:0 ~len:(min (length s) len)
+let take s len =
+  let length = length s in
+  sub s ~pos:0 ~len:(if len < length then len else length)
+;;
 
 let drop s n =
   let len = length s in
-  sub s ~pos:(min n len) ~len:(max (len - n) 0)
+  let pos = if n < len then n else len in
+  sub s ~pos ~len:(len - pos)
 ;;
 
 let split_n s n =
   let len = length s in
-  let n = min n len in
+  let n = if n < len then n else len in
   sub s ~pos:0 ~len:n, sub s ~pos:n ~len:(len - n)
 ;;
 
@@ -257,7 +265,7 @@ let need_quoting s =
     if i = len
     then false
     else (
-      match s.[i] with
+      match String.unsafe_get s i with
       | ' ' | '\"' | '(' | ')' | '{' | '}' | ';' | '#' -> true
       | _ -> loop (i + 1))
   in
@@ -307,14 +315,17 @@ let contains_double_underscore =
   let rec aux s len i =
     if i > len - 2
     then false
-    else if s.[i] = '_' && s.[i + 1] = '_'
+    else if String.unsafe_get s i = '_' && String.unsafe_get s (i + 1) = '_'
     then true
     else aux s len (i + 1)
   in
   fun s -> aux s (String.length s) 0
 ;;
 
-let last s = if length s > 0 then Some s.[length s - 1] else None
+let last s =
+  let len = length s in
+  if len > 0 then Some (String.unsafe_get s (len - 1)) else None
+;;
 
 let replace_char s ~from ~to_ =
   String.map (fun c -> if Char.equal c from then to_ else c) s

--- a/otherlibs/stdune/src/string_split.ml
+++ b/otherlibs/stdune/src/string_split.ml
@@ -3,10 +3,11 @@ module String = Stdlib.StringLabels
 open String
 
 let split s ~on =
+  let len = length s in
   let rec loop i j =
-    if j = length s
+    if j = len
     then [ sub s ~pos:i ~len:(j - i) ]
-    else if s.[j] = on
+    else if String.unsafe_get s j = on
     then sub s ~pos:i ~len:(j - i) :: loop (j + 1) (j + 1)
     else loop i (j + 1)
   in
@@ -14,8 +15,9 @@ let split s ~on =
 ;;
 
 let split_lines s =
+  let len = length s in
   let rec loop ~last_is_cr ~acc i j =
-    if j = length s
+    if j = len
     then (
       let acc =
         if j = i || (j = i + 1 && last_is_cr)
@@ -24,7 +26,7 @@ let split_lines s =
       in
       List.rev acc)
     else (
-      match s.[j] with
+      match String.unsafe_get s j with
       | '\r' -> loop ~last_is_cr:true ~acc i (j + 1)
       | '\n' ->
         let line =

--- a/src/dune_digest/digest.ml
+++ b/src/dune_digest/digest.ml
@@ -38,8 +38,14 @@ module Hasher = struct
       Scratch.flush ();
       Blake3_mini.feed_string ~pos:0 ~len:length (Lazy.force singleton) s)
     else (
-      if !Scratch.pos + length > Scratch.len then Scratch.flush ();
       let pos = !Scratch.pos in
+      let pos =
+        if pos + length > Scratch.len
+        then (
+          Scratch.flush ();
+          0)
+        else pos
+      in
       Bytes.unsafe_blit_string ~src:s ~src_pos:0 ~dst:Scratch.buf ~dst_pos:pos ~len:length;
       Scratch.pos := pos + length)
   ;;
@@ -53,7 +59,7 @@ module Hasher = struct
 
   let feed_manual_bool b =
     if !Scratch.pos = Scratch.len then Scratch.flush ();
-    Bytes.set Scratch.buf !Scratch.pos (if b then '\001' else '\000');
+    Bytes.unsafe_set Scratch.buf !Scratch.pos (if b then '\001' else '\000');
     Scratch.pos := !Scratch.pos + 1
   ;;
 

--- a/src/dune_engine/context_name.ml
+++ b/src/dune_engine/context_name.ml
@@ -15,13 +15,22 @@ include (
     let module_ = "Context_name"
     let description = "context name"
 
+    let rec contains_dir_sep name i =
+      if i < 0
+      then false
+      else (
+        match String.unsafe_get name i with
+        | '/' | '\\' -> true
+        | _ -> contains_dir_sep name (i - 1))
+    ;;
+
     let of_string_opt name =
+      let len = String.length name in
       if
-        name = ""
-        || String.starts_with ~prefix:"." name
-        || name = "log"
-        || String.contains name '/'
-        || String.contains name '\\'
+        len = 0
+        || Char.equal (String.unsafe_get name 0) '.'
+        || (len = 3 && String.equal name "log")
+        || contains_dir_sep name (len - 1)
       then None
       else Some name
     ;;

--- a/src/dune_lang/package_name.ml
+++ b/src/dune_lang/package_name.ml
@@ -12,7 +12,7 @@ include (
     let description = "package name"
     let description_of_valid_string = None
     let hint_valid = None
-    let of_string_opt s = if s = "" then None else Some s
+    let of_string_opt s = if String.is_empty s then None else Some s
   end) :
     Dune_util.Stringlike with type t := t)
 
@@ -44,9 +44,17 @@ module Opam_compatible = struct
     let is_valid_char c = is_letter c || is_other_valid_char c
 
     let is_valid_string s =
-      let all_chars_valid = String.for_all s ~f:is_valid_char in
-      let has_one_letter = String.exists s ~f:is_letter in
-      all_chars_valid && has_one_letter
+      let len = String.length s in
+      let rec loop i has_one_letter =
+        if i = len
+        then has_one_letter
+        else (
+          match String.unsafe_get s i with
+          | 'a' .. 'z' | 'A' .. 'Z' -> loop (i + 1) true
+          | '0' .. '9' | '-' | '+' | '_' -> loop (i + 1) has_one_letter
+          | _ -> false)
+      in
+      loop 0 false
     ;;
 
     let of_string_opt s = Option.some_if (is_valid_string s) s

--- a/src/dune_lang/site.ml
+++ b/src/dune_lang/site.ml
@@ -20,7 +20,7 @@ module Modulelike (S : sig
 Stringlike.Make (struct
     include S
 
-    let valid_char = function
+    let[@inline always] valid_char = function
       | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '\'' | '_' -> true
       | _ -> false
     ;;
@@ -49,8 +49,16 @@ Stringlike.Make (struct
           if has_valid_first_char name then name else "M" ^ name)
     ;;
 
+    let rec has_only_valid_chars name len i =
+      i = len
+      || (valid_char (String.unsafe_get name i) && has_only_valid_chars name len (i + 1))
+    ;;
+
     let is_valid_module_name name =
-      name <> "" && has_valid_first_char name && String.for_all name ~f:valid_char
+      let len = String.length name in
+      len > 0
+      && is_valid_first_char (String.unsafe_get name 0)
+      && has_only_valid_chars name len 1
     ;;
 
     let of_string_opt s = if is_valid_module_name s then Some (S.make s) else None


### PR DESCRIPTION
- Remove unnecessary bounds checks from explicitly bounded string, byte, and array loops.
- Hoist invariant string lengths and buffered-digest positions out of hot loops.
- Deforest repeated package, context, and module-name validation traversals into direct scans.
- Reuse a direct filename-separator scan across filename operations.
- Replace polymorphic `min` and `max` calls with monomorphic integer conditionals.
- Inline hot module-name character validation.