### PR TITLE
test(stdune): expose repeated environment rendering

### DIFF
--- a/otherlibs/stdune/test/env_tests.ml
+++ b/otherlibs/stdune/test/env_tests.ml
@@ -1,0 +1,19 @@
+open Stdune
+
+let find_assignment env var =
+  Env.to_unix env
+  |> List.find_map ~f:(fun assignment ->
+    match String.lsplit2 assignment ~on:'=' with
+    | Some (key, _) when String.equal key var -> Some assignment
+    | Some _ | None -> None)
+  |> Option.value_exn
+;;
+
+let%expect_test "unchanged assignments are shared between environments" =
+  let env = Env.empty |> Env.add ~var:"A" ~value:"one" |> Env.add ~var:"B" ~value:"two" in
+  let assignment = find_assignment env "A" in
+  let updated = Env.add env ~var:"B" ~value:"three" in
+  let updated_assignment = find_assignment updated "A" in
+  print_endline (Bool.to_string (assignment == updated_assignment));
+  [%expect {| false |}]
+;;


### PR DESCRIPTION
Updating one variable in an `Env` currently rerenders assignments for unchanged variables. Add an expect test that records this allocation behavior by checking physical identity across derived environments.
