### PR TITLE
perf(stdune): reuse rendered environment bindings

### DIFF
--- a/otherlibs/stdune/src/env.ml
+++ b/otherlibs/stdune/src/env.ml
@@ -10,6 +10,10 @@ module Var = struct
       else String.compare
     ;;
 
+    let hash =
+      if Sys.win32 then fun var -> String.hash (String.lowercase var) else String.hash
+    ;;
+
     let to_dyn = Dyn.string
   end
 
@@ -22,46 +26,65 @@ end
 module Set = Var.Set
 module Map = Var.Map
 
-(* The use of [mutable] here is safe, since we never call (back) to the
-   memoization framework when computing [unix]. *)
+module Binding = struct
+  type t =
+    { value : string
+    ; mutable rendered : string Option.Unboxed.t
+    }
+
+  let create value = { value; rendered = Option.Unboxed.none }
+
+  let render t ~var =
+    if Option.Unboxed.is_some t.rendered
+    then Option.Unboxed.value_exn t.rendered
+    else (
+      let rendered = String.append_with_char var ~sep:'=' t.value in
+      t.rendered <- Option.Unboxed.some rendered;
+      rendered)
+  ;;
+end
+
+(* The use of [mutable] for these caches is safe, since we never call (back) to
+   the memoization framework when computing [unix]. *)
 type t =
-  { vars : string Map.t
+  { vars : Binding.t Map.t
   ; mutable unix : string list option
   }
 
-let equal t { vars; unix = _ } = Map.equal ~equal:String.equal t.vars vars
-let hash { vars; unix = _ } = Poly.hash vars
-let of_map vars = { vars; unix = None }
-let empty = of_map Map.empty
+let equal t { vars; unix = _ } =
+  Map.equal
+    ~equal:(fun { Binding.value = x; _ } { Binding.value = y; _ } -> String.equal x y)
+    t.vars
+    vars
+;;
+
+let hash { vars; unix = _ } =
+  Map.foldi vars ~init:(Hash.create ()) ~f:(fun var { Binding.value; _ } acc ->
+    let acc = Hash.feed acc (Var.hash var) in
+    Hash.feed acc (String.hash value))
+  |> Hash.hash
+;;
+
+let of_bindings vars = { vars; unix = None }
+let of_map vars = Map.map vars ~f:Binding.create |> of_bindings
+let empty = of_bindings Map.empty
 let is_empty t = Map.is_empty t.vars
 let vars t = Var.Set.of_keys t.vars
-let get t k = Map.find t.vars k
-
-let binding var value =
-  let var_length = String.length var in
-  let value_length = String.length value in
-  let result = Bytes.create (var_length + 1 + value_length) in
-  Bytes.blit_string ~src:var ~src_pos:0 ~dst:result ~dst_pos:0 ~len:var_length;
-  Bytes.set result var_length '=';
-  Bytes.blit_string
-    ~src:value
-    ~src_pos:0
-    ~dst:result
-    ~dst_pos:(var_length + 1)
-    ~len:value_length;
-  Bytes.unsafe_to_string result
-;;
+let get t k = Option.map (Map.find t.vars k) ~f:(fun { Binding.value; _ } -> value)
 
 let to_unix t =
   match t.unix with
   | Some v -> v
   | None ->
-    let res = Map.foldi ~init:[] ~f:(fun k v acc -> binding k v :: acc) t.vars in
+    let res =
+      Map.foldi t.vars ~init:[] ~f:(fun var binding acc ->
+        Binding.render binding ~var :: acc)
+    in
     t.unix <- Some res;
     res
 ;;
 
-let of_unix arr =
+let map_of_unix arr =
   Array.to_list arr
   |> List.map ~f:(fun s ->
     match String.lsplit2 s ~on:'=' with
@@ -76,20 +99,29 @@ let of_unix arr =
     | x :: _ -> x)
 ;;
 
-let initial = of_map (of_unix (Unix.environment ()))
-let of_unix u = of_map (of_unix u)
-let add t ~var ~value = of_map (Map.set t.vars var value)
+let initial = of_map (map_of_unix (Unix.environment ()))
+let of_unix u = of_map (map_of_unix u)
+let add t ~var ~value = of_bindings (Map.set t.vars var (Binding.create value))
 let mem t ~var = Map.mem t.vars var
-let remove t ~var = of_map (Map.remove t.vars var)
-let extend t ~vars = if Map.is_empty vars then t else of_map (Map.superpose vars t.vars)
+let remove t ~var = of_bindings (Map.remove t.vars var)
+
+let extend t ~vars =
+  if Map.is_empty vars
+  then t
+  else of_bindings (Map.superpose (Map.map vars ~f:Binding.create) t.vars)
+;;
 
 let extend_env x y =
-  if is_empty y then x else if is_empty x then y else extend x ~vars:y.vars
+  if is_empty y
+  then x
+  else if is_empty x
+  then y
+  else of_bindings (Map.superpose y.vars x.vars)
 ;;
 
 let to_dyn t =
   let open Dyn in
-  Map.to_dyn string t.vars
+  Map.to_dyn (fun { Binding.value; _ } -> string value) t.vars
 ;;
 
 let diff x y =
@@ -97,14 +129,19 @@ let diff x y =
     match vy with
     | Some _ -> None
     | None -> vx)
-  |> of_map
+  |> of_bindings
 ;;
 
-let update t ~var ~f = of_map (Map.update t.vars var ~f)
+let update t ~var ~f =
+  let old = Option.map (Map.find t.vars var) ~f:(fun { Binding.value; _ } -> value) in
+  match f old with
+  | None -> remove t ~var
+  | Some value -> add t ~var ~value
+;;
 
 let of_string_map m =
   of_map (String.Map.foldi ~init:Map.empty ~f:(fun k v acc -> Map.set acc k v) m)
 ;;
 
-let iter t = Map.iteri t.vars
-let to_map t = t.vars
+let iter t ~f = Map.iteri t.vars ~f:(fun var { Binding.value; _ } -> f var value)
+let to_map t = Map.map t.vars ~f:(fun { Binding.value; _ } -> value)

--- a/otherlibs/stdune/src/path0.ml
+++ b/otherlibs/stdune/src/path0.ml
@@ -2,16 +2,6 @@
 
 module Unspecified = Path_intf.Unspecified
 
-let append_with_slash x y =
-  let len_x = String.length x in
-  let len_y = String.length y in
-  let dst = Bytes.create (len_x + 1 + len_y) in
-  Bytes.unsafe_blit_string ~src:x ~src_pos:0 ~dst ~dst_pos:0 ~len:len_x;
-  Bytes.unsafe_set dst len_x '/';
-  Bytes.unsafe_blit_string ~src:y ~src_pos:0 ~dst ~dst_pos:(len_x + 1) ~len:len_y;
-  Bytes.unsafe_to_string dst
-;;
-
 let is_dir_sep =
   if Sys.win32 || Sys.cygwin
   then fun c -> c = '/' || c = '\\' || c = ':'
@@ -93,7 +83,9 @@ module Local_gen = struct
            | None -> Result.Error `Outside_the_workspace
            | Some parent -> loop parent rest)
         | fn :: rest ->
-          if is_root t then loop fn rest else loop (append_with_slash t fn) rest
+          if is_root t
+          then loop fn rest
+          else loop (String.append_with_char t ~sep:'/' fn) rest
       in
       loop t components
     ;;
@@ -195,7 +187,7 @@ module Local_gen = struct
     match is_root a, is_root b with
     | true, _ -> b
     | _, true -> a
-    | _, _ -> append_with_slash a b
+    | _, _ -> String.append_with_char a ~sep:'/' b
   ;;
 
   let descendant t ~of_ =

--- a/otherlibs/stdune/src/path0.mli
+++ b/otherlibs/stdune/src/path0.mli
@@ -1,6 +1,5 @@
 module Unspecified = Path_intf.Unspecified
 
-val append_with_slash : string -> string -> string
 val basename_opt : is_root:('a -> bool) -> basename:('a -> 'b) -> 'a -> 'b option
 val explode_path : string -> string list
 val is_dir_sep : char -> bool

--- a/otherlibs/stdune/src/path_external.ml
+++ b/otherlibs/stdune/src/path_external.ml
@@ -44,7 +44,7 @@ let relative x y =
          let len = String.length x in
          if len > 0 && is_dir_sep x.[len - 1] then String.take x (len - 1) else x
        in
-       append_with_slash x y)
+       String.append_with_char x ~sep:'/' y)
 ;;
 
 let relative_fname t fn = relative t (Filename.to_string fn)

--- a/otherlibs/stdune/src/string.ml
+++ b/otherlibs/stdune/src/string.ml
@@ -102,6 +102,16 @@ let rindex_from s i c = rindex_from_opt s i c
 let break s ~pos = sub s ~pos:0 ~len:pos, sub s ~pos ~len:(length s - pos)
 let is_empty s = length s = 0
 
+let append_with_char x ~sep y =
+  let len_x = length x in
+  let len_y = length y in
+  let result = Bytes.create (len_x + 1 + len_y) in
+  Bytes.unsafe_blit_string ~src:x ~src_pos:0 ~dst:result ~dst_pos:0 ~len:len_x;
+  Bytes.unsafe_set result len_x sep;
+  Bytes.unsafe_blit_string ~src:y ~src_pos:0 ~dst:result ~dst_pos:(len_x + 1) ~len:len_y;
+  Bytes.unsafe_to_string result
+;;
+
 let extract_words s ~is_word_char =
   let rec skip_blanks i =
     if i = length s

--- a/otherlibs/stdune/src/string.mli
+++ b/otherlibs/stdune/src/string.mli
@@ -13,6 +13,10 @@ val to_dyn : t -> Dyn.t
 val break : t -> pos:int -> t * t
 val to_string : t -> t
 val is_empty : t -> bool
+
+(** [append_with_char x ~sep y] concatenates [x], [sep], and [y]. *)
+val append_with_char : t -> sep:char -> t -> t
+
 val of_list : char list -> t
 val starts_with : prefix:t -> t -> bool
 val ends_with : suffix:t -> t -> bool

--- a/otherlibs/stdune/test/env_tests.ml
+++ b/otherlibs/stdune/test/env_tests.ml
@@ -15,5 +15,13 @@ let%expect_test "unchanged assignments are shared between environments" =
   let updated = Env.add env ~var:"B" ~value:"three" in
   let updated_assignment = find_assignment updated "A" in
   print_endline (Bool.to_string (assignment == updated_assignment));
-  [%expect {| false |}]
+  [%expect {| true |}]
+;;
+
+let%expect_test "rendering preserves the environment hash" =
+  let env = Env.empty |> Env.add ~var:"A" ~value:"one" in
+  let before = Env.hash env in
+  ignore (Env.to_unix env);
+  print_endline (Bool.to_string (Int.equal before (Env.hash env)));
+  [%expect {| true |}]
 ;;


### PR DESCRIPTION
`Env.to_unix` currently rebuilds every `KEY=value` string when each derived environment is first rendered, even though the persistent map shares most unchanged bindings.

Store each value with a lazily populated `Option.Unboxed` rendering cache. Derived environments then share rendered strings for unchanged bindings, while environments never converted to Unix form avoid those allocations entirely. Hashing uses only immutable variable/value data so populating the cache cannot change `Env.hash`.

Generalize the allocation-efficient path join into `String.append_with_char` and use it for environment bindings and slash-separated paths.