### PR TITLE
test(engine): expose mkdir calls on rule cache hits

### DIFF
--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -128,6 +128,12 @@
  (deps %{bin:strace} %{bin:head}))
 
 (cram
+ (applies_to mkdir-on-rule-cache-hit)
+ (enabled_if
+  (= %{system} linux))
+ (deps %{bin:strace}))
+
+(cram
  (applies_to reason)
  (deps %{bin:refmt}))
 

--- a/test/blackbox-tests/test-cases/engine/mkdir-on-rule-cache-hit.t
+++ b/test/blackbox-tests/test-cases/engine/mkdir-on-rule-cache-hit.t
@@ -1,0 +1,23 @@
+  $ cat > dune-project <<'EOF'
+  > (lang dune 3.20)
+  > EOF
+  $ mkdir sub
+  $ cat > sub/dune <<'EOF'
+  > (rule
+  >  (target a)
+  >  (action (write-file %{target} a)))
+  > (rule
+  >  (target b)
+  >  (action (write-file %{target} b)))
+  > EOF
+
+Warm the workspace-local rule cache.
+
+  $ dune build sub/a sub/b
+
+A null build tries to create the common target directory once for each rule,
+even though both rules hit the workspace-local cache.
+
+  $ strace -e trace=mkdir,mkdirat -o trace dune build sub/a sub/b
+  $ grep -c 'mkdir.*"_build/default/sub"' trace || true
+  2


### PR DESCRIPTION
Add a Linux cram test using `strace` to expose that a null build calls `mkdir` once per rule even when the rules share a target directory and hit the workspace-local cache.