### PR TITLE
perf(engine): create target directories after cache misses

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -547,7 +547,6 @@ module Internal = struct
     wrap_fiber (fun () ->
       let open Fiber.O in
       report_evaluated_rule_exn ();
-      Path.mkdir_p (Path.build targets.root);
       let is_action_dynamic = Action.is_dynamic action.action in
       let sandbox_mode =
         select_sandbox_mode
@@ -606,6 +605,7 @@ module Internal = struct
         >>= function
         | Some produced_targets -> Fiber.return produced_targets
         | None ->
+          Path.mkdir_p (Path.build targets.root);
           (* Step II. Remove stale targets both from the digest table and from
              the build directory. *)
           Rule_cache.Workspace_local.remove targets;

--- a/test/blackbox-tests/test-cases/engine/mkdir-on-rule-cache-hit.t
+++ b/test/blackbox-tests/test-cases/engine/mkdir-on-rule-cache-hit.t
@@ -15,9 +15,9 @@ Warm the workspace-local rule cache.
 
   $ dune build sub/a sub/b
 
-A null build tries to create the common target directory once for each rule,
-even though both rules hit the workspace-local cache.
+A null build does not try to create the common target directory when both
+rules hit the workspace-local cache.
 
   $ strace -e trace=mkdir,mkdirat -o trace dune build sub/a sub/b
   $ grep -c 'mkdir.*"_build/default/sub"' trace || true
-  2
+  0


### PR DESCRIPTION
Move target-directory creation after the workspace-local rule-cache lookup so cache hits do not issue redundant `mkdir` calls. The regression test was added separately in #15746.