### PR TITLE
refactor(memo): remove unused phase arguments

### DIFF
--- a/src/memo/exec.ml
+++ b/src/memo/exec.ml
@@ -149,25 +149,21 @@ and start_restoring : 'i 'o. ('i, 'o) Dep_node.t -> Cycle_error.t Changed_or_not
   fun node ->
   let computation = Computation.create () in
   node.state <- Restoring { restore_from_cache = computation };
-  Computation.force
-    computation
-    ~phase:Restore_from_cache
-    ~dep_node:node
-    (fun _stack_frame ->
-       let* restore_result = restore_from_cache node in
-       let+ () =
-         match restore_result with
-         | Unchanged ->
-           validate_value node;
-           Fiber.return ()
-         | Cancelled { dependency_cycle } ->
-           update_value node (Error (cancelled ~dependency_cycle)) ~deps:Deps.empty;
-           Fiber.return ()
-         | Changed ->
-           node.state <- Out_of_date;
-           Fiber.return ()
-       in
-       restore_result)
+  Computation.force computation ~dep_node:node (fun _stack_frame ->
+    let* restore_result = restore_from_cache node in
+    let+ () =
+      match restore_result with
+      | Unchanged ->
+        validate_value node;
+        Fiber.return ()
+      | Cancelled { dependency_cycle } ->
+        update_value node (Error (cancelled ~dependency_cycle)) ~deps:Deps.empty;
+        Fiber.return ()
+      | Changed ->
+        node.state <- Out_of_date;
+        Fiber.return ()
+    in
+    restore_result)
 
 (* Recompute a node. The node has a [Computing] state during the computation. Once
    finished, the node's state is [Cached] with an up to date [last_validated_at]. *)
@@ -175,8 +171,7 @@ and start_computing : 'i 'o. ('i, 'o) Dep_node.t -> unit Fiber.t =
   fun node ->
   let computation = Computation.create () in
   node.state <- Computing { compute = computation };
-  Computation.force computation ~phase:Compute ~dep_node:node (fun _stack_frame ->
-    compute node)
+  Computation.force computation ~dep_node:node (fun _stack_frame -> compute node)
 
 (* Try to validate a [Cached] node without recomputing it. Once done, the node's state is
    either [Cached] with an up to date [last_validated_at] or [Out_of_date]. *)

--- a/src/memo/node.ml
+++ b/src/memo/node.ml
@@ -397,7 +397,7 @@ module Stack_frame_with_state : sig
   val to_dyn : t -> Dyn.t
 
   (* Create a new stack frame related to restoring or computing a [dep_node]. *)
-  val create : dag_node:Lazy_dag_node.t -> phase -> dep_node:_ Dep_node.t -> t
+  val create : dag_node:Lazy_dag_node.t -> dep_node:_ Dep_node.t -> t
   val dep_node : t -> Dep_node.packed
   val dag_node : t -> Dag.node
   val children_added_to_dag : t -> Dag.Id.Set.t
@@ -431,7 +431,7 @@ end = struct
 
   let to_dyn t = Dep_node.Packed.to_dyn_without_state t.dep_node
 
-  let create ~dag_node (_ : phase) ~dep_node =
+  let create ~dag_node ~dep_node =
     { dep_node = Dep_node.T dep_node; dag_node; children_added_to_dag = Dag.Id.Set.empty }
   ;;
 
@@ -596,8 +596,8 @@ module Computation = struct
 
   (* Each computation should be forced exactly once. Not forcing it will lead to
      a deadlock. Forcing it twice will lead to [Fiber.Ivar.fill] raising. *)
-  let force { ivar; dag_node } ~phase ~dep_node fiber =
-    let frame = Stack_frame_with_state.create phase ~dag_node ~dep_node in
+  let force { ivar; dag_node } ~dep_node fiber =
+    let frame = Stack_frame_with_state.create ~dag_node ~dep_node in
     let* result =
       (* The only reason we make the stack [frame] available to the [fiber] is
          to let the latter get the discovered dependencies [deps_rev]. *)

--- a/src/memo/node.mli
+++ b/src/memo/node.mli
@@ -235,7 +235,7 @@ module Stack_frame_with_state : sig
   val to_dyn : t -> Dyn.t
 
   (** Create a new stack frame related to restoring or computing a [dep_node]. *)
-  val create : dag_node:Lazy_dag_node.t -> phase -> dep_node:('a, 'b) Dep_node.t -> t
+  val create : dag_node:Lazy_dag_node.t -> dep_node:('a, 'b) Dep_node.t -> t
 
   val dep_node : t -> Dep_node.packed
   val dag_node : t -> Dag.node
@@ -271,7 +271,6 @@ module Computation : sig
       leads to a deadlock. *)
   val force
     :  'a t
-    -> phase:Stack_frame_with_state.phase
     -> dep_node:('b, 'c) Dep_node.t
     -> (Stack_frame_with_state.t -> 'a Fiber.t)
     -> 'a Fiber.t


### PR DESCRIPTION
`Stack_frame_with_state.create` accepted a computation phase but ignored it. As a result, `Computation.force`'s phase parameter existed only to forward it.

Remove both unused parameters and update their callers. Phase information remains on cycle-detection reads, where it selects the corresponding blocked-computation metrics.
