### PR TITLE
test: fix mkdir-on-rule-cache-hit.t

### DIFF
--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -128,12 +128,6 @@
  (deps %{bin:strace} %{bin:head}))
 
 (cram
- (applies_to mkdir-on-rule-cache-hit)
- (enabled_if
-  (= %{system} linux))
- (deps %{bin:strace}))
-
-(cram
  (applies_to reason)
  (deps %{bin:refmt}))
 

--- a/test/blackbox-tests/test-cases/engine/dune
+++ b/test/blackbox-tests/test-cases/engine/dune
@@ -1,0 +1,5 @@
+(cram
+ (applies_to mkdir-on-rule-cache-hit)
+ (enabled_if
+  (= %{system} linux))
+ (deps %{bin:strace}))


### PR DESCRIPTION
The dependency on %{bin:strace} was applied at the wrong dune file