### PR TITLE
Add melange.emit artifact variable

### DIFF
--- a/doc/changes/added/15751.md
+++ b/doc/changes/added/15751.md
@@ -1,0 +1,2 @@
+- Add `%{melange.emit:...}` to reference a Melange output directory and
+  depend on its emitted files (#15751, @anmonteiro)

--- a/src/dune_lang/pform.ml
+++ b/src/dune_lang/pform.ml
@@ -301,6 +301,7 @@ module Macro = struct
     | Ocaml_config
     | Rocq_config
     | Env
+    | Melange_emit
     | Artifact of Artifact.t
     | Pkg
     | Pkg_self
@@ -356,6 +357,9 @@ module Macro = struct
     | Env, Env -> Eq
     | Env, _ -> Lt
     | _, Env -> Gt
+    | Melange_emit, Melange_emit -> Eq
+    | Melange_emit, _ -> Lt
+    | _, Melange_emit -> Gt
     | Pkg, Pkg -> Eq
     | Pkg, _ -> Lt
     | _, Pkg -> Gt
@@ -389,6 +393,7 @@ module Macro = struct
     | Ocaml_config -> string "Ocaml_config"
     | Rocq_config -> string "Rocq_config"
     | Env -> string "Env"
+    | Melange_emit -> string "Melange_emit"
     | Artifact ext -> variant "Artifact" [ Artifact.to_dyn ext ]
     | Pkg -> variant "Pkg" []
     | Pkg_self -> variant "Pkg_self" []
@@ -414,6 +419,7 @@ module Macro = struct
     | Ocaml_config -> Ok "ocaml-config"
     | Rocq_config -> Ok "rocq"
     | Env -> Ok "env"
+    | Melange_emit -> Ok "melange.emit"
     | Pkg -> Ok "pkg"
     | Pkg_self -> Ok "pkg-self"
     | Ppx -> Ok "ppx"
@@ -688,6 +694,7 @@ module Env = struct
          ; "path-no-dep", deleted_in ~version:(1, 0) Macro.Path_no_dep
          ; "ocaml-config", macro Ocaml_config
          ; "env", since ~version:(1, 4) Macro.Env
+         ; "melange.emit", since ~version:(3, 25) Macro.Melange_emit
          ; "ppx", since ~version:(3, 21) Macro.Ppx
          ; "pkg", since ~version:(3, 24) Macro.Pkg
          ; "rocq", macro Rocq_config

--- a/src/dune_lang/pform.mli
+++ b/src/dune_lang/pform.mli
@@ -140,6 +140,7 @@ module Macro : sig
     | Ocaml_config
     | Rocq_config
     | Env
+    | Melange_emit
     | Artifact of Artifact.t
     | Pkg
     | Pkg_self

--- a/src/dune_rules/artifacts_obj.ml
+++ b/src/dune_rules/artifacts_obj.ml
@@ -4,11 +4,19 @@ open Memo.O
 type t =
   { libraries : Lib_info.local Lib_name.Map.t
   ; modules : (Path.Build.t Obj_dir.t * Module.t) Path.Build.Map.t
+  ; melange_emits : Melange.Emit.t Path.Build.Map.t
   }
 
-let empty = { libraries = Lib_name.Map.empty; modules = Path.Build.Map.empty }
+let empty =
+  { libraries = Lib_name.Map.empty
+  ; modules = Path.Build.Map.empty
+  ; melange_emits = Path.Build.Map.empty
+  }
+;;
+
 let lookup_module { modules; _ } = Path.Build.Map.find modules
 let lookup_library { libraries; _ } = Lib_name.Map.find libraries
+let lookup_melange_emit { melange_emits; _ } = Path.Build.Map.find melange_emits
 
 (* The source file build path of a module, with the [.ml]/[.mli] extension
    stripped. This matches the form a user writes in a module artifact pform
@@ -23,7 +31,7 @@ let module_source_path_without_extension m =
   |> Option.map ~f:(fun p -> fst (Path.Build.split_extension p))
 ;;
 
-let make ~dir ~expander ~lib_config ~libs ~exes =
+let make ~dir ~expander ~lib_config ~libs ~exes ~melange_emits =
   let+ libraries =
     Memo.List.map libs ~f:(fun ((lib : Library.t), _, _) ->
       let+ lib_config = lib_config in
@@ -48,5 +56,17 @@ let make ~dir ~expander ~lib_config ~libs ~exes =
     List.fold_left libs ~init ~f:(fun modules (_, m, obj_dir) ->
       by_path modules obj_dir m)
   in
-  { libraries; modules }
+  let melange_emits =
+    match Path.Build.Map.of_list melange_emits with
+    | Ok map -> Path.Build.Map.map map ~f:fst
+    | Error (target_dir, (_, loc1), (_, loc2)) ->
+      User_error.raise
+        ~loc:loc1
+        [ Pp.textf
+            "Melange emit target directory %S appears more than once."
+            (Path.Build.to_string target_dir)
+        ; Pp.textf "Already defined at %s" (Loc.to_file_colon_line loc2)
+        ]
+  in
+  { libraries; modules; melange_emits }
 ;;

--- a/src/dune_rules/artifacts_obj.mli
+++ b/src/dune_rules/artifacts_obj.mli
@@ -10,7 +10,9 @@ val make
   -> lib_config:Lib_config.t Memo.t
   -> libs:(Library.t * Modules.t * Path.Build.t Obj_dir.t) list
   -> exes:(Modules.t * Path.Build.t Obj_dir.t) list
+  -> melange_emits:(Path.Build.t * (Melange.Emit.t * Loc.t)) list
   -> t Memo.t
 
 val lookup_module : t -> Path.Build.t -> (Path.Build.t Obj_dir.t * Module.t) option
 val lookup_library : t -> Lib_name.t -> Lib_info.local option
+val lookup_melange_emit : t -> Path.Build.t -> Melange.Emit.t option

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -238,26 +238,33 @@ let rec dep expander : Dep_conf.t -> _ = function
     in
     Include_result (Action_builder.memoize "include-eval" pair)
   | File s ->
-    (match Expander.With_deps_if_necessary.expand_path expander s with
-     | Without paths ->
-       (* This special case is to support this pattern:
+    let expanded = Expander.With_deps_if_necessary.expand_path expander s in
+    (match String_with_vars.pform_only s with
+     | Some (Macro { macro = Melange_emit; _ }) ->
+       (match expanded with
+        | Without paths -> Simple paths
+        | With paths -> Other paths)
+     | _ ->
+       (match expanded with
+        | Without paths ->
+          (* This special case is to support this pattern:
 
-          {v
+             {v
 ... (deps (:x foo)) (action (... (diff? %{x} %{x}.corrected))) ...
-          v}
+             v}
 
-          Indeed, the second argument of [diff?] must be something that can be
-          evaluated at rule production time since the dependency/target inferrer
-          treats this argument as "consuming a target", and targets must be known
-          at rule production time. This is not compatible with computing its
-          expansion in the action builder monad, which is evaluated at rule
-          execution time. *)
-       Simple paths
-     | With paths ->
-       Other
-         (let* paths = paths in
-          let+ () = Action_builder.all_unit (List.map ~f:Action_builder.path paths) in
-          paths))
+             Indeed, the second argument of [diff?] must be something that can be
+             evaluated at rule production time since the dependency/target inferrer
+             treats this argument as "consuming a target", and targets must be known
+             at rule production time. This is not compatible with computing its
+             expansion in the action builder monad, which is evaluated at rule
+             execution time. *)
+          Simple paths
+        | With paths ->
+          Other
+            (let* paths = paths in
+             let+ () = Action_builder.all_unit (List.map ~f:Action_builder.path paths) in
+             paths)))
   | Alias s ->
     Other
       (let* a = make_alias expander s in

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -221,6 +221,29 @@ let expand_artifact ~source t artifact arg =
          Value.Path fn))
 ;;
 
+let expand_melange_emit ~source t arg =
+  let target_dir = Path.Build.relative t.dir arg in
+  let loc = Dune_lang.Template.Pform.loc source in
+  let stanza_dir = Path.Build.parent_exn target_dir in
+  if Path.Build.is_root stanza_dir
+  then User_error.raise ~loc [ Pp.text "cannot escape the workspace root directory" ];
+  let* artifacts =
+    let lookup = Fdecl.get lookup_artifacts in
+    Action_builder.of_memo (lookup ~dir:stanza_dir)
+  in
+  match Artifacts_obj.lookup_melange_emit artifacts target_dir with
+  | None ->
+    User_error.raise ~loc [ Pp.textf "Melange emit target %S does not exist." arg ]
+  | Some { Melange.Emit.output_dir; stanza_dir; alias } ->
+    let stanza_alias = Alias.make alias ~dir:stanza_dir in
+    let target_alias = Alias.make alias ~dir:target_dir in
+    let output_dir = Path.build output_dir in
+    let open Action_builder.O in
+    let+ () = Action_builder.dep (Dep.alias stanza_alias)
+    and+ () = Action_builder.dep (Dep.alias target_alias) in
+    [ Value.Path output_dir ]
+;;
+
 let foreign_flags = Fdecl.create Dyn.opaque
 
 let cc t =
@@ -775,6 +798,8 @@ let expand_pform_macro
   | Env -> Need_full_expander (fun t -> env_macro t source macro_invocation)
   | Version -> Need_full_expander (fun t -> Deps.Without (expand_version t ~source s))
   | Artifact a -> Need_full_expander (fun t -> Deps.With (expand_artifact ~source t a s))
+  | Melange_emit ->
+    Need_full_expander (fun t -> Deps.With (expand_melange_emit ~source t s))
   | Path_no_dep ->
     (* This case is for %{path-no-dep:...} which was only allowed inside
            jbuild files *)

--- a/src/dune_rules/melange/melange.ml
+++ b/src/dune_rules/melange/melange.ml
@@ -19,6 +19,14 @@ let output_path ~target_dir source =
   Path.Build.append_source target_dir (Path.Build.drop_build_context_exn source)
 ;;
 
+module Emit = struct
+  type t =
+    { output_dir : Path.Build.t
+    ; stanza_dir : Path.Build.t
+    ; alias : Alias.Name.t
+    }
+end
+
 module Source = struct
   let dir = ".melange_src"
 end

--- a/src/dune_rules/melange/melange.mli
+++ b/src/dune_rules/melange/melange.mli
@@ -13,6 +13,14 @@ module Cm_kind : module type of Dune_lang.Melange.Cm_kind
 
 val output_path : target_dir:Path.Build.t -> Path.Build.t -> Path.Build.t
 
+module Emit : sig
+  type t =
+    { output_dir : Path.Build.t
+    ; stanza_dir : Path.Build.t
+    ; alias : Alias.Name.t
+    }
+end
+
 module Source : sig
   val dir : string
 end

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -1380,13 +1380,22 @@ let make
           ; List.map modules_of_stanzas.tests ~f:modules_and_obj_dir
           ]
       in
+      let melange_emits =
+        List.map modules_of_stanzas.melange_emits ~f:(fun { Per_stanza.stanza; dir; _ } ->
+          let target_dir = Melange_stanzas.Emit.target_dir stanza ~dir in
+          let output_dir = Melange.output_path ~target_dir dir in
+          let { Melange_stanzas.Emit.alias; loc; _ } = stanza in
+          let alias = Option.value alias ~default:Melange_stanzas.Emit.implicit_alias in
+          target_dir, ({ Melange.Emit.output_dir; stanza_dir = dir; alias }, loc))
+      in
       let { Source_file_dir.dir; _ } = Nonempty_list.hd dirs in
       Artifacts_obj.make
         ~dir
         ~expander:(Expander.to_expander0 expander)
         ~lib_config
         ~libs
-        ~exes)
+        ~exes
+        ~melange_emits)
   in
   { modules; artifacts; include_subdirs }
 ;;

--- a/test/blackbox-tests/test-cases/melange/emit-variable.t
+++ b/test/blackbox-tests/test-cases/melange/emit-variable.t
@@ -49,29 +49,18 @@ stanza's target directory, relative to the dune file where the macro appears.
   > EOF
 
   $ dune build lib/local-paths root-paths
-  File "dune", line 4, characters 2-25:
-  4 |   %{melange.emit:lib/out}
-        ^^^^^^^^^^^^^^^^^^^^^^^
-  Error: Unknown macro %{melange.emit:..}
-  File "lib/dune", line 14, characters 2-21:
-  14 |   %{melange.emit:out}
-         ^^^^^^^^^^^^^^^^^^^
-  Error: Unknown macro %{melange.emit:..}
-  [1]
   $ cat _build/default/lib/local-paths
-  cat: _build/default/lib/local-paths: No such file or directory
-  [1]
+  out/lib
+  out2/lib
   $ cat _build/default/root-paths
-  cat: _build/default/root-paths: No such file or directory
-  [1]
+  lib/out/lib
+  lib/out2/lib
 
 Using the macro as a dependency also builds the JavaScript outputs for the
 selected emits.
 
   $ test -f _build/default/lib/out/lib/index.js
-  [1]
   $ test -f _build/default/lib/out2/lib/other.js
-  [1]
 
 The macro also works when the melange.emit stanza uses a custom alias.
 
@@ -95,21 +84,6 @@ The macro also works when the melange.emit stanza uses a custom alias.
   > EOF
 
   $ dune build custom/custom-path
-  File "custom/dune", line 11, characters 10-30:
-  11 |    (echo "%{melange.emit:dist}\n"))))
-                 ^^^^^^^^^^^^^^^^^^^^
-  Error: Unknown macro %{melange.emit:..}
-  File "dune", line 4, characters 2-25:
-  4 |   %{melange.emit:lib/out}
-        ^^^^^^^^^^^^^^^^^^^^^^^
-  Error: Unknown macro %{melange.emit:..}
-  File "lib/dune", line 14, characters 2-21:
-  14 |   %{melange.emit:out}
-         ^^^^^^^^^^^^^^^^^^^
-  Error: Unknown macro %{melange.emit:..}
-  [1]
   $ cat _build/default/custom/custom-path
-  cat: _build/default/custom/custom-path: No such file or directory
-  [1]
+  dist/custom
   $ test -f _build/default/custom/dist/custom/main.js
-  [1]


### PR DESCRIPTION
Add a `%{melange.emit:...}` artifact variable for referencing output directories and building their dependencies.