### PR TITLE
Forward format-dune-file requests over RPC

### DIFF
--- a/bin/format_dune_file.ml
+++ b/bin/format_dune_file.ml
@@ -14,6 +14,40 @@ let man =
 
 let info = Cmd.info "format-dune-file" ~doc ~man
 
+let input_contents = function
+  | Some path -> Io.read_file path
+  | None ->
+    Exn.protect
+      ~f:(fun () ->
+        match Fs_io.read_all_unless_large stdin with
+        | Ok contents -> contents
+        | Error exn -> raise exn)
+      ~finally:(fun () -> close_in_noerr stdin)
+;;
+
+let format_via_rpc ~builder ~config ~lock_held_by ~path ~input =
+  let contents = input_contents input in
+  match Dune_lang.Format.parse (Lexing.from_string contents) with
+  | OCaml_syntax loc ->
+    (match input with
+     | None -> User_error.raise ~loc [ Pp.text "OCaml syntax is not supported." ]
+     | Some _ -> print_string contents)
+  | Sexps _ ->
+    Scheduler_setup.no_build_no_rpc ~config (fun () ->
+      let open Fiber.O in
+      let+ formatted =
+        Rpc.Rpc_common.fire_request
+          ~name:"format-dune-file"
+          ~wait:false
+          ~warn_forwarding:false
+          ~lock_held_by
+          builder
+          Dune_rpc.Procedures.Public.format_dune_file
+          (path, `Contents contents)
+      in
+      print_string formatted)
+;;
+
 let format_file ~version ~input =
   let with_input =
     match input with
@@ -47,9 +81,9 @@ let term =
     let doc = "Which version of Dune language to use." in
     Arg.(value & opt (some version) None & info [ "dune-version" ] ~docv ~doc:(Some doc))
   and+ builder = Common.Builder.term in
-  let version =
+  let action =
     match version with
-    | Some version -> version
+    | Some version -> `Format_locally version
     | None ->
       let from =
         match path_opt with
@@ -63,23 +97,44 @@ let term =
            ~specified_by_user:(Common.Builder.root builder)
            ()
        with
-       | None -> Dune_lang.Syntax.greatest_supported_version_exn Dune_lang.Stanza.syntax
+       | None ->
+         `Format_locally
+           (Dune_lang.Syntax.greatest_supported_version_exn Dune_lang.Stanza.syntax)
        | Some root ->
          let _common, config = Common.init_with_root ~root builder in
-         Scheduler_setup.no_build_no_rpc ~config
-         @@ fun () ->
-         Memo.run
-         @@
-         let open Memo.O in
-         let+ dir =
-           match Path.as_in_source_tree (Path.of_string root.reach_from_root_prefix) with
-           | None -> Source_tree.root ()
-           | Some path -> Source_tree.nearest_dir path
-         in
-         Dune_project.dune_version (Source_tree.Dir.project dir))
+         let input = Option.map ~f:Path.of_filename_relative_to_initial_cwd path_opt in
+         (match Global_lock.lock () with
+          | Error lock_held_by ->
+            let path =
+              match input with
+              | Some path -> Path.to_absolute_filename path
+              | None -> Filename.concat root.dir root.reach_from_root_prefix
+            in
+            format_via_rpc ~builder ~config ~lock_held_by ~path ~input;
+            `Done
+          | Ok () ->
+            let version =
+              Scheduler_setup.no_build_no_rpc ~config
+              @@ fun () ->
+              Memo.run
+              @@
+              let open Memo.O in
+              let+ dir =
+                match
+                  Path.as_in_source_tree (Path.of_string root.reach_from_root_prefix)
+                with
+                | None -> Source_tree.root ()
+                | Some path -> Source_tree.nearest_dir path
+              in
+              Dune_project.dune_version (Source_tree.Dir.project dir)
+            in
+            `Format_locally version))
   in
-  let input = Option.map ~f:Path.of_filename_relative_to_initial_cwd path_opt in
-  format_file ~version ~input
+  match action with
+  | `Done -> ()
+  | `Format_locally version ->
+    let input = Option.map ~f:Path.of_filename_relative_to_initial_cwd path_opt in
+    format_file ~version ~input
 ;;
 
 let command = Cmd.v info term

--- a/doc/changes/fixed/15757.md
+++ b/doc/changes/fixed/15757.md
@@ -1,0 +1,2 @@
+- Allow `dune format-dune-file` to run while a watch server is active by
+  forwarding the request over RPC. (#15757, fixes #13525, @pengpengyi92)


### PR DESCRIPTION
## What

When another Dune process holds the workspace lock, forward `dune format-dune-file` through the existing `format-dune-file` RPC request instead of starting a competing scheduler.

The direct formatting path remains unchanged when no watch server is active or when `--dune-version` is supplied. OCaml-syntax input also preserves the command's existing behavior.

## Why

Editor integrations invoke this low-level command on save. Since Dune 3.21, that can conflict with a concurrent `dune build --watch` process and prevent formatting.

## Split evidence

Per maintainer review, the black-box reproduction has been factored into the test-only draft PR #15826. That branch contains no implementation and is expected to demonstrate the baseline lock failure on `main`.

This PR now contains only:

- the RPC-forwarding implementation;
- the changelog entry.

Fixes #13525.