### PR TITLE
test(include-qualified): cover parent-cycle attribution

### DIFF
--- a/test/blackbox-tests/test-cases/include-qualified/ocamldep-regression.t
+++ b/test/blackbox-tests/test-cases/include-qualified/ocamldep-regression.t
@@ -47,8 +47,12 @@ We also forbid submodules from depending on their interface modules:
 Or their parent interface modules:
 
   $ rm -rf baz
+  $ cat >a.ml <<EOF
+  > let f = ()
+  > EOF
   $ mkdir -p baz/foo/
   $ cat >baz/foo/z.ml <<EOF
+  > let () = A.f
   > let () = Baz.f
   > EOF
   $ dune build


### PR DESCRIPTION
Cover parent-interface dependency errors when a valid dependency precedes the offending one.

Independent coverage for #15724.