### PR TITLE
test(trace): match the shell executable precisely

### DIFF
--- a/test/blackbox-tests/test-cases/trace/commands.t
+++ b/test/blackbox-tests/test-cases/trace/commands.t
@@ -31,7 +31,10 @@ Now test the basic trace commands output - it should show commands in shell form
 
 Verify the format is executable by checking it contains cd && pattern:
 
-  $ dune trace commands | grep "cd.*&&.*sh" | dune_cmd subst '[^ ]*/bin/' '' | head -1
+  $ dune trace commands \
+  > | grep -E '^\(cd .* && ([^ ]*/)?sh -c ' \
+  > | dune_cmd subst '[^ ]*/bin/' '' \
+  > | head -1
   (cd _build/default && sh -c "echo 'Hello World' > success.txt")
 
 Test with a failing command to verify stderr output:


### PR DESCRIPTION
The `dune trace commands` cram test searched for `sh` anywhere after the command prefix. A Nix store hash containing that substring could make the test select the `ocamlc.opt -config` event instead of the shell command.

Match `sh` as the executable basename while continuing to accept both bare and absolute executable paths.