### PR TITLE
refactor: share executable path helpers

### DIFF
--- a/bin/action_runner.ml
+++ b/bin/action_runner.ml
@@ -2,22 +2,10 @@ open Import
 
 let name = Action_runner_name.of_string "action-runner"
 
-let find_in_path_exn prog =
-  match Bin.which ~path:(Env_path.path Env.initial) prog with
-  | Some path -> path
-  | None -> User_error.raise [ Pp.textf "unable to find %s in PATH" prog ]
-;;
-
-let has_directory_component prog =
-  String.exists prog ~f:(function
-    | '/' | '\\' -> true
-    | _ -> false)
-;;
-
 let dune_prog () =
   let prog = Sys.executable_name in
-  if Filename.is_relative prog && not (has_directory_component prog)
-  then find_in_path_exn prog
+  if Filename.is_relative prog && not (Fpath.contains_path_sep prog)
+  then Util.find_in_path_exn prog
   else Path.of_filename_relative_to_initial_cwd prog
 ;;
 

--- a/bin/bwrap.ml
+++ b/bin/bwrap.ml
@@ -5,15 +5,9 @@ type command =
   ; argv : string list
   }
 
-let find_in_path_exn prog =
-  match Bin.which ~path:(Env_path.path Env.initial) prog with
-  | Some path -> path
-  | None -> User_error.raise [ Pp.textf "unable to find %s in PATH" prog ]
-;;
-
 let bwrap_prog () =
   match Platform.OS.value with
-  | Linux -> find_in_path_exn "bwrap"
+  | Linux -> Util.find_in_path_exn "bwrap"
   | _ ->
     User_error.raise [ Pp.text "Dune's bubblewrap wrapper is only supported on Linux" ]
 ;;
@@ -88,7 +82,7 @@ let wrap_with_sandbox_exec =
     let prog =
       Path.to_string
         (match Platform.OS.value with
-         | Darwin -> find_in_path_exn "sandbox-exec"
+         | Darwin -> Util.find_in_path_exn "sandbox-exec"
          | _ ->
            User_error.raise
              [ Pp.text "Dune's sandbox-exec wrapper is only supported on macOS" ])

--- a/bin/util.ml
+++ b/bin/util.ml
@@ -7,6 +7,12 @@ type checked =
   | In_source_dir of Path.Source.t
   | External of Path.External.t
 
+let find_in_path_exn prog =
+  match Bin.which ~path:(Env_path.path Env.initial) prog with
+  | Some path -> path
+  | None -> User_error.raise [ Pp.textf "unable to find %s in PATH" prog ]
+;;
+
 let check_path contexts =
   let contexts =
     Dune_engine.Context_name.Map.of_list_map_exn contexts ~f:(fun c -> Context.name c, c)

--- a/bin/util.mli
+++ b/bin/util.mli
@@ -7,6 +7,7 @@ type checked =
   | In_source_dir of Path.Source.t
   | External of Path.External.t
 
+val find_in_path_exn : string -> Path.t
 val check_path : Context.t list -> Path.t -> checked
 val restore_cwd_and_execve : Workspace_root.t -> string -> string list -> Env.t -> 'a
 val setup : unit -> Dune_rules.Main.build_system Memo.t

--- a/otherlibs/stdune/src/fpath.ml
+++ b/otherlibs/stdune/src/fpath.ml
@@ -6,6 +6,7 @@ let is_root =
     fun s -> Filename.dirname s = s
 ;;
 
+let contains_path_sep s = String.contains s '/' || String.contains s '\\'
 let initial_cwd = Stdlib.Sys.getcwd ()
 
 type mkdir_result =

--- a/otherlibs/stdune/src/fpath.mli
+++ b/otherlibs/stdune/src/fpath.mli
@@ -1,5 +1,8 @@
 (** Functions on paths that are represented as strings *)
 
+(** Whether a string contains either kind of path separator. *)
+val contains_path_sep : string -> bool
+
 (** No parent directory, use [mkdir_p] if you want to create it too. *)
 type mkdir_result =
   [ `Already_exists (** The directory already exists. No action was taken. *)

--- a/otherlibs/stdune/src/temp.ml
+++ b/otherlibs/stdune/src/temp.ml
@@ -88,8 +88,6 @@ let temp_in_dir ?perms what ~dir ~prefix ~suffix =
   path
 ;;
 
-let contains_path_sep s = String.contains s '/' || String.contains s '\\'
-
 let create ?perms what ~prefix ~suffix =
   let dir =
     (* CR-someday amokhov: There are two issues with this: (i) we run this code
@@ -99,12 +97,12 @@ let create ?perms what ~prefix ~suffix =
        Perhaps, we should use something like [_build/.temp] instead? *)
     Filename.get_temp_dir_name () |> Path.of_filename_relative_to_initial_cwd
   in
-  if contains_path_sep prefix
+  if Fpath.contains_path_sep prefix
   then
     Code_error.raise
       "Temp.create: prefix must not contain path elements"
       [ "prefix", Dyn.string prefix ];
-  if contains_path_sep suffix
+  if Fpath.contains_path_sep suffix
   then
     Code_error.raise
       "Temp.create: suffix must not contain path elements"


### PR DESCRIPTION
Centralize executable lookup used by the action runner and sandbox wrappers in `bin/Util`. Move cross-platform path-separator detection to `Fpath` so temporary-file validation and executable resolution share the same implementation.

This is a behavior-preserving preparation for adding another internal wrapper.