### PR TITLE
fix(cram): rewrite Windows paths in cram output

### DIFF
--- a/doc/changes/fixed/15762.md
+++ b/doc/changes/fixed/15762.md
@@ -1,0 +1,4 @@
+- Fix Windows cram test path rewriting: mapped roots containing a drive
+  letter colon (e.g. `C:\foo`) no longer crash the decoder, and native
+  Windows paths are rewritten regardless of separator style.
+  (#15762, fixes #4017, fixes #4018, fixes #10176, @Alizter)

--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -323,15 +323,79 @@ let line_number =
   seq [ set "123456789"; rep digit ]
 ;;
 
-let rewrite_paths ~build_path_prefix_map ~parent_script ~command_script s =
+(* Windows paths may be emitted with a mix of '/' and '\' separators (for
+   instance a native path combined with a POSIX-style suffix), and '\' may be
+   escaped in output formats such as JSON. On Windows, match map sources
+   separator-insensitively and rewrite the remainder of the path using '/'
+   separators. *)
+let is_windows = Sys.win32
+
+let win_separator_re =
+  let open Re in
+  (* an escaped backslash (e.g. "\\" in JSON output) or a single separator *)
+  alt [ str "\\\\"; set "\\/" ]
+;;
+
+(* Compiled form of [win_separator_re], used for rewriting. *)
+let compiled_win_separator_re = Re.compile win_separator_re
+
+(* Once a mapped root is matched on Windows, consume the rest of the path
+   (separator followed by a component) so that it is rewritten with
+   normalized separators too. Components cannot contain '\', '/', or '"'
+   (the latter cannot appear in Windows paths and terminates e.g. JSON
+   strings). A single '\' followed by a JSON escape character (e.g. "\n")
+   is indistinguishable from a separator and a component starting with that
+   character, and is consumed as such; JSON output that escapes its
+   separators as "\\" is matched by the escaped-separator alternative. *)
+let win_path_continuation_re =
+  let open Re in
+  rep (seq [ win_separator_re; rep (compl [ set "\\/\"" ]) ])
+;;
+
+let windows_source_re source =
+  let open Re in
+  let parts =
+    String.fold_left source ~init:[] ~f:(fun acc c ->
+      if c = '/' || c = '\\'
+      then win_separator_re :: acc
+      else str (String.make 1 c) :: acc)
+    |> List.rev
+  in
+  seq (parts @ [ win_path_continuation_re ])
+;;
+
+(* Rewrite '\' and '\\' to '/'. Only applied to Windows output, where '\' is
+   always a path separator and '\\' is its escaped form. *)
+let normalize_windows_separators s = Re.replace_string compiled_win_separator_re s ~by:"/"
+
+let rewrite_paths ~src ~build_path_prefix_map ~parent_script ~command_script s =
   match Build_path_prefix_map.decode_map build_path_prefix_map with
   | Error msg ->
-    Code_error.raise
-      "Cannot decode build prefix map"
-      [ "build_path_prefix_map", String build_path_prefix_map; "msg", String msg ]
+    User_error.raise
+      ~loc:(Loc.in_file (Path.drop_optional_build_context_maybe_sandboxed src))
+      [ Pp.textf
+          "Invalid %s: %s"
+          Dune_util.Build_path_prefix_map._BUILD_PATH_PREFIX_MAP
+          msg
+      ]
   | Ok map ->
+    (* On Windows, normalize the map sources once so that the rewrite below
+       matches and drops prefixes separator-insensitively. *)
+    let map =
+      if is_windows
+      then
+        List.map map ~f:(function
+          | None -> None
+          | Some (p : Build_path_prefix_map.pair) ->
+            Some
+              { p with
+                Build_path_prefix_map.source = normalize_windows_separators p.source
+              })
+      else map
+    in
     let s =
-      (* Match map sources literally, longest first, so spaced paths match. *)
+      (* Match map sources, longest first, so spaced paths match. On Windows
+         separators are matched flexibly. *)
       match
         (* Drop None and empty sources: [Re.str ""] would match everywhere. *)
         List.filter_map map ~f:(function
@@ -344,12 +408,16 @@ let rewrite_paths ~build_path_prefix_map ~parent_script ~command_script s =
           sources
           |> List.sort ~compare:(fun a b ->
             Int.compare (String.length b) (String.length a))
-          |> List.map ~f:Re.str
+          |> List.map ~f:(if is_windows then windows_source_re else Re.str)
           |> Re.alt
           |> Re.compile
         in
         Re.replace abs_path_re s ~f:(fun g ->
-          Build_path_prefix_map.rewrite map (Re.Group.get g 0))
+          let matched = Re.Group.get g 0 in
+          let matched =
+            if is_windows then normalize_windows_separators matched else matched
+          in
+          Build_path_prefix_map.rewrite map matched)
     in
     let error_msg =
       let open Re in
@@ -380,7 +448,7 @@ let command_out_repr =
     ]
 ;;
 
-let sanitize ~parent_script cram_to_output : command_out Cram_lexer.block list =
+let sanitize ~src ~parent_script cram_to_output : command_out Cram_lexer.block list =
   List.map cram_to_output ~f:(fun (t : full_block_result Cram_lexer.block) ->
     match t with
     | Cram_lexer.Comment t -> Cram_lexer.Comment t
@@ -399,6 +467,7 @@ let sanitize ~parent_script cram_to_output : command_out Cram_lexer.block list =
             output
             ~f:
               (rewrite_paths
+                 ~src
                  ~parent_script
                  ~command_script:block.script
                  ~build_path_prefix_map)
@@ -754,13 +823,13 @@ let run_cram_test
            | None -> None
            | Some times -> Some { Dune_trace.Event.Cram.command; times }))
       |> Dune_trace.Event.Cram.test ~test:src);
-    sanitize ~parent_script:script detailed_output
+    sanitize ~src ~parent_script:script detailed_output
   | Error `Timed_out ->
     (match
        read_and_attach_metadata sh_script ~timed_out:true |> mark_timed_out_command
      with
      | None -> raise_timeout_error ~src ~timeout
-     | Some detailed_output -> sanitize ~parent_script:script detailed_output)
+     | Some detailed_output -> sanitize ~src ~parent_script:script detailed_output)
 ;;
 
 let run_produce_correction

--- a/test/blackbox-tests/test-cases/cram/windows-path-rewriting.t
+++ b/test/blackbox-tests/test-cases/cram/windows-path-rewriting.t
@@ -10,16 +10,10 @@ See https://github.com/ocaml/dune/issues/4017
 and https://github.com/ocaml/dune/issues/4018
 and https://github.com/ocaml/dune/issues/10176
 
-CR-soon Alizter: this is wrong, the paths should be rewritten. Adding a
-native Windows path with a drive letter colon to the map crashes the
-decoder with an internal error, output whose separators do not match the
-mapped root exactly (e.g. escaped backslashes in JSON) is not rewritten,
-and malformed maps are reported as internal errors instead of user errors.
-
   $ make_dune_project 3.23
 
-A native Windows path with a drive letter colon crashes the decoder
-(issue #10176):
+A native Windows path with a drive letter colon can be added to the map
+directly, without encoding the colon; decoding must not fail:
 
   $ cat >t1.t <<'EOF'
   >   $ native_root=$(cygpath -m /)
@@ -28,25 +22,63 @@ A native Windows path with a drive letter colon crashes the decoder
   >   path is /NATIVEPATH/something
   > EOF
 
-  $ dune runtest t1.t > t1.out 2>&1
-  [1]
-  $ grep -c "Cannot decode build prefix map" t1.out
-  1
-
-Output containing escaped backslashes (JSON) is not rewritten to
-$TESTCASE_ROOT (issue #4017):
+The mappings that Dune adds itself (with encoded drive-letter colons) still
+rewrite native output, including JSON-escaped backslashes:
 
   $ cat >t2.t <<'EOF'
+  >   $ echo "$(cygpath -w "$PWD")/tcs"
+  >   $TESTCASE_ROOT/tcs
   >   $ printf '{"file": "%s\\\\file.ml"}\n' "$(cygpath -w "$PWD")"
   >   {"file": "$TESTCASE_ROOT/file.ml"}
   > EOF
 
-  $ dune runtest t2.t > t2.out 2>&1
-  [1]
-  $ grep -c 'File "t2.t"' t2.out
-  1
+Native backslash paths, forward-slash paths, mixed separators and
+JSON-escaped backslashes are all rewritten:
 
-A malformed map is reported as an internal error instead of a user error:
+  $ cat >t3.t <<'EOF'
+  >   $ export BUILD_PATH_PREFIX_MAP="/ROOT=C:/work/test:$BUILD_PATH_PREFIX_MAP"
+  >   $ echo 'C:\work\test\file.ml'
+  >   /ROOT/file.ml
+  >   $ echo 'C:/work/test/file.ml'
+  >   /ROOT/file.ml
+  >   $ echo 'C:\work/test\file.ml'
+  >   /ROOT/file.ml
+  >   $ echo 'C:/work\test\file.ml'
+  >   /ROOT/file.ml
+  >   $ printf '{"file": "C:\\\\work\\\\test\\\\file.ml"}\n'
+  >   {"file": "/ROOT/file.ml"}
+  >   $ printf '{"file": "C:\\\\work\\\\test\\\\n"}\n'
+  >   {"file": "/ROOT/n"}
+  >   $ echo 'C:\work\test\n'
+  >   /ROOT/n
+  > EOF
+
+Overlapping mappings: the longest mapped root matches, and the rightmost
+rule wins when several rules apply to the same path:
+
+  $ cat >t4.t <<'EOF'
+  >   $ export BUILD_PATH_PREFIX_MAP="/CROOT=C%.:/CWORK=C:/work:$BUILD_PATH_PREFIX_MAP"
+  >   $ echo "C:/work/file"
+  >   /CWORK/file
+  >   $ echo "C:/other"
+  >   /CROOT/other
+  >   $ export BUILD_PATH_PREFIX_MAP="$BUILD_PATH_PREFIX_MAP:/SECOND=C:/work"
+  >   $ echo "C:/work/file"
+  >   /SECOND/file
+  > EOF
+
+Mapped roots containing spaces remain valid:
+
+  $ cat >t5.t <<'EOF'
+  >   $ spaced_src="C:/work/sub dir"
+  >   $ export BUILD_PATH_PREFIX_MAP="/SPACED TARGET=$spaced_src:$BUILD_PATH_PREFIX_MAP"
+  >   $ echo "$spaced_src/file.txt"
+  >   /SPACED TARGET/file.txt
+  > EOF
+
+  $ dune runtest
+
+A malformed map is reported as a user error, not an internal error:
 
   $ cat >bad.t <<'EOF'
   >   $ export BUILD_PATH_PREFIX_MAP=":/NOEQUALS"
@@ -54,7 +86,8 @@ A malformed map is reported as an internal error instead of a user error:
   >   ok
   > EOF
 
-  $ dune runtest bad.t > bad.out 2>&1
+  $ dune runtest bad.t 2>&1
+  File "bad.t", line 1, characters 0-0:
+  Error: Invalid BUILD_PATH_PREFIX_MAP: invalid key/value pair "/NOEQUALS", no
+  '=' separator
   [1]
-  $ grep -c "Cannot decode build prefix map" bad.out
-  1

--- a/test/expect-tests/build_path_prefix_map/bpp_tests.ml
+++ b/test/expect-tests/build_path_prefix_map/bpp_tests.ml
@@ -30,33 +30,45 @@ let%expect_test "encode then decode preserves the map" =
 ;;
 
 let%expect_test "decoding an unescaped drive-letter colon in a source (#10176)" =
-  (* CR-soon Alizter: this is wrong, it should decode to
-     /NATIVEPATH=C:/
-     $TESTCASE_ROOT=C:\foo *)
   decode_and_print "/NATIVEPATH=C:/:$TESTCASE_ROOT=C%.\\foo";
-  [%expect {| Error: invalid key/value pair "/", no '=' separator |}]
+  [%expect
+    {|
+    /NATIVEPATH=C:/
+    $TESTCASE_ROOT=C:\foo
+    |}]
 ;;
 
 let%expect_test "decoding a drive-letter colon in a target" =
-  (* CR-soon Alizter: this is wrong, it should be C:\work\test=src *)
   decode_and_print "C:\\work\\test=src";
-  [%expect {| Error: invalid key/value pair "C", no '=' separator |}]
+  [%expect
+    {|
+    C:\work\test=src
+    |}]
+;;
+
+let%expect_test "a drive-letter target in a non-initial entry stays with its entry" =
+  decode_and_print "A=B:C:\\work=/ROOT";
+  [%expect
+    {|
+    A=B
+    C:\work=/ROOT
+    |}]
 ;;
 
 let%expect_test "decoding a drive-letter colon in the middle of a map" =
-  (* CR-soon Alizter: this is wrong, it should be
-     a=b:C:/foo
-     d=e *)
   decode_and_print "a=b:C:/foo:d=e";
-  [%expect {| Error: invalid key/value pair "C", no '=' separator |}]
+  [%expect
+    {|
+    a=b:C:/foo
+    d=e
+    |}]
 ;;
 
-let%expect_test "decode_prefix rejects an unescaped colon" =
-  (* CR-soon Alizter: this is wrong, it should be C: *)
+let%expect_test "decode_prefix accepts an unescaped colon" =
   (match Build_path_prefix_map.decode_prefix "C:" with
    | Error msg -> print_endline ("Error: " ^ msg)
    | Ok p -> print_endline p);
-  [%expect {| Error: invalid character ':' in key or value |}]
+  [%expect {| C: |}]
 ;;
 
 let%expect_test "empty entries are preserved" =
@@ -67,12 +79,39 @@ let%expect_test "empty entries are preserved" =
     (empty)
     B=/a/b
     (empty)
+    |}];
+  decode_and_print ":A=B";
+  [%expect
+    {|
+    (empty)
+    A=B
+    |}]
+;;
+
+let%expect_test "empty entries adjacent to rejoined segments" =
+  decode_and_print "a=b:C::/x:d=e";
+  [%expect
+    {|
+    a=b:C:/x
+    (empty)
+    d=e
+    |}]
+;;
+
+let%expect_test "a colon at the end of a value is ambiguous with an empty entry" =
+  decode_and_print "A=B:garbage";
+  [%expect {| A=B:garbage |}];
+  decode_and_print "A=B:";
+  [%expect
+    {|
+    A=B
+    (empty)
     |}]
 ;;
 
 let%expect_test "malformed maps are errors" =
   decode_and_print "foo:bar";
-  [%expect {| Error: invalid key/value pair "foo", no '=' separator |}];
+  [%expect {| Error: invalid key/value pair "foo:bar", no '=' separator |}];
   decode_and_print ":/NOEQUALS";
   [%expect {| Error: invalid key/value pair "/NOEQUALS", no '=' separator |}];
   decode_and_print "a=b=c";

--- a/vendor/build_path_prefix_map.patch
+++ b/vendor/build_path_prefix_map.patch
@@ -1,0 +1,115 @@
+diff --git a/build_path_prefix_map/src/build_path_prefix_map.ml b/build_path_prefix_map/src/build_path_prefix_map.ml
+index c73dae444c2..9aa343948f8 100644
+--- a/build_path_prefix_map/src/build_path_prefix_map.ml
++++ b/build_path_prefix_map/src/build_path_prefix_map.ml
+@@ -1,3 +1,9 @@
++(* NOTE: this file contains local modifications with respect to upstream
++   (see vendor/update-build_path_prefix_map.sh): [decode_prefix] accepts
++   unescaped ':' characters and [decode_map] rejoins segments that contain
++   no '=' separator (merging a drive-letter prefix with the entry that
++   follows it), so that maps containing Windows drive letters such as
++   "C:\foo" can be decoded. *)
+ type path = string
+ type path_prefix = string
+ type error_message = string
+@@ -21,8 +27,8 @@ let decode_prefix str =
+     if i >= String.length str
+     then Ok (Buffer.contents buf)
+     else match str.[i] with
+-      | ('=' | ':') as c ->
+-        errorf "invalid character '%c' in key or value" c
++      | '=' ->
++        errorf "invalid character '=' in key or value"
+       | '%' ->
+         let push c = Buffer.add_char buf c; loop (i + 2) in
+         if i + 1 = String.length str then
+@@ -75,10 +81,87 @@ let decode_map str =
+         | Error err -> raise (Shortcut err)
+       end
+   in
+-  let pairs = String.split_on_char ':' str in
+-  match List.map decode_or_empty pairs with
++  (* An unescaped ':' inside a key/value pair (e.g. the drive letter of a
++     Windows path such as "C:\foo") is split by [String.split_on_char].
++     Rejoin the segments that contain no '=' separator with their neighbour
++     so that such pairs can be decoded. This is a leniency for maps that do
++     not follow the recommended encoding; properly encoded maps are
++     unaffected. A ':' at the very end of a value is ambiguous with an empty
++     entry and must be encoded (e.g. "C%."). A drive letter at the start of
++     a non-initial entry is merged with the entry that follows it (see
++     [merge_drive_letters]); other ':' in the target of a non-initial entry
++     must be encoded. *)
++  (* A drive-letter prefix (a single letter followed by a native path, e.g.
++     "C" in "C:\work=src") is split from its entry by
++     [String.split_on_char]. If the entry is not the first one, the letter
++     would be absorbed into the previous pair's value, so merge it with the
++     segment that follows it (a native path containing an '='). *)
++  let merge_drive_letters lst =
++    let is_drive_letter s =
++      String.length s = 1
++      &&
++      let c = s.[0] in
++      (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
++    in
++    let is_native_entry s =
++      String.length s > 0
++      && (s.[0] = '\\' || s.[0] = '/')
++      && String.contains s '='
++    in
++    let rec loop = function
++      | [] | [ _ ] as l -> l
++      | x :: y :: rest ->
++        if is_drive_letter x && is_native_entry y
++        then (x ^ ":" ^ y) :: loop rest
++        else x :: loop (y :: rest)
++    in
++    loop lst
++  in
++  let split_pairs str =
++    (* Walk the ':'-split segments, accumulating entries in reverse. A
++       segment containing '=' opens a pair; a segment without '=' continues
++       the nearest preceding entry (before any pair it is a target prefix
++       and joins the pair that follows it). Empty segments are preserved as
++       empty entries. *)
++    let rec loop acc = function
++      | [] -> List.rev acc
++      | "" :: rest -> loop ("" :: acc) rest
++      | seg :: rest ->
++        if String.contains seg '='
++        then
++          (* join a pending target prefix, if any *)
++          let rec join_prefix = function
++            | e :: tl when e <> "" && not (String.contains e '=') ->
++              Some ((e ^ ":" ^ seg) :: tl)
++            | x :: tl ->
++              (match join_prefix tl with
++               | Some tl -> Some (x :: tl)
++               | None -> None)
++            | [] -> None
++          in
++          (match join_prefix acc with
++           | Some acc -> loop acc rest
++           | None -> loop (seg :: acc) rest)
++        else
++          (* continue the nearest preceding entry *)
++          let rec join_prev = function
++            | e :: tl when e <> "" -> Some ((e ^ ":" ^ seg) :: tl)
++            | x :: tl ->
++              (match join_prev tl with
++               | Some tl -> Some (x :: tl)
++               | None -> None)
++            | [] -> None
++          in
++          (match join_prev acc with
++           | Some acc -> loop acc rest
++           | None -> loop (seg :: acc) rest)
++    in
++    loop [] (merge_drive_letters (String.split_on_char ':' str))
++  in
++  match List.map decode_or_empty (split_pairs str) with
+   | exception (Shortcut err) -> Error err
+   | map -> Ok map
++;;
+ 
+ let rewrite_opt prefix_map path =
+   let is_prefix = function

--- a/vendor/build_path_prefix_map/src/build_path_prefix_map.ml
+++ b/vendor/build_path_prefix_map/src/build_path_prefix_map.ml
@@ -1,3 +1,9 @@
+(* NOTE: this file contains local modifications with respect to upstream
+   (see vendor/update-build_path_prefix_map.sh): [decode_prefix] accepts
+   unescaped ':' characters and [decode_map] rejoins segments that contain
+   no '=' separator (merging a drive-letter prefix with the entry that
+   follows it), so that maps containing Windows drive letters such as
+   "C:\foo" can be decoded. *)
 type path = string
 type path_prefix = string
 type error_message = string
@@ -21,8 +27,8 @@ let decode_prefix str =
     if i >= String.length str
     then Ok (Buffer.contents buf)
     else match str.[i] with
-      | ('=' | ':') as c ->
-        errorf "invalid character '%c' in key or value" c
+      | '=' ->
+        errorf "invalid character '=' in key or value"
       | '%' ->
         let push c = Buffer.add_char buf c; loop (i + 2) in
         if i + 1 = String.length str then
@@ -75,10 +81,87 @@ let decode_map str =
         | Error err -> raise (Shortcut err)
       end
   in
-  let pairs = String.split_on_char ':' str in
-  match List.map decode_or_empty pairs with
+  (* An unescaped ':' inside a key/value pair (e.g. the drive letter of a
+     Windows path such as "C:\foo") is split by [String.split_on_char].
+     Rejoin the segments that contain no '=' separator with their neighbour
+     so that such pairs can be decoded. This is a leniency for maps that do
+     not follow the recommended encoding; properly encoded maps are
+     unaffected. A ':' at the very end of a value is ambiguous with an empty
+     entry and must be encoded (e.g. "C%."). A drive letter at the start of
+     a non-initial entry is merged with the entry that follows it (see
+     [merge_drive_letters]); other ':' in the target of a non-initial entry
+     must be encoded. *)
+  (* A drive-letter prefix (a single letter followed by a native path, e.g.
+     "C" in "C:\work=src") is split from its entry by
+     [String.split_on_char]. If the entry is not the first one, the letter
+     would be absorbed into the previous pair's value, so merge it with the
+     segment that follows it (a native path containing an '='). *)
+  let merge_drive_letters lst =
+    let is_drive_letter s =
+      String.length s = 1
+      &&
+      let c = s.[0] in
+      (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+    in
+    let is_native_entry s =
+      String.length s > 0
+      && (s.[0] = '\\' || s.[0] = '/')
+      && String.contains s '='
+    in
+    let rec loop = function
+      | [] | [ _ ] as l -> l
+      | x :: y :: rest ->
+        if is_drive_letter x && is_native_entry y
+        then (x ^ ":" ^ y) :: loop rest
+        else x :: loop (y :: rest)
+    in
+    loop lst
+  in
+  let split_pairs str =
+    (* Walk the ':'-split segments, accumulating entries in reverse. A
+       segment containing '=' opens a pair; a segment without '=' continues
+       the nearest preceding entry (before any pair it is a target prefix
+       and joins the pair that follows it). Empty segments are preserved as
+       empty entries. *)
+    let rec loop acc = function
+      | [] -> List.rev acc
+      | "" :: rest -> loop ("" :: acc) rest
+      | seg :: rest ->
+        if String.contains seg '='
+        then
+          (* join a pending target prefix, if any *)
+          let rec join_prefix = function
+            | e :: tl when e <> "" && not (String.contains e '=') ->
+              Some ((e ^ ":" ^ seg) :: tl)
+            | x :: tl ->
+              (match join_prefix tl with
+               | Some tl -> Some (x :: tl)
+               | None -> None)
+            | [] -> None
+          in
+          (match join_prefix acc with
+           | Some acc -> loop acc rest
+           | None -> loop (seg :: acc) rest)
+        else
+          (* continue the nearest preceding entry *)
+          let rec join_prev = function
+            | e :: tl when e <> "" -> Some ((e ^ ":" ^ seg) :: tl)
+            | x :: tl ->
+              (match join_prev tl with
+               | Some tl -> Some (x :: tl)
+               | None -> None)
+            | [] -> None
+          in
+          (match join_prev acc with
+           | Some acc -> loop acc rest
+           | None -> loop (seg :: acc) rest)
+    in
+    loop [] (merge_drive_letters (String.split_on_char ':' str))
+  in
+  match List.map decode_or_empty (split_pairs str) with
   | exception (Shortcut err) -> Error err
   | map -> Ok map
+;;
 
 let rewrite_opt prefix_map path =
   let is_prefix = function

--- a/vendor/update-build_path_prefix_map.sh
+++ b/vendor/update-build_path_prefix_map.sh
@@ -21,5 +21,10 @@ SRC=$TMP/build_path_prefix_map
 
 cp -v $SRC/build_path_prefix_map.{ml,mli} build_path_prefix_map/src
 
+# The vendored .ml carries local modifications (the decoder leniency for
+# Windows drive letters, marked by a NOTE at the top of the file); re-apply
+# them on top of the fresh upstream copy.
+git apply build_path_prefix_map.patch
+
 git checkout build_path_prefix_map/src/dune
 git add -A .


### PR DESCRIPTION
- Fixes #4017
- Fixes #4018
- Fixes #10176


## Problem

Cram tests on Windows could not rewrite native Windows paths emitted by tested programs:

- Adding a mapped root with a drive letter colon (e.g. `C:\foo`) to `BUILD_PATH_PREFIX_MAP` crashed the map decoder, which surfaced as an internal error: the drive-letter colon conflicted with the map's `:` entry separator.
- Native output whose separators did not match the mapped root exactly (backslashes, forward slashes, a mix of both, or escaped backslashes in JSON output) was not rewritten at all, leaking machine-specific paths into oracles.
- Malformed maps crashed as internal errors instead of user errors.

## Solution

- The decoder now tolerates unescaped `:` characters in key/value pairs: segments that contain no `=` separator are rejoined with their neighbour, and a drive-letter prefix (e.g. `C`) followed by a native path is kept with the entry that follows it rather than absorbed into the previous pair's value. This is a leniency for maps that do not follow the recommended encoding; properly encoded maps are unaffected. The vendored `build_path_prefix_map` library carries these local changes (marked with a NOTE header and re-applied by `update-build_path_prefix_map.sh`).
- Cram output rewriting on Windows matches mapped roots separator-insensitively and rewrites the rest of the path with normalized separators, so Windows oracles stay platform-independent. A single `\` followed by a JSON escape character (e.g. `\n`) after the mapped root is indistinguishable from a separator plus a component starting with that character and is consumed as such; JSON output that escapes its separators (`\\`) is matched by the escaped-separator alternative.
- Malformed maps are reported as user errors pointing at the cram test rather than internal errors.

## Verification

- `test/expect-tests/build_path_prefix_map`: ppx_expect tests for encoding/decoding/rewriting; pass on both the old and the new code (the test commit records the faulty behavior and this PR flips the expectations).
- `windows-path-rewriting.t` and `@runtest-windows` pass on a Windows VM (mingw) for both the test commit and this fix commit.
- `@check` and `@fmt` pass on Linux.
