### PR TITLE
refactor(stdune): use Fd.t in Spawn

### DIFF
--- a/otherlibs/stdune/src/spawn.ml
+++ b/otherlibs/stdune/src/spawn.ml
@@ -3,10 +3,22 @@ external is_osx : unit -> bool = "dune_spawn_is_osx" [@@noalloc]
 let is_osx = is_osx ()
 
 module Working_dir = struct
-  type t =
+  type 'a gen =
     | Path of string
-    | Fd of Unix.file_descr
+    | Fd of 'a
     | Inherit
+
+  type t = Fd.t gen
+  type raw = Unix.file_descr gen
+
+  let raw : t -> raw = function
+    | Fd fd -> Fd (Fd.unsafe_to_unix_file_descr fd)
+    | (Path _ | Inherit) as x -> x
+  ;;
+
+  let path s = Path s
+  let fd fd = Fd fd
+  let inherit_ = Inherit
 end
 
 module Unix_backend = struct
@@ -89,9 +101,9 @@ module Pgid = struct
   ;;
 end
 
-external spawn_unix
+external spawn_unix_raw
   :  env:Env.t option
-  -> cwd:Working_dir.t
+  -> cwd:Working_dir.raw
   -> prog:string
   -> argv0:string
   -> args:string Array.Immutable.t
@@ -121,15 +133,15 @@ let spawn_unix
   =
   let setpgid = Option.map ~f:Pgid.to_int setpgid in
   let pdeathsig = Signal.to_int pdeathsig in
-  spawn_unix
+  spawn_unix_raw
     ~env
-    ~cwd
+    ~cwd:(Working_dir.raw cwd)
     ~prog
     ~argv0
     ~args
-    ~stdin
-    ~stdout
-    ~stderr
+    ~stdin:(Fd.unsafe_to_unix_file_descr stdin)
+    ~stdout:(Fd.unsafe_to_unix_file_descr stdout)
+    ~stderr:(Fd.unsafe_to_unix_file_descr stderr)
     ~use_vfork
     ~setpgid
     ~sigprocmask
@@ -137,7 +149,7 @@ let spawn_unix
   |> Pid.of_int_exn
 ;;
 
-external spawn_windows
+external spawn_windows_raw
   :  env:Env.t option
   -> cwd:string option
   -> prog:string
@@ -181,7 +193,15 @@ let spawn_windows
     | true, Some p -> Filename.concat p prog
     | _ -> prog
   in
-  spawn_windows ~env ~cwd ~prog ~cmdline ~stdin ~stdout ~stderr |> Pid.of_int_exn
+  spawn_windows_raw
+    ~env
+    ~cwd
+    ~prog
+    ~cmdline
+    ~stdin:(Fd.unsafe_to_unix_file_descr stdin)
+    ~stdout:(Fd.unsafe_to_unix_file_descr stdout)
+    ~stderr:(Fd.unsafe_to_unix_file_descr stderr)
+  |> Pid.of_int_exn
 ;;
 
 let no_null s =
@@ -193,15 +213,19 @@ let no_null s =
       s
 ;;
 
+let default_stdin = Fd.unsafe_of_unix_file_descr Unix.stdin
+let default_stdout = Fd.unsafe_of_unix_file_descr Unix.stdout
+let default_stderr = Fd.unsafe_of_unix_file_descr Unix.stderr
+
 let spawn
       ?env
-      ?(cwd = Working_dir.Inherit)
+      ?(cwd = Working_dir.inherit_)
       ~prog
       ~argv0
       ~args
-      ?(stdin = Unix.stdin)
-      ?(stdout = Unix.stdout)
-      ?(stderr = Unix.stderr)
+      ?(stdin = default_stdin)
+      ?(stdout = default_stdout)
+      ?(stderr = default_stderr)
       ?(unix_backend = Unix_backend.default)
       ?setpgid
       ?(pdeathsig = Signal.Kill)
@@ -250,6 +274,9 @@ let spawn
       ~pdeathsig
 ;;
 
-external safe_pipe : unit -> Unix.file_descr * Unix.file_descr = "dune_spawn_pipe"
+external safe_pipe_raw : unit -> Unix.file_descr * Unix.file_descr = "dune_spawn_pipe"
 
-let safe_pipe = if Sys.win32 then fun () -> Unix.pipe ~cloexec:true () else safe_pipe
+let safe_pipe () =
+  let read, write = if Sys.win32 then Unix.pipe ~cloexec:true () else safe_pipe_raw () in
+  Fd.unsafe_of_unix_file_descr read, Fd.unsafe_of_unix_file_descr write
+;;

--- a/otherlibs/stdune/src/spawn.mli
+++ b/otherlibs/stdune/src/spawn.mli
@@ -5,11 +5,16 @@
     default at runtime by setting the environment variable [SPAWN_USE_FORK]. *)
 
 module Working_dir : sig
-  type t =
-    | Path of string (** Path in the filesystem *)
-    | Fd of Unix.file_descr
-    (** File descriptor pointing to a directory. Not supported on Windows. *)
-    | Inherit (** Inherit the working directory of the current process *)
+  type t
+
+  (** Path in the filesystem *)
+  val path : string -> t
+
+  (** File descriptor pointing to a directory. Not supported on Windows. *)
+  val fd : Fd.t -> t
+
+  (** Inherit the working directory of the current process *)
+  val inherit_ : t
 end
 
 module Unix_backend : sig
@@ -119,9 +124,9 @@ val spawn
   -> prog:string
   -> argv0:string
   -> args:string Array.Immutable.t
-  -> ?stdin:Unix.file_descr
-  -> ?stdout:Unix.file_descr
-  -> ?stderr:Unix.file_descr
+  -> ?stdin:Fd.t
+  -> ?stdout:Fd.t
+  -> ?stderr:Fd.t
   -> ?unix_backend:Unix_backend.t (* default: [Unix_backend.default] *)
   -> ?setpgid:Pgid.t
   -> ?pdeathsig:Signal.t
@@ -145,4 +150,4 @@ val spawn
    It is implemented using the [pipe2] system calls, except on OSX where [pipe2]
    is not available. On OSX, both [safe_pipe] and [spawn] lock the same mutex to
    prevent race conditions. *)
-val safe_pipe : unit -> Unix.file_descr * Unix.file_descr
+val safe_pipe : unit -> Fd.t * Fd.t

--- a/otherlibs/stdune/test/spawn/tests.ml
+++ b/otherlibs/stdune/test/spawn/tests.ml
@@ -30,7 +30,7 @@ let%expect_test "non-existing dir" =
       ~prog:"/bin/true"
       ~argv0:"true"
       ~args:no_args
-      ~cwd:(Spawn.Working_dir.Path "/doesnt-exist"));
+      ~cwd:(Spawn.Working_dir.path "/doesnt-exist"));
   [%expect
     {|
     raised Unix.Unix_error _
@@ -73,7 +73,7 @@ let%expect_test "cwd:Path" =
        ~prog:list_files
        ~argv0:"list_files.exe"
        ~args:no_args
-       ~cwd:(Spawn.Working_dir.Path "sub"));
+       ~cwd:(Spawn.Working_dir.path "sub"));
   [%expect
     {|
     bar
@@ -85,15 +85,15 @@ let%expect_test "cwd:Fd" =
   if Sys.win32
   then print_endline "bar\nfoo"
   else (
-    let fd = Unix.openfile "sub" [ O_RDONLY ] 0 in
+    let fd = Unix.openfile "sub" [ O_RDONLY ] 0 |> Fd.unsafe_of_unix_file_descr in
     wait
       (Spawn.spawn
          ()
          ~prog:list_files
          ~argv0:"list_files.exe"
          ~args:no_args
-         ~cwd:(Spawn.Working_dir.Fd fd));
-    Unix.close fd);
+         ~cwd:(Spawn.Working_dir.fd fd));
+    Fd.close fd);
   [%expect
     {|
     bar
@@ -111,7 +111,7 @@ let%expect_test "cwd:Fd (invalid)" =
         ~prog:"/bin/pwd"
         ~argv0:"pwd"
         ~args:no_args
-        ~cwd:(Spawn.Working_dir.Fd Unix.stdin));
+        ~cwd:(Spawn.Working_dir.fd (Fd.unsafe_of_unix_file_descr Unix.stdin)));
   [%expect
     {|
     raised Unix.Unix_error _
@@ -174,7 +174,7 @@ let%expect_test "prog relative to cwd" =
          ~prog:"./hello.exe"
          ~argv0:"hello"
          ~args:no_args
-         ~cwd:(Spawn.Working_dir.Path "exe"));
+         ~cwd:(Spawn.Working_dir.path "exe"));
   [%expect {| Hello, world! |}]
 ;;
 
@@ -192,7 +192,7 @@ let%expect_test "env" =
          ~prog:"./print_env.exe"
          ~argv0:"print_env"
          ~args:no_args
-         ~cwd:(Spawn.Working_dir.Path "exe"))
+         ~cwd:(Spawn.Working_dir.path "exe"))
   in
   tst (Some "foo");
   [%expect {| Some "foo" |}];

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -724,22 +724,23 @@ module Dune_config = struct
               | Some prog ->
                 let prog = Path.to_string prog in
                 let fdr, fdw = Unix.pipe () ~cloexec:true in
+                let fdw = Fd.unsafe_of_unix_file_descr fdw in
                 (match
                    Stdune.Spawn.spawn
                      ~prog
                      ~argv0:prog
                      ~args:(Stdune.Array.Immutable.of_list args)
-                     ~stdin:(Fd.unsafe_to_unix_file_descr (Lazy.force Dev_null.in_))
+                     ~stdin:(Lazy.force Dev_null.in_)
                      ~stdout:fdw
-                     ~stderr:(Fd.unsafe_to_unix_file_descr (Lazy.force Dev_null.out))
+                     ~stderr:(Lazy.force Dev_null.out)
                      ()
                  with
                  | exception Unix.Unix_error _ ->
-                   Unix.close fdw;
+                   Fd.close fdw;
                    Unix.close fdr;
                    loop commands
                  | pid ->
-                   Unix.close fdw;
+                   Fd.close fdw;
                    let ic = Unix.in_channel_of_descr fdr in
                    let n =
                      match input_line ic with

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -986,13 +986,13 @@ let spawn
       let env = Dtemp.add_to_env env in
       Env.to_unix env |> Spawn.Env.of_list
     in
-    let stdout = Io.fd stdout |> Fd.unsafe_to_unix_file_descr in
-    let stderr = Io.fd stderr |> Fd.unsafe_to_unix_file_descr in
-    let stdin = Io.fd stdin |> Fd.unsafe_to_unix_file_descr in
+    let stdout = Io.fd stdout in
+    let stderr = Io.fd stderr in
+    let stdin = Io.fd stdin in
     let cwd =
       match dir with
-      | None -> Spawn.Working_dir.Inherit
-      | Some dir -> Spawn.Working_dir.Path (Path.to_string dir)
+      | None -> Spawn.Working_dir.inherit_
+      | Some dir -> Spawn.Working_dir.path (Path.to_string dir)
     in
     Spawn.spawn
       ()

--- a/src/dune_scheduler/file_watcher.ml
+++ b/src/dune_scheduler/file_watcher.ml
@@ -542,13 +542,14 @@ let spawn_external_watcher ~backend ~watch_exclusions =
   prepare_sync ();
   let prog, args = command ~backend ~watch_exclusions in
   let r_stdout, w_stdout = Unix.pipe () in
+  let w_stdout = Fd.unsafe_of_unix_file_descr w_stdout in
   let pid =
     let prog = Path.to_absolute_filename prog in
     let args = Array.Immutable.of_list args in
     (* CR-someday rgrinberg: we sohuldn't let this program write anything to our stderr *)
     Spawn.spawn () ~prog ~argv0:prog ~args ~stdout:w_stdout
   in
-  Unix.close w_stdout;
+  Fd.close w_stdout;
   Unix.in_channel_of_descr r_stdout, pid
 ;;
 

--- a/src/lev/test/lev_tests_unix.ml
+++ b/src/lev/test/lev_tests_unix.ml
@@ -10,6 +10,9 @@ let%expect_test "child" =
   Unix.close stdin_w;
   Unix.close stdout_r;
   Unix.close stderr_r;
+  let stdin = Fd.unsafe_of_unix_file_descr stdin in
+  let stdout = Fd.unsafe_of_unix_file_descr stdout in
+  let stderr = Fd.unsafe_of_unix_file_descr stderr in
   let prog =
     Bin.which ~path:(Env_path.path Env.initial) "sh" |> Option.value_exn |> Path.to_string
   in

--- a/test/expect-tests/dune_pkg/rev_store_fetch_depth/rev_store_fetch_depth_test.ml
+++ b/test/expect-tests/dune_pkg/rev_store_fetch_depth/rev_store_fetch_depth_test.ml
@@ -34,9 +34,9 @@ let with_git_daemon ~parent_dir ~port ~repo_dir ~unrelated_repo_dir ~f =
            ; Path.to_string repo_dir
            ; Path.to_string unrelated_repo_dir
            ])
-      ~stdin:(Fd.unsafe_to_unix_file_descr (Lazy.force Dev_null.in_))
-      ~stdout:(Fd.unsafe_to_unix_file_descr (Lazy.force Dev_null.out))
-      ~stderr:(Fd.unsafe_to_unix_file_descr (Lazy.force Dev_null.out))
+      ~stdin:(Lazy.force Dev_null.in_)
+      ~stdout:(Lazy.force Dev_null.out)
+      ~stderr:(Lazy.force Dev_null.out)
       ()
   in
   let stop_daemon () =

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -92,6 +92,8 @@ let read_lines in_ =
 let run ?env ~prog ~argv () =
   let stdout_i, stdout_w = Unix.pipe ~cloexec:true () in
   let stderr_i, stderr_w = Unix.pipe ~cloexec:true () in
+  let stdout_w = Fd.unsafe_of_unix_file_descr stdout_w in
+  let stderr_w = Fd.unsafe_of_unix_file_descr stderr_w in
   let pid =
     let args = Array.Immutable.of_list argv in
     let env = Option.map ~f:Spawn.Env.of_list env in
@@ -101,12 +103,12 @@ let run ?env ~prog ~argv () =
       ~args
       ~stdout:stdout_w
       ~stderr:stderr_w
-      ~stdin:(Fd.unsafe_to_unix_file_descr (Lazy.force Dev_null.in_))
+      ~stdin:(Lazy.force Dev_null.in_)
       ?env
       ()
   in
-  Unix.close stdout_w;
-  Unix.close stderr_w;
+  Fd.close stdout_w;
+  Fd.close stderr_w;
   ( pid
   , (let+ proc =
        Scheduler.wait_for_process

--- a/test/expect-tests/foreign_stubs/archive_creation_behavior.ml
+++ b/test/expect-tests/foreign_stubs/archive_creation_behavior.ml
@@ -38,18 +38,20 @@ let spawn_and_capture ?env ~prog ~argv ~cwd () =
           (Path.to_absolute_filename stdout_path)
           [ Unix.O_WRONLY; Unix.O_TRUNC ]
           0o666
+        |> Fd.unsafe_of_unix_file_descr
       in
       let stderr_fd =
         Unix.openfile
           (Path.to_absolute_filename stderr_path)
           [ Unix.O_WRONLY; Unix.O_TRUNC ]
           0o666
+        |> Fd.unsafe_of_unix_file_descr
       in
       let pid =
         Exn.protect
           ~finally:(fun () ->
-            Unix.close stdout_fd;
-            Unix.close stderr_fd)
+            Fd.close stdout_fd;
+            Fd.close stderr_fd)
           ~f:(fun () ->
             let env = Option.map env ~f:Spawn.Env.of_list in
             Spawn.spawn


### PR DESCRIPTION
Replace raw `Unix.file_descr` values exposed by `Spawn` with `Fd.t`, including standard streams, working directories, and `safe_pipe` results. Make `Working_dir.t` abstract, keep raw descriptors confined to the foreign-function boundary, and update callers to use the managed descriptor API.

This removes unnecessary unsafe conversions from callers and gives spawned-process descriptors consistent close tracking.