### PR TITLE
refactor(config): reuse toggle representation

### DIFF
--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -120,20 +120,9 @@ module Dune_config = struct
       | Unset
 
     let repr =
-      let toggle_repr =
-        Repr.variant
-          "config-toggle"
-          [ Repr.case0 "Enabled" ~test:(function
-              | `Enabled -> true
-              | `Disabled -> false)
-          ; Repr.case0 "Disabled" ~test:(function
-              | `Disabled -> true
-              | `Enabled -> false)
-          ]
-      in
       Repr.variant
         "pkg-enabled"
-        [ Repr.case "Set" (Repr.pair Where.repr toggle_repr) ~proj:(function
+        [ Repr.case "Set" (Repr.pair Where.repr Toggle.repr) ~proj:(function
             | Set (where, toggle) -> Some (where, toggle)
             | Unset -> None)
         ; Repr.case0 "Unset" ~test:(function


### PR DESCRIPTION
Use the canonical `Toggle.repr` when representing the package-management toggle in Dune configuration. This removes a duplicate `Repr.variant` definition and keeps the configuration representation aligned with `Toggle`.