### PR TITLE
refactor(rules): share duplicate-definition diagnostics

### DIFF
--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -64,7 +64,17 @@ include struct
   module Fs = Fs
 end
 
-module Compound_user_error = Dune_rpc.Private.Compound_user_error
+module Compound_user_error = struct
+  include Dune_rpc.Private.Compound_user_error
+
+  let duplicate ~main_loc ~previous_loc main_message =
+    let main = User_message.make ~loc:main_loc [ main_message ] in
+    let related =
+      [ User_message.make ~loc:previous_loc [ Pp.text "Already defined here" ] ]
+    in
+    [ make ~main ~related ]
+  ;;
+end
 
 include struct
   open Ocaml

--- a/src/dune_rules/melange/melange_stanzas.ml
+++ b/src/dune_rules/melange/melange_stanzas.ml
@@ -75,11 +75,7 @@ module Emit = struct
               (Filename.Extension.to_string ext)
           in
           let compound =
-            let main = User_message.make ~loc:loc2 [ main_message ] in
-            let related =
-              [ User_message.make ~loc:loc1 [ Pp.text "Already defined here" ] ]
-            in
-            [ Compound_user_error.make ~main ~related ]
+            Compound_user_error.duplicate ~main_loc:loc2 ~previous_loc:loc1 main_message
           in
           User_error.raise
             ~compound

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -784,11 +784,10 @@ let make_lib_modules
         Pp.text "a library with (stdlib ...) may not use (include_subdirs qualified)"
       in
       let compound =
-        let main = User_message.make ~loc:loc_include_subdirs [ main_message ] in
-        let related =
-          [ User_message.make ~loc:stdlib.loc [ Pp.text "Already defined here" ] ]
-        in
-        [ Compound_user_error.make ~main ~related ]
+        Compound_user_error.duplicate
+          ~main_loc:loc_include_subdirs
+          ~previous_loc:stdlib.loc
+          main_message
       in
       User_error.raise ~compound ~loc:loc_include_subdirs [ main_message ]
     | _, _ -> ()

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -159,12 +159,10 @@ module DB = struct
                        Pp.textf "Library %s is defined twice:" (Lib_name.to_string name)
                      in
                      let compound =
-                       let main = User_message.make ~loc:loc2 [ main_message ] in
-                       let related =
-                         [ User_message.make ~loc:loc1 [ Pp.text "Already defined here" ]
-                         ]
-                       in
-                       [ Compound_user_error.make ~main ~related ]
+                       Compound_user_error.duplicate
+                         ~main_loc:loc2
+                         ~previous_loc:loc1
+                         main_message
                      in
                      User_error.raise
                        ~compound
@@ -576,11 +574,10 @@ module DB = struct
                     (Lib_name.to_string public_name)
                 in
                 let compound =
-                  let main = User_message.make ~loc:loc2 [ main_message ] in
-                  let related =
-                    [ User_message.make ~loc:loc1 [ Pp.text "Already defined here" ] ]
-                  in
-                  [ Compound_user_error.make ~main ~related ]
+                  Compound_user_error.duplicate
+                    ~main_loc:loc2
+                    ~previous_loc:loc1
+                    main_message
                 in
                 User_error.raise
                   ~compound


### PR DESCRIPTION
Centralize construction of compound diagnostics that point from a duplicate or conflicting definition to its original location. Reuse the helper for library definitions, Melange extensions, and incompatible library fields while preserving the existing messages and locations.