### PR TITLE
fix(engine): separate Dune and action temporary directories

### DIFF
--- a/src/dune_engine/dtemp.ml
+++ b/src/dune_engine/dtemp.ml
@@ -1,16 +1,28 @@
 open Import
 
-let temp_dir = lazy (Temp.create Dir ~prefix:"build" ~suffix:"dune")
-let temp_dir_value = lazy (Path.to_absolute_filename (Lazy.force temp_dir))
+let dune_temp_dir = lazy (Temp.create Dir ~prefix:"dune" ~suffix:"internal")
+let action_temp_dir = lazy (Temp.create Dir ~prefix:"dune" ~suffix:"actions")
+let dune_temp_dir_value = lazy (Path.to_absolute_filename (Lazy.force dune_temp_dir))
+let action_temp_dir_value = lazy (Path.to_absolute_filename (Lazy.force action_temp_dir))
 
-let file ~prefix ~suffix =
-  Temp.temp_in_dir File ~dir:(Lazy.force temp_dir) ~suffix ~prefix
+let temp_dir_value (purpose : Process_metadata.purpose) =
+  match purpose with
+  | Internal_job -> dune_temp_dir_value
+  | Build_job _ -> action_temp_dir_value
 ;;
 
-let add_to_env env =
-  let value = Lazy.force temp_dir_value in
+let file ~prefix ~suffix =
+  Temp.temp_in_dir File ~dir:(Lazy.force dune_temp_dir) ~suffix ~prefix
+;;
+
+let add_to_env env ~purpose =
+  let value = Lazy.force (temp_dir_value purpose) in
   Env.add env ~var:Env.Var.temp_dir ~value
 ;;
 
 let destroy = Temp.destroy
-let clear () = if Lazy.is_val temp_dir then Temp.clear_dir (Lazy.force temp_dir)
+
+let clear () =
+  List.iter [ dune_temp_dir; action_temp_dir ] ~f:(fun temp_dir ->
+    if Lazy.is_val temp_dir then Temp.clear_dir (Lazy.force temp_dir))
+;;

--- a/src/dune_engine/dtemp.mli
+++ b/src/dune_engine/dtemp.mli
@@ -1,15 +1,16 @@
-(** Temp directory used by dune processes *)
+(** Temporary directories used by Dune and build actions. *)
 
 open Import
 
 (** This returns a build path, but we don't rely on that *)
 val file : prefix:string -> suffix:string -> Path.t
 
-(** Add the temp env var to the environment passed or return the initial
-    environment with the temp var added. *)
-val add_to_env : Env.t -> Env.t
+(** Set the platform's temporary-directory environment variable. Build jobs use
+    the action directory and internal jobs use Dune's directory. *)
+val add_to_env : Env.t -> purpose:Process_metadata.purpose -> Env.t
 
 (** Destroy the temporary file or directory *)
 val destroy : Temp.what -> Path.t -> unit
 
+(** Clear both temporary directories. *)
 val clear : unit -> unit

--- a/src/dune_engine/dune_engine.ml
+++ b/src/dune_engine/dune_engine.ml
@@ -43,4 +43,5 @@ module Fs = Fs
 
 module For_tests = struct
   module Debouncer = Debouncer
+  module Dtemp = Dtemp
 end

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -982,10 +982,7 @@ let spawn
     Time.now ()
   in
   let pid =
-    let env =
-      let env = Dtemp.add_to_env env in
-      Env.to_unix env |> Spawn.Env.of_list
-    in
+    let env = Env.to_unix env |> Spawn.Env.of_list in
     let stdout = Io.fd stdout in
     let stderr = Io.fd stderr in
     let stdin = Io.fd stdin in
@@ -1252,6 +1249,10 @@ let run_internal
     let timeout = Failure_mode.timeout fail_mode in
     let prepared_outputs = prepare_outputs ~stdout:stdout_to ~stderr:stderr_to in
     let env = Option.value env ~default:Env.initial in
+    let env =
+      let { Process_metadata.purpose; _ } = metadata in
+      Dtemp.add_to_env env ~purpose
+    in
     let local () =
       let t =
         spawn

--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -728,6 +728,7 @@ let run_cram_test
       ~can_run_in_action_runner:true
       ~name
       ~categories:[ "cram" ]
+      ~purpose:(Build_job None)
       ()
   in
   Process.run

--- a/test/blackbox-tests/test-cases/watching/action-runner-shutdown.t
+++ b/test/blackbox-tests/test-cases/watching/action-runner-shutdown.t
@@ -3,13 +3,21 @@
   $ setup_xdg_runtime_dir
   $ export DUNE_TRACE=rpc
   $ echo "(lang dune 3.23)" > dune-project
-  $ cat > dune <<EOF
+  $ cat > dune <<'EOF'
   > (rule
   >  (target x)
-  >  (action (bash "echo ok > %{target}")))
+  >  (action (bash "touch \"$TMPDIR/stale\"; echo ok > %{target}")))
+  > (rule
+  >  (target y)
+  >  (action
+  >   (bash "test ! -e \"$TMPDIR/stale\"; echo ok > %{target}")))
   > EOF
   $ start_dune --action-runner
   $ build_quiet x
+
+The action's temporary directory is cleared when the build iteration finishes.
+
+  $ build_quiet y
   $ shutdown_dune_quiet >/dev/null 2>&1
   $ wait_for_dune_exit_with_timeout >/dev/null 2>&1
   $ [ "$?" = 0 ]

--- a/test/expect-tests/process_tests.ml
+++ b/test/expect-tests/process_tests.ml
@@ -15,6 +15,34 @@ let go =
 
 let true_ = Bin.which "true" ~path:(Env_path.path Env.initial) |> Option.value_exn
 
+let dtemp_dir purpose =
+  let env = Dune_engine.For_tests.Dtemp.add_to_env Env.empty ~purpose in
+  Env.get env Env.Var.temp_dir |> Option.value_exn |> Path.of_string
+;;
+
+let%expect_test "action and Dune temporary directories" =
+  let dune_dir = dtemp_dir Internal_job in
+  let action_dir = dtemp_dir (Build_job None) in
+  let dune_file = Dune_engine.For_tests.Dtemp.file ~prefix:"dune" ~suffix:"file" in
+  let action_file = Path.relative action_dir "action-file" in
+  Io.write_file action_file "";
+  let exists path = Fpath.exists (Path.to_string path) in
+  Printf.printf "same directory: %b\n" (Path.equal dune_dir action_dir);
+  Printf.printf
+    "Dune file uses Dune directory: %b\n"
+    (Path.equal dune_dir (Path.parent_exn dune_file));
+  Printf.printf "files before clear: %b %b\n" (exists dune_file) (exists action_file);
+  Dune_engine.For_tests.Dtemp.clear ();
+  Printf.printf "files after clear: %b %b\n" (exists dune_file) (exists action_file);
+  [%expect
+    {|
+    same directory: false
+    Dune file uses Dune directory: true
+    files before clear: true true
+    files after clear: false false
+    |}]
+;;
+
 let%expect_test "null input" =
   let stdin_from = Process.(Io.null In) in
   let run () = Process.run ~display:Quiet ~stdin_from Strict true_ [] in


### PR DESCRIPTION
This does not make much of a difference for well behaved actions, and
isn't sufficient from preventing the remaining actions from misbehaving,
but at least it makes it a bit harder.