### PR TITLE
chore(release): update release scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,16 +185,52 @@ dune: $(BIN)
 opam-release: dev
 	$(BIN) exec -- $(MAKE) dune-release
 
+# Resume an interrupted publication from a single step, e.g. with
+# 'make opam-release-opam-submit', still under the in source dune.
+opam-release-%: dev
+	$(BIN) exec -- $(MAKE) dune-release-$*
+
 # Set DUNE_RELEASE_YES_FLAG=true to force dune-release to run with the --yes flag
 # Avoiding the need for interaction
 DUNE_RELEASE_YES_FLAG := $(if $(filter true,$(DUNE_RELEASE_YES)),--yes)
+
+# An alpha is submitted to opam as a draft pull request, so that it cannot be
+# merged while its reverse dependency CI is still being triaged. Removes
+# a manual step after every alpha.
+DUNE_RELEASE_DRAFT_FLAG := $(if $(filter prerelease,$(RELEASE_KIND)),--draft)
+
+# Publishing is a sequence of steps that is not transactional: a failure part
+# way through leaves the earlier steps done. Each step is therefore also a
+# target of its own, so that an interrupted release can be resumed from the
+# step that failed rather than requiring a restart of entire process.
+.PHONY: dune-release
 dune-release:
+	$(MAKE) dune-release-tag
+	$(MAKE) dune-release-distrib
+	$(MAKE) dune-release-publish
+	$(MAKE) dune-release-opam-pkg
+	$(MAKE) dune-release-opam-submit
+
+.PHONY: dune-release-tag
+dune-release-tag:
 	dune-release tag $(DUNE_RELEASE_YES_FLAG)
+
+.PHONY: dune-release-distrib
+dune-release-distrib:
 	dune-release distrib --skip-build --skip-lint --skip-tests
+
+.PHONY: dune-release-publish
+dune-release-publish:
 # See https://github.com/ocamllabs/dune-release/issues/206
 	DUNE_RELEASE_DELEGATE=github-dune-release-delegate dune-release publish --verbose $(if $(filter prerelease,$(RELEASE_KIND)),--prerelease) $(DUNE_RELEASE_YES_FLAG)
+
+.PHONY: dune-release-opam-pkg
+dune-release-opam-pkg:
 	dune-release opam pkg $(DUNE_RELEASE_YES_FLAG)
-	dune-release opam submit $(DUNE_RELEASE_YES_FLAG)
+
+.PHONY: dune-release-opam-submit
+dune-release-opam-submit:
+	dune-release opam submit $(DUNE_RELEASE_DRAFT_FLAG) $(DUNE_RELEASE_YES_FLAG)
 
 .PHONY: docker-build-image
 docker-build-image:

--- a/doc/changes/scripts/build_changelog.sh
+++ b/doc/changes/scripts/build_changelog.sh
@@ -36,7 +36,9 @@ add_newline() {
 # Using setext level 2 headings.
 # See https://spec.commonmark.org/0.31.2/#setext-headings
 generate_version_header() {
-  today=$(date "+%Y-%m-%d")
+  # Stamp the date in UTC so that the header does not depend on the timezone
+  # of whoever cuts the release.
+  today=$(TZ=UTC date "+%Y-%m-%d")
 
   header="$version ($today)"
   header_size=${#header}

--- a/doc/dev/releases/dune
+++ b/doc/dev/releases/dune
@@ -1,0 +1,6 @@
+(rule
+ (alias lint-release-scripts)
+ (enabled_if %{bin-available:shellcheck})
+ (deps backport.sh release-cut.sh release-init.sh)
+ (action
+  (run %{bin:shellcheck} -s bash %{deps})))

--- a/doc/dev/releases/process.md
+++ b/doc/dev/releases/process.md
@@ -16,12 +16,21 @@ aspects to this:
 - The latest [dune-release](https://github.com/tarides/dune-release) installed in your dev switch
 - A recent version of [github-cli](https://github.com/cli/cli) installed on your system
 
+The mechanical steps below are automated by the scripts in this directory. See
+[./README.md](./README.md) for what each one does.
+
 ## Prepare
 
-Open a [release tracking issue][release-issue] and work thru its checklist,
-including listing and updating known blockers that are preventing release
+Run
 
-[release-issue]: https://github.com/ocaml/dune/issues/new?template=release.md
+```
+$ INCREMENT=(patch|minor|major) ./doc/dev/releases/release-init.sh
+```
+
+This opens the release tracking issue, creates the release candidate branch
+`X.Y.Z-rc`, and opens the draft release pull request. Then work thru the
+checklist on the tracking issue, including listing and updating the known
+blockers that are preventing release.
 
 ## Major / Minor Releases (`x.y.0`)
 
@@ -31,12 +40,12 @@ gitGraph
   commit id: "feat(2)"
   commit id: "feat(3)"
   branch "x.y"
-  commit tag: "x.y.0~alpha1"
+  commit tag: "x.y.0~alpha0"
   checkout main
   commit id: "fix(1)"
   checkout "x.y"
   cherry-pick id: "fix(1)"
-  commit tag: "x.y.0~alpha2"
+  commit tag: "x.y.0~alpha1"
   commit tag: "x.y.0"
 ```
 
@@ -57,7 +66,7 @@ During the pre-release phase, we produce alpha releases, which we use to run the
 opam-ci to check for integration with the wider ocaml ecosystem.
 
 1. Create and checkout the release candidate branch `X.Y.Z-rc` from the head of
-   `main`
+   `main` (done by `release-init.sh`)
 2. Let `N=0`
 3. Prepare alpha release
     - If `N>0`
@@ -66,16 +75,27 @@ opam-ci to check for integration with the wider ocaml ecosystem.
           new branch off `main`. (This is a judgment call, based on weighing risk of
           picking up new regressions vs. the benefits of simpler process and picking
           up additional improvements from main.)
-        - Run pre-release CI jobs on `X.Y.Z-rc` branch
-            - [mirage](https://github.com/ocaml/dune/actions/workflows/mirage.yml)
-            - [packaging](https://github.com/ocaml/dune/actions/workflows/isolated-package-build.yml)
-        - If the pre-release CI detects regreessions, goto (3).
-    - Build the changelog via `doc/changes/scripts/build_changelog.sh x.y.0~alphaN`
-    - Review the resulting changelog for intelligibility.
-    - Commit the changelog update to the release branch with the commit message `[X.Y.Z] prepare alphaN release`
-    - Run `make opam-release`
-        - [edit the release][edit-release] to mark it with `Set as a pre-release`
-        - mark resulting opam-repo PR as a draft
+        - Pushing to the `X.Y.Z-rc` branch runs the pre-release CI jobs
+          automatically: [mirage](https://github.com/ocaml/dune/actions/workflows/mirage.yml),
+          [packaging](https://github.com/ocaml/dune/actions/workflows/isolated-package-build-pre-release.yml),
+          [revdep packages](https://github.com/ocaml/dune/actions/workflows/revdeps-release-coverage.yml)
+          and [revdep devtools](https://github.com/ocaml/dune/actions/workflows/revdeps-release-devtools.yml).
+        - If the pre-release CI detects regressions, goto (3).
+    - Cut the alpha from the release candidate branch:
+
+      ```
+      $ RELEASE_KIND=prerelease ./doc/dev/releases/release-cut.sh
+      ```
+
+      The alpha number is derived from the existing tags, starting at
+      `X.Y.Z~alpha0`. The script verifies that the branch is fit to release,
+      prints the changelog it is about to commit for review, and then commits
+      it, pushes, and publishes. Passing `DRY_RUN=true` stops short of every
+      mutating step, so the same checks and the same changelog preview can be
+      seen without cutting anything.
+
+      The GitHub release is marked as a pre-release and the opam repository
+      pull request is opened as a draft, both automatically.
     - Wait for the `opam-ci` results
     - Review the results:
         - Any build or test failures in dune's own packages require fixes
@@ -87,17 +107,20 @@ opam-ci to check for integration with the wider ocaml ecosystem.
             - Mark opam alpha PR as closed
             - Let `N=N+1` and goto (3)
 
-[edit-release]: https://docs.github.com/en/rest/releases/releases?apiVersion=2026-03-10#update-a-release
 [prev-releases]: https://github.com/ocaml/dune/wiki/Reverse-dependencies-CI-logs
 
 ### Release phase
 
-- On release branch, prepare changelog
-    - combine all entries from different alpha release
-    - set the version header to `X.Y.Z (<date>)`
-- commit onto `X.Y.Z-rc` branch with message `[X.Y.Z] release` and push to remote
-- Push release branch to remote
-- Run `make opam-release` from updated `X.Y.Z-rc` branch
+- Cut the release from the `X.Y.Z-rc` branch:
+
+  ```
+  $ RELEASE_KIND=release ./doc/dev/releases/release-cut.sh
+  ```
+
+  The changelog section for `X.Y.Z` is regenerated from the change fragments,
+  which have been accumulating across the alphas rather than being consumed by
+  them, so the entries from every alpha are combined into one section dated the
+  day of the release. The fragments are consumed only now.
 - Add a comment on the opam repo PR linking back to the release tracker issues
  and explaining that all triage is completed, and ask the opam repo maintainers
  to bypass the opam-ci.
@@ -138,11 +161,15 @@ stateDiagram-v2
     PostRelease --> [*]
 ```
 
-- Build the changelog via `doc/changes/scripts/build_changelog.sh X.Y.Z`
-- Review the resulting changelog for intelligibility.
-- Commit the changelog update to the release branch with the commit message `[X.Y.Z] release`
-- Push release branch to remote
-- Run `make opam-release`.
+- Backport each fix from `main` with
+  `VERSION=X.Y.Z PR=<pr-number> ./doc/dev/releases/backport.sh`, and merge the
+  resulting pull request once its CI passes.
+- Cut the release from the `X.Y.Z-rc` branch:
+
+  ```
+  $ RELEASE_KIND=release ./doc/dev/releases/release-cut.sh
+  ```
+
 - Wait for the `opam-ci` results
 - Review the results:
     - Any build or test failures in dune's own packages require fixes
@@ -154,11 +181,48 @@ stateDiagram-v2
         - Mark GitHub release as a pre-release.
         - Cut a new patch release.
 
+## Cutting a release
+
+`release-cut.sh` refuses to cut a release unless
+
+- the working tree is clean,
+- `dune-project` declares the language version of the release series, and the
+  `dune` lower bounds in `opam/*.opam` agree with it,
+- the tag the release would create does not already exist, locally or on the
+  remote, and
+
+It then prints the changelog it is about to commit and asks for confirmation.
+Reviewing that diff is the review of the changelog: nothing has been committed,
+pushed, or published at that point.
+
+### Resuming an interrupted release
+
+Publication is a sequence of steps that is not transactional, so a failure part
+way through leaves the earlier steps done — a failure at `opam submit` leaves a
+pushed tag and a published GitHub release behind. Rerunning `release-cut.sh` in
+that state is refused, because the tag now exists.
+
+Resume from the step that failed instead, using the individual targets:
+
+```
+$ make opam-release-tag
+$ make opam-release-distrib
+$ make opam-release-publish
+$ make opam-release-opam-pkg
+$ make opam-release-opam-submit
+```
+
+Use the `opam-release-` targets rather than the `dune-release-` ones they wrap:
+like `opam-release`, they run the step under the dune being released, instead of
+whichever dune executable happens to be on `PATH`.
+
+Pass the same `RELEASE_KIND` that the release was started with, so that an alpha
+is still published as a pre-release and still submitted to opam as a draft.
+
 ## Decisions
 
 - Release cadence:
-  - we aim for a minor release roughly every 4 to 6 weeks. More than 8 tends to
-    make riskier releases; less than 3 would be too much overhead.
+  - we aim for a minor release weekly or fortnightly.
   - we do point releases only for the latest release minor version.
 
 - Release Go/No Go after alpha:

--- a/doc/dev/releases/release-cut.sh
+++ b/doc/dev/releases/release-cut.sh
@@ -18,6 +18,9 @@
 # - The optional DUNE_REMOTE can be used to set the name of the git remote to
 #   fetch tags from and push the release branch to. It defaults to 'git config
 #   remote.pushdefault' if set or finally to 'origin' if not.
+# - The optional DUNE_REPO is the repository whose CI results gate the release,
+#   in owner/repo form. It defaults to 'ocaml/dune'. Set it to your fork when
+#   staging a release, since it is resolved independently of DUNE_REMOTE.
 # - NB. To stage a release against forks, dune-release reads the following from
 #   the environment; they pass through 'make opam-release' unchanged:
 #   - DUNE_RELEASE_DEV_REPO    the dune fork the release/tag/tarball goes to
@@ -38,6 +41,7 @@
 #
 #  $ RELEASE_KIND=prerelease \
 #      DUNE_REMOTE=my-fork \
+#      DUNE_REPO=me/dune \
 #      DUNE_RELEASE_DEV_REPO=https://github.com/me/dune.git \
 #      DUNE_RELEASE_OPAM_REPO=me/opam-repository \
 #      ./release-cut.sh
@@ -54,20 +58,41 @@ function err () {
     exit 1
 }
 
+# Set try run to true to skip running mutating commands
+DRY_RUN=${DRY_RUN:-"false"}
+
 # run command if DRY_RUN is false or not set, else just print the command
 function run_cmd () {
-    if [[ "${DRY_RUN:-false}" == "true" ]]; then
+    if [[ "${DRY_RUN}" == "true" ]]; then
         echo "DRY RUN: $*"
     else
         "$@"
     fi
 }
 
+# run a precondition check, and if DRY_RUN is true, don't stop
+# allowing every every unmet precondition to be reported in DRY_RUNS
+function run_check () {
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        ( "$@" ) || echo >&2 "DRY RUN: continuing despite the failure above"
+    else
+        "$@"
+    fi
+}
+
+
 # Prompt for confirmation before running the irreversible release steps
 function confirm () {
     local release_version="$1"
     read \
-        -p "About to cut ${RELEASE_KIND} ${release_version} on branch '${branch}', push to '${DUNE_REMOTE}', and publish via dune-release. Continue? (y/Y) " \
+        -p "About to
+
+  - cut ${RELEASE_KIND} ${release_version} on branch '${branch}'
+  - push to '${DUNE_REMOTE}'
+  - and publish via dune-release
+  - with the changelog above.
+
+Confirm? (y/Y) " \
         -n 1 -r
     echo # Print a newline since -n 1 suppresses the newline after input
     if [[ $REPLY =~ ^[Yy]$ ]]; then
@@ -80,6 +105,7 @@ function confirm () {
 
 # Validate and prepare input variables
 [ ! -z "${RELEASE_KIND}" ] || err "variable RELEASE_KIND is not set"
+DUNE_REPO=${DUNE_REPO:-"ocaml/dune"}
 # Get the remote configured by envvar, or via the git config remote.pushDefault,
 DUNE_REMOTE=${DUNE_REMOTE:-$(git config remote.pushdefault || echo "")}
 # Finally fallback to 'origin' if the remote isn't configured
@@ -91,6 +117,7 @@ ROOT_DIR=$(realpath "${SCRIPT_DIR}/../../..")
 # Check for required utilities
 command -v git >/dev/null 2>&1 || err "script requires git"
 command -v dune-release >/dev/null 2>&1 || err "script requires dune-release"
+command -v gh >/dev/null 2>&1 || err "script requires gh"
 
 # All variables should be set from this point on
 set -u
@@ -177,20 +204,99 @@ function strip_in_progress_section () {
     fi
 }
 
-# Regenerate the in-progress changelog section from the change fragments in
-# doc/changes. Those fragments are the single source of truth: they are consumed
+# Rewrite the in-progress changelog section from the change fragments in
+# doc/changes, replacing any section already there for that version.
+function render_changelog () {
+    local keep_fragments="$1" release_version="$2"
+    strip_in_progress_section
+    env "KEEP_FRAGMENTS=${keep_fragments}" \
+        "${ROOT_DIR}/doc/changes/scripts/build_changelog.sh" "${release_version}"
+}
+
+# Refuse to release from a tree with uncommitted changes: the tarball is built
+# from the tag, so local edits would be published silently or not at all.
+function check_clean_worktree () {
+    if [[ -n "$(git status --porcelain)" ]]; then
+        err "the working tree has uncommitted changes"
+    fi
+}
+
+# The packages declare their dune dependency from the language version in
+# dune-project, so cutting X.Y.Z from a branch that still declares an older
+# language version publishes packages with the wrong lower bound.
+function check_version_consistency () {
+    local series lang_version
+    local bounds=()
+    series=$(cut -d. -f1,2 <<< "${version}")
+    lang_version=$(sed -n 's/^(lang dune \([0-9]*\.[0-9]*\))$/\1/p' \
+        "${ROOT_DIR}/dune-project")
+    if [[ -z "${lang_version}" ]]; then
+        err "could not read the dune language version from dune-project"
+    fi
+    if [[ "${lang_version}" != "${series}" ]]; then
+        err "dune-project declares (lang dune ${lang_version}) but ${version} is a ${series} release"
+    fi
+    mapfile -t bounds < <(sed -n 's/.*"dune" {>= "\([0-9.]*\)".*/\1/p' \
+        "${ROOT_DIR}"/opam/*.opam | sort -u)
+    if [[ "${#bounds[@]}" -ne 1 || "${bounds[0]}" != "${series}" ]]; then
+        err "opam files declare dune lower bounds '${bounds[*]}' but ${version} is a ${series} release"
+    fi
+}
+
+# dune-release escapes '~' as '_' when it creates the tag. An existing tag means
+# this version was already cut, so publishing again would either fail or move a
+# published tag.
+function check_tag_unused () {
+    local release_version="$1"
+    local tag="${release_version//\~/_}"
+    if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+        err "tag ${tag} already exists locally; if a previous attempt failed part
+way through, resume it with the individual make opam-release-<step> targets
+rather than rerunning this script"
+    fi
+    if [[ -n "$(git ls-remote --tags "${DUNE_REMOTE}" "refs/tags/${tag}")" ]]; then
+        err "tag ${tag} already exists on ${DUNE_REMOTE}"
+    fi
+}
+
+
+# Render the changelog exactly as the release would and print the resulting
+# diff, then restore the working tree. Fragments are always kept: a preview
+# must not consume them, not even when previewing a full release.
+function preview_changelog () {
+    local release_version="$1"
+    local changes="${ROOT_DIR}/CHANGES.md"
+    (
+        backup=$(mktemp "${changes}.XXXXXX") \
+            || err "could not create a temporary file"
+        cp "${changes}" "${backup}"
+        trap 'mv -f "${backup}" "${changes}"' EXIT
+        render_changelog true "${release_version}"
+        echo
+        # diff exits 1 when the files differ, which is the expected case here,
+        # and 2 or more when it actually failed.
+        status=0
+        diff -u \
+            --label "CHANGES.md (current)" \
+            --label "CHANGES.md (after cutting ${release_version})" \
+            "${backup}" "${changes}" || status=$?
+        if (( status > 1 )); then
+            err "could not diff the generated changelog"
+        fi
+        echo
+    )
+}
+
+# The change fragments are the single source of truth: they are consumed
 # (deleted) only for a full release, so successive prereleases regenerate the
-# section in place from the accumulating fragments. Any existing section for the
-# in-progress version is stripped first so the regenerated one replaces it.
+# section in place from the accumulating fragments.
 function update_changelog () {
     local release_version="$1"
     local keep_fragments=true
     if [[ "${RELEASE_KIND}" == "release" ]]; then
         keep_fragments=false
     fi
-    run_cmd strip_in_progress_section
-    run_cmd env "KEEP_FRAGMENTS=${keep_fragments}" \
-        "${ROOT_DIR}/doc/changes/scripts/build_changelog.sh" "${release_version}"
+    run_cmd render_changelog "${keep_fragments}" "${release_version}"
 }
 
 function pre_release_version () {
@@ -207,10 +313,14 @@ function pre_release_version () {
 
 function release () {
     local release_version="$1"
+    run_check check_clean_worktree
+    run_cmd git pull --ff-only "${DUNE_REMOTE}" "${branch}"
+    run_check check_version_consistency
+    run_check check_tag_unused "${release_version}"
+    preview_changelog "${release_version}"
     if [[ "${DRY_RUN:-false}" != "true" ]]; then
         confirm "${release_version}"
     fi
-    run_cmd git pull --ff-only "${DUNE_REMOTE}" "${branch}"
     update_changelog "${release_version}"
     run_cmd git add "${ROOT_DIR}/doc/changes" "${ROOT_DIR}/CHANGES.md"
     run_cmd git commit -s -m "[${release_version}] prepare release"

--- a/doc/dev/releases/release-init.sh
+++ b/doc/dev/releases/release-init.sh
@@ -52,15 +52,15 @@ set -u
 # For testing, you can set this to your fork
 DUNE_GIT_URL="https://github.com/${DUNE_REPO}.git"
 
-POST_RELEASE_STEPS="""## Post-release
+POST_RELEASE_STEPS="## Post-release
 
 - [ ] Merge release branch into \`main\`
 - [ ] Write a post about the release on Discuss: [link]
 - [ ] Open PR announcing release on ocaml.org: [link]
 - [ ] Store the revdeps error file in the [logs](https://github.com/ocaml/dune/wiki/Reverse-dependencies-CI-logs) as HTML
-"""
+"
 
-MINOR_OR_MAJOR_BODY="""## Known blockers
+MINOR_OR_MAJOR_BODY="## Known blockers
 
 Issues blocking the release
 
@@ -89,7 +89,7 @@ ${POST_RELEASE_STEPS}
   - [ ] in the [CI workflow](https://github.com/ocaml/dune/tree/main/.github/workflows/workflow.yml.in)
   - [ ] in [dune-project](https://github.com/ocaml/dune/blob/main/dune-project#L1)
   - [ ] in the [dune-rpc](https://github.com/ocaml/dune/blob/main/otherlibs/dune-rpc/types.ml#L30)
-"""
+"
 
 function confirm () {
     read \
@@ -111,13 +111,14 @@ issue_body=
 rc_branch=
 
 function patch_release () {
-    local last_version=$(git -c versionsort.suffix="_alpha" tag --list '*.*.*' --sort=-version:refname | head -n 1 )
+    local last_version
+    last_version=$(git -c versionsort.suffix="_alpha" tag --list '*.*.*' --sort=-version:refname | head -n 1 )
     next_version=$(echo "${last_version}" | awk -F. -v OFS=. '{print $1, $2, $3+1 }')
     rc_branch="${next_version}-rc"
 
     confirm
 
-    issue_body="""## Fixes
+    issue_body="## Fixes
 
 Regressions requiring fixes in \`main\` and backports to \`${next_version}-rc\`:
 
@@ -140,7 +141,7 @@ For each PR needing a backport
 [point-release]: https://github.com/ocaml/dune/blob/main/doc/dev/releases/process.md#point-releases--patch-releases-xyz-z--0
 
 ${POST_RELEASE_STEPS}
-"""
+"
     git switch -c "${rc_branch}" "${last_version}"
 }
 


### PR DESCRIPTION
- The version header date in the changelog script was taken from the releaser's local timezone, so the same release cut at the same instant records a different date depending on who runs the script.
- make release-init.sh pash shellcheck
- lint the release scripts from the build
- add a step to preview the changelog before cutting a release
- make each publication step its own target, allowing the release process to be resumed
- submit alphas to opam as draft pull requests, because these are pre-releases used to check CI results
- update docs to refer to current and scripted release process

I plan to exercise these changes to the scripts when we cut 3.25 #15593 , and mark it as ready for merge after that. Any input or review in the meantime is welcome.
 
<!-- Thank you for contributing to dune!

 For general guidelines on contributing to dune, see
 https://github.com/ocaml/dune/blob/main/CONTRIBUTING.md#developing-dune -->

## Description
<!-- Briefly describe your changes -->

## Related Issue and Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it closes an open issue, link to the issue here. -->
<!-- Non-trivial contributions are expected to be preceded by an issue, as
     per CONTRIBUTING.md. -->

Fixes #13771

## Checklist

- [ ] Tests added, if applicable.
- [x] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [x] Documentation added for any user-facing changes.
