### PR TITLE
perf(fiber): specialize sequential list traversals

### DIFF
--- a/src/fiber/src/core.ml
+++ b/src/fiber/src/core.ml
@@ -16,6 +16,11 @@ type _ t =
   | Bind_t : 'a t * ('a -> 'b t) -> 'b t
   | Thunk_t : (unit -> 'a t) -> 'a t
   | Thunk_apply_t : ('a -> 'b t) * 'a -> 'b t
+  | Sequential_fold_left_t : 'acc t * 'a list * ('acc -> 'a -> 'acc t) -> 'acc t
+  | Sequential_fold_left_result_t :
+      ('acc, 'error) result t * 'a list * ('acc -> 'a -> ('acc, 'error) result t)
+      -> ('acc, 'error) result t
+  | Sequential_iter_t : unit t * 'a list * ('a -> unit t) -> unit t
   | With_error_handler_t : (unit -> 'a t) * (Exn_with_backtrace.t -> Nothing.t t) -> 'a t
   | Map_reduce_errors_t :
       (module Monoid with type t = 'a) * (Exn_with_backtrace.t -> 'a t) * (unit -> 'b t)
@@ -67,6 +72,24 @@ and 'a continuation =
       ('a, 'b) fork_and_join_state ref * ('a * 'b) continuation
       -> 'b continuation
   | Resume_many : unit k list * unit continuation -> unit continuation
+  | Sequential_fold_left_complete :
+      { mutable rest : 'a list
+      ; f : 'acc -> 'a -> 'acc t
+      ; k : 'acc continuation
+      }
+      -> 'acc continuation
+  | Sequential_fold_left_result_complete :
+      { mutable rest : 'a list
+      ; f : 'acc -> 'a -> ('acc, 'error) result t
+      ; k : ('acc, 'error) result continuation
+      }
+      -> ('acc, 'error) result continuation
+  | Sequential_iter_complete :
+      { mutable rest : 'a list
+      ; f : 'a -> unit t
+      ; k : unit continuation
+      }
+      -> unit continuation
   | Unreachable : Nothing.t continuation
   | Never_called : 'a continuation
   | Accumulate_error : ('result, 'errors) map_reduce_context' -> 'errors continuation
@@ -241,6 +264,24 @@ let rec continue : type a. a continuation -> a -> eff =
     (match suspended with
      | [] -> continue k ()
      | suspended :: rest -> Resume (suspended, (), Resume_many (rest, k)))
+  | Sequential_fold_left_complete state as complete ->
+    (match state.rest with
+     | [] -> continue state.k x
+     | y :: rest ->
+       state.rest <- rest;
+       Run (state.f x y, complete))
+  | Sequential_fold_left_result_complete state as complete ->
+    (match x, state.rest with
+     | Error _, _ | Ok _, [] -> continue state.k x
+     | Ok acc, y :: rest ->
+       state.rest <- rest;
+       Run (state.f acc y, complete))
+  | Sequential_iter_complete state as complete ->
+    (match state.rest with
+     | [] -> continue state.k ()
+     | x :: rest ->
+       state.rest <- rest;
+       Run (state.f x, complete))
   | Unreachable -> Nothing.unreachable_code x
   | Never_called -> assert false
   | Accumulate_error map_reduce_context ->
@@ -301,6 +342,12 @@ let rec eval : type a. a t -> a continuation -> eff =
   | Bind_t (t, f) -> eval t (Bind (f, k))
   | Thunk_t f -> eval (f ()) k
   | Thunk_apply_t (f, x) -> eval (f x) k
+  | Sequential_fold_left_t (first, rest, f) ->
+    eval first (Sequential_fold_left_complete { rest; f; k })
+  | Sequential_fold_left_result_t (first, rest, f) ->
+    eval first (Sequential_fold_left_result_complete { rest; f; k })
+  | Sequential_iter_t (first, rest, f) ->
+    eval first (Sequential_iter_complete { rest; f; k })
   | With_error_handler_t (f, on_error) -> With_error_handler (on_error, f, k)
   | Map_reduce_errors_t (m, on_error, f) -> Map_reduce_errors (m, on_error, f, k)
   | Collect_errors_t f -> Run_collect_errors (f, k)
@@ -568,15 +615,25 @@ let sequential_map l ~f =
   loop l []
 ;;
 
+let sequential_fold_left l ~f ~init =
+  match l with
+  | [] -> return init
+  | [ x ] -> f init x
+  | x :: rest -> Sequential_fold_left_t (f init x, rest, f)
+;;
+
+let sequential_fold_left_result l ~f ~init =
+  match l with
+  | [] -> return (Ok init)
+  | [ x ] -> f init x
+  | x :: rest -> Sequential_fold_left_result_t (f init x, rest, f)
+;;
+
 let sequential_iter l ~f =
-  let rec loop l =
-    match l with
-    | [] -> return ()
-    | x :: l ->
-      let* () = f x in
-      loop l
-  in
-  loop l
+  match l with
+  | [] -> return ()
+  | [ x ] -> f x
+  | x :: rest -> Sequential_iter_t (f x, rest, f)
 ;;
 
 let run_parallel_iter l f k =

--- a/src/fiber/src/fiber.mli
+++ b/src/fiber/src/fiber.mli
@@ -66,6 +66,14 @@ val both : 'a t -> 'b t -> ('a * 'b) t
 val all : 'a t list -> 'a list t
 
 val sequential_map : 'a list -> f:('a -> 'b t) -> 'b list t
+val sequential_fold_left : 'a list -> f:('acc -> 'a -> 'acc t) -> init:'acc -> 'acc t
+
+val sequential_fold_left_result
+  :  'a list
+  -> f:('acc -> 'a -> ('acc, 'error) result t)
+  -> init:'acc
+  -> ('acc, 'error) result t
+
 val sequential_iter : 'a list -> f:('a -> unit t) -> unit t
 
 (** {1 Forking + joining} *)

--- a/src/fiber/src/scheduler.ml
+++ b/src/fiber/src/scheduler.ml
@@ -104,6 +104,24 @@ and exec : type a. context -> a continuation -> a -> Jobs.t -> step' =
   | Fork_join_left _ as k -> exec_core_continuation ctx k x jobs
   | Fork_join_right _ as k -> exec_core_continuation ctx k x jobs
   | Resume_many _ as k -> exec_core_continuation ctx k x jobs
+  | Sequential_fold_left_complete state as complete ->
+    (match state.rest with
+     | [] -> exec ctx state.k x jobs
+     | y :: rest ->
+       state.rest <- rest;
+       exec_fiber_apply2 ctx state.f x y complete jobs)
+  | Sequential_fold_left_result_complete state as complete ->
+    (match x, state.rest with
+     | Error _, _ | Ok _, [] -> exec ctx state.k x jobs
+     | Ok acc, y :: rest ->
+       state.rest <- rest;
+       exec_fiber_apply2 ctx state.f acc y complete jobs)
+  | Sequential_iter_complete state as complete ->
+    (match state.rest with
+     | [] -> exec ctx state.k () jobs
+     | x :: rest ->
+       state.rest <- rest;
+       exec_fiber_apply ctx state.f x complete jobs)
   | Unreachable -> Nothing.unreachable_code x
   | Never_called -> assert false
   | Accumulate_error map_reduce_context ->
@@ -336,6 +354,12 @@ and exec_fiber : type a. context -> a t -> a continuation -> Jobs.t -> step' =
   | Bind_t (t, f) -> exec_fiber ctx t (Bind (f, k)) jobs
   | Thunk_t f -> exec_fiber_thunk ctx f k jobs
   | Thunk_apply_t (f, x) -> exec_fiber_apply ctx f x k jobs
+  | Sequential_fold_left_t (first, rest, f) ->
+    exec_fiber ctx first (Sequential_fold_left_complete { rest; f; k }) jobs
+  | Sequential_fold_left_result_t (first, rest, f) ->
+    exec_fiber ctx first (Sequential_fold_left_result_complete { rest; f; k }) jobs
+  | Sequential_iter_t (first, rest, f) ->
+    exec_fiber ctx first (Sequential_iter_complete { rest; f; k }) jobs
   | With_error_handler_t (f, on_error) -> with_error_handler ctx on_error f k jobs
   | Map_reduce_errors_t (m, on_error, f) -> map_reduce_errors ctx m on_error f k jobs
   | Collect_errors_t f ->

--- a/src/fiber/test/fiber_tests.ml
+++ b/src/fiber/test/fiber_tests.ml
@@ -469,6 +469,46 @@ let%expect_test "context switch and raise inside finalize" =
     [PASS] got Exit |}]
 ;;
 
+let%expect_test "sequential fold callback errors are collected" =
+  let check name fiber =
+    match Scheduler.run (Fiber.collect_errors (fun () -> fiber)) with
+    | Error [ { exn = Exit; _ } ] -> printfn "%s: caught" name
+    | Ok _ | Error _ -> printfn "%s: unexpected result" name
+  in
+  let fold () =
+    Fiber.sequential_fold_left [ 1; 2 ] ~init:0 ~f:(fun acc x ->
+      if x = 2 then raise Exit;
+      let+ () = Scheduler.yield () in
+      acc + x)
+  in
+  let fold_result () =
+    Fiber.sequential_fold_left_result [ 1; 2 ] ~init:0 ~f:(fun acc x ->
+      if x = 2 then raise Exit;
+      let+ () = Scheduler.yield () in
+      Ok (acc + x))
+  in
+  check "fold after suspension" (fold ());
+  check "result fold after suspension" (fold_result ());
+  check
+    "fold under parallel_map"
+    (Fiber.parallel_map [ () ] ~f:(fun () ->
+       Fiber.sequential_fold_left [ 1; 2 ] ~init:0 ~f:(fun acc x ->
+         if x = 2 then raise Exit;
+         Fiber.return (acc + x))));
+  check
+    "result fold under parallel_map"
+    (Fiber.parallel_map [ () ] ~f:(fun () ->
+       Fiber.sequential_fold_left_result [ 1; 2 ] ~init:0 ~f:(fun acc x ->
+         if x = 2 then raise Exit;
+         Fiber.return (Ok (acc + x)))));
+  [%expect
+    {|
+    fold after suspension: caught
+    result fold after suspension: caught
+    fold under parallel_map: caught
+    result fold under parallel_map: caught |}]
+;;
+
 let%expect_test "sequential_iter error handling" =
   let fiber =
     Fiber.finalize
@@ -507,6 +547,100 @@ let%expect_test "sequential_iter" =
     count: 3
     finally
     () |}]
+;;
+
+let%expect_test "sequential_fold_left is reusable across suspension" =
+  let fiber =
+    Fiber.sequential_fold_left [ 1; 2; 3 ] ~init:0 ~f:(fun acc x ->
+      let+ () = Scheduler.yield () in
+      acc + x)
+  in
+  Scheduler.run fiber |> printfn "%d";
+  Scheduler.run fiber |> printfn "%d";
+  [%expect
+    {|
+    6
+    6 |}]
+;;
+
+let%expect_test "sequential_iter is reusable across suspension" =
+  let fiber =
+    Fiber.sequential_iter [ 1; 2; 3 ] ~f:(fun x ->
+      let+ () = Scheduler.yield () in
+      printfn "%d" x)
+  in
+  Scheduler.run fiber;
+  Scheduler.run fiber;
+  [%expect
+    {|
+    1
+    2
+    3
+    1
+    2
+    3 |}]
+;;
+
+let%expect_test "sequential_fold_left_result is reusable across suspension" =
+  let fiber =
+    Fiber.sequential_fold_left_result [ 1; 2; 3 ] ~init:0 ~f:(fun acc x ->
+      let+ () = Scheduler.yield () in
+      Ok (acc + x))
+  in
+  let run () =
+    match Scheduler.run fiber with
+    | Ok x -> printfn "%d" x
+    | Error message -> printfn "error: %s" message
+  in
+  run ();
+  run ();
+  [%expect
+    {|
+    6
+    6 |}]
+;;
+
+let%expect_test "sequential_fold_left_result stops after an error" =
+  let fiber =
+    Fiber.sequential_fold_left_result [ 1; 2; 3 ] ~init:0 ~f:(fun acc x ->
+      printfn "visit %d" x;
+      let+ () = Scheduler.yield () in
+      if x = 2 then Error "failure" else Ok (acc + x))
+  in
+  (match Scheduler.run fiber with
+   | Ok x -> printfn "ok %d" x
+   | Error message -> print_endline message);
+  [%expect
+    {|
+    visit 1
+    visit 2
+    failure |}]
+;;
+
+let%expect_test "sequential traversal nodes work under parallel_map" =
+  let run fiber ~f =
+    match Scheduler.run (Fiber.parallel_map [ () ] ~f:(fun () -> fiber)) with
+    | [ x ] -> f x
+    | xs -> printfn "unexpected result count: %d" (List.length xs)
+  in
+  run
+    (Fiber.sequential_fold_left [ 1; 2; 3 ] ~init:0 ~f:(fun acc x ->
+       Fiber.return (acc + x)))
+    ~f:(printfn "fold: %d");
+  run
+    (Fiber.sequential_fold_left_result [ 1; 2; 3 ] ~init:0 ~f:(fun acc x ->
+       Fiber.return (Ok (acc + x))))
+    ~f:(function
+      | Ok x -> printfn "result: %d" x
+      | Error message -> printfn "error: %s" message);
+  run
+    (Fiber.sequential_iter [ 1; 2; 3 ] ~f:(fun _ -> Fiber.return ()))
+    ~f:(fun () -> print_endline "iter: done");
+  [%expect
+    {|
+    fold: 6
+    result: 6
+    iter: done |}]
 ;;
 
 let%expect_test _ =


### PR DESCRIPTION
Represent fold_left, result fold, and iter traversal frames directly in
the Fiber scheduler. Keep the fibers reusable, fast-path singleton lists,
and cover suspension, parallel evaluation, short-circuiting, and errors.