### PR TITLE
fix(patch): preserve spaces in git diff filenames

### DIFF
--- a/doc/changes/fixed/15781.md
+++ b/doc/changes/fixed/15781.md
@@ -1,0 +1,2 @@
+- Preserve spaces in unquoted filenames when applying Git patches instead of
+  truncating paths at the first space (#15781, @rgrinberg)

--- a/src/dune_patch/dune_patch.ml
+++ b/src/dune_patch/dune_patch.ml
@@ -49,6 +49,30 @@ let re =
 
 let git_header_re = Re.compile @@ Re.seq [ Re.bol; Re.str "diff --git " ]
 
+let disambiguate_git_header_filenames patch_string =
+  let add_tab line =
+    if String.contains line '\t'
+    then line
+    else if String.ends_with line ~suffix:"\r"
+    then String.drop_suffix_if_exists line ~suffix:"\r" ^ "\t\r"
+    else line ^ "\t"
+  in
+  let rec loop in_git_header acc = function
+    | [] -> List.rev acc
+    | line :: lines ->
+      if String.starts_with line ~prefix:"diff --git "
+      then loop true (line :: acc) lines
+      else if in_git_header && String.starts_with line ~prefix:"--- "
+      then loop true (add_tab line :: acc) lines
+      else if in_git_header && String.starts_with line ~prefix:"+++ "
+      then loop false (add_tab line :: acc) lines
+      else if in_git_header && String.starts_with line ~prefix:"@@"
+      then loop false (line :: acc) lines
+      else loop in_git_header (line :: acc) lines
+  in
+  String.split patch_string ~on:'\n' |> loop false [] |> String.concat ~sep:"\n"
+;;
+
 let prefix_of_patch ~patch_loc patch_string =
   Re.all re patch_string
   |> List.filter_map ~f:(fun group ->
@@ -110,9 +134,9 @@ let prefix_of_patch ~patch_loc patch_string =
 
 let parse_patches ~loc ~patch_file patch_contents =
   let patch_loc = Loc.in_file patch_file in
-  match
-    Patch.parse ~loc ~p:(prefix_of_patch ~patch_loc patch_contents) patch_contents
-  with
+  let p = prefix_of_patch ~patch_loc patch_contents in
+  let patch_contents = disambiguate_git_header_filenames patch_contents in
+  match Patch.parse ~loc ~p patch_contents with
   | [] ->
     User_error.raise
       ~loc

--- a/test/expect-tests/dune_patch/patch_action_tests.ml
+++ b/test/expect-tests/dune_patch/patch_action_tests.ml
@@ -118,17 +118,10 @@ let%expect_test "action test - random_prefix" =
   [%expect {| This is right |}]
 ;;
 
-(* CR-soon alizter: the prefix_of_patch regex truncates unquoted
-   filenames at the first space, so "foo bar" becomes "foo". *)
 let%expect_test "action test - spaces" =
-  try
-    test [ "foo bar", "This is wrong\n" ] ("foo.patch", Patch_examples.spaces);
-    check "foo bar";
-    [%expect.unreachable]
-  with
-  | Dune_util.Report_error.Already_reported ->
-    print_endline @@ normalize_error_path [%expect.output];
-    [%expect {| Error: Cannot edit file "foo": file does not exist |}]
+  test [ "foo bar", "This is wrong\n" ] ("foo.patch", Patch_examples.spaces);
+  check "foo bar";
+  [%expect {| This is right |}]
 ;;
 
 let%expect_test "action test - unified_spaces" =

--- a/test/expect-tests/dune_patch/patch_parsing_tests.ml
+++ b/test/expect-tests/dune_patch/patch_parsing_tests.ml
@@ -230,11 +230,10 @@ let%expect_test "parse_patches - random_prefix" =
 ;;
 
 let%expect_test "parse_patches - spaces" =
-  (* CR-soon alizter: Should be Edit ("foo bar", "foo bar") but parser truncates at space *)
   test Patch_examples.spaces;
   [%expect
     {|
-    [ { operation = Edit ("foo", "foo")
+    [ { operation = Edit ("foo bar", "foo bar")
       ; hunks =
           [ { mine_start = 1
             ; mine_len = 1


### PR DESCRIPTION
Disambiguate the --- and +++ filename fields in git patch headers before
parsing so unquoted filenames containing spaces are not truncated. Preserve
CRLF endings when adding the separator.

Update parsing and patch-action tests to cover filenames containing spaces.