### PR TITLE
refactor(describe): share name field rendering

### DIFF
--- a/bin/describe/describe_external_lib_deps.ml
+++ b/bin/describe/describe_external_lib_deps.ml
@@ -63,26 +63,7 @@ module Item = struct
     =
     let open Dyn in
     let name_fields =
-      if split_public_names
-      then (
-        let public_names =
-          match public_names with
-          | Some public_names -> public_names
-          | None -> List.map names ~f:(fun _ -> None)
-        in
-        [ "names", (list string) names
-        ; "public_names", (list (option string)) public_names
-        ])
-      else (
-        (* replace each private name by its public name when there is one *)
-        let best_names =
-          match public_names with
-          | None -> names
-          | Some public_names ->
-            List.map2 names public_names ~f:(fun name public_name ->
-              Option.value public_name ~default:name)
-        in
-        [ "names", (list string) best_names ])
+      Describe_format.name_fields ~split_public_names ~names ~public_names
     in
     let record =
       record

--- a/bin/describe/describe_format.ml
+++ b/bin/describe/describe_format.ml
@@ -27,6 +27,27 @@ let print_as_sexp dyn =
   Pp.to_fmt Stdlib.Format.std_formatter (Dune_lang.Format.pp_top_sexps ~version [ cst ])
 ;;
 
+let name_fields ~split_public_names ~names ~public_names =
+  let open Dyn in
+  if split_public_names
+  then (
+    let public_names =
+      match public_names with
+      | Some public_names -> public_names
+      | None -> List.map names ~f:(fun _ -> None)
+    in
+    [ "names", list string names; "public_names", list (option string) public_names ])
+  else (
+    let names =
+      match public_names with
+      | None -> names
+      | Some public_names ->
+        List.map2 names public_names ~f:(fun name public_name ->
+          Option.value public_name ~default:name)
+    in
+    [ "names", list string names ])
+;;
+
 let print_dyn t dyn =
   match t with
   | Csexp -> Csexp.to_channel stdout (Sexp.of_dyn dyn)

--- a/bin/describe/describe_format.mli
+++ b/bin/describe/describe_format.mli
@@ -10,4 +10,10 @@ type t =
 val arg : t Term.t
 
 (** [print_dyn t dyn] prints the dyn to stdout serialised as configured in [t] *)
+val name_fields
+  :  split_public_names:bool
+  -> names:string list
+  -> public_names:string option list option
+  -> (string * Dyn.t) list
+
 val print_dyn : t -> Dyn.t -> unit

--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -175,32 +175,18 @@ module Descr = struct
 
     let map_path t ~f = { t with include_dirs = List.map ~f t.include_dirs }
 
-    (* [best_names] replaces each private name by its public name when there is one *)
-    let best_names { names; public_names; _ } =
-      match public_names with
-      | None -> names
-      | Some public_names ->
-        List.map2 names public_names ~f:(fun name public_name ->
-          Option.value public_name ~default:name)
-    ;;
-
     (* Conversion to the [Dyn.t] type *)
-    let to_dyn options ({ names; public_names; requires; modules; include_dirs } as t)
+    let to_dyn
+          (options : Options.t)
+          { names; public_names; requires; modules; include_dirs }
       : Dyn.t
       =
       let open Dyn in
       let name_fields =
-        if options.Options.split_public_names
-        then (
-          let public_names =
-            match public_names with
-            | Some public_names -> public_names
-            | None -> List.map names ~f:(fun _ -> None)
-          in
-          [ "names", (list string) names
-          ; "public_names", (list (option string)) public_names
-          ])
-        else [ "names", (list string) (best_names t) ]
+        Describe_format.name_fields
+          ~split_public_names:options.split_public_names
+          ~names
+          ~public_names
       in
       record
       @@ name_fields


### PR DESCRIPTION
Centralize rendering of private and public library names in `Describe_format.name_fields`. Both `dune describe workspace` and `dune describe external-lib-deps` now use the same implementation for regular and `--split-public-names` output.

This removes duplicate formatting logic without changing command output.