### PR TITLE
refactor(cli): share debug-backtrace option

### DIFF
--- a/bin/cache.ml
+++ b/bin/cache.ml
@@ -2,16 +2,6 @@ open Import
 
 (* CR-someday amokhov: Implement other commands supported by Jenga. *)
 
-let debug_backtraces =
-  Arg.(
-    value
-    & flag
-    & info
-        [ "debug-backtraces" ]
-        ~docs:"COMMON OPTIONS"
-        ~doc:(Some "Always print exception backtraces."))
-;;
-
 let trim =
   let info =
     let doc = "Trim the Dune cache." in
@@ -31,7 +21,7 @@ let trim =
     Cmd.info "trim" ~doc ~man
   in
   Cmd.v info
-  @@ let+ debug_backtraces = debug_backtraces
+  @@ let+ debug_backtraces = Common.No_build.debug_backtraces
      and+ trimmed_size =
        Arg.(
          value
@@ -93,7 +83,7 @@ let size =
     Cmd.info "size" ~doc ~man
   in
   Cmd.v info
-  @@ let+ debug_backtraces = debug_backtraces
+  @@ let+ debug_backtraces = Common.No_build.debug_backtraces
      and+ machine_readable =
        Arg.(
          value
@@ -116,7 +106,7 @@ let clear =
     Cmd.info "clear" ~doc ~man
   in
   Cmd.v info
-  @@ let+ debug_backtraces = debug_backtraces in
+  @@ let+ debug_backtraces = Common.No_build.debug_backtraces in
      Common.No_build.set_debug_backtraces debug_backtraces;
      Dune_cache.Trimmer.clear ()
 ;;

--- a/bin/trace.ml
+++ b/bin/trace.ml
@@ -1,15 +1,5 @@
 open Import
 
-let debug_backtraces =
-  Arg.(
-    value
-    & flag
-    & info
-        [ "debug-backtraces" ]
-        ~docs:"COMMON OPTIONS"
-        ~doc:(Some "Always print exception backtraces."))
-;;
-
 let iter_sexps file ~f =
   Io.String_path.with_file_in ~binary:true file ~f:(fun chan ->
     let rec loop () =
@@ -223,7 +213,7 @@ let json_of_event ~chrome (sexp : Sexp.t) =
 let cat =
   let info = Cmd.info "cat" in
   let term =
-    let+ debug_backtraces = debug_backtraces
+    let+ debug_backtraces = Common.No_build.debug_backtraces
     and+ sexp =
       Arg.(
         value
@@ -299,7 +289,7 @@ let commands =
     Cmd.info "commands" ~doc
   in
   let term =
-    let+ debug_backtraces = debug_backtraces
+    let+ debug_backtraces = Common.No_build.debug_backtraces
     and+ trace_file =
       Arg.(
         value


### PR DESCRIPTION
Reuse `Common.No_build.debug_backtraces` for the cache and trace commands instead of maintaining identical Cmdliner argument definitions. This keeps the option spelling, documentation, and behavior in one place.