### PR TITLE
refactor(rules): centralize optional promotion expansion

### DIFF
--- a/src/dune_rules/exe.ml
+++ b/src/dune_rules/exe.ml
@@ -242,12 +242,7 @@ let link_exe
   and* mode =
     let sctx = Compilation_context.super_context cctx in
     let* expander = Super_context.expander sctx ~dir in
-    let rule_mode =
-      match promote with
-      | None -> Rule_mode.Standard
-      | Some p -> Promote p
-    in
-    Rule_mode_expand.expand_path ~expander ~dir rule_mode
+    Rule_mode_expand.expand_optional_promote ~expander ~dir promote
   in
   Super_context.add_rule sctx ~loc ~dir ~mode action_with_targets
 ;;

--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -1175,12 +1175,7 @@ let build_exe
   let target = Path.Build.set_extension src ~ext:(Js_of_ocaml.Ext.exe ~mode) in
   let* rule_mode : Rule.Mode.t =
     let* expander = Super_context.expander sctx ~dir in
-    let rule_mode =
-      match promote with
-      | None -> Rule_mode.Standard
-      | Some p -> Promote p
-    in
-    Rule_mode_expand.expand_path ~expander ~dir rule_mode
+    Rule_mode_expand.expand_optional_promote ~expander ~dir promote
   in
   let* cmode =
     match compilation_mode with

--- a/src/dune_rules/rule_mode_expand.ml
+++ b/src/dune_rules/rule_mode_expand.ml
@@ -24,6 +24,15 @@ let expand_path t ~expander ~dir =
     Path.reach ~from:(Path.build dir) path)
 ;;
 
+let expand_optional_promote promote ~expander ~dir =
+  let rule_mode =
+    match promote with
+    | None -> Rule_mode.Standard
+    | Some promote -> Promote promote
+  in
+  expand_path ~expander ~dir rule_mode
+;;
+
 let expand_str t ~expander =
   expand t ~f:(fun into_dir ->
     let open Memo.O in

--- a/src/dune_rules/rule_mode_expand.mli
+++ b/src/dune_rules/rule_mode_expand.mli
@@ -6,4 +6,10 @@ val expand_path
   -> dir:Path.Build.t
   -> Rule.Mode.t Memo.t
 
+val expand_optional_promote
+  :  Rule_mode.Promote.t option
+  -> expander:Expander.t
+  -> dir:Path.Build.t
+  -> Rule.Mode.t Memo.t
+
 val expand_str : Rule_mode.t -> expander:Expander.t -> Rule.Mode.t Memo.t


### PR DESCRIPTION
Add a `Rule_mode_expand` helper for converting an optional promotion configuration into an expanded rule mode. Reuse it when generating executable and js_of_ocaml rules, removing duplicate conversion logic.