### PR TITLE
refactor(stdune): pass Env.t directly to Spawn

### DIFF
--- a/bin/action_runner.ml
+++ b/bin/action_runner.ml
@@ -41,8 +41,6 @@ let create ~config ~sandbox_actions =
           in
           Env.add Env.initial ~var:"DUNE_JOBS" ~value:jobs
           |> Env.add ~var:"DUNE_BUILD_DIR" ~value:(Path.Build.to_string Path.Build.root)
-          |> Env.to_unix
-          |> Spawn.Env.of_list
         in
         let trace_fd = Dune_trace.duplicate_global_fd () in
         let prog, argv =

--- a/otherlibs/stdune/src/env.ml
+++ b/otherlibs/stdune/src/env.ml
@@ -73,15 +73,37 @@ let vars t = Var.Set.of_keys t.vars
 let get t k = Option.map (Map.find t.vars k) ~f:(fun { Binding.value; _ } -> value)
 
 let to_unix t =
-  match t.unix with
-  | Some v -> v
-  | None ->
-    let res =
-      Map.foldi t.vars ~init:[] ~f:(fun var binding acc ->
-        Binding.render binding ~var :: acc)
-    in
-    t.unix <- Some res;
-    res
+  let bindings =
+    match t.unix with
+    | Some bindings -> bindings
+    | None ->
+      let bindings =
+        Map.foldi t.vars ~init:[] ~f:(fun var binding acc ->
+          Binding.render binding ~var :: acc)
+      in
+      t.unix <- Some bindings;
+      bindings
+  in
+  List.iter bindings ~f:(fun binding ->
+    if String.contains binding '\000'
+    then
+      Code_error.raise
+        "Env.to_unix: NUL byte in environment binding"
+        [ "binding", Dyn.string binding ]);
+  bindings
+;;
+
+let to_windows_block t =
+  match to_unix t with
+  | [] -> "\000\000"
+  | env ->
+    let len = List.fold_left env ~init:1 ~f:(fun acc s -> acc + String.length s + 1) in
+    let block = Buffer.create len in
+    List.iter env ~f:(fun binding ->
+      Buffer.add_string block binding;
+      Buffer.add_char block '\000');
+    Buffer.add_char block '\000';
+    Buffer.contents block
 ;;
 
 let map_of_unix arr =

--- a/otherlibs/stdune/src/env.mli
+++ b/otherlibs/stdune/src/env.mli
@@ -27,6 +27,10 @@ val vars : t -> Var.Set.t
 val initial : t
 
 val to_unix : t -> string list
+
+(** Render the environment as a double-NUL-terminated Windows environment block. *)
+val to_windows_block : t -> string
+
 val of_unix : string array -> t
 val get : t -> Var.t -> string option
 

--- a/otherlibs/stdune/src/spawn.ml
+++ b/otherlibs/stdune/src/spawn.ml
@@ -42,51 +42,6 @@ module Unix_backend = struct
   ;;
 end
 
-let no_null s =
-  if String.contains s '\000'
-  then
-    Printf.ksprintf
-      invalid_arg
-      "Spawn.Env.of_list: NUL bytes are not allowed in the environment but found one in \
-       %S"
-      s
-;;
-
-module type Env = sig
-  type t
-
-  val of_list : string list -> t
-end
-
-module Env_win32 : Env = struct
-  type t = string
-
-  let of_list env =
-    if env = []
-    then "\000\000"
-    else (
-      let len = List.fold_left env ~init:1 ~f:(fun acc s -> acc + String.length s + 1) in
-      let buf = Buffer.create len in
-      List.iter env ~f:(fun s ->
-        no_null s;
-        Buffer.add_string buf s;
-        Buffer.add_char buf '\000');
-      Buffer.add_char buf '\000';
-      Buffer.contents buf)
-  ;;
-end
-
-module Env_unix : Env = struct
-  type t = string list
-
-  let of_list l =
-    List.iter l ~f:no_null;
-    l
-  ;;
-end
-
-module Env : Env = (val if Sys.win32 then (module Env_win32) else (module Env_unix) : Env)
-
 module Pgid = struct
   type t =
     | New
@@ -102,7 +57,7 @@ module Pgid = struct
 end
 
 external spawn_unix_raw
-  :  env:Env.t option
+  :  env:string list option
   -> cwd:Working_dir.raw
   -> prog:string
   -> argv0:string
@@ -131,6 +86,7 @@ let spawn_unix
       ~sigprocmask
       ~pdeathsig
   =
+  let env = Option.map env ~f:Env.to_unix in
   let setpgid = Option.map ~f:Pgid.to_int setpgid in
   let pdeathsig = Signal.to_int pdeathsig in
   spawn_unix_raw
@@ -150,7 +106,7 @@ let spawn_unix
 ;;
 
 external spawn_windows_raw
-  :  env:Env.t option
+  :  env:string option
   -> cwd:string option
   -> prog:string
   -> cmdline:string
@@ -180,6 +136,7 @@ let spawn_windows
       ~sigprocmask:_
       ~pdeathsig:_
   =
+  let env = Option.map env ~f:Env.to_windows_block in
   let cwd =
     match (cwd : Working_dir.t) with
     | Path p -> Some p

--- a/otherlibs/stdune/src/spawn.mli
+++ b/otherlibs/stdune/src/spawn.mli
@@ -28,14 +28,6 @@ module Unix_backend : sig
   val default : t
 end
 
-module Env : sig
-  (** Representation of an environment *)
-  type t
-
-  (** Create an environment from a list of strings of the form ["KEY=VALUE"]. *)
-  val of_list : string list -> t
-end
-
 (** Process group IDs *)
 module Pgid : sig
   (** Representation of the second parameter to [setpgid]. If a value of this

--- a/otherlibs/stdune/test/spawn/tests.ml
+++ b/otherlibs/stdune/test/spawn/tests.ml
@@ -182,8 +182,8 @@ let%expect_test "env" =
   let tst v =
     let env =
       match v with
-      | None -> Spawn.Env.of_list []
-      | Some v -> Spawn.Env.of_list [ "FOO=" ^ v ]
+      | None -> Env.empty
+      | Some value -> Env.add Env.empty ~var:"FOO" ~value
     in
     wait
       (Spawn.spawn

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -982,7 +982,6 @@ let spawn
     Time.now ()
   in
   let pid =
-    let env = Env.to_unix env |> Spawn.Env.of_list in
     let stdout = Io.fd stdout in
     let stderr = Io.fd stderr in
     let stdin = Io.fd stdin in

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -96,7 +96,7 @@ let run ?env ~prog ~argv () =
   let stderr_w = Fd.unsafe_of_unix_file_descr stderr_w in
   let pid =
     let args = Array.Immutable.of_list argv in
-    let env = Option.map ~f:Spawn.Env.of_list env in
+    let env = Option.map env ~f:(fun env -> Env.of_unix (Array.of_list env)) in
     Spawn.spawn
       ~prog
       ~argv0:prog

--- a/test/expect-tests/foreign_stubs/archive_creation_behavior.ml
+++ b/test/expect-tests/foreign_stubs/archive_creation_behavior.ml
@@ -53,7 +53,7 @@ let spawn_and_capture ?env ~prog ~argv ~cwd () =
             Fd.close stdout_fd;
             Fd.close stderr_fd)
           ~f:(fun () ->
-            let env = Option.map env ~f:Spawn.Env.of_list in
+            let env = Option.map env ~f:(fun env -> Env.of_unix (Array.of_list env)) in
             Spawn.spawn
               ~prog
               ~argv0:prog


### PR DESCRIPTION
`Spawn` maintained a second environment abstraction alongside `Stdune.Env`, requiring callers to render and wrap environments before starting a process. This refactoring makes `Spawn.spawn` accept `Env.t` directly, moves Unix and Windows environment rendering into `Env`, and updates the affected callers.

Environment validation remains at the rendering boundary, while `Spawn` continues to validate executable paths and arguments. This removes the duplicate abstraction ahead of follow-up environment caching work.
