### PR TITLE
fix(pkg): use sha256 for source archives that lack a checksum

### DIFF
--- a/doc/changes/changed/15824.md
+++ b/doc/changes/changed/15824.md
@@ -1,0 +1,2 @@
+- Use sha256 instead of md5 for source archives that lack a checksum
+  (#15824, @shunueda)

--- a/src/dune_pkg/checksum.ml
+++ b/src/dune_pkg/checksum.ml
@@ -22,7 +22,6 @@ include (
 let repr = Repr.view Repr.string ~to_:to_string
 let to_opam_hash v = v
 let of_opam_hash v = v
-let of_md5 md5 = md5 |> Md5.to_hex |> OpamHash.md5
 
 let pp v =
   let s = to_string v in

--- a/src/dune_pkg/checksum.mli
+++ b/src/dune_pkg/checksum.mli
@@ -15,9 +15,6 @@ val to_opam_hash : t -> OpamHash.t
 (** [of_opam_hash h] converts [h] from the representation used by OPAM to Dune's *)
 val of_opam_hash : OpamHash.t -> t
 
-(** Convert an [Md5.t] into OPAM's checksum representation *)
-val of_md5 : Md5.t -> t
-
 val pp : t -> 'a Pp.t
 val equal : t -> t -> bool
 val hash : t -> int

--- a/src/dune_pkg/source.ml
+++ b/src/dune_pkg/source.ml
@@ -51,8 +51,11 @@ let fetch_and_hash_archive_cached (url_loc, url) =
   >>| function
   | Ok target ->
     Some
-      (match Md5.file target with
-       | Ok digest -> Checksum.of_md5 digest
+      (match
+         Result.try_with (fun () ->
+           OpamHash.compute ~kind:`SHA256 (Path.to_string target))
+       with
+       | Ok checksum -> Checksum.of_opam_hash checksum
        | Error exn ->
          User_error.raise
            ~loc:url_loc

--- a/test/blackbox-tests/test-cases/pkg/compute-checksums-when-missing.t
+++ b/test/blackbox-tests/test-cases/pkg/compute-checksums-when-missing.t
@@ -32,7 +32,8 @@ path.
   (source
    (fetch
     (url http://0.0.0.0:1)
-    (checksum md5=bea8252ff4e80f41719ea13cdf007273)))
+    (checksum
+     sha256=c98c24b677eff44860afea6f493bbaec5bb1c4cbb209c6fc2bbb47f66ff2ad31)))
   
   (dev)
 

--- a/test/blackbox-tests/test-cases/pkg/pin-depends.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-depends.t
@@ -181,11 +181,11 @@ Pin to an HTTP archive work
   > opam-version: "2.0"
   > EOF
   $ tar cf tarball.tar -C _source bar.opam
-  $ MD5_CHECKSUM=$(md5sum tarball.tar  | cut -f1 -d' ')
+  $ SHA256_CHECKSUM=$(sha256sum tarball.tar  | cut -f1 -d' ')
   $ echo tarball.tar > fake-curls
   $ PORT=1
   $ runtest "http://0.0.0.0:$PORT/tarball.tar" > output
-  $ grep "md5=$MD5_CHECKSUM" output 2>&1 > /dev/null && echo "Checksum matches"
+  $ grep "sha256=$SHA256_CHECKSUM" output 2>&1 > /dev/null && echo "Checksum matches"
   Checksum matches
 
 Pin to an HTTP archive detects wrong hash
@@ -195,11 +195,11 @@ Pin to an HTTP archive detects wrong hash
   >  (name foo)
   >  (libraries bar))
   > EOF
-  $ dune_cmd subst "$MD5_CHECKSUM" '92449184682b45b5f07e811fdd61d35f' ${default_lock_dir}/bar.1.0.0.pkg
+  $ dune_cmd subst "$SHA256_CHECKSUM" '92449184682b45b5f07e811fdd61d35f92449184682b45b5f07e811fdd61d35f' ${default_lock_dir}/bar.1.0.0.pkg
   $ rm -rf already-served
-  $ dune build 2>&1 | grep -v "md5"
-  File "dune.lock/bar.1.0.0.pkg", line 6, characters 12-48:
-                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  $ dune build 2>&1 | grep -v "sha256"
+  File "dune.lock/bar.1.0.0.pkg", line 7, characters 3-74:
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Invalid checksum, got
   [1]
 
@@ -209,9 +209,9 @@ of the target again
   $ rm tarball.tar already-served
   $ echo "update checksum" > _source/random_file
   $ tar cf tarball.tar -C _source bar.opam random_file
-  $ MD5_CHECKSUM=$(md5sum tarball.tar  | cut -f1 -d' ')
+  $ SHA256_CHECKSUM=$(sha256sum tarball.tar  | cut -f1 -d' ')
   $ echo tarball.tar > fake-curls
   $ runtest "http://0.0.0.0:$PORT/tarball.tar" > output
-  $ grep "md5=$MD5_CHECKSUM" output 2>&1 > /dev/null && echo "Checksum matches"
+  $ grep "sha256=$SHA256_CHECKSUM" output 2>&1 > /dev/null && echo "Checksum matches"
   Checksum matches
 


### PR DESCRIPTION
<!-- Thank you for contributing to dune!

 For general guidelines on contributing to dune, see
 https://github.com/ocaml/dune/blob/main/CONTRIBUTING.md#developing-dune -->

## Description
<!-- Briefly describe your changes -->

## Related Issue and Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it closes an open issue, link to the issue here. -->
<!-- Non-trivial contributions are expected to be preceded by an issue, as
     per CONTRIBUTING.md. -->

Use sha256 instead of md5 when generating a checksum for source archives that lack a checksum.

## Checklist

- [ ] Tests added, if applicable.
- [x] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [ ] Documentation added for any user-facing changes.
