### PR TITLE
test: cover concurrent format-dune-file with watch mode

### DIFF
--- a/test/blackbox-tests/test-cases/watching/watching-eager-concurrent-format-dune-file.t
+++ b/test/blackbox-tests/test-cases/watching/watching-eager-concurrent-format-dune-file.t
@@ -1,0 +1,22 @@
+Regression test for running "dune format-dune-file" concurrently with a
+watch server. The format command runs locally rather than through the RPC
+server. It does not need to build anything, so it must not contend for the
+workspace lock.
+
+  $ echo '(lang dune 3.18)' > dune-project
+  $ echo '(a(b c))' > input
+
+  $ dune build --watch > .#dune-output 2>&1 &
+
+Make sure the RPC server is properly started:
+  $ dune rpc ping --wait
+  Server appears to be responding normally
+
+Formatting a dune file while watch mode owns the workspace lock succeeds:
+  $ dune format-dune-file input
+  (a
+   (b c))
+
+  $ dune shutdown
+  $ wait
+


### PR DESCRIPTION
## Purpose

This test-only PR records the existing behavior for #13525: while
`dune build --watch` owns the workspace lock, `dune format-dune-file` can run
locally without contending for that lock.

This behavior was fixed indirectly by #12958, which runs the command with
`Scheduler.no_build_no_rpc` rather than starting another RPC server. The test
waits for the watch server to acquire the lock, then formats a file in the same
workspace.

## Current behavior

`dune format-dune-file` does not forward through the active RPC server. It does
not need to build anything, so no additional production-code fix is required.

## Scope

- one black-box regression test
- no production code
- no changelog entry

Closes #13525.