### PR TITLE
Document the melange.emit artifact variable

### DIFF
--- a/doc/advanced/variables-artifacts.rst
+++ b/doc/advanced/variables-artifacts.rst
@@ -36,5 +36,11 @@ interpreted relative to the current directory:
 
   .. versionadded:: 3.21
 
+- ``melange.emit:<path>`` expands to the output directory of the
+  :ref:`melange.emit stanza <melange-emit>` whose target directory is
+  ``<path>``. See :ref:`melange-emit-artifact-variable` for examples.
+
+  .. versionadded:: 3.25
+
 In each case, the expansion of the variable is a path pointing inside the build
 context (i.e., ``_build/<context>``).

--- a/doc/concepts/variables.rst
+++ b/doc/concepts/variables.rst
@@ -108,8 +108,8 @@ corresponding ``%{ocaml-config:...}`` variables expand to the same values.
 - ``git-sha`` expands to the short git SHA of the HEAD commit of the workspace's
   git repository (equivalent to ``git rev-parse --short HEAD``). Expands to the
   empty string when no commit sha was found. Available since Dune 3.24.
-- ``<ext>:<path>`` where ``<ext>`` is one of ``cmo``, ``cmi``, ``cma``,
-  ``cmx``, or ``cmxa``. See :ref:`variables-for-artifacts`.
+- Artifact variables such as ``cmi:<path>`` and ``melange.emit:<path>`` expand
+  to paths of build artifacts. See :ref:`variables-for-artifacts`.
 - ``env:<var>=<default`` expands to the value of the environment
   variable ``<var>``, or ``<default>`` if it does not exist.
   For example, ``%{env:BIN=/usr/bin}``.

--- a/doc/melange.rst
+++ b/doc/melange.rst
@@ -146,6 +146,24 @@ The resulting layout in ``_build/default/output`` will be as follows:
         ├── lib.js
         └── helper.js
 
+.. _melange-emit-artifact-variable:
+
+Artifact Variable
+-----------------
+
+.. versionadded:: 3.25
+
+The ``%{melange.emit:<target-dir>}`` variable expands to the output directory
+of the selected ``melange.emit`` stanza. ``<target-dir>`` is the path to the
+stanza's target directory, relative to the ``dune`` file containing the
+variable. Like other :ref:`artifact variables <variables-for-artifacts>`, it
+adds a dependency on the stanza's outputs.
+
+For example, suppose ``lib/dune`` contains a stanza with ``(target output)``.
+In that file, ``%{melange.emit:output}`` expands to ``output/lib``. In a
+``dune`` file at the workspace root, ``%{melange.emit:lib/output}`` expands to
+``lib/output/lib``.
+
 ``<optional-fields>`` are:
 
 - ``(alias <alias-name>)`` specifies an alias to which to attach the targets of


### PR DESCRIPTION
Document the `%{melange.emit:...}` artifact variable. Follow-up to #15751.