### PR TITLE
test(trace): isolate follow tests from ancestor traces

### DIFF
--- a/test/blackbox-tests/test-cases/trace/trace-cat-follow-nested.t
+++ b/test/blackbox-tests/test-cases/trace/trace-cat-follow-nested.t
@@ -4,7 +4,9 @@ no digest hash).
 
   $ make_dune_project 3.22
 
-  $ fifo="$(mktemp -d)/fifo"
+  $ tmpdir="$(mktemp -d)"
+  $ fifo="$tmpdir/fifo"
+  $ trace_file="$tmpdir/trace.csexp"
   $ mkfifo $fifo
 
 Set up a nested dune project:
@@ -25,18 +27,18 @@ Set up a nested dune project:
   > EOF
 
   $ checkStart() {
-  >   dune trace cat \
+  >   dune trace cat --trace-file "$trace_file" \
   >     | jq -e 'select(.name == "init" and .cat == "config")'
   > } 1> /dev/null 2>&1
 
-  $ dune build ./x &
+  $ dune build ./x --trace-file "$trace_file" &
 
   $ while ! checkStart; do sleep 0.1; done
 
 Follow mode should see both init/exit pairs. Inner dune has a digest hash in its
 events, outer dune does not:
 
-  $ ( dune trace cat --follow \
+  $ ( dune trace cat --follow --trace-file "$trace_file" \
   > | jq 'select(.cat == "config" and (.name == "init" or .name == "exit"))
   >       | { name, has_digest_hash: (if .args.digest then (.args.digest | type == "string") else false end) }' ) &
   {

--- a/test/blackbox-tests/test-cases/trace/trace-cat-follow.t
+++ b/test/blackbox-tests/test-cases/trace/trace-cat-follow.t
@@ -2,7 +2,9 @@ dune trace cat --follow
 
   $ make_dune_project 3.21
 
-  $ fifo="$(mktemp -d)/fifo"
+  $ tmpdir="$(mktemp -d)"
+  $ fifo="$tmpdir/fifo"
+  $ trace_file="$tmpdir/trace.csexp"
   $ mkfifo $fifo
 
   $ cat >dune <<EOF
@@ -12,17 +14,19 @@ dune trace cat --follow
   > EOF
 
   $ checkStart() {
-  >   dune trace cat \
-  >     | jq 'select(.name == "init" and .cat == "config")' \
-  >     | head -n 1 \
-  >     || true
+  >   dune trace cat --trace-file "$trace_file" \
+  >     | jq -e 'select(.name == "init" and .cat == "config")'
   > } 1> /dev/null 2>&1
 
-  $ dune build ./x &
+The poll must not find an ancestor build's trace before this build starts:
+
+  $ ! checkStart
+
+  $ dune build ./x --trace-file "$trace_file" &
 
   $ while ! checkStart; do sleep 0.1; done
 
-  $ ( dune trace cat --follow \
+  $ ( dune trace cat --follow --trace-file "$trace_file" \
   > | jq 'select(.cat == "config" and (.name == "init" or .name == "exit")) | .name' ) &
   "init"
   "exit"


### PR DESCRIPTION
`dune trace cat` locates the default trace by searching parent directories. In CI, the startup poll could therefore read the enclosing Dune invocation's trace before the test build created its own. Because `trace-cat-follow.t` also discarded the poll result, it could start following that ancestor trace and print repeated unrelated `init` and `exit` events.

Give both follow tests a private trace file and pass it explicitly to the build, polling, and follow commands. The non-nested test now uses `jq -e` for polling and verifies that its private trace is absent before the build starts.
