### PR TITLE
fix(sexp): allow release builds with expect-test helper

### DIFF
--- a/src/dune_sexp/escape.ml
+++ b/src/dune_sexp/escape.ml
@@ -108,7 +108,7 @@ let quoted s =
   Bytes.unsafe_to_string s'
 ;;
 
-let print_escaped s = Printf.printf "%S -> %S\n" s (escaped s)
+let[@warning "-32"] print_escaped s = Printf.printf "%S -> %S\n" s (escaped s)
 
 let%expect_test "escaped - plain strings pass through unchanged" =
   print_escaped "hello";


### PR DESCRIPTION
The build-time benchmark clones Dune and builds `@install` with the release
profile. In that profile, expect-test bodies are omitted, so the shared
`print_escaped` test helper appears unused and warning 32 aborts the build.

Suppress warning 32 only on this test helper so release builds, including the
benchmark, succeed while preserving its descriptive name.
