### PR TITLE
feat: confine sandboxed actions with Landlock

### DIFF
--- a/bin/describe/describe_pp.ml
+++ b/bin/describe/describe_pp.ml
@@ -74,6 +74,7 @@ let execute_pp_action ~sctx file pp_file dump_file =
     ; env
     ; rule_loc = Loc.none
     ; execution_parameters
+    ; sandbox = None
     ; action
     }
   in

--- a/bin/internal.ml
+++ b/bin/internal.ml
@@ -231,6 +231,7 @@ let group =
     ; Internal_action_runner.group
     ; Bwrap.With_bwrap.command
     ; Bwrap.With_sandbox_exec.command
+    ; Landlock.With_landlock.command
     ; latest_lang_version
     ; bootstrap_info
     ; Sexp_pp.command

--- a/bin/landlock.ml
+++ b/bin/landlock.ml
@@ -1,0 +1,43 @@
+open Import
+
+let resolve_prog prog =
+  if Fpath.contains_path_sep prog
+  then prog
+  else Path.to_string (Util.find_in_path_exn prog)
+;;
+
+module With_landlock = struct
+  let command =
+    let doc = "Run a command under Dune's Landlock wrapper." in
+    let info = Cmd.info "with-landlock" ~doc in
+    let term =
+      let+ write_dirs =
+        Arg.(
+          value
+          & opt_all string []
+          & info
+              [ "write-dir" ]
+              ~docv:"DIR"
+              ~doc:(Some "Allow writes under this directory."))
+      and+ argv = Arg.(value & pos_all string [] (info [] ~docv:"COMMAND" ~doc:None)) in
+      match argv with
+      | [] -> User_error.raise [ Pp.text "missing command after --" ]
+      | prog :: args ->
+        if not (Spawn.Landlock.available ())
+        then User_error.raise [ Pp.text "Landlock is not available on this system" ];
+        let fds =
+          List.map write_dirs ~f:(fun dir ->
+            let dir = Path.of_filename_relative_to_initial_cwd dir in
+            Path.mkdir_p dir;
+            Unix.openfile (Path.to_string dir) [ O_RDONLY; O_CLOEXEC ] 0
+            |> Fd.unsafe_of_unix_file_descr)
+        in
+        Exn.protect
+          ~finally:(fun () -> List.iter fds ~f:Fd.close)
+          ~f:(fun () ->
+            Spawn.Landlock.allow_writes_to_directories fds |> Spawn.Landlock.restrict);
+        Proc.restore_cwd_and_execve (resolve_prog prog) args ~env:Env.initial
+    in
+    Cmd.v info term
+  ;;
+end

--- a/bin/landlock.mli
+++ b/bin/landlock.mli
@@ -1,0 +1,5 @@
+open Import
+
+module With_landlock : sig
+  val command : unit Cmd.t
+end

--- a/bin/promotion.ml
+++ b/bin/promotion.ml
@@ -144,7 +144,7 @@ module Diff = struct
   let diff_for_file (file : Diff_promotion.File.t) =
     let original = Diff_promotion.File.source file in
     let correction = Diff_promotion.File.correction_file file in
-    Dune_engine.Print_diff.get (Path.source original) correction
+    Dune_engine.Print_diff.get ~sandbox:None (Path.source original) correction
   ;;
 
   let display_diffs present =

--- a/doc/changes/changed/15858.md
+++ b/doc/changes/changed/15858.md
@@ -1,0 +1,4 @@
+- Starting with Dune language 3.25, restrict sandboxed actions on Linux
+  systems with Landlock ABI 3 or newer from writing outside their sandbox,
+  temporary directory, action-trace directory, and `/dev`. Set
+  `DUNE_CONFIG__LANDLOCK=disabled` to opt out. (#15858, @rgrinberg)

--- a/otherlibs/dune-rpc-lwt/examples/rpc_client/test/rpc-client-example.t/run.t
+++ b/otherlibs/dune-rpc-lwt/examples/rpc_client/test/rpc-client-example.t/run.t
@@ -1,8 +1,9 @@
 Start Dune in watch mode, sending errors to `/dev/null` to suppress the alerts
 about using the unstable module Dune_rpc.
 
-  $ export XDG_STATE_HOME="$PWD/.dune.state"
-  $ mkdir $XDG_STATE_HOME
+  $ unset XDG_RUNTIME_DIR
+  $ export XDG_DATA_HOME="$PWD/.local/share"
+  $ mkdir -p $XDG_DATA_HOME
 
   $ dune build -w 2> /dev/null &
 

--- a/otherlibs/dune-rpc-lwt/test/dune_rpc_lwt_tests.ml
+++ b/otherlibs/dune-rpc-lwt/test/dune_rpc_lwt_tests.ml
@@ -6,21 +6,20 @@ open Lwt.Syntax
 open Dune_rpc.V1
 open Dune_rpc_lwt.V1
 
-let _XDG_DATA_HOME = "XDG_DATA_HOME"
-let xdg_data_dir = Temp.create Dir ~prefix:"lwt" ~suffix:"dune"
-let () = Unix.putenv _XDG_DATA_HOME (Stdune.Path.to_absolute_filename xdg_data_dir)
+let _XDG_DATA_HOME = Env.Var.of_string "XDG_DATA_HOME"
+let _XDG_RUNTIME_DIR = Env.Var.of_string "XDG_RUNTIME_DIR"
+
+let xdg_env =
+  let data_dir = Temp.create Dir ~prefix:"lwt" ~suffix:"dune" in
+  let data_dir = Stdune.Path.to_absolute_filename data_dir in
+  Env.initial
+  |> Env.remove ~var:_XDG_RUNTIME_DIR
+  |> Env.add ~var:_XDG_DATA_HOME ~value:data_dir
+;;
 
 let connect ~root_dir =
   let build_dir = Filename.concat root_dir "_build" in
-  let env =
-    let env =
-      Env.add
-        Env.initial
-        ~var:(Env.Var.of_string _XDG_DATA_HOME)
-        ~value:(Stdune.Path.to_absolute_filename xdg_data_dir)
-    in
-    fun var -> Env.get env (Env.Var.of_string var)
-  in
+  let env var = Env.get xdg_env (Env.Var.of_string var) in
   let* res = Where.get ~env ~build_dir in
   match res with
   | Error e -> Lwt.fail e
@@ -47,6 +46,7 @@ let connect ~root_dir =
 
 let build_watch ~root_dir =
   Lwt_process.open_process_none
+    ~env:(Env.to_unix xdg_env |> Array.of_list)
     ~stdin:`Close
     ~stderr:`Dev_null
     ( "dune"

--- a/otherlibs/stdune/src/spawn.ml
+++ b/otherlibs/stdune/src/spawn.ml
@@ -17,6 +17,76 @@ module Working_dir = struct
   let inherit_ = Inherit
 end
 
+module Landlock = struct
+  module Raw = struct
+    external abi_version : unit -> int = "dune_spawn_landlock_abi_version"
+
+    external write_access_rights
+      :  int
+      -> int64
+      = "dune_spawn_landlock_write_access_rights"
+
+    external create_ruleset
+      :  int64
+      -> Unix.file_descr
+      = "dune_spawn_landlock_create_ruleset"
+
+    external add_rule
+      :  Unix.file_descr
+      -> Unix.file_descr
+      -> int64
+      -> unit
+      = "dune_spawn_landlock_add_rule"
+
+    external restrict_self : Unix.file_descr -> unit = "dune_spawn_landlock_restrict_self"
+  end
+
+  type t =
+    { handled_access : int64
+    ; writable_directories : Fd.t list
+    }
+
+  let minimum_abi = 3
+
+  let available () =
+    match Raw.abi_version () with
+    | abi -> abi >= minimum_abi && not (Int64.equal (Raw.write_access_rights abi) 0L)
+    | exception Unix.Unix_error _ -> false
+  ;;
+
+  let write_access_rights () =
+    let abi = Raw.abi_version () in
+    if abi < minimum_abi then Code_error.raise "Landlock is not available" [];
+    let write_access = Raw.write_access_rights abi in
+    if Int64.equal write_access 0L
+    then Code_error.raise "Landlock write restrictions are not available" [];
+    write_access
+  ;;
+
+  let add_writable_directories directories t =
+    { t with writable_directories = t.writable_directories @ directories }
+  ;;
+
+  let allow_writes_to_directories writable_directories =
+    { handled_access = write_access_rights (); writable_directories }
+  ;;
+
+  let with_ruleset { handled_access; writable_directories } ~f =
+    let fd = Raw.create_ruleset handled_access |> Fd.unsafe_of_unix_file_descr in
+    Exn.protect
+      ~finally:(fun () -> Fd.close fd)
+      ~f:(fun () ->
+        let raw_fd = Fd.unsafe_to_unix_file_descr fd in
+        List.iter writable_directories ~f:(fun directory ->
+          Raw.add_rule raw_fd (Fd.unsafe_to_unix_file_descr directory) handled_access);
+        f fd)
+  ;;
+
+  let restrict t =
+    with_ruleset t ~f:(fun fd -> Raw.restrict_self (Fd.unsafe_to_unix_file_descr fd))
+  ;;
+end
+
 module Pgid = struct
   type t =
     | New
@@ -43,6 +113,7 @@ external spawn_unix_raw
   -> use_vfork:bool
   -> setpgid:int option
   -> sigprocmask:(Unix.sigprocmask_command * int list) option
+  -> landlock_fd:Unix.file_descr option
   -> pdeathsig:int
   -> int
   = "dune_spawn_unix_byte" "dune_spawn_unix"
@@ -59,27 +130,39 @@ let spawn_unix
       ~use_vfork
       ~setpgid
       ~sigprocmask
+      ~landlock
       ~pdeathsig
   =
   let env = Option.map env ~f:Env.to_list in
   let setpgid = Option.map ~f:Pgid.to_int setpgid in
   let pdeathsig = Signal.to_int pdeathsig in
-  spawn_unix_raw
-    ~env
-    ~cwd:(Working_dir.raw cwd)
-    ~prog
-    ~argv0
-    ~args
-    ~stdin:(Fd.unsafe_to_unix_file_descr stdin)
-    ~stdout:(Fd.unsafe_to_unix_file_descr stdout)
-    ~stderr:(Fd.unsafe_to_unix_file_descr stderr)
-    ~use_vfork
-    ~setpgid
-    ~sigprocmask:
-      (Option.map sigprocmask ~f:(fun (mask, signals) ->
-         mask, List.map signals ~f:Signal.to_int))
-    ~pdeathsig
-  |> Pid.of_int_exn
+  let sigprocmask =
+    Option.map sigprocmask ~f:(fun (mask, signals) ->
+      mask, List.map signals ~f:Signal.to_int)
+  in
+  let spawn landlock_fd =
+    spawn_unix_raw
+      ~env
+      ~cwd:(Working_dir.raw cwd)
+      ~prog
+      ~argv0
+      ~args
+      ~stdin:(Fd.unsafe_to_unix_file_descr stdin)
+      ~stdout:(Fd.unsafe_to_unix_file_descr stdout)
+      ~stderr:(Fd.unsafe_to_unix_file_descr stderr)
+      ~use_vfork
+      ~setpgid
+      ~sigprocmask
+      ~landlock_fd:(Option.map landlock_fd ~f:Fd.unsafe_to_unix_file_descr)
+      ~pdeathsig
+    |> Pid.of_int_exn
+  in
+  (* CR-soon rgrinberg: [landlock] is a policy recipe, so this creates an
+     equivalent kernel ruleset for every process. Create one ruleset per action
+     and reuse its descriptor for every process executing that action. *)
+  match landlock with
+  | None -> spawn None
+  | Some landlock -> Landlock.with_ruleset landlock ~f:(fun fd -> spawn (Some fd))
 ;;
 
 external spawn_windows_raw
@@ -164,6 +247,7 @@ let spawn
       ?setpgid
       ?(pdeathsig = Signal.Kill)
       ?sigprocmask
+      ?landlock
       ()
   =
   (match cwd with
@@ -200,6 +284,7 @@ let spawn
       ~use_vfork
       ~setpgid
       ~sigprocmask
+      ~landlock
       ~pdeathsig
 ;;
 

--- a/otherlibs/stdune/src/spawn.mli
+++ b/otherlibs/stdune/src/spawn.mli
@@ -13,6 +13,23 @@ module Working_dir : sig
   val inherit_ : t
 end
 
+module Landlock : sig
+  type t
+
+  val available : unit -> bool
+
+  (** Handle filesystem writes and allow them only under the directories
+      referenced by the given file descriptors. The descriptors must remain open
+      while the policy is used. *)
+  val allow_writes_to_directories : Fd.t list -> t
+
+  (** Extend a policy with additional writable directories. The descriptors must
+      remain open while the policy is used. *)
+  val add_writable_directories : Fd.t list -> t -> t
+
+  val restrict : t -> unit
+end
+
 (** Process group IDs *)
 module Pgid : sig
   (** Representation of the second parameter to [setpgid]. If a value of this
@@ -88,7 +105,13 @@ end
     On Linux, the sub-process will ask the kernel to send it [pdeathsig] when
     its parent dies. This defaults to [Signal.Kill]. On other platforms,
     [pdeathsig] is ignored. The parent is the thread that created the
-    sub-process, not necessarily the whole parent process. *)
+    sub-process, not necessarily the whole parent process.
+
+    {b Landlock}
+
+    If [landlock] is provided, its restrictions are applied to the child before
+    executing [prog]. This parameter is only supported on systems where
+    [Landlock.available ()] is true. *)
 val spawn
   :  ?env:Env.t
   -> ?cwd:Working_dir.t (* default: [Inherit] *)
@@ -102,6 +125,7 @@ val spawn
   -> ?pdeathsig:Signal.t
   -> ?sigprocmask:Unix.sigprocmask_command * Signal.t list
        (** default: unblock all signals in child *)
+  -> ?landlock:Landlock.t
   -> unit
   -> Pid.t
 

--- a/otherlibs/stdune/src/spawn_stubs.c
+++ b/otherlibs/stdune/src/spawn_stubs.c
@@ -25,10 +25,151 @@
 #include <caml/signals.h>
 
 #include <errno.h>
+#include <stdint.h>
+
+#ifndef ENOSYS
+#define ENOSYS EINVAL
+#endif
 
 #if defined(__linux__)
+#include <fcntl.h>
+#include <unistd.h>
 #include <sys/prctl.h>
+#include <sys/syscall.h>
+#if defined(__has_include)
+#if __has_include(<linux/landlock.h>)
+#define DUNE_SPAWN_HAS_LINUX_LANDLOCK_H 1
+#include <linux/landlock.h>
 #endif
+#endif
+#endif
+
+#if defined(__linux__) && defined(DUNE_SPAWN_HAS_LINUX_LANDLOCK_H) &&           \
+    defined(SYS_landlock_create_ruleset) && defined(SYS_landlock_add_rule) &&  \
+    defined(SYS_landlock_restrict_self) &&                                     \
+    defined(LANDLOCK_CREATE_RULESET_VERSION) &&                                \
+    defined(LANDLOCK_ACCESS_FS_WRITE_FILE) &&                                  \
+    defined(LANDLOCK_ACCESS_FS_REMOVE_DIR) &&                                  \
+    defined(LANDLOCK_ACCESS_FS_REMOVE_FILE) &&                                 \
+    defined(LANDLOCK_ACCESS_FS_MAKE_CHAR) &&                                   \
+    defined(LANDLOCK_ACCESS_FS_MAKE_DIR) &&                                    \
+    defined(LANDLOCK_ACCESS_FS_MAKE_REG) &&                                    \
+    defined(LANDLOCK_ACCESS_FS_MAKE_SOCK) &&                                   \
+    defined(LANDLOCK_ACCESS_FS_MAKE_FIFO) &&                                   \
+    defined(LANDLOCK_ACCESS_FS_MAKE_BLOCK) &&                                  \
+    defined(LANDLOCK_ACCESS_FS_MAKE_SYM) &&                                    \
+    defined(LANDLOCK_ACCESS_FS_REFER) &&                                       \
+    defined(LANDLOCK_ACCESS_FS_TRUNCATE)
+#define DUNE_SPAWN_HAS_LANDLOCK 1
+#else
+#define DUNE_SPAWN_HAS_LANDLOCK 0
+#endif
+
+#if DUNE_SPAWN_HAS_LANDLOCK
+static uint64_t landlock_write_access_rights(int abi)
+{
+  uint64_t access = LANDLOCK_ACCESS_FS_WRITE_FILE |
+                    LANDLOCK_ACCESS_FS_REMOVE_DIR |
+                    LANDLOCK_ACCESS_FS_REMOVE_FILE |
+                    LANDLOCK_ACCESS_FS_MAKE_CHAR |
+                    LANDLOCK_ACCESS_FS_MAKE_DIR |
+                    LANDLOCK_ACCESS_FS_MAKE_REG |
+                    LANDLOCK_ACCESS_FS_MAKE_SOCK |
+                    LANDLOCK_ACCESS_FS_MAKE_FIFO |
+                    LANDLOCK_ACCESS_FS_MAKE_BLOCK |
+                    LANDLOCK_ACCESS_FS_MAKE_SYM;
+  if (abi >= 2) access |= LANDLOCK_ACCESS_FS_REFER;
+  if (abi >= 3) access |= LANDLOCK_ACCESS_FS_TRUNCATE;
+  return access;
+}
+#endif
+
+CAMLprim value dune_spawn_landlock_abi_version(value unit)
+{
+  (void)unit;
+#if DUNE_SPAWN_HAS_LANDLOCK
+  int abi = syscall(SYS_landlock_create_ruleset, NULL, 0,
+                    LANDLOCK_CREATE_RULESET_VERSION);
+  if (abi < 0) {
+    switch (errno) {
+      case ENOSYS:
+      case EOPNOTSUPP:
+      case EINVAL:
+        return Val_int(0);
+      default:
+        uerror("landlock_create_ruleset", Nothing);
+    }
+  }
+  return Val_int(abi);
+#else
+  return Val_int(0);
+#endif
+}
+
+CAMLprim value dune_spawn_landlock_write_access_rights(value v_abi)
+{
+  CAMLparam1(v_abi);
+#if DUNE_SPAWN_HAS_LANDLOCK
+  CAMLreturn(caml_copy_int64(landlock_write_access_rights(Int_val(v_abi))));
+#else
+  CAMLreturn(caml_copy_int64(0));
+#endif
+}
+
+CAMLprim value dune_spawn_landlock_create_ruleset(value v_handled_access)
+{
+#if DUNE_SPAWN_HAS_LANDLOCK
+  struct landlock_ruleset_attr ruleset_attr = {
+    .handled_access_fs = Int64_val(v_handled_access),
+  };
+  int ruleset_fd = syscall(SYS_landlock_create_ruleset, &ruleset_attr,
+                           sizeof(ruleset_attr), 0);
+  if (ruleset_fd < 0) uerror("landlock_create_ruleset", Nothing);
+  return Val_int(ruleset_fd);
+#else
+  (void)v_handled_access;
+  errno = ENOSYS;
+  uerror("landlock_create_ruleset", Nothing);
+#endif
+}
+
+CAMLprim value dune_spawn_landlock_add_rule(value v_ruleset_fd,
+                                            value v_parent_fd,
+                                            value v_allowed_access)
+{
+  CAMLparam3(v_ruleset_fd, v_parent_fd, v_allowed_access);
+#if DUNE_SPAWN_HAS_LANDLOCK
+  struct landlock_path_beneath_attr path_beneath = {
+    .allowed_access = Int64_val(v_allowed_access),
+    .parent_fd = Int_val(v_parent_fd),
+  };
+  if (syscall(SYS_landlock_add_rule, Int_val(v_ruleset_fd),
+              LANDLOCK_RULE_PATH_BENEATH, &path_beneath, 0) < 0)
+    uerror("landlock_add_rule", Nothing);
+#else
+  (void)v_ruleset_fd;
+  (void)v_parent_fd;
+  (void)v_allowed_access;
+  errno = ENOSYS;
+  uerror("landlock_add_rule", Nothing);
+#endif
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value dune_spawn_landlock_restrict_self(value v_ruleset_fd)
+{
+#if DUNE_SPAWN_HAS_LANDLOCK
+  if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0)
+    uerror("prctl", Nothing);
+  if (syscall(SYS_landlock_restrict_self, Int_val(v_ruleset_fd), 0) != 0)
+    uerror("landlock_restrict_self", Nothing);
+  return Val_unit;
+#else
+  (void)v_ruleset_fd;
+  errno = ENOSYS;
+  uerror("landlock_restrict_self", Nothing);
+#endif
+}
 
 #if defined(__APPLE__)
 
@@ -282,6 +423,7 @@ struct spawn_info {
   int std_fds[3];
   int set_pgid;
   pid_t pgid;
+  int landlock_fd;
   int pdeathsig;
   pid_t parent_pid;
   sigset_t child_sigmask;
@@ -316,6 +458,21 @@ static void set_parent_death_signal(int failure_fd, struct spawn_info *info)
 #else
   (void)failure_fd;
   (void)info;
+#endif
+}
+
+static void apply_landlock(int failure_fd, struct spawn_info *info)
+{
+  if (info->landlock_fd == -1) return;
+#if DUNE_SPAWN_HAS_LANDLOCK
+  if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0)
+    subprocess_failure(failure_fd, "prctl", NOTHING);
+  if (syscall(SYS_landlock_restrict_self, info->landlock_fd, 0) != 0)
+    subprocess_failure(failure_fd, "landlock_restrict_self", NOTHING);
+  close(info->landlock_fd);
+#else
+  errno = ENOSYS;
+  subprocess_failure(failure_fd, "landlock_restrict_self", NOTHING);
 #endif
 }
 
@@ -366,6 +523,7 @@ static void subprocess(int failure_fd, struct spawn_info *info)
     close(tmp_fds[fd]);
   }
 
+  apply_landlock(failure_fd, info);
   pthread_sigmask(SIG_SETMASK, &info->child_sigmask, NULL);
 
   execve(info->prog, info->argv, info->env);
@@ -526,6 +684,7 @@ static void init_spawn_info(struct spawn_info *info,
                             value v_stderr,
                             value v_setpgid,
                             value v_sigprocmask,
+                            value v_landlock_fd,
                             value v_pdeathsig)
 {
   extern char ** environ;
@@ -565,6 +724,8 @@ static void init_spawn_info(struct spawn_info *info,
   info->pgid =
     Is_block(v_setpgid) ?
     Long_val(Field(v_setpgid, 0)) : 0;
+  info->landlock_fd =
+    Is_block(v_landlock_fd) ? Int_val(Field(v_landlock_fd, 0)) : -1;
 #if defined(__linux__)
   int pdeathsig = Int_val(v_pdeathsig);
   info->pdeathsig =
@@ -631,6 +792,7 @@ CAMLprim value dune_spawn_unix(value v_env,
                                value v_use_vfork,
                                value v_setpgid,
                                value v_sigprocmask,
+                               value v_landlock_fd,
                                value v_pdeathsig)
 {
   CAMLparam5(v_env, v_cwd, v_prog, v_argv0, v_args);
@@ -658,7 +820,7 @@ CAMLprim value dune_spawn_unix(value v_env,
   struct spawn_info info;
   init_spawn_info(&info, v_env, v_cwd, v_prog, v_argv0, v_args,
                   v_stdin, v_stdout, v_stderr, v_setpgid, v_sigprocmask,
-                  v_pdeathsig);
+                  v_landlock_fd, v_pdeathsig);
 
   short attr_flags = POSIX_SPAWN_SETSIGMASK;
   if (info.set_pgid) attr_flags |= POSIX_SPAWN_SETPGROUP;
@@ -764,6 +926,7 @@ CAMLprim value dune_spawn_unix(value v_env,
                                value v_use_vfork,
                                value v_setpgid,
                                value v_sigprocmask,
+                               value v_landlock_fd,
                                value v_pdeathsig)
 {
   CAMLparam5(v_env, v_cwd, v_prog, v_argv0, v_args);
@@ -780,7 +943,7 @@ CAMLprim value dune_spawn_unix(value v_env,
 
   init_spawn_info(&info, v_env, v_cwd, v_prog, v_argv0, v_args,
                   v_stdin, v_stdout, v_stderr, v_setpgid, v_sigprocmask,
-                  v_pdeathsig);
+                  v_landlock_fd, v_pdeathsig);
 
   caml_enter_blocking_section();
   enter_safe_pipe_section();
@@ -906,6 +1069,7 @@ CAMLprim value dune_spawn_unix(value v_env,
                                value v_use_vfork,
                                value v_setpgid,
                                value v_sigprocmask,
+                               value v_landlock_fd,
                                value v_pdeathsig)
 {
   (void)v_env;
@@ -919,6 +1083,7 @@ CAMLprim value dune_spawn_unix(value v_env,
   (void)v_use_vfork;
   (void)v_setpgid;
   (void)v_sigprocmask;
+  (void)v_landlock_fd;
   (void)v_pdeathsig;
   unix_error(ENOSYS, "spawn_unix", Nothing);
 }
@@ -1024,7 +1189,8 @@ CAMLprim value dune_spawn_unix_byte(value * argv)
                     argv[8],
                     argv[9],
                     argv[10],
-                    argv[11]);
+                    argv[11],
+                    argv[12]);
 }
 
 CAMLprim value dune_spawn_windows_byte(value * argv)

--- a/otherlibs/stdune/test/spawn/dune
+++ b/otherlibs/stdune/test/spawn/dune
@@ -3,6 +3,7 @@
  (inline_tests
   (deps
    exe/hello.exe
+   exe/landlock_probe.exe
    exe/list_files.exe
    exe/print_env.exe
    pgid_test/checkpgid.exe

--- a/otherlibs/stdune/test/spawn/exe/dune
+++ b/otherlibs/stdune/test/spawn/exe/dune
@@ -1,3 +1,3 @@
 (executables
- (names hello list_files print_env)
+ (names hello landlock_probe list_files print_env)
  (libraries unix))

--- a/otherlibs/stdune/test/spawn/exe/landlock_probe.ml
+++ b/otherlibs/stdune/test/spawn/exe/landlock_probe.ml
@@ -1,0 +1,46 @@
+let create path =
+  let fd = Unix.openfile path [ O_WRONLY; O_CREAT; O_TRUNC ] 0o600 in
+  Unix.close fd
+;;
+
+let expect_denied f =
+  match f () with
+  | () -> exit 1
+  | exception Unix.Unix_error ((EACCES | EPERM | EXDEV), _, _) -> ()
+;;
+
+let access_rights allowed denied =
+  Unix.truncate (Filename.concat allowed "truncate") 0;
+  Unix.unlink (Filename.concat allowed "delete");
+  Unix.symlink "target" (Filename.concat allowed "symlink");
+  Unix.rename
+    (Filename.concat allowed "rename-source")
+    (Filename.concat allowed "rename-target");
+  Unix.rmdir (Filename.concat allowed "remove-dir");
+  Unix.mkdir (Filename.concat allowed "mkdir") 0o700;
+  expect_denied (fun () -> Unix.truncate (Filename.concat denied "truncate") 0);
+  expect_denied (fun () -> Unix.unlink (Filename.concat denied "delete"));
+  expect_denied (fun () -> Unix.symlink "target" (Filename.concat denied "symlink"));
+  expect_denied (fun () ->
+    Unix.rename
+      (Filename.concat denied "rename-source")
+      (Filename.concat denied "rename-target"));
+  expect_denied (fun () ->
+    Unix.rename
+      (Filename.concat allowed "reparent-source")
+      (Filename.concat denied "reparent-target"));
+  expect_denied (fun () -> Unix.rmdir (Filename.concat denied "remove-dir"));
+  expect_denied (fun () -> Unix.mkdir (Filename.concat denied "mkdir") 0o700)
+;;
+
+let () =
+  match Array.to_list Sys.argv with
+  | [ _; allowed; denied ] ->
+    create allowed;
+    expect_denied (fun () -> create denied)
+  | [ _; "write-three"; allowed1; allowed2; allowed3; denied ] ->
+    List.iter create [ allowed1; allowed2; allowed3 ];
+    expect_denied (fun () -> create denied)
+  | [ _; "access-rights"; allowed; denied ] -> access_rights allowed denied
+  | _ -> exit 2
+;;

--- a/otherlibs/stdune/test/spawn/landlock_tests.ml
+++ b/otherlibs/stdune/test/spawn/landlock_tests.ml
@@ -1,0 +1,193 @@
+open Stdune
+module Exn = Exn
+module Proc = Proc
+module Spawn = Spawn
+
+let landlock_probe = Filename.concat (Sys.getcwd ()) "exe/landlock_probe.exe"
+
+let open_directory path =
+  Unix.openfile path [ O_RDONLY; O_CLOEXEC ] 0 |> Fd.unsafe_of_unix_file_descr
+;;
+
+let wait pid =
+  match Proc.wait (Proc.Pid pid) [] with
+  | None -> failwith "process was not reaped"
+  | Some { status = WEXITED 0; _ } -> ()
+  | Some { status = WEXITED n; _ } -> Printf.ksprintf failwith "exited with code %d" n
+  | Some { status = WSIGNALED n; _ } -> Printf.ksprintf failwith "got signal %d" n
+  | Some { status = WSTOPPED n; _ } -> Printf.ksprintf failwith "stopped with signal %d" n
+;;
+
+let with_landlock f =
+  if Spawn.Landlock.available ()
+  then f ()
+  else if
+    String.equal (Option.value (Sys.getenv_opt "CI") ~default:"false") "true"
+    && Sys.file_exists "/proc/sys/kernel"
+  then failwith "Landlock must be available in Linux CI"
+;;
+
+let with_open_directories paths ~f =
+  let fds = List.map paths ~f:open_directory in
+  Exn.protect ~finally:(fun () -> List.iter fds ~f:Fd.close) ~f:(fun () -> f fds)
+;;
+
+let create_file path = close_out (open_out path)
+
+let remove_if_exists path =
+  match Unix.lstat path with
+  | { st_kind = S_DIR; _ } -> Unix.rmdir path
+  | _ -> Unix.unlink path
+  | exception Unix.Unix_error (ENOENT, _, _) -> ()
+;;
+
+let run_landlock_probe dir =
+  with_landlock (fun () ->
+    let allowed_dir = Filename.concat dir "allowed" in
+    let denied_dir = Filename.concat dir "denied" in
+    let allowed_marker = Filename.concat allowed_dir "marker" in
+    let denied_marker = Filename.concat denied_dir "marker" in
+    let cleanup () =
+      List.iter [ allowed_marker; denied_marker ] ~f:remove_if_exists;
+      List.iter [ allowed_dir; denied_dir; dir ] ~f:remove_if_exists
+    in
+    cleanup ();
+    List.iter [ dir; allowed_dir; denied_dir ] ~f:(fun path -> Unix.mkdir path 0o700);
+    Exn.protect ~finally:cleanup ~f:(fun () ->
+      with_open_directories [ allowed_dir ] ~f:(fun allowed_dirs ->
+        let landlock = Spawn.Landlock.allow_writes_to_directories allowed_dirs in
+        wait
+          (Spawn.spawn
+             ~landlock
+             ~prog:landlock_probe
+             ~argv0:"landlock_probe.exe"
+             ~args:(Array.Immutable.of_list [ allowed_marker; denied_marker ])
+             ()));
+      create_file denied_marker))
+;;
+
+let%expect_test "landlock rules follow file descriptors across renames" =
+  with_landlock (fun () ->
+    let root = "landlock-renamed" in
+    let original = Filename.concat root "original" in
+    let renamed = Filename.concat root "renamed" in
+    let allowed_marker = Filename.concat renamed "allowed" in
+    let denied_marker = Filename.concat original "denied" in
+    let cleanup () =
+      List.iter [ allowed_marker; denied_marker ] ~f:remove_if_exists;
+      List.iter [ original; renamed; root ] ~f:remove_if_exists
+    in
+    cleanup ();
+    Unix.mkdir root 0o700;
+    Unix.mkdir original 0o700;
+    Exn.protect ~finally:cleanup ~f:(fun () ->
+      with_open_directories [ original ] ~f:(fun original_fds ->
+        let landlock = Spawn.Landlock.allow_writes_to_directories original_fds in
+        Unix.rename original renamed;
+        Unix.mkdir original 0o700;
+        wait
+          (Spawn.spawn
+             ~landlock
+             ~prog:landlock_probe
+             ~argv0:"landlock_probe.exe"
+             ~args:(Array.Immutable.of_list [ allowed_marker; denied_marker ])
+             ()))));
+  [%expect {| |}]
+;;
+
+let%expect_test "landlock when spawning" =
+  run_landlock_probe "landlock-spawn";
+  [%expect {| |}]
+;;
+
+let%expect_test "extend a policy with multiple writable directories" =
+  with_landlock (fun () ->
+    let root = "landlock-multiple-directories" in
+    let base = Filename.concat root "base" in
+    let added1 = Filename.concat root "added1" in
+    let added2 = Filename.concat root "added2" in
+    let denied = Filename.concat root "denied" in
+    let directories = [ base; added1; added2; denied ] in
+    let base_marker = Filename.concat base "marker" in
+    let added1_marker = Filename.concat added1 "marker" in
+    let added2_marker = Filename.concat added2 "marker" in
+    let denied_marker = Filename.concat denied "marker" in
+    let markers = [ base_marker; added1_marker; added2_marker; denied_marker ] in
+    let cleanup () =
+      List.iter markers ~f:remove_if_exists;
+      List.iter (directories @ [ root ]) ~f:remove_if_exists
+    in
+    cleanup ();
+    Unix.mkdir root 0o700;
+    List.iter directories ~f:(fun path -> Unix.mkdir path 0o700);
+    Exn.protect ~finally:cleanup ~f:(fun () ->
+      with_open_directories directories ~f:(function
+        | [ base_fd; added1_fd; added2_fd; _ ] ->
+          let landlock = Spawn.Landlock.allow_writes_to_directories [ base_fd ] in
+          let landlock =
+            Spawn.Landlock.add_writable_directories [ added1_fd; added2_fd ] landlock
+          in
+          wait
+            (Spawn.spawn
+               ~landlock
+               ~prog:landlock_probe
+               ~argv0:"landlock_probe.exe"
+               ~args:
+                 (Array.Immutable.of_list
+                    [ "write-three"
+                    ; base_marker
+                    ; added1_marker
+                    ; added2_marker
+                    ; denied_marker
+                    ])
+               ())
+        | _ -> failwith "unexpected number of directory descriptors")));
+  [%expect {| |}]
+;;
+
+let%expect_test "write access rights" =
+  with_landlock (fun () ->
+    let root = "landlock-access-rights" in
+    let allowed = Filename.concat root "allowed" in
+    let denied = Filename.concat root "denied" in
+    let names = [ "truncate"; "delete"; "rename-source"; "reparent-source" ] in
+    let files =
+      List.concat_map [ allowed; denied ] ~f:(fun dir ->
+        List.map names ~f:(Filename.concat dir))
+    in
+    let directories =
+      List.concat_map [ allowed; denied ] ~f:(fun dir ->
+        [ Filename.concat dir "remove-dir"; Filename.concat dir "mkdir" ])
+    in
+    let symlinks =
+      List.map [ allowed; denied ] ~f:(fun dir -> Filename.concat dir "symlink")
+    in
+    let rename_targets =
+      [ Filename.concat allowed "rename-target"
+      ; Filename.concat denied "rename-target"
+      ; Filename.concat denied "reparent-target"
+      ]
+    in
+    let cleanup () =
+      List.iter (symlinks @ rename_targets @ files) ~f:remove_if_exists;
+      List.iter (directories @ [ allowed; denied; root ]) ~f:remove_if_exists
+    in
+    cleanup ();
+    Unix.mkdir root 0o700;
+    List.iter [ allowed; denied ] ~f:(fun path -> Unix.mkdir path 0o700);
+    List.iter files ~f:create_file;
+    List.iter
+      [ Filename.concat allowed "remove-dir"; Filename.concat denied "remove-dir" ]
+      ~f:(fun path -> Unix.mkdir path 0o700);
+    Exn.protect ~finally:cleanup ~f:(fun () ->
+      with_open_directories [ allowed ] ~f:(fun allowed_fds ->
+        let landlock = Spawn.Landlock.allow_writes_to_directories allowed_fds in
+        wait
+          (Spawn.spawn
+             ~landlock
+             ~prog:landlock_probe
+             ~argv0:"landlock_probe.exe"
+             ~args:(Array.Immutable.of_list [ "access-rights"; allowed; denied ])
+             ()))));
+  [%expect {| |}]
+;;

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -454,6 +454,7 @@ module Full = struct
       ; env : Env.t
       ; locks : Path.t list
       ; can_go_in_shared_cache : bool
+      ; can_use_sandbox_policy : bool
       ; sandbox : Sandbox_config.t
       ; corrections : Corrections.t option
       }
@@ -463,6 +464,7 @@ module Full = struct
       ; env = Env.empty
       ; locks = []
       ; can_go_in_shared_cache = true
+      ; can_use_sandbox_policy = true
       ; sandbox = Sandbox_config.default
       ; corrections = None
       }
@@ -480,11 +482,22 @@ module Full = struct
           [ "x", Corrections.to_dyn x; "y", Corrections.to_dyn y ]
     ;;
 
-    let combine { action; env; locks; can_go_in_shared_cache; sandbox; corrections } x =
+    let combine
+          { action
+          ; env
+          ; locks
+          ; can_go_in_shared_cache
+          ; can_use_sandbox_policy
+          ; sandbox
+          ; corrections
+          }
+          x
+      =
       { action = combine action x.action
       ; env = Env.extend_env env x.env
       ; locks = locks @ x.locks
       ; can_go_in_shared_cache = can_go_in_shared_cache && x.can_go_in_shared_cache
+      ; can_use_sandbox_policy = can_use_sandbox_policy && x.can_use_sandbox_policy
       ; sandbox = Sandbox_config.inter sandbox x.sandbox
       ; corrections = combine_corrections corrections x.corrections
       }
@@ -502,7 +515,14 @@ module Full = struct
         ?corrections
         action
     =
-    { action; env; locks; can_go_in_shared_cache; sandbox; corrections }
+    { action
+    ; env
+    ; locks
+    ; can_go_in_shared_cache
+    ; can_use_sandbox_policy = true
+    ; sandbox
+    ; corrections
+    }
   ;;
 
   let map t ~f = { t with action = f t.action }
@@ -513,6 +533,7 @@ module Full = struct
     { t with can_go_in_shared_cache = t.can_go_in_shared_cache && b }
   ;;
 
+  let disable_sandbox_policy t = { t with can_use_sandbox_policy = false }
   let add_sandbox s t = { t with sandbox = Sandbox_config.inter t.sandbox s }
 
   let add_corrections corrections t =

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -105,6 +105,8 @@ module Full : sig
     ; env : Env.t
     ; locks : Path.t list
     ; can_go_in_shared_cache : bool
+    ; can_use_sandbox_policy : bool
+      (** Whether spawned processes can be subject to an additional sandbox policy. *)
     ; sandbox : Sandbox_config.t
     ; corrections : Corrections.t option
     }
@@ -121,17 +123,14 @@ module Full : sig
 
   val map : t -> f:(action -> action) -> t
 
-  (** The various [add_xxx] functions merge the given value with existing field
-      of the action. Put another way, [add_xxx x t] is the same as:
-
-      {[
-        combine t (make ~xxx:x (Progn []))
-      ]} *)
+  (** The various [add_xxx] functions merge the given value with the existing
+      field of the action. *)
 
   val add_env : Env.t -> t -> t
   val add_locks : Path.t list -> t -> t
   val add_sandbox : Sandbox_config.t -> t -> t
   val add_can_go_in_shared_cache : bool -> t -> t
+  val disable_sandbox_policy : t -> t
   val add_corrections : Corrections.t -> t -> t
 
   include Monoid with type t := t

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -75,6 +75,7 @@ let exec_run ~(ectx : context) ~(eenv : env) ~can_run_in_action_runner prog args
       ~stderr_to:eenv.stderr_to
       ~stdin_from:eenv.stdin_from
       ~metadata
+      ?sandbox:ectx.sandbox
       prog
       args
   in
@@ -221,7 +222,9 @@ let rec exec t ~ectx ~eenv : Done_or_more_deps.t Fiber.t =
     Fiber.return Done
   | Pipe (outputs, l) -> exec_pipe ~ectx ~eenv outputs l
   | Diff diff ->
-    let+ () = Diff_action.exec ~patch_back:None ectx.rule_loc diff in
+    let+ () =
+      Diff_action.exec ~sandbox:ectx.sandbox ~patch_back:None ectx.rule_loc diff
+    in
     Done
   | Extension (module A) ->
     let metadata =
@@ -347,18 +350,19 @@ type input =
   ; env : Env.t
   ; rule_loc : Loc.t
   ; execution_parameters : Execution_parameters.t
+  ; sandbox : Process.Sandbox.t option
   ; action : Action.t
   }
 
 let exec
-      { targets; root; context; env; rule_loc; execution_parameters; action = t }
+      { targets; root; context; env; rule_loc; execution_parameters; sandbox; action = t }
       ~build_deps
   =
   let ectx =
     let metadata =
       Process_metadata.create ~purpose:(Process_metadata.Build_job targets) ()
     in
-    { targets; metadata; context; rule_loc; build_deps }
+    { targets; metadata; context; sandbox; rule_loc; build_deps }
   and eenv =
     let env =
       match

--- a/src/dune_engine/action_exec.mli
+++ b/src/dune_engine/action_exec.mli
@@ -34,6 +34,7 @@ type input =
   ; env : Env.t
   ; rule_loc : Loc.t
   ; execution_parameters : Execution_parameters.t
+  ; sandbox : Process.Sandbox.t option
   ; action : Action.t
   }
 

--- a/src/dune_engine/action_intf.ml
+++ b/src/dune_engine/action_intf.ml
@@ -109,6 +109,7 @@ module Exec = struct
     { targets : Targets.Validated.t option
     ; context : Build_context.t option
     ; metadata : Process_metadata.t
+    ; sandbox : Process.Sandbox.t option
     ; rule_loc : Loc.t
     ; build_deps : Dep.Set.t -> Dep.Facts.t Fiber.t
     }

--- a/src/dune_engine/action_plugin.ml
+++ b/src/dune_engine/action_plugin.ml
@@ -24,8 +24,8 @@ let to_dune_dep_set =
 
 let exec ~(ectx : context) ~(eenv : env) prog args =
   let open Fiber.O in
-  let run_arguments_fn = Temp.create File ~prefix:"dune" ~suffix:"run" in
-  let response_fn = Temp.create File ~prefix:"dune" ~suffix:"response" in
+  let run_arguments_fn = Dtemp.action File ~prefix:"dune" ~suffix:"run" in
+  let response_fn = Dtemp.action File ~prefix:"dune" ~suffix:"response" in
   let run_arguments =
     let targets =
       match ectx.targets with
@@ -67,6 +67,7 @@ let exec ~(ectx : context) ~(eenv : env) prog args =
       ~stderr_to:eenv.stderr_to
       ~stdin_from:eenv.stdin_from
       ~metadata:ectx.metadata
+      ?sandbox:ectx.sandbox
       prog
       args
   in

--- a/src/dune_engine/action_trace.ml
+++ b/src/dune_engine/action_trace.ml
@@ -8,6 +8,8 @@ let action_trace_root =
      root)
 ;;
 
+let root () = Path.build (Lazy.force action_trace_root)
+
 type t =
   { dir : Path.Build.t
   ; digest : string

--- a/src/dune_engine/action_trace.mli
+++ b/src/dune_engine/action_trace.mli
@@ -5,6 +5,7 @@ open Import
 
 type t
 
+val root : unit -> Path.t
 val add_to_env : t -> Env.t -> Env.t
 val create : Dune_digest.t -> t
 val collect : t -> unit Fiber.t

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -263,7 +263,7 @@ module Internal = struct
 
   (* The current version of the rule digest scheme. We should increment it when
      making any changes to the scheme, to avoid collisions. *)
-  let rule_digest_version = 31
+  let rule_digest_version = 33
 
   let compute_rule_digest
         (rule : Rule.t)
@@ -276,6 +276,7 @@ module Internal = struct
         ; env
         ; locks
         ; can_go_in_shared_cache
+        ; can_use_sandbox_policy
         ; sandbox = _ (* already taken into account in [sandbox_mode] *)
         ; corrections
         }
@@ -285,7 +286,10 @@ module Internal = struct
     let execution_parameters =
       if Action.runs_process action
       then execution_parameters
-      else Execution_parameters.set_sandbox_actions false execution_parameters
+      else
+        execution_parameters
+        |> Execution_parameters.set_sandbox_actions false
+        |> Execution_parameters.set_use_sandbox_policy false
     in
     let digest =
       let d = Digest.Manual.create () in
@@ -296,6 +300,7 @@ module Internal = struct
       digest_target_paths d rule;
       Action.digest d action;
       Digest.Manual.bool d can_go_in_shared_cache;
+      Digest.Manual.bool d can_use_sandbox_policy;
       digest_locks d locks;
       Digest.Manual.repr d Repr.(option Corrections.repr) corrections;
       Digest.Manual.digest d (Execution_parameters.digest execution_parameters);
@@ -364,6 +369,10 @@ module Internal = struct
     | File_target, Dir_target _ | Dir_target _, File_target -> false
   ;;
 
+  let process_sandbox_base =
+    lazy (Process.Sandbox.create_base ~action_trace_root:(Action_trace.root ()))
+  ;;
+
   let rec build_alias alias = Memo.exec (Lazy.force build_alias_memo) alias
   and build_file path = Memo.exec (Lazy.force build_file_memo) path >>| fst
 
@@ -423,6 +432,7 @@ module Internal = struct
         ; env
         ; locks
         ; can_go_in_shared_cache = _
+        ; can_use_sandbox_policy
         ; sandbox = _
         ; corrections
         }
@@ -430,7 +440,20 @@ module Internal = struct
       action
     in
     let execute_action sandbox =
-      let is_sandboxed = Sandbox.is_sandboxed sandbox in
+      let action_trace = Action_trace.create rule_digest in
+      let sandbox_root = Sandbox.root sandbox in
+      let is_sandboxed = Option.is_some sandbox_root in
+      let process_sandbox =
+        match sandbox_root with
+        | None -> None
+        | Some root ->
+          if
+            can_use_sandbox_policy
+            && Action.runs_process action
+            && Execution_parameters.use_sandbox_policy execution_parameters
+          then Some (Process.Sandbox.for_action (Lazy.force process_sandbox_base) ~root)
+          else None
+      in
       let action = if is_sandboxed then Action.sandbox action sandbox else action in
       let action =
         (* We must add the creation of the stamp file after sandboxing it, as
@@ -455,41 +478,49 @@ module Internal = struct
         | Some context -> context.build_dir
       in
       let root = Path.build (Sandbox.map_path sandbox root) in
-      let action_trace = Action_trace.create rule_digest in
-      with_locks locks ~f:(fun () ->
-        let* action_exec_result =
-          let input =
-            let env = Action_trace.add_to_env action_trace env in
-            { Action_exec.root
-            ; context (* can be derived from the root *)
-            ; env
-            ; targets = Some targets
-            ; rule_loc = loc
-            ; execution_parameters
-            ; action
-            }
-          in
-          let build_deps deps = Memo.run (build_deps deps) in
-          Action_exec.exec input ~build_deps
-        in
-        let* action_exec_result = Action_exec.Exec_result.ok_exn action_exec_result in
-        let* () = Action_trace.collect action_trace in
-        let+ () =
-          if not is_sandboxed
-          then Fiber.return ()
-          else (
-            (* The stamp file for anonymous actions is always created outside
-               the sandbox, so we can't move it. *)
-            let should_be_skipped =
-              match rule_kind with
-              | Normal_rule -> fun (_ : Path.Build.t) -> false
-              | Anonymous_action { stamp_file; _ } -> Path.Build.equal stamp_file
+      let execute () =
+        with_locks locks ~f:(fun () ->
+          let* action_exec_result =
+            let input =
+              let env = Action_trace.add_to_env action_trace env in
+              { Action_exec.root
+              ; context (* can be derived from the root *)
+              ; env
+              ; targets = Some targets
+              ; rule_loc = loc
+              ; execution_parameters
+              ; sandbox = process_sandbox
+              ; action
+              }
             in
-            Sandbox.move_targets_to_build_dir sandbox ~should_be_skipped ~targets)
-        in
-        match Targets.Produced.of_validated targets with
-        | Ok produced_targets -> { Exec_result.produced_targets; action_exec_result }
-        | Error error -> User_error.raise ~loc (Targets.Produced.Error.message error))
+            let build_deps deps = Memo.run (build_deps deps) in
+            Action_exec.exec input ~build_deps
+          in
+          let* action_exec_result = Action_exec.Exec_result.ok_exn action_exec_result in
+          let* () = Action_trace.collect action_trace in
+          let+ () =
+            if not is_sandboxed
+            then Fiber.return ()
+            else (
+              (* The stamp file for anonymous actions is always created outside
+               the sandbox, so we can't move it. *)
+              let should_be_skipped =
+                match rule_kind with
+                | Normal_rule -> fun (_ : Path.Build.t) -> false
+                | Anonymous_action { stamp_file; _ } -> Path.Build.equal stamp_file
+              in
+              Sandbox.move_targets_to_build_dir sandbox ~should_be_skipped ~targets)
+          in
+          match Targets.Produced.of_validated targets with
+          | Ok produced_targets -> { Exec_result.produced_targets; action_exec_result }
+          | Error error -> User_error.raise ~loc (Targets.Produced.Error.message error))
+      in
+      match process_sandbox with
+      | None -> execute ()
+      | Some process_sandbox ->
+        Fiber.finalize execute ~finally:(fun () ->
+          Process.Sandbox.destroy process_sandbox;
+          Fiber.return ())
     in
     let deps, sandbox_dirs =
       match sandbox_mode with
@@ -766,7 +797,14 @@ module Internal = struct
     ignore observing_facts;
     let digest =
       let { Rule.Anonymous_action.action =
-              { action; env; locks; can_go_in_shared_cache; sandbox; corrections }
+              { action
+              ; env
+              ; locks
+              ; can_go_in_shared_cache
+              ; can_use_sandbox_policy
+              ; sandbox
+              ; corrections
+              }
           ; loc = _
           ; dir
           }
@@ -791,6 +829,7 @@ module Internal = struct
         Digest.Manual.string d (Path.Build.to_string dir);
         Digest.Manual.bool d capture_stdout;
         Digest.Manual.bool d can_go_in_shared_cache;
+        Digest.Manual.bool d can_use_sandbox_policy;
         digest_sandbox_config d sandbox;
         Digest.Manual.repr d Repr.(option Corrections.repr) corrections;
         Digest.Manual.get d

--- a/src/dune_engine/diff_action.ml
+++ b/src/dune_engine/diff_action.ml
@@ -73,12 +73,13 @@ let promotion source_file =
   }
 ;;
 
-let run_change loc ~patch_back (mode : Diff.Mode.t) = function
+let run_change loc ~patch_back ~sandbox (mode : Diff.Mode.t) = function
   | Message messages -> User_error.raise ~loc messages
   | File_diff { source_file; file1; file2 } ->
     (match mode with
      | Text ->
        Print_diff.print
+         ~sandbox
          ~patch_back
          (promotion source_file)
          file1
@@ -295,6 +296,7 @@ let plan_diff loc { Diff.optional; file1; file2; mode; directory_diffs } =
 let exec_plan
       loc
       ~patch_back
+      ~sandbox
       { Diff.optional; mode; file1; file2; _ }
       ({ changes; promotions } : plan)
   =
@@ -308,7 +310,8 @@ let exec_plan
       is_copied_from_source_tree (Path.build file2)
     in
     Fiber.finalize
-      (fun () -> Fiber.parallel_iter changes ~f:(run_change loc ~patch_back mode))
+      (fun () ->
+         Fiber.parallel_iter changes ~f:(run_change loc ~patch_back ~sandbox mode))
       ~finally:(fun () ->
         (match optional with
          | false ->
@@ -321,4 +324,6 @@ let exec_plan
         Fiber.return ())
 ;;
 
-let exec loc ~patch_back diff = exec_plan loc ~patch_back diff (plan_diff loc diff)
+let exec ~sandbox loc ~patch_back diff =
+  exec_plan loc ~patch_back ~sandbox diff (plan_diff loc diff)
+;;

--- a/src/dune_engine/diff_action.mli
+++ b/src/dune_engine/diff_action.mli
@@ -1,7 +1,8 @@
 open Import
 
 val exec
-  :  Loc.t
+  :  sandbox:Process.Sandbox.t option
+  -> Loc.t
   -> patch_back:Path.t option
   -> (Path.t, Path.Build.t) Stdune.Action_types.Diff.t
   -> unit Fiber.t

--- a/src/dune_engine/dtemp.ml
+++ b/src/dune_engine/dtemp.ml
@@ -1,9 +1,10 @@
 open Import
 
 let dune_temp_dir = lazy (Temp.create Dir ~prefix:"dune" ~suffix:"internal")
-let action_temp_dir = lazy (Temp.create Dir ~prefix:"dune" ~suffix:"actions")
+let action_temp_dir_ = lazy (Temp.create Dir ~prefix:"dune" ~suffix:"actions")
+let action_temp_dir () = Lazy.force action_temp_dir_
 let dune_temp_dir_value = lazy (Path.to_absolute_filename (Lazy.force dune_temp_dir))
-let action_temp_dir_value = lazy (Path.to_absolute_filename (Lazy.force action_temp_dir))
+let action_temp_dir_value = lazy (Path.to_absolute_filename (action_temp_dir ()))
 
 let temp_dir_value (purpose : Process_metadata.purpose) =
   match purpose with
@@ -15,8 +16,8 @@ let file ~prefix ~suffix =
   Temp.temp_in_dir File ~dir:(Lazy.force dune_temp_dir) ~suffix ~prefix
 ;;
 
-let action_dir ~prefix ~suffix =
-  Temp.temp_in_dir Dir ~dir:(Lazy.force action_temp_dir) ~suffix ~prefix
+let action what ~prefix ~suffix =
+  Temp.temp_in_dir what ~dir:(action_temp_dir ()) ~suffix ~prefix
 ;;
 
 let add_to_env env ~purpose =
@@ -27,6 +28,6 @@ let add_to_env env ~purpose =
 let destroy = Temp.destroy
 
 let clear () =
-  List.iter [ dune_temp_dir; action_temp_dir ] ~f:(fun temp_dir ->
+  List.iter [ dune_temp_dir; action_temp_dir_ ] ~f:(fun temp_dir ->
     if Lazy.is_val temp_dir then Temp.clear_dir (Lazy.force temp_dir))
 ;;

--- a/src/dune_engine/dtemp.mli
+++ b/src/dune_engine/dtemp.mli
@@ -2,11 +2,14 @@
 
 open Import
 
+(** The temporary directory exposed to build actions. *)
+val action_temp_dir : unit -> Path.t
+
 (** This returns a build path, but we don't rely on that *)
 val file : prefix:string -> suffix:string -> Path.t
 
-(** Create a temporary directory that build actions may access. *)
-val action_dir : prefix:string -> suffix:string -> Path.t
+(** Create a temporary file or directory that build actions may access. *)
+val action : Temp.what -> prefix:string -> suffix:string -> Path.t
 
 (** Set the platform's temporary-directory environment variable. Build jobs use
     the action directory and internal jobs use Dune's directory. *)

--- a/src/dune_engine/execution_parameters.ml
+++ b/src/dune_engine/execution_parameters.ml
@@ -47,6 +47,7 @@ type t =
   ; action_project_root : Path.Source.t option
   ; should_remove_write_permissions_on_generated_files : bool
   ; sandbox_actions : bool
+  ; use_sandbox_policy : bool
   }
 
 let equal
@@ -59,6 +60,7 @@ let equal
       ; action_project_root
       ; should_remove_write_permissions_on_generated_files
       ; sandbox_actions
+      ; use_sandbox_policy
       }
       t
   =
@@ -75,6 +77,7 @@ let equal
        should_remove_write_permissions_on_generated_files
        t.should_remove_write_permissions_on_generated_files
   && Bool.equal sandbox_actions t.sandbox_actions
+  && Bool.equal use_sandbox_policy t.use_sandbox_policy
 ;;
 
 let hash
@@ -87,6 +90,7 @@ let hash
       ; action_project_root
       ; should_remove_write_permissions_on_generated_files
       ; sandbox_actions
+      ; use_sandbox_policy
       }
   =
   Poly.hash
@@ -98,7 +102,8 @@ let hash
     , workspace_root_to_build_path_prefix_map
     , action_project_root
     , should_remove_write_permissions_on_generated_files
-    , sandbox_actions )
+    , sandbox_actions
+    , use_sandbox_policy )
 ;;
 
 let bool_to_int b = if b then 1 else 0
@@ -113,6 +118,7 @@ let digest
       ; action_project_root
       ; should_remove_write_permissions_on_generated_files
       ; sandbox_actions
+      ; use_sandbox_policy
       }
   =
   let d = Digest.Manual.create () in
@@ -128,6 +134,7 @@ let digest
     lor (bool_to_int root_is_set lsl 5)
     lor (bool_to_int should_remove_write_permissions_on_generated_files lsl 6)
     lor (bool_to_int sandbox_actions lsl 7)
+    lor (bool_to_int use_sandbox_policy lsl 8)
   in
   Digest.Manual.int d flags;
   Digest.Manual.int d action_stdout_limit;
@@ -152,6 +159,7 @@ let make
       ~action_project_root
       ~should_remove_write_permissions_on_generated_files
       ~sandbox_actions
+      ~use_sandbox_policy
   =
   { action_stdout_on_success
   ; action_stderr_on_success
@@ -162,6 +170,7 @@ let make
   ; action_project_root
   ; should_remove_write_permissions_on_generated_files
   ; sandbox_actions
+  ; use_sandbox_policy
   }
 ;;
 
@@ -191,6 +200,7 @@ let repr =
         Repr.bool
         ~get:(fun t -> t.should_remove_write_permissions_on_generated_files)
     ; Repr.field "sandbox_actions" Repr.bool ~get:(fun t -> t.sandbox_actions)
+    ; Repr.field "use_sandbox_policy" Repr.bool ~get:(fun t -> t.use_sandbox_policy)
     ]
 ;;
 
@@ -208,6 +218,7 @@ let builtin_default =
     ~action_project_root:None
     ~should_remove_write_permissions_on_generated_files:true
     ~sandbox_actions:false
+    ~use_sandbox_policy:false
 ;;
 
 let set_action_stdout_on_success x t = { t with action_stdout_on_success = x }
@@ -220,6 +231,7 @@ let set_workspace_root_to_build_path_prefix_map x t =
 
 let set_action_project_root x t = { t with action_project_root = x }
 let set_sandbox_actions x t = { t with sandbox_actions = x }
+let set_use_sandbox_policy x t = { t with use_sandbox_policy = x }
 
 let set_should_remove_write_permissions_on_generated_files x t =
   { t with should_remove_write_permissions_on_generated_files = x }
@@ -232,6 +244,7 @@ let action_stderr_on_success t = t.action_stderr_on_success
 let action_stdout_limit t = t.action_stdout_limit
 let action_stderr_limit t = t.action_stderr_limit
 let action_project_root t = t.action_project_root
+let use_sandbox_policy t = t.use_sandbox_policy
 
 let should_remove_write_permissions_on_generated_files t =
   t.should_remove_write_permissions_on_generated_files

--- a/src/dune_engine/execution_parameters.mli
+++ b/src/dune_engine/execution_parameters.mli
@@ -64,6 +64,7 @@ val set_workspace_root_to_build_path_prefix_map
 val set_action_project_root : Path.Source.t option -> t -> t
 val set_should_remove_write_permissions_on_generated_files : bool -> t -> t
 val set_sandbox_actions : bool -> t -> t
+val set_use_sandbox_policy : bool -> t -> t
 
 (** As configured by [init] *)
 val default : t Memo.t
@@ -78,6 +79,7 @@ val action_stdout_limit : t -> Action_output_limit.t
 val action_stderr_limit : t -> Action_output_limit.t
 val workspace_root_to_build_path_prefix_map : t -> Workspace_root_for_build_prefix_map.t
 val action_project_root : t -> Path.Source.t option
+val use_sandbox_policy : t -> bool
 
 (** {1 Initialisation} *)
 

--- a/src/dune_engine/print_diff.ml
+++ b/src/dune_engine/print_diff.ml
@@ -42,8 +42,12 @@ module With_fallback : sig
 
   val fail : User_message.t -> t
   val run : command -> fallback:t -> t
-  val exec : t -> _ Fiber.t
-  val capture : t -> (Diff.t, User_message.t) result Fiber.t
+  val exec : t -> sandbox:Process.Sandbox.t option -> _ Fiber.t
+
+  val capture
+    :  t
+    -> sandbox:Process.Sandbox.t option
+    -> (Diff.t, User_message.t) result Fiber.t
 end = struct
   type t =
     { commands : command list
@@ -56,16 +60,26 @@ end = struct
 
   let fail error = { commands = []; error }
 
-  let rec exec = function
+  let rec exec t ~sandbox =
+    match t with
     | { commands = []; error } -> raise (User_error.E error)
     | { commands = { dir; metadata; prog; args } :: commands; error } ->
       let* () =
-        Process.run ~display:Quiet ~dir ~env:Env.initial Strict prog args ~metadata
+        Process.run
+          ~display:Quiet
+          ~dir
+          ~env:Env.initial
+          Strict
+          prog
+          args
+          ~metadata
+          ?sandbox
       in
-      exec { commands; error }
+      exec { commands; error } ~sandbox
   ;;
 
-  let rec capture = function
+  let rec capture t ~sandbox =
+    match t with
     | { commands = []; error } -> Fiber.return (Error error)
     | { commands = { dir; metadata; prog; args } :: commands; error } ->
       let* output, code =
@@ -77,10 +91,11 @@ end = struct
           prog
           args
           ~metadata
+          ?sandbox
       in
       (match code with
        | 1 -> Fiber.return (Ok { Diff.output; loc = metadata.Process_metadata.loc })
-       | _ -> capture { commands; error })
+       | _ -> capture { commands; error } ~sandbox)
   ;;
 end
 
@@ -252,7 +267,7 @@ let prepare ~skip_trailing_cr promotion path1 path2 =
   prepare_with_labels ~skip_trailing_cr ~dir loc promotion (label1, path1) (label2, path2)
 ;;
 
-let print ~skip_trailing_cr ~patch_back promotion path1 path2 =
+let print ~sandbox ~skip_trailing_cr ~patch_back promotion path1 path2 =
   let p =
     match patch_back with
     | None -> prepare ~skip_trailing_cr (Some promotion) path1 path2
@@ -269,10 +284,10 @@ let print ~skip_trailing_cr ~patch_back promotion path1 path2 =
         (label1, path1)
         (label2, path2)
   in
-  With_fallback.exec p
+  With_fallback.exec p ~sandbox
 ;;
 
-let get path1 path2 =
+let get ~sandbox path1 path2 =
   let p = prepare ~skip_trailing_cr:Sys.win32 None path1 path2 in
-  With_fallback.capture p
+  With_fallback.capture p ~sandbox
 ;;

--- a/src/dune_engine/print_diff.mli
+++ b/src/dune_engine/print_diff.mli
@@ -2,7 +2,8 @@ open Import
 
 (** Diff two files that are expected not to match. *)
 val print
-  :  skip_trailing_cr:bool
+  :  sandbox:Process.Sandbox.t option
+  -> skip_trailing_cr:bool
   -> patch_back:Path.t option
   -> User_message.Diff_annot.t
   -> Path.t
@@ -15,4 +16,8 @@ module Diff : sig
   val print : t -> unit
 end
 
-val get : Path.t -> Path.t -> (Diff.t, User_message.t) result Fiber.t
+val get
+  :  sandbox:Process.Sandbox.t option
+  -> Path.t
+  -> Path.t
+  -> (Diff.t, User_message.t) result Fiber.t

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -3,6 +3,66 @@ open Fiber.O
 open Action_types
 module Action_output_limit = Execution_parameters.Action_output_limit
 
+module Sandbox = struct
+  type base = { landlock : Spawn.Landlock.t option Lazy.t }
+  type t = { landlock : (Fd.t * Spawn.Landlock.t) option Lazy.t }
+
+  let landlock_config = Config.make_toggle ~name:"landlock" ~default:`Enabled
+
+  let landlock_enabled () =
+    match Config.get landlock_config with
+    | `Enabled -> Spawn.Landlock.available ()
+    | `Disabled -> false
+  ;;
+
+  let open_directory path =
+    Unix.openfile (Path.to_string path) [ O_RDONLY; O_CLOEXEC ] 0
+    |> Fd.unsafe_of_unix_file_descr
+  ;;
+
+  let action_temp_dir = lazy (open_directory (Dtemp.action_temp_dir ()))
+  let dev = lazy (open_directory (Path.of_string "/dev"))
+
+  let create_base ~action_trace_root : base =
+    let action_trace_root = lazy (open_directory action_trace_root) in
+    let writable_directories = [ action_trace_root; action_temp_dir; dev ] in
+    let landlock =
+      lazy
+        (if landlock_enabled ()
+         then
+           List.map writable_directories ~f:Lazy.force
+           |> Spawn.Landlock.allow_writes_to_directories
+           |> Option.some
+         else None)
+    in
+    { landlock }
+  ;;
+
+  let for_action ({ landlock } : base) ~root : t =
+    let landlock =
+      lazy
+        (match Lazy.force landlock with
+         | None -> None
+         | Some landlock ->
+           let fd = open_directory root in
+           (match Spawn.Landlock.add_writable_directories [ fd ] landlock with
+            | landlock -> Some (fd, landlock)
+            | exception exn ->
+              let backtrace = Printexc.get_raw_backtrace () in
+              Fd.close fd;
+              Exn.raise_with_backtrace exn backtrace))
+    in
+    { landlock }
+  ;;
+
+  let to_landlock { landlock } = Option.map (Lazy.force landlock) ~f:snd
+
+  let destroy { landlock } =
+    if Lazy.is_val landlock
+    then Option.iter (Lazy.force landlock) ~f:(fun (fd, _) -> Fd.close fd)
+  ;;
+end
+
 let limit_output output ~n =
   let message = "TRUNCATED BY DUNE" in
   let noutput = String.length output in
@@ -939,6 +999,7 @@ let spawn
       ~args
       ~metadata
       ~timeout
+      ~sandbox
       ()
   =
   let { stdout_on_success
@@ -990,6 +1051,7 @@ let spawn
       | None -> Spawn.Working_dir.inherit_
       | Some dir -> Spawn.Working_dir.path (Path.to_string dir)
     in
+    let landlock = Option.bind sandbox ~f:Sandbox.to_landlock in
     Spawn.spawn
       ()
       ~prog:prog_str
@@ -1000,6 +1062,7 @@ let spawn
       ~stderr
       ~stdin
       ?setpgid
+      ?landlock
       ~cwd
   in
   if emit_trace
@@ -1160,6 +1223,7 @@ let exec_locally
            ~args
            ~metadata
            ~timeout
+           ~sandbox:None
            ()
        in
        let { Build.cancellation; _ } = build in
@@ -1190,6 +1254,7 @@ let run_internal
       ?(metadata = Process_metadata.default)
       ?(setpgid = Some Spawn.Pgid.new_process_group)
       ?build
+      ?sandbox
       fail_mode
       prog
       args
@@ -1265,6 +1330,7 @@ let run_internal
           ~args
           ~metadata
           ~timeout
+          ~sandbox
           ()
       in
       let* () =
@@ -1448,6 +1514,7 @@ let run
       ?env
       ?metadata
       ?build
+      ?sandbox
       fail_mode
       prog
       args
@@ -1462,6 +1529,7 @@ let run
       ?env
       ?metadata
       ?build
+      ?sandbox
       fail_mode
       prog
       (Array.Immutable.of_list args)
@@ -1478,6 +1546,7 @@ let run_with_array_args
       ?env
       ?metadata
       ?build
+      ?sandbox
       fail_mode
       prog
       args
@@ -1492,6 +1561,7 @@ let run_with_array_args
       ?env
       ?metadata
       ?build
+      ?sandbox
       fail_mode
       prog
       args
@@ -1537,6 +1607,7 @@ let run_capture_gen
       ?env
       ?metadata
       ?build
+      ?sandbox
       fail_mode
       prog
       args
@@ -1553,6 +1624,7 @@ let run_capture_gen
       ?env
       ?metadata
       ?build
+      ?sandbox
       fail_mode
       prog
       (Array.Immutable.of_list args)
@@ -1564,8 +1636,11 @@ let run_capture_gen
 ;;
 
 let run_capture = run_capture_gen ~f:Stdune.Io.read_file
-let run_capture_lines = run_capture_gen ~f:Stdune.Io.lines_of_file
-let run_capture_zero_separated = run_capture_gen ~f:Stdune.Io.zero_strings_of_file
+let run_capture_lines = run_capture_gen ?sandbox:None ~f:Stdune.Io.lines_of_file
+
+let run_capture_zero_separated =
+  run_capture_gen ?sandbox:None ~f:Stdune.Io.zero_strings_of_file
+;;
 
 let run_capture_line
       ?dir
@@ -1587,6 +1662,7 @@ let run_capture_line
     ?env
     ?metadata
     ?build
+    ?sandbox:None
     fail_mode
     prog
     args

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -4,6 +4,18 @@ open Import
 open Action_types
 module Action_output_limit := Execution_parameters.Action_output_limit
 
+module Sandbox : sig
+  (** Platform-independent sandbox requirements for a process. The concrete
+      enforcement mechanism is selected when the process is spawned. *)
+  type base
+
+  type t
+
+  val create_base : action_trace_root:Path.t -> base
+  val for_action : base -> root:Path.t -> t
+  val destroy : t -> unit
+end
+
 module Failure_mode : sig
   (** How to handle sub-process failures. This type controls the way in which
       the process we are running can fail. *)
@@ -101,6 +113,7 @@ val run
   -> ?env:Env.t
   -> ?metadata:Process_metadata.t
   -> ?build:Build.t
+  -> ?sandbox:Sandbox.t
   -> (unit, 'a) Failure_mode.t
   -> Path.t
   -> string list
@@ -115,6 +128,7 @@ val run_with_array_args
   -> ?env:Env.t
   -> ?metadata:Process_metadata.t
   -> ?build:Build.t
+  -> ?sandbox:Sandbox.t
   -> (unit, 'a) Failure_mode.t
   -> Path.t
   -> string Array.Immutable.t
@@ -143,6 +157,7 @@ val run_capture
   -> ?env:Env.t
   -> ?metadata:Process_metadata.t
   -> ?build:Build.t
+  -> ?sandbox:Sandbox.t
   -> (string, 'a) Failure_mode.t
   -> Path.t
   -> string list

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -96,11 +96,12 @@ type t =
   | Sandboxed of real
   | No_sandbox of { targets : Targets.Validated.t }
 
-let is_sandboxed = function
-  | Sandboxed _ -> true
-  | No_sandbox _ -> false
+let root = function
+  | Sandboxed { dir; _ } -> Some (Path.build dir)
+  | No_sandbox _ -> None
 ;;
 
+let is_sandboxed t = Option.is_some (root t)
 let map_real_path t p = Path.Build.append t.dir p
 
 let map_path t p =
@@ -288,6 +289,7 @@ let register_corrected_file_promotions t ~deps =
     in
     let file1 = build_path_without_corrected_suffix file2_without_sandbox |> Path.build in
     Diff_action.exec
+      ~sandbox:None
       ~patch_back:(Some (Path.build t.dir))
       t.loc
       { Diff.file1; file2; optional = false; mode = Text; directory_diffs = false })
@@ -397,6 +399,7 @@ let register_snapshot_promotion t (targets : Targets.Validated.t) ~old_snapshot 
        Fiber.parallel_iter !diffs ~f:(fun path ->
          let source = Path.drop_optional_sandbox_root path in
          Diff_action.exec
+           ~sandbox:None
            ~patch_back:(Some (Path.build t.dir))
            t.loc
            { Diff.file1 = source

--- a/src/dune_engine/sandbox.mli
+++ b/src/dune_engine/sandbox.mli
@@ -4,6 +4,8 @@ open Import
 
 type t
 
+val root : t -> Path.t option
+
 (** [is_sandboxed t] is [true] when [t] represents a real sandbox. *)
 val is_sandboxed : t -> bool
 

--- a/src/dune_lang/dune_project.ml
+++ b/src/dune_lang/dune_project.ml
@@ -790,6 +790,7 @@ let update_execution_parameters t ep =
        (if t.dune_version >= (3, 23) then Some t.root else None)
   |> Execution_parameters.set_should_remove_write_permissions_on_generated_files
        (t.dune_version >= (2, 4))
+  |> Execution_parameters.set_use_sandbox_policy (t.dune_version >= (3, 25))
 ;;
 
 let opam_file_location t = t.opam_file_location

--- a/src/dune_rules/cc_flags.ml
+++ b/src/dune_rules/cc_flags.ml
@@ -106,7 +106,8 @@ module Detect = struct
              ~stderr_to:eenv.stderr_to
              ~stdin_from:eenv.stdin_from
              ~dir:eenv.working_dir
-             ~env:eenv.env)
+             ~env:eenv.env
+             ?sandbox:ectx.sandbox)
         ~finally:(fun () ->
           Temp.destroy File header;
           Fiber.return ())

--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -606,7 +606,7 @@ let make_temp_dir ~script =
       in
       "." ^ Filename.to_string suffix
     in
-    Dune_engine.Dtemp.action_dir ~prefix:"dune_cram" ~suffix
+    Dune_engine.Dtemp.action Dir ~prefix:"dune_cram" ~suffix
   in
   Path.mkdir_p temp_dir;
   temp_dir
@@ -642,7 +642,13 @@ let combine_with_current_stanzas =
   fun current_stanzas expected -> loop [] current_stanzas expected |> List.rev
 ;;
 
-let print_timeout_correction_and_fail ~src ~conflict_markers ~timeout command_outputs =
+let print_timeout_correction_and_fail
+      ~src
+      ~conflict_markers
+      ~timeout
+      ~sandbox
+      command_outputs
+  =
   let open Fiber.O in
   let* () =
     let source_contents = Io.read_file ~binary:false src in
@@ -661,7 +667,7 @@ let print_timeout_correction_and_fail ~src ~conflict_markers ~timeout command_ou
       Fiber.return ())
     else (
       Io.write_file ~binary:false corrected_file expected;
-      let+ diff = Dune_engine.Print_diff.get src corrected_file in
+      let+ diff = Dune_engine.Print_diff.get ~sandbox src corrected_file in
       let () =
         let source_file = Path.drop_optional_build_context_src_exn src in
         let correction_file = Path.as_in_build_dir_exn corrected_file in
@@ -690,6 +696,7 @@ let run_cram_test
       ~cwd
       ~timeout
       ~setup_scripts
+      ~sandbox
       (shell : Cram_stanza.Shell.t)
   =
   let open Fiber.O in
@@ -732,6 +739,7 @@ let run_cram_test
     ~metadata
     ~dir:cwd
     ~env
+    ?sandbox
     (Timeout { timeout = Option.map ~f:snd timeout; failure_mode = Strict })
     sh
     ((match shell with
@@ -767,6 +775,7 @@ let run_produce_correction
       ~script
       ~timeout
       ~setup_scripts
+      ~sandbox
       shell
       lexbuf
   =
@@ -784,6 +793,7 @@ let run_produce_correction
     ~cwd
     ~timeout
     ~setup_scripts
+    ~sandbox
     shell
   >>| compose_cram_output
 ;;
@@ -806,6 +816,7 @@ let run_and_produce_output
       ~dst
       ~timeout
       ~setup_scripts
+      ~sandbox
       shell
   =
   let open Fiber.O in
@@ -830,6 +841,7 @@ let run_and_produce_output
         ~cwd
         ~timeout
         ~setup_scripts
+        ~sandbox
         shell
     in
     List.filter_map cram_to_output ~f:(function
@@ -840,7 +852,7 @@ let run_and_produce_output
     List.exists commands ~f:(function
       | { metadata = Timed_out _; _ } -> true
       | _ -> false)
-  then print_timeout_correction_and_fail ~src ~conflict_markers ~timeout commands
+  then print_timeout_correction_and_fail ~src ~conflict_markers ~timeout ~sandbox commands
   else (
     let dst = Path.build dst in
     Path.mkdir_p (Path.parent_exn dst);
@@ -898,7 +910,7 @@ module Run = struct
 
     let action
           { src; dir; script; output; timeout; setup_scripts; shell }
-          ~ectx:_
+          ~(ectx : Action.context)
           ~(eenv : Action.env)
       =
       run_and_produce_output
@@ -910,6 +922,7 @@ module Run = struct
         ~dst:output
         ~timeout
         ~setup_scripts
+        ~sandbox:ectx.sandbox
         shell
     ;;
   end
@@ -1028,7 +1041,7 @@ module Action = struct
     let is_useful_to ~memoize:_ = true
     let encode script path _ : Sexp.t = List [ path script ]
 
-    let action script ~ectx:_ ~(eenv : Action.env) =
+    let action script ~(ectx : Action.context) ~(eenv : Action.env) =
       run_expect_test
         script
         ~f:
@@ -1039,6 +1052,7 @@ module Action = struct
              ~script
              ~timeout:None
              ~setup_scripts:[]
+             ~sandbox:ectx.sandbox
              Sh)
     ;;
   end

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -2372,6 +2372,7 @@ let build_rule context_name ~source_deps (pkg : Pkg.t) =
    Action_builder.deps deps |> Action_builder.with_no_targets)
   (* TODO should we add env deps on these? *)
   >>> add_env (Pkg.exported_env pkg) build_action
+  |> Action_builder.With_targets.map ~f:Action.Full.disable_sandbox_policy
   |> Action_builder.With_targets.add_directories
        ~directory_targets:[ pkg.write_paths.target_dir ]
 ;;

--- a/src/dune_rules/run_with_path.ml
+++ b/src/dune_rules/run_with_path.ml
@@ -285,6 +285,7 @@ module Spec = struct
                ~stdin_from:eenv.stdin_from
                ~dir:eenv.working_dir
                ~env
+               ?sandbox:ectx.sandbox
            in
            Output.prerr ~rc error;
            Fiber.return ())

--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -50,6 +50,8 @@ export XDG_CACHE_HOME="$PWD/.cache"
 export XDG_CONFIG_HOME="$PWD/.config"
 export XDG_DATA_HOME="$PWD/.local/share"
 export XDG_STATE_HOME="$PWD/.local/state"
+# Use sandbox-local data unless a test sets up a runtime directory.
+unset XDG_RUNTIME_DIR
 
 setup_xdg_runtime_dir () {
     export XDG_RUNTIME_DIR="${TMPDIR:-$PWD}/.xdg-runtime"

--- a/test/blackbox-tests/test-cases/action-runner/basic.t
+++ b/test/blackbox-tests/test-cases/action-runner/basic.t
@@ -1,6 +1,8 @@
 `--action-runner` does not invalidate stale outputs when it is toggled.
 
   $ make_dune_project 3.23
+  $ # Needed when upgrading this test to Dune language 3.25:
+  $ # export DUNE_CONFIG__LANDLOCK=disabled
   $ export TEST_DIR=$PWD
   $ export DUNE_TRACE=action,process
   $ echo one > input

--- a/test/blackbox-tests/test-cases/actions/subreaper.t
+++ b/test/blackbox-tests/test-cases/actions/subreaper.t
@@ -1,6 +1,8 @@
 Dune is a Linux subreaper, so a process that leaves the action's process group
 is adopted by Dune and cleaned up after the build.
 
+  $ # Needed when upgrading this test to Dune language 3.25:
+  $ # export DUNE_CONFIG__LANDLOCK=disabled
   $ make_dune_project 3.23
 
   $ wait_for_child_process_cleanup_finished () {

--- a/test/blackbox-tests/test-cases/bin-pform/inline-tests-include.t
+++ b/test/blackbox-tests/test-cases/bin-pform/inline-tests-include.t
@@ -4,6 +4,8 @@ behavior of a top-level %{bin:NAME} dep (see inline-tests.t).
 Dep_conf_eval.unnamed mirrors named_paths_builder's include_envs
 collection to drain the env contribution from Include_result.
 
+  $ # Needed when upgrading this test to Dune language 3.25:
+  $ # export DUNE_CONFIG__LANDLOCK=disabled
   $ make_mypkg_bin_project
 
   $ cat >deps.sexp <<'EOF'

--- a/test/blackbox-tests/test-cases/bin-pform/inline-tests.t
+++ b/test/blackbox-tests/test-cases/bin-pform/inline-tests.t
@@ -1,6 +1,8 @@
 %{bin:...} in (inline_tests (deps ...)) adds a bin-layout dir to
 the test runner's PATH.
 
+  $ # Needed when upgrading this test to Dune language 3.25:
+  $ # export DUNE_CONFIG__LANDLOCK=disabled
   $ make_mypkg_bin_project
 
 Custom backend whose runner records PATH to a file outside the

--- a/test/blackbox-tests/test-cases/cram/double-run-promote.t
+++ b/test/blackbox-tests/test-cases/cram/double-run-promote.t
@@ -2,6 +2,8 @@ This test demonstrates that we pointlessly re-run cram tests
 after they're promted
 
   $ make_dune_project 3.12
+  $ # Needed when upgrading this test to Dune language 3.25:
+  $ # export DUNE_CONFIG__LANDLOCK=disabled
 
   $ cat >foo.t <<EOF
   >   $ echo run >> $PWD/side-effect

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t
@@ -80,7 +80,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune_build_sorted_actions --config-file config reproducible non-reproducible
-  Warning: cache store error [542059eb7b9f78e6cebedf4dd1de4e91]: ((in_cache
+  Warning: cache store error [1ce77805b0b209e689d1ddac29fa75b5]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   action at dune:6
@@ -136,7 +136,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune_build_sorted_actions --cache=enabled reproducible non-reproducible
-  Warning: cache store error [542059eb7b9f78e6cebedf4dd1de4e91]: ((in_cache
+  Warning: cache store error [1ce77805b0b209e689d1ddac29fa75b5]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   action at dune:6
@@ -148,7 +148,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune_build_sorted_actions --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [542059eb7b9f78e6cebedf4dd1de4e91]: ((in_cache
+  Warning: cache store error [1ce77805b0b209e689d1ddac29fa75b5]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   action at dune:6

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -82,8 +82,8 @@ entries uniformly.
   $ metadata_dir="$PWD/.xdg-cache/dune/db/meta/v5"
   $ (cd "$metadata_dir"; find . -mindepth 2 -maxdepth 2 -type f | sort) > metadata-paths
   $ cat metadata-paths | censor
-  ./bf/$DIGEST1
-  ./c9/$DIGEST2
+  ./42/$DIGEST1
+  ./54/$DIGEST2
 
   $ while read path; do dune internal cache-metadata "$metadata_dir/$path"; done < metadata-paths \
   > | jq_dune -S -s 'sortCacheMetadataByFirstPath' \

--- a/test/blackbox-tests/test-cases/package-materialization/inline-tests.t
+++ b/test/blackbox-tests/test-cases/package-materialization/inline-tests.t
@@ -1,6 +1,8 @@
 Test that (inline_tests (deps (package ...))) sets up layout env vars
 for the test runner.
 
+  $ # Needed when upgrading this test to Dune language 3.25:
+  $ # export DUNE_CONFIG__LANDLOCK=disabled
   $ make_mypkg_lib_project
 
 Custom backend that writes OCAMLPATH to a file outside the sandbox:

--- a/test/blackbox-tests/test-cases/pkg/build-single-package.t
+++ b/test/blackbox-tests/test-cases/pkg/build-single-package.t
@@ -2,7 +2,7 @@ Requesting to build a single package should not build unrelated things:
 
   $ make_lockdir
 
-  $ make_dune_project 3.12
+  $ make_dune_project 3.25
 
   $ cat > dune-workspace <<EOF
   > (lang dune 3.20)
@@ -30,3 +30,15 @@ We should only see the result of building "bar"
 
   $ build_pkg bar
   building bar
+
+Package build commands are not restricted by the shared-cache Landlock policy.
+
+  $ export DUNE_CACHE_ROOT=$PWD/cache-root
+  $ mkdir -p "$DUNE_CACHE_ROOT/db"
+  $ make_lockpkg cache-writer <<EOF
+  > (build (run touch $DUNE_CACHE_ROOT/db/package-marker))
+  > (version dev)
+  > EOF
+  $ build_pkg cache-writer
+  $ test -e "$DUNE_CACHE_ROOT/db/package-marker" && echo wrote
+  wrote

--- a/test/blackbox-tests/test-cases/rpc-batch-idle-client.t
+++ b/test/blackbox-tests/test-cases/rpc-batch-idle-client.t
@@ -2,6 +2,8 @@ A batch build should not wait for an idle RPC client to disconnect before
 exiting. The helper below is that idle client: it connects, sends an incomplete
 packet, writes a marker file, and then stays alive until this test kills it.
 
+  $ # Needed when upgrading this test to Dune language 3.25:
+  $ # export DUNE_CONFIG__LANDLOCK=disabled
   $ cat > dune-project <<EOF
   > (lang dune 3.23)
   > EOF

--- a/test/blackbox-tests/test-cases/rpc/batch-monitor-client.t
+++ b/test/blackbox-tests/test-cases/rpc/batch-monitor-client.t
@@ -7,6 +7,8 @@ the real CLI paths: the temporary RPC server started by a batch build, an
 external dune monitor client, and the monitor's long-poll subscriptions. The
 point is to catch the user-visible hang, not just the protocol-level behavior.
 
+  $ # Needed when upgrading this test to Dune language 3.25:
+  $ # export DUNE_CONFIG__LANDLOCK=disabled
   $ cat > dune-project <<EOF
   > (lang dune 3.23)
   > EOF

--- a/test/blackbox-tests/test-cases/rule/digest.t/run.t
+++ b/test/blackbox-tests/test-cases/rule/digest.t/run.t
@@ -1,6 +1,8 @@
 ----------------------------------------------------------------------------------
 Test that rule digest doesn't depend on irrelevant details of the dune file
 
+  $ # Needed when upgrading this test to Dune language 3.25:
+  $ # export DUNE_CONFIG__LANDLOCK=disabled
   $ export DUNE_PWD_STORE="$(mktemp)"
 
   $ make_dune_project 3.0

--- a/test/blackbox-tests/test-cases/sandbox-actions/dune
+++ b/test/blackbox-tests/test-cases/sandbox-actions/dune
@@ -1,3 +1,16 @@
+(env
+ (_
+  (binaries ../../utils/action_plugin_helper.exe)))
+
+(cram
+ (applies_to landlock-policy)
+ (deps %{bin:action_plugin_helper})
+ (enabled_if
+  (= %{system} linux)))
+
+(cram
+ (applies_to shared-cache))
+
 (cram
  (applies_to basic with-bwrap)
  (alias runtest-bwrap)

--- a/test/blackbox-tests/test-cases/sandbox-actions/landlock-policy.t
+++ b/test/blackbox-tests/test-cases/sandbox-actions/landlock-policy.t
@@ -1,0 +1,157 @@
+Landlock policy propagation through compound actions and helper processes.
+
+  $ unset DUNE_CONFIG__LANDLOCK
+  $ make_dune_project 3.25
+  $ cat >> dune-project <<'EOF'
+  > (using action-plugin 0.1)
+  > EOF
+  $ export OUTSIDE=$PWD/outside
+  $ mkdir "$OUTSIDE"
+  $ if dune internal with-landlock -- true >/dev/null 2>&1; then
+  >   policy=blocked
+  > elif test "${CI:-false}" = true && test -d /proc/sys/kernel; then
+  >   echo 'Landlock must be available in Linux CI'
+  >   exit 1
+  > else
+  >   policy=wrote
+  > fi
+  $ cat > probe.sh <<'EOF'
+  > if touch "$OUTSIDE/$1" 2>/dev/null; then
+  >   echo "$1-wrote" > "$2"
+  > else
+  >   echo "$1-blocked" > "$2"
+  > fi
+  > EOF
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (targets progn-1 progn-2)
+  >  (deps probe.sh (sandbox always))
+  >  (action
+  >   (progn
+  >    (bash "sh %{dep:probe.sh} progn-1 progn-1")
+  >    (bash "sh %{dep:probe.sh} progn-2 progn-2"))))
+  > (rule
+  >  (targets concurrent-1 concurrent-2)
+  >  (deps probe.sh (sandbox always))
+  >  (action
+  >   (concurrent
+  >    (bash "sh %{dep:probe.sh} concurrent-1 concurrent-1")
+  >    (bash "sh %{dep:probe.sh} concurrent-2 concurrent-2"))))
+  > (rule
+  >  (targets pipe pipe-1 pipe-2)
+  >  (deps probe.sh (sandbox always))
+  >  (action
+  >   (with-stdout-to pipe
+  >    (pipe-stdout
+  >     (bash "sh %{dep:probe.sh} pipe-1 pipe-1; printf 'pipe\\n'")
+  >     (bash "sh %{dep:probe.sh} pipe-2 pipe-2; cat")))))
+  > (rule
+  >  (target plugin)
+  >  (deps (sandbox always))
+  >  (action
+  >   (progn
+  >    (dynamic-run action_plugin_helper touch "$OUTSIDE/plugin")
+  >    (write-file %{target} plugin-blocked))))
+  > EOF
+
+  $ dune build progn-1 progn-2 concurrent-1 concurrent-2 pipe plugin
+  $ test "$policy" = blocked || test -e outside/plugin
+  $ test "$policy" = blocked || rm -f outside/*
+  $ for name in progn-1 progn-2 concurrent-1 concurrent-2 pipe-1 pipe-2; do
+  >   test "$(cat _build/default/$name)" = "$name-$policy"
+  > done
+  $ test "$(cat _build/default/pipe)" = pipe
+  $ test "$(cat _build/default/plugin)" = plugin-blocked
+  $ test "$policy" = wrote || test ! -e outside/plugin
+
+Cram commands receive the policy too.
+
+  $ cat > policy.t <<EOF
+  >   \$ if touch "\$OUTSIDE/cram" 2>/dev/null; then echo wrote; else echo blocked; fi
+  >   $policy
+  > EOF
+  $ cat >> dune <<'EOF'
+  > (cram
+  >  (deps (sandbox always)))
+  > EOF
+  $ dune runtest policy.t
+  $ test "$policy" = blocked || rm -f outside/*
+  $ test "$policy" = wrote || test ! -e outside/cram
+
+The C compiler vendor probe receives the policy.
+
+  $ actual_ocamlc=$(command -v ocamlc)
+  $ actual_cc=$(command -v "$(ocamlc -config-var c_compiler)")
+  $ cat > ocamlc-wrapper <<EOF
+  > #!/bin/sh
+  > if test "\$1" = -config; then
+  >   "$actual_ocamlc" -config | sed 's|^c_compiler:.*|c_compiler: $PWD/cc-wrapper|'
+  > else
+  >   exec "$actual_ocamlc" "\$@"
+  > fi
+  > EOF
+  $ cat > cc-wrapper <<EOF
+  > #!/bin/sh
+  > case " \$* " in
+  >   *" -E "*)
+  >     touch "$OUTSIDE/cc-vendor" 2>/dev/null || :
+  >     echo gcc
+  >     ;;
+  >   *) exec "$actual_cc" "\$@" ;;
+  > esac
+  > EOF
+  $ chmod +x ocamlc-wrapper cc-wrapper
+  $ mkdir -p findlib
+  $ external_findlib_path=$(ocamlfind printconf path | tr '\n' ':' | sed 's/:$//')
+  $ cat > findlib/findlib.conf <<EOF
+  > path="$external_findlib_path"
+  > ocamlc="$PWD/ocamlc-wrapper"
+  > EOF
+  $ cat >> dune <<'EOF'
+  > (library
+  >  (name foreign)
+  >  (foreign_stubs
+  >   (language c)
+  >   (names foreign)))
+  > EOF
+  $ echo 'void foreign(void) {}' > foreign.c
+  $ OCAMLFIND_CONF=$PWD/findlib/findlib.conf dune build foreign.cma
+  $ test "$policy" = blocked || test -e outside/cc-vendor
+  $ test "$policy" = blocked || rm -f outside/*
+  $ test "$policy" = wrote || test ! -e outside/cc-vendor
+
+External diff commands execute under the action's policy.
+
+  $ echo expected > expected
+  $ echo actual > actual
+  $ cat >> dune <<'EOF'
+  > (rule
+  >  (alias diff)
+  >  (deps expected actual (sandbox always))
+  >  (action (diff expected actual)))
+  > EOF
+  $ cat > diff.sh <<'EOF'
+  > if touch "$OUTSIDE/diff" 2>/dev/null; then echo wrote; else echo blocked; fi
+  > exit 1
+  > EOF
+  $ dune build @diff --diff-command "sh $PWD/diff.sh" >diff.output 2>&1 || :
+  $ test "$policy" = blocked || rm -f outside/*
+  $ grep -qx "$policy" diff.output
+  $ test "$policy" = wrote || test ! -e outside/diff
+
+The external diff used to report a timed-out cram test also receives the policy.
+
+  $ cat >> dune <<'EOF'
+  > (cram
+  >  (applies_to timeout)
+  >  (deps (sandbox always))
+  >  (timeout 0.05))
+  > EOF
+  $ cat > timeout.t <<'EOF'
+  >   $ sleep 1
+  > EOF
+  $ rm -f outside/diff
+  $ dune runtest timeout.t --diff-command "sh $PWD/diff.sh" >timeout.output 2>&1 || :
+  $ test "$policy" = blocked || rm -f outside/*
+  $ grep -qx "$policy" timeout.output
+  $ test "$policy" = wrote || test ! -e outside/diff

--- a/test/blackbox-tests/test-cases/sandbox-actions/shared-cache.t
+++ b/test/blackbox-tests/test-cases/sandbox-actions/shared-cache.t
@@ -1,47 +1,145 @@
-`--sandbox-actions` prevents the worker from writing to the launching dune's
-shared cache.
+Dune uses Landlock, when available, to confine sandboxed build actions.
 
-  $ make_dune_project 3.23
+  $ rm -rf _build cache-root outside
+  $ make_dune_project 3.24
   $ export DUNE_CACHE_ROOT=$PWD/cache-root
-  $ echo "$DUNE_CACHE_ROOT" > cache-root-name
-  $ mkdir -p "$DUNE_CACHE_ROOT/db"
+  $ export OUTSIDE=$PWD/outside
+  $ mkdir -p "$DUNE_CACHE_ROOT/db" "$OUTSIDE"
+  $ cat > try-writes.sh <<'EOF'
+  > try_touch () {
+  >   if touch "$1" 2>/dev/null; then echo "$2-wrote"; else echo "$2-blocked"; fi
+  > }
+  > if : > "$1"; then echo target-wrote >> "$1"; else echo target-blocked; fi
+  > if printf ignored > /dev/null; then echo null-wrote >> "$1"; else echo null-blocked >> "$1"; fi
+  > if head -c 1 /dev/zero >/dev/null && printf ignored > /dev/zero; then
+  >   echo dev-wrote >> "$1"
+  > else
+  >   echo dev-blocked >> "$1"
+  > fi
+  > if mkdir -p "$DUNE_ACTION_TRACE_DIR" 2>/dev/null && touch "$DUNE_ACTION_TRACE_DIR/$2.json"; then
+  >   echo trace-wrote >> "$1"
+  > else
+  >   echo trace-blocked >> "$1"
+  > fi
+  > if test -d /dev/shm; then
+  >   shm_path="/dev/shm/dune-landlock-$2-$$"
+  >   try_touch "$shm_path" shm >> "$1"
+  >   rm -f "$shm_path" 2>/dev/null
+  > else
+  >   echo shm-wrote >> "$1"
+  > fi
+  > try_touch "$DUNE_CACHE_ROOT/db/$2" cache >> "$1"
+  > try_touch "$OUTSIDE/$2" outside >> "$1"
+  > try_touch "$TMPDIR/$2" tmp >> "$1"
+  > tmp_parent_path="${TMPDIR%/*}/dune-landlock-$2-$$"
+  > try_touch "$tmp_parent_path" tmp-parent >> "$1"
+  > rm -f "$tmp_parent_path" 2>/dev/null
+  > EOF
   $ cat > dune <<'EOF'
   > (rule
-  >  (target result)
-  >  (deps cache-root-name)
-  >  (action
-  >   (bash
-  >    "if touch \"$DUNE_CACHE_ROOT/db/runner-marker\" 2>/dev/null; then echo wrote > %{target}; else echo blocked > %{target}; fi")))
+  >  (target unsandboxed)
+  >  (deps try-writes.sh)
+  >  (action (run sh %{dep:try-writes.sh} %{target} unsandboxed)))
+  > (rule
+  >  (target sandboxed)
+  >  (deps try-writes.sh (sandbox always))
+  >  (action (run sh %{dep:try-writes.sh} %{target} sandboxed)))
+  > (rule
+  >  (target sandboxed-disabled)
+  >  (deps try-writes.sh (sandbox always))
+  >  (action (run sh %{dep:try-writes.sh} %{target} sandboxed-disabled)))
+  > (rule
+  >  (target action-runner)
+  >  (deps try-writes.sh (sandbox always))
+  >  (action (run sh %{dep:try-writes.sh} %{target} action-runner)))
   > EOF
 
-Normal actions can still write there.
+Unsandboxed actions are not restricted.
 
-  $ dune build result
-  $ cat _build/default/result
-  wrote
-  $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present
-  present
+  $ dune build --sandbox=none unsandboxed
+  $ cat _build/default/unsandboxed
+  target-wrote
+  null-wrote
+  dev-wrote
+  trace-wrote
+  shm-wrote
+  cache-wrote
+  outside-wrote
+  tmp-wrote
+  tmp-parent-wrote
 
-Sandboxed actions are blocked from writing there.
+Projects using versions of the Dune language older than 3.25 do not restrict
+sandboxed actions with Landlock.
 
-  $ rm -f "$DUNE_CACHE_ROOT/db/runner-marker"
-  $ dune build --sandbox-actions result
-  $ cat _build/default/result
-  blocked
-  $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present || echo missing
-  missing
+  $ dune build sandboxed
+  $ cat _build/default/sandboxed
+  target-wrote
+  null-wrote
+  dev-wrote
+  trace-wrote
+  shm-wrote
+  cache-wrote
+  outside-wrote
+  tmp-wrote
+  tmp-parent-wrote
 
-If the shared cache path does not exist yet, dune creates it and still protects
-it from the worker.
+Changing the language version invalidates the previous result and enables the
+policy.
 
-  $ export DUNE_CACHE_ROOT=$PWD/fresh-cache-root
-  $ echo "$DUNE_CACHE_ROOT" > cache-root-name
-  $ test -e "$DUNE_CACHE_ROOT/db" && echo present || echo missing
-  missing
-  $ dune build --sandbox-actions result
-  $ cat _build/default/result
-  blocked
-  $ test -d "$DUNE_CACHE_ROOT/db" && echo present || echo missing
-  present
-  $ test -e "$DUNE_CACHE_ROOT/db/runner-marker" && echo present || echo missing
-  missing
+  $ rm -f "$DUNE_CACHE_ROOT/db/sandboxed" "$OUTSIDE/sandboxed" "$TMPDIR/sandboxed"
+  $ make_dune_project 3.25
+
+Sandboxed actions can write to their sandbox and temporary directory and can
+read and write devices under /dev, but cannot write elsewhere.
+
+  $ if dune internal with-landlock -- true >/dev/null 2>&1; then
+  >   dune build sandboxed
+  >   cat _build/default/sandboxed
+  > else
+  >   echo target-wrote
+  >   echo null-wrote
+  >   echo dev-wrote
+  >   echo trace-wrote
+  >   echo shm-wrote
+  >   echo cache-blocked
+  >   echo outside-blocked
+  >   echo tmp-wrote
+  >   echo tmp-parent-blocked
+  > fi
+  target-wrote
+  null-wrote
+  dev-wrote
+  trace-wrote
+  shm-wrote
+  cache-blocked
+  outside-blocked
+  tmp-wrote
+  tmp-parent-blocked
+
+DUNE_CONFIG__LANDLOCK=disabled disables the restriction.
+
+  $ DUNE_CONFIG__LANDLOCK=disabled dune build sandboxed-disabled
+  $ cat _build/default/sandboxed-disabled
+  target-wrote
+  null-wrote
+  dev-wrote
+  trace-wrote
+  shm-wrote
+  cache-wrote
+  outside-wrote
+  tmp-wrote
+  tmp-parent-wrote
+
+Actions delegated to an action runner are not restricted with Landlock.
+
+  $ dune build --action-runner action-runner
+  $ cat _build/default/action-runner
+  target-wrote
+  null-wrote
+  dev-wrote
+  trace-wrote
+  shm-wrote
+  cache-wrote
+  outside-wrote
+  tmp-wrote
+  tmp-parent-wrote

--- a/test/blackbox-tests/test-cases/sandbox/sandboxing-stale-directory-target.t
+++ b/test/blackbox-tests/test-cases/sandbox/sandboxing-stale-directory-target.t
@@ -1,6 +1,8 @@
 A faulty test escapes the sandbox by creating its target outside the sandbox
 
   $ make_directory_targets_project 3.11
+  $ # Needed when upgrading this test to Dune language 3.25:
+  $ # export DUNE_CONFIG__LANDLOCK=disabled
 
   $ cat >dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/trace/debug-event.t
+++ b/test/blackbox-tests/test-cases/trace/debug-event.t
@@ -1,5 +1,7 @@
 The debug event can be triggered with Sigusr1
 
+  $ # Needed when upgrading this test to Dune language 3.25:
+  $ # export DUNE_CONFIG__LANDLOCK=disabled
   $ debug_events_jq='select(.name == "debug") | .name'
   $ build_request_starts_jq='select(.cat == "rpc" and .name == "request" and .args.meth == "build" and .args.stage == "start") | .name'
   $ count_trace_events () {

--- a/test/blackbox-tests/test-cases/watching/rpc-build-auto-promote-restart.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-auto-promote-restart.t
@@ -5,6 +5,8 @@ correction. The source change invalidates the just-finished build, so the RPC
 request must not complete with the initial failure; it should wait for the
 watch loop to rebuild the alias successfully.
 
+  $ # Needed when upgrading this test to Dune language 3.25:
+  $ # export DUNE_CONFIG__LANDLOCK=disabled
   $ make_dune_project 3.23
   $ cat > source <<EOF
   > old

--- a/test/blackbox-tests/test-cases/watching/rpc-build-concurrent-finish.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-concurrent-finish.t
@@ -1,5 +1,7 @@
 Concurrent RPC build requests finish independently when their targets are done.
 
+  $ # Needed when upgrading this test to Dune language 3.25:
+  $ # export DUNE_CONFIG__LANDLOCK=disabled
   $ make_dune_project 3.23
   $ export DUNE_TRACE=rpc,process
   $ count_trace_events () {

--- a/test/blackbox-tests/test-cases/watching/rpc-build-during-batch-build.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-during-batch-build.t
@@ -6,6 +6,7 @@ error instead.
 Use marker files to ensure that the first build is blocked in its action before
 starting the second build.
 
+  $ export DUNE_CONFIG__LANDLOCK=disabled
   $ make_dune_project 3.25
   $ STARTED="$PWD/started"
   $ RELEASE="$PWD/release"

--- a/test/blackbox-tests/test-cases/watching/rpc-build-status-line.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-status-line.t
@@ -1,6 +1,8 @@
 Forwarded watch builds display a rich status line with the current run once
 connected over RPC.
 
+  $ # Needed when upgrading this test to Dune language 3.25:
+  $ # export DUNE_CONFIG__LANDLOCK=disabled
   $ setup_xdg_runtime_dir
 
   $ make_simple_rpc_watch_project

--- a/test/blackbox-tests/test-cases/watching/rpc-build-stop.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-stop.t
@@ -1,5 +1,7 @@
 Minimal RPC watch shutdown after an RPC build.
 
+  $ # Needed when upgrading this test to Dune language 3.25:
+  $ # export DUNE_CONFIG__LANDLOCK=disabled
   $ export DUNE_TRACE=rpc
 
   $ make_simple_rpc_watch_project

--- a/test/blackbox-tests/test-cases/watching/rpc-flush-file-watcher.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-flush-file-watcher.t
@@ -2,6 +2,8 @@ The flush-file-watcher RPC waits for pending file watcher notifications to be
 handled by the watch server.
 
   $ export DUNE_TRACE=cache
+  $ # Needed when upgrading this test to Dune language 3.25:
+  $ # export DUNE_CONFIG__LANDLOCK=disabled
   $ setup_xdg_runtime_dir
 
   $ cat > dune-project <<EOF

--- a/test/blackbox-tests/test-cases/watching/shutdown.t
+++ b/test/blackbox-tests/test-cases/watching/shutdown.t
@@ -1,6 +1,8 @@
 Demonstrate what happens when the server is shut down in the middle of serving
 a client.
 
+  $ # Needed when upgrading this test to Dune language 3.25:
+  $ # export DUNE_CONFIG__LANDLOCK=disabled
   $ make_dune_project 3.21
   $ STARTED=$(mktemp)
   $ RELEASE=$(mktemp)

--- a/test/blackbox-tests/test-cases/watching/source-backed-promotion.t
+++ b/test/blackbox-tests/test-cases/watching/source-backed-promotion.t
@@ -1,5 +1,8 @@
 Test source-backed artifacts produced by promotion in file-watching mode.
 
+  $ # Needed when upgrading this test to Dune language 3.25:
+  $ # export DUNE_CONFIG__LANDLOCK=disabled
+
 A promoted file should be available through the corresponding source-copy target
 in _build.
 

--- a/test/blackbox-tests/utils/action_plugin_helper.ml
+++ b/test/blackbox-tests/utils/action_plugin_helper.ml
@@ -20,11 +20,19 @@ let hold started release =
   run (return ())
 ;;
 
+let touch_and_respond path =
+  (try touch path with
+   | Sys_error _ -> ());
+  run (return ())
+;;
+
 let () =
   match Array.to_list Sys.argv with
   | [ _; "noop" ] -> noop ()
   | [ _; "hold"; started; release ] -> hold started release
+  | [ _; "touch"; path ] -> touch_and_respond path
   | _ ->
-    prerr_endline "Usage: action_plugin_helper (noop | hold <started> <release>)";
+    prerr_endline
+      "Usage: action_plugin_helper (noop | hold <started> <release> | touch <path>)";
     exit 1
 ;;

--- a/test/expect-tests/dune_pkg/dune
+++ b/test/expect-tests/dune_pkg/dune
@@ -36,7 +36,9 @@
  (deps
   (source_tree tar-inputs))
  (action
-  (run tar -czf %{target} %{deps})))
+  ;; Dependencies are symlinks in the action sandbox. Dereference them so the
+  ;; archive is self-contained rather than referring back to _build/default.
+  (run tar -chzf %{target} %{deps})))
 
 (alias
  (name pkg)


### PR DESCRIPTION
Add directory-FD-backed Landlock policies to Spawn and apply them to directly executed sandboxed actions when Landlock is available. Restrict writes to the action sandbox, dedicated action temporary directory, action-trace directory, and /dev.

Lazily open and retain descriptors for policy directories shared by all actions. Keep each action sandbox descriptor open only for the lifetime of that action, allowing the policy recipe to be reused by every process it launches.

Propagate the opaque process sandbox through action execution, including helper processes such as diff tools, cram commands, and action plugins. Leave unsandboxed actions, action-runner processes, and package builds unrestricted. DUNE_CONFIG__LANDLOCK=disabled disables enforcement.

Add the internal with-landlock command and spawn and black-box coverage for allowed and denied writes, descriptor identity, opt-outs, action tracing, temporary files, /dev, and package builds.