### PR TITLE
test(melange): cover melange.emit errors

### DIFF
--- a/test/blackbox-tests/test-cases/melange/emit-variable.t
+++ b/test/blackbox-tests/test-cases/melange/emit-variable.t
@@ -87,3 +87,54 @@ The macro also works when the melange.emit stanza uses a custom alias.
   $ cat _build/default/custom/custom-path
   dist/custom
   $ test -f _build/default/custom/dist/custom/main.js
+
+An unknown melange.emit target is rejected.
+
+  $ cat >> dune <<EOF
+  > (rule
+  >  (alias unknown-emit)
+  >  (action (echo "%{melange.emit:missing}")))
+  > EOF
+
+  $ dune build @unknown-emit
+  File "dune", line 13, characters 16-39:
+  13 |  (action (echo "%{melange.emit:missing}")))
+                       ^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Melange emit target "missing" does not exist.
+  [1]
+
+The macro cannot refer to a target outside the workspace root.
+
+  $ cat >> dune <<EOF
+  > (rule
+  >  (alias escaped-emit)
+  >  (action (echo "%{melange.emit:../outside}")))
+  > EOF
+
+  $ dune build @escaped-emit
+  File "dune", line 16, characters 16-42:
+  16 |  (action (echo "%{melange.emit:../outside}")))
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: cannot escape the workspace root directory
+  [1]
+
+The macro is only available starting with Dune 3.25.
+
+  $ mkdir old-language
+  $ cat > old-language/dune-project <<EOF
+  > (lang dune 3.24)
+  > EOF
+  $ cat > old-language/dune <<EOF
+  > (rule
+  >  (alias default)
+  >  (action (echo "%{melange.emit:out}")))
+  > EOF
+  $ dune build --root old-language
+  Entering directory 'old-language'
+  File "dune", line 3, characters 16-35:
+  3 |  (action (echo "%{melange.emit:out}")))
+                      ^^^^^^^^^^^^^^^^^^^
+  Error: %{melange.emit:..} is only available since version 3.25 of the dune
+  language. Please update your dune-project file to have (lang dune 3.25).
+  Leaving directory 'old-language'
+  [1]


### PR DESCRIPTION
Add negative coverage for `%{melange.emit:...}`. Follow-up to #15751.