### PR TITLE
test: keep test state inside sandboxes

### DIFF
--- a/otherlibs/dune-rpc-lwt/test/dune_rpc_lwt_tests.ml
+++ b/otherlibs/dune-rpc-lwt/test/dune_rpc_lwt_tests.ml
@@ -6,9 +6,9 @@ open Lwt.Syntax
 open Dune_rpc.V1
 open Dune_rpc_lwt.V1
 
-let _XDG_STATE_HOME = "XDG_STATE_HOME"
-let xdg_state_dir = Temp.create Dir ~prefix:"lwt" ~suffix:"dune"
-let () = Unix.putenv _XDG_STATE_HOME (Stdune.Path.to_absolute_filename xdg_state_dir)
+let _XDG_DATA_HOME = "XDG_DATA_HOME"
+let xdg_data_dir = Temp.create Dir ~prefix:"lwt" ~suffix:"dune"
+let () = Unix.putenv _XDG_DATA_HOME (Stdune.Path.to_absolute_filename xdg_data_dir)
 
 let connect ~root_dir =
   let build_dir = Filename.concat root_dir "_build" in
@@ -16,8 +16,8 @@ let connect ~root_dir =
     let env =
       Env.add
         Env.initial
-        ~var:_XDG_STATE_HOME
-        ~value:(Stdune.Path.to_absolute_filename xdg_state_dir)
+        ~var:_XDG_DATA_HOME
+        ~value:(Stdune.Path.to_absolute_filename xdg_data_dir)
     in
     Env.get env
   in

--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -47,6 +47,9 @@ is_linked() {
 }
 
 export XDG_CACHE_HOME="$PWD/.cache"
+export XDG_CONFIG_HOME="$PWD/.config"
+export XDG_DATA_HOME="$PWD/.local/share"
+export XDG_STATE_HOME="$PWD/.local/state"
 
 setup_xdg_runtime_dir () {
     export XDG_RUNTIME_DIR="${TMPDIR:-$PWD}/.xdg-runtime"

--- a/test/blackbox-tests/test-cases/cram/cram-setup-scripts/external-scripts.t
+++ b/test/blackbox-tests/test-cases/cram/cram-setup-scripts/external-scripts.t
@@ -1,8 +1,8 @@
 Test that external (absolute path) setup scripts work and are NOT deleted
 
-First, create an external script in /tmp:
+First, create an external script in the test's temporary directory:
 
-  $ EXTERNAL_SCRIPT="/tmp/dune_test_external_helper_$$.sh"
+  $ EXTERNAL_SCRIPT="$TMPDIR/dune_test_external_helper_$$.sh"
   $ cat > "$EXTERNAL_SCRIPT" << 'EOF'
   > #!/bin/sh
   > external_helper() {


### PR DESCRIPTION
Keep test-generated state within per-test writable directories so sandboxed test actions do not attempt to write to user XDG directories or global `/tmp`.

This configures the blackbox environment’s XDG base directories, points the dune-rpc-lwt test at its actual `XDG_DATA_HOME` registry location, and creates the external setup-script fixture under `$TMPDIR`.

Preparatory for #15858.