### PR TITLE
perf(stdune): validate environment bindings once

### DIFF
--- a/otherlibs/stdune/src/env.ml
+++ b/otherlibs/stdune/src/env.ml
@@ -57,6 +57,11 @@ module Binding = struct
     if Option.Unboxed.is_some t.rendered
     then Option.Unboxed.value_exn t.rendered
     else (
+      if String.contains t.value '\000'
+      then
+        Code_error.raise
+          "Env: NUL byte in environment variable value"
+          [ "value", Dyn.string t.value ];
       let rendered = String.append_with_char var ~sep:'=' t.value in
       t.rendered <- Option.Unboxed.some rendered;
       rendered)
@@ -92,24 +97,15 @@ let vars t = Var.Set.of_keys t.vars
 let get t k = Option.map (Map.find t.vars k) ~f:(fun { Binding.value; _ } -> value)
 
 let to_unix t =
-  let bindings =
-    match t.unix with
-    | Some bindings -> bindings
-    | None ->
-      let bindings =
-        Map.foldi t.vars ~init:[] ~f:(fun var binding acc ->
-          Binding.render binding ~var:(Var.to_string var) :: acc)
-      in
-      t.unix <- Some bindings;
-      bindings
-  in
-  List.iter bindings ~f:(fun binding ->
-    if String.contains binding '\000'
-    then
-      Code_error.raise
-        "Env.to_unix: NUL byte in environment binding"
-        [ "binding", Dyn.string binding ]);
-  bindings
+  match t.unix with
+  | Some bindings -> bindings
+  | None ->
+    let bindings =
+      Map.foldi t.vars ~init:[] ~f:(fun var binding acc ->
+        Binding.render binding ~var:(Var.to_string var) :: acc)
+    in
+    t.unix <- Some bindings;
+    bindings
 ;;
 
 let to_windows_block t =

--- a/otherlibs/stdune/test/env_tests.ml
+++ b/otherlibs/stdune/test/env_tests.ml
@@ -35,3 +35,11 @@ let%expect_test "rendering preserves the environment hash" =
   print_endline (Bool.to_string (Int.equal before (Env.hash env)));
   [%expect {| true |}]
 ;;
+
+let%expect_test "environment values reject NUL bytes when rendered" =
+  let env = Env.add Env.empty ~var:a ~value:"value\000" in
+  (match Env.to_unix env with
+   | exception Code_error.E _ -> print_endline "rejected"
+   | _ -> print_endline "accepted");
+  [%expect {| rejected |}]
+;;


### PR DESCRIPTION
Reject NUL bytes while constructing bindings rather than scanning rendered
environments each time they are passed to spawn.