### PR TITLE
refactor(stdune): make Env.Var.t abstract

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -45,7 +45,7 @@ end
 
 let git =
   lazy
-    (let path = Env.get Env.initial "PATH" |> Option.value_exn |> Bin.parse_path in
+    (let path = Env.get Env.initial Env.Var._PATH |> Option.value_exn |> Bin.parse_path in
      Bin.which ~path "git" |> Option.value_exn)
 ;;
 

--- a/bin/action_runner.ml
+++ b/bin/action_runner.ml
@@ -39,8 +39,10 @@ let create ~config ~sandbox_actions =
             in
             Int.to_string scheduler_config.concurrency
           in
-          Env.add Env.initial ~var:"DUNE_JOBS" ~value:jobs
-          |> Env.add ~var:"DUNE_BUILD_DIR" ~value:(Path.Build.to_string Path.Build.root)
+          Env.add Env.initial ~var:(Env.Var.of_string "DUNE_JOBS") ~value:jobs
+          |> Env.add
+               ~var:(Env.Var.of_string "DUNE_BUILD_DIR")
+               ~value:(Path.Build.to_string Path.Build.root)
         in
         let trace_fd = Dune_trace.duplicate_global_fd () in
         let prog, argv =

--- a/bin/ocaml/utop.ml
+++ b/bin/ocaml/utop.ml
@@ -106,7 +106,10 @@ let term =
                  directory. Setting this environment variable causes the custom
                  findlib.conf file to be used instead of the default
                  findlib.conf. *)
-              Env.add env ~var:"OCAMLFIND_CONF" ~value:(Path.to_string utop_findlib_conf)
+              Env.add
+                env
+                ~var:Env.Var._OCAMLFIND_CONF
+                ~value:(Path.to_string utop_findlib_conf)
             else env
           in
           env, Path.to_string utop_exe))

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -186,7 +186,7 @@ let dep_repr =
         | Dep.File_selector selector -> Some selector
         | Dep.Env _ | Dep.File _ | Dep.Alias _ | Dep.Universe -> None)
     ; Repr.case "Env" Repr.string ~proj:(function
-        | Dep.Env var -> Some var
+        | Dep.Env var -> Some (Env.Var.to_string var)
         | Dep.File_selector _ | Dep.File _ | Dep.Alias _ | Dep.Universe -> None)
     ; Repr.case "File" path_repr ~proj:(function
         | Dep.File path -> Some path

--- a/bin/tools/tools_common.ml
+++ b/bin/tools/tools_common.ml
@@ -181,7 +181,8 @@ let env_command =
       in
       match new_path with
       | None -> ()
-      | Some new_path -> print_endline (sprintf "export %s=%s" Env_path.var new_path))
+      | Some new_path ->
+        print_endline (sprintf "export %s=%s" (Env.Var.to_string Env_path.var) new_path))
   in
   let info =
     let doc =

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -124,12 +124,6 @@ let local_libraries =
     ; special_builtin_support = None
     ; root_module = None
     }
-  ; { path = "otherlibs/dune-action-trace"
-    ; main_module_name = Some "Dune_action_trace"
-    ; include_subdirs = No
-    ; special_builtin_support = None
-    ; root_module = None
-    }
   ; { path = "vendor/bigstringaf"
     ; main_module_name = Some "Bigstringaf"
     ; include_subdirs = No
@@ -222,6 +216,12 @@ let local_libraries =
     }
   ; { path = "src/rpc"
     ; main_module_name = Some "Rpc"
+    ; include_subdirs = No
+    ; special_builtin_support = None
+    ; root_module = None
+    }
+  ; { path = "otherlibs/dune-action-trace"
+    ; main_module_name = Some "Dune_action_trace"
     ; include_subdirs = No
     ; special_builtin_support = None
     ; root_module = None

--- a/otherlibs/dune-rpc-lwt/test/dune_rpc_lwt_tests.ml
+++ b/otherlibs/dune-rpc-lwt/test/dune_rpc_lwt_tests.ml
@@ -16,10 +16,10 @@ let connect ~root_dir =
     let env =
       Env.add
         Env.initial
-        ~var:_XDG_DATA_HOME
+        ~var:(Env.Var.of_string _XDG_DATA_HOME)
         ~value:(Stdune.Path.to_absolute_filename xdg_data_dir)
     in
-    Env.get env
+    fun var -> Env.get env (Env.Var.of_string var)
   in
   let* res = Where.get ~env ~build_dir in
   match res with

--- a/otherlibs/dune-rpc/where.ml
+++ b/otherlibs/dune-rpc/where.ml
@@ -58,7 +58,7 @@ let of_string s : (t, exn) result =
 ;;
 
 let rpc_socket_relative_to_build_dir = ".rpc/dune"
-let env_var = "DUNE_RPC"
+let env_var = Env.Var.of_string "DUNE_RPC"
 
 let to_dbus : t -> Dbus_address.t = function
   | `Unix p -> { name = "unix"; args = [ "path", p ] }
@@ -144,7 +144,7 @@ module Make
   let get ~env ~build_dir : (t option, exn) result Fiber.t =
     let open Fiber.O in
     let* () = Fiber.return () in
-    match env env_var with
+    match env (Env.Var.to_string env_var) with
     | Some d ->
       Fiber.return
         (match of_string d with

--- a/otherlibs/stdune/src/ansi_color.ml
+++ b/otherlibs/stdune/src/ansi_color.ml
@@ -463,15 +463,15 @@ end
 
 let supports_color isatty =
   let is_smart =
-    match Env.(get initial) "TERM" with
+    match Env.(get initial (Var.of_string "TERM")) with
     | Some "dumb" -> false
     | _ -> true
   and clicolor =
-    match Env.(get initial) "CLICOLOR" with
+    match Env.(get initial (Var.of_string "CLICOLOR")) with
     | Some "0" -> false
     | _ -> true
   and clicolor_force =
-    match Env.(get initial) "CLICOLOR_FORCE" with
+    match Env.(get initial (Var.of_string "CLICOLOR_FORCE")) with
     | None | Some "0" -> false
     | _ -> true
   in

--- a/otherlibs/stdune/src/env.ml
+++ b/otherlibs/stdune/src/env.ml
@@ -17,10 +17,21 @@ module Var = struct
     let to_dyn = Dyn.string
   end
 
-  let temp_dir = if Sys.win32 then "TEMP" else "TMPDIR"
-
   include Comparable.Make (T)
   include T
+
+  let of_string s = s
+  let to_string t = t
+  let repr = Repr.view Repr.string ~to_:to_string
+  let temp_dir = of_string (if Sys.win32 then "TEMP" else "TMPDIR")
+  let _PATH = of_string "PATH"
+  let _OCAMLPARAM = of_string "OCAMLPARAM"
+  let _OCAMLFIND_CONF = of_string "OCAMLFIND_CONF"
+  let _INSIDE_EMACS = of_string "INSIDE_EMACS"
+  let _LC_ALL = of_string "LC_ALL"
+  let _GIT_DIR = of_string "GIT_DIR"
+  let _XDG_CACHE_HOME = of_string "XDG_CACHE_HOME"
+  let _DUNE_ACTION_TRACE_DIR = of_string "DUNE_ACTION_TRACE_DIR"
 end
 
 module Set = Var.Set
@@ -79,7 +90,7 @@ let to_unix t =
     | None ->
       let bindings =
         Map.foldi t.vars ~init:[] ~f:(fun var binding acc ->
-          Binding.render binding ~var :: acc)
+          Binding.render binding ~var:(Var.to_string var) :: acc)
       in
       t.unix <- Some bindings;
       bindings
@@ -114,7 +125,7 @@ let map_of_unix arr =
       Code_error.raise
         "Env.of_unix: entry without '=' found in the environment"
         [ "var", String s ]
-    | Some (k, v) -> k, v)
+    | Some (k, v) -> Var.of_string k, v)
   |> Map.of_list_multi
   |> Map.map ~f:(function
     | [] -> assert false
@@ -162,7 +173,11 @@ let update t ~var ~f =
 ;;
 
 let of_string_map m =
-  of_map (String.Map.foldi ~init:Map.empty ~f:(fun k v acc -> Map.set acc k v) m)
+  of_map
+    (String.Map.foldi
+       ~init:Map.empty
+       ~f:(fun k v acc -> Map.set acc (Var.of_string k) v)
+       m)
 ;;
 
 let iter t ~f = Map.iteri t.vars ~f:(fun var { Binding.value; _ } -> f var value)

--- a/otherlibs/stdune/src/env.mli
+++ b/otherlibs/stdune/src/env.mli
@@ -2,13 +2,24 @@
    in a separate module [Env_path]. *)
 
 module Var : sig
-  type t = string
+  type t
 
   val compare : t -> t -> Ordering.t
-  val temp_dir : t
 
   include Comparable_intf.S with type key := t
 
+  val of_string : string -> t
+  val to_string : t -> string
+  val repr : t Repr.t
+  val temp_dir : t
+  val _PATH : t
+  val _OCAMLPARAM : t
+  val _OCAMLFIND_CONF : t
+  val _INSIDE_EMACS : t
+  val _LC_ALL : t
+  val _GIT_DIR : t
+  val _XDG_CACHE_HOME : t
+  val _DUNE_ACTION_TRACE_DIR : t
   val to_dyn : t -> Dyn.t
 end
 
@@ -51,4 +62,4 @@ val to_dyn : t -> Dyn.t
 val of_string_map : string String.Map.t -> t
 val to_map : t -> string Map.t
 val of_map : string Map.t -> t
-val iter : t -> f:(string -> string -> unit) -> unit
+val iter : t -> f:(Var.t -> string -> unit) -> unit

--- a/otherlibs/stdune/src/env_path.ml
+++ b/otherlibs/stdune/src/env_path.ml
@@ -1,4 +1,4 @@
-let var = "PATH"
+let var = Env.Var._PATH
 
 let cons ?(var = var) env ~dir =
   Env.update env ~var ~f:(fun _PATH -> Some (Bin.cons_path dir ~_PATH))

--- a/otherlibs/stdune/src/execution_env.ml
+++ b/otherlibs/stdune/src/execution_env.ml
@@ -1,12 +1,12 @@
-let inside_emacs = Option.is_some (Env.get Env.initial "INSIDE_EMACS")
-let inside_ci = Option.is_some (Env.get Env.initial "CI")
+let inside_emacs = Option.is_some (Env.get Env.initial Env.Var._INSIDE_EMACS)
+let inside_ci = Option.is_some (Env.get Env.initial (Env.Var.of_string "CI"))
 
 module Inside_dune = struct
   type t =
     | Yes
     | In_context of Path.Build.t
 
-  let var = "INSIDE_DUNE"
+  let var = Env.Var.of_string "INSIDE_DUNE"
 
   let value = function
     | Yes -> "1"

--- a/otherlibs/stdune/src/log.ml
+++ b/otherlibs/stdune/src/log.ml
@@ -25,7 +25,7 @@ module Message = struct
     ; args =
         [ ( "OCAMLPARAM"
           , Dyn.string
-              (match Env.get Env.initial "OCAMLPARAM" with
+              (match Env.get Env.initial Env.Var._OCAMLPARAM with
                | Some s -> Printf.sprintf "%S" s
                | None -> "unset") )
         ]

--- a/otherlibs/stdune/test/env_tests.ml
+++ b/otherlibs/stdune/test/env_tests.ml
@@ -1,5 +1,8 @@
 open Stdune
 
+let a = Env.Var.of_string "A"
+let b = Env.Var.of_string "B"
+
 let find_assignment env var =
   Env.to_unix env
   |> List.find_map ~f:(fun assignment ->
@@ -10,16 +13,16 @@ let find_assignment env var =
 ;;
 
 let%expect_test "unchanged assignments are shared between environments" =
-  let env = Env.empty |> Env.add ~var:"A" ~value:"one" |> Env.add ~var:"B" ~value:"two" in
+  let env = Env.empty |> Env.add ~var:a ~value:"one" |> Env.add ~var:b ~value:"two" in
   let assignment = find_assignment env "A" in
-  let updated = Env.add env ~var:"B" ~value:"three" in
+  let updated = Env.add env ~var:b ~value:"three" in
   let updated_assignment = find_assignment updated "A" in
   print_endline (Bool.to_string (assignment == updated_assignment));
   [%expect {| true |}]
 ;;
 
 let%expect_test "rendering preserves the environment hash" =
-  let env = Env.empty |> Env.add ~var:"A" ~value:"one" in
+  let env = Env.empty |> Env.add ~var:a ~value:"one" in
   let before = Env.hash env in
   ignore (Env.to_unix env);
   print_endline (Bool.to_string (Int.equal before (Env.hash env)));

--- a/otherlibs/stdune/test/spawn/tests.ml
+++ b/otherlibs/stdune/test/spawn/tests.ml
@@ -183,7 +183,7 @@ let%expect_test "env" =
     let env =
       match v with
       | None -> Env.empty
-      | Some value -> Env.add Env.empty ~var:"FOO" ~value
+      | Some value -> Env.add Env.empty ~var:(Env.Var.of_string "FOO") ~value
     in
     wait
       (Spawn.spawn

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -695,7 +695,7 @@ module Dune_config = struct
     lazy
       (if Sys.win32
        then (
-         match Env.get Env.initial "NUMBER_OF_PROCESSORS" with
+         match Env.get Env.initial (Env.Var.of_string "NUMBER_OF_PROCESSORS") with
          | None -> 1
          | Some s -> Int.of_string s |> Option.value ~default:1)
        else (

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -114,7 +114,10 @@ let rec exec t ~ectx ~eenv : Done_or_more_deps.t Fiber.t =
     exec t ~ectx ~eenv
   | Chdir (dir, t) -> exec t ~ectx ~eenv:{ eenv with working_dir = dir }
   | Setenv (var, value, t) ->
-    exec t ~ectx ~eenv:{ eenv with env = Env.add eenv.env ~var ~value }
+    exec
+      t
+      ~ectx
+      ~eenv:{ eenv with env = Env.add eenv.env ~var:(Env.Var.of_string var) ~value }
   | Redirect_out (Stdout, fn, perm, Echo s) ->
     let perm = File_perm.to_unix_perm perm in
     Io.write_file ~perm (Path.build fn) (String.concat s ~sep:" ");
@@ -370,7 +373,7 @@ let exec
           [ Some { source = Path.to_absolute_filename root; target } ]
     in
     let env =
-      let var = "DUNE_PROJECT_ROOT" in
+      let var = Env.Var.of_string "DUNE_PROJECT_ROOT" in
       match Execution_parameters.action_project_root execution_parameters with
       | None -> Env.remove env ~var
       | Some project_root ->

--- a/src/dune_engine/action_plugin.ml
+++ b/src/dune_engine/action_plugin.ml
@@ -56,7 +56,7 @@ let exec ~(ectx : context) ~(eenv : env) prog args =
           })
       |> Csexp.to_string
     in
-    Env.add eenv.env ~var:DAP.run_by_dune_env_variable ~value
+    Env.add eenv.env ~var:(Env.Var.of_string DAP.run_by_dune_env_variable) ~value
   in
   let+ () =
     Process.run

--- a/src/dune_engine/action_trace.ml
+++ b/src/dune_engine/action_trace.ml
@@ -16,7 +16,7 @@ type t =
 let add_to_env t env =
   Env.add
     env
-    ~var:Dune_action_trace.Private.trace_dir_env_var
+    ~var:Env.Var._DUNE_ACTION_TRACE_DIR
     ~value:(Path.to_absolute_filename (Path.build t.dir))
 ;;
 

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -249,7 +249,7 @@ module Internal = struct
     Digest.Manual.int d count;
     Dep.Set.iter deps ~f:(function
       | Env var ->
-        Digest.Manual.string d var;
+        Digest.Manual.string d (Env.Var.to_string var);
         Digest.Manual.option d ~f:Digest.Manual.string (Env.get env var)
       | _ -> ())
   ;;

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -68,7 +68,7 @@ module T = struct
       [ Repr.case "File_selector" File_selector.repr ~proj:(function
           | File_selector g -> Some g
           | _ -> None)
-      ; Repr.case "Env" Repr.string ~proj:(function
+      ; Repr.case "Env" Env.Var.repr ~proj:(function
           | Env e -> Some e
           | _ -> None)
       ; Repr.case "File" Path.repr ~proj:(function
@@ -325,7 +325,8 @@ module Set = struct
   let digest t digest =
     iter t ~f:(fun dep ->
       match dep with
-      | Env var -> Stable_for_digest.digest digest (Stable_for_digest.Env var)
+      | Env var ->
+        Stable_for_digest.digest digest (Stable_for_digest.Env (Env.Var.to_string var))
       | Universe -> Stable_for_digest.digest digest Stable_for_digest.Universe
       | File p ->
         Stable_for_digest.digest
@@ -406,7 +407,7 @@ module Facts = struct
       | Env var ->
         Fact.Stable_for_digest.digest
           digest
-          (Fact.Stable_for_digest.Env (var, Env.get env var))
+          (Fact.Stable_for_digest.Env (Env.Var.to_string var, Env.get env var))
       | Universe -> ()
       | File _ | File_selector _ | Alias _ ->
         (match (fact : Fact.t) with

--- a/src/dune_findlib/config.ml
+++ b/src/dune_findlib/config.ml
@@ -85,8 +85,8 @@ let ocamlpath_sep =
   else Bin.path_sep
 ;;
 
-let ocamlpath_var = "OCAMLPATH"
-let ocamlfind_ignore_dups_in = "OCAMLFIND_IGNORE_DUPS_IN"
+let ocamlpath_var = Env.Var.of_string "OCAMLPATH"
+let ocamlfind_ignore_dups_in = Env.Var.of_string "OCAMLFIND_IGNORE_DUPS_IN"
 let path_var = Bin.parse_path ~sep:ocamlpath_sep
 let ocamlpath_of_env env = Env.get env ocamlpath_var |> Option.map ~f:path_var
 
@@ -136,7 +136,7 @@ let ocamlfind_config_path ~env ~which ~findlib_toolchain =
        dune attempts to find [ocaml], [ocamlopt], etc. in the findlib
        configuration for the toolchain first to account for cross-compilation
        use cases. It then falls back to searching in [$PATH] *)
-    match Env.get env "OCAMLFIND_CONF" with
+    match Env.get env Env.Var._OCAMLFIND_CONF with
     | Some s -> Memo.return (Some s)
     | None ->
       (match findlib_toolchain with

--- a/src/dune_lang/action.ml
+++ b/src/dune_lang/action.ml
@@ -148,7 +148,7 @@ module Env_update = struct
     Repr.record
       "env-update"
       [ Repr.field "op" Op.repr ~get:(fun t -> t.op)
-      ; Repr.field "var" Repr.string ~get:(fun t -> t.var)
+      ; Repr.field "var" Env.Var.repr ~get:(fun t -> t.var)
       ; Repr.field "value" value_repr ~get:(fun t -> t.value)
       ]
   ;;
@@ -165,7 +165,7 @@ module Env_update = struct
     let open Decoder in
     let env_update_op = enum Op.all in
     let+ op, var, value = triple env_update_op string String_with_vars.decode in
-    { op; var; value }
+    { op; var = Env.Var.of_string var; value }
   ;;
 
   let encode { op; var; value } =
@@ -173,7 +173,7 @@ module Env_update = struct
       List.find_map Op.all ~f:(fun (k, v) -> if Poly.equal v op then Some k else None)
       |> Option.value_exn
     in
-    List [ atom op; atom var; String_with_vars.encode value ]
+    List [ atom op; atom (Env.Var.to_string var); String_with_vars.encode value ]
   ;;
 end
 

--- a/src/dune_lang/dune_env.ml
+++ b/src/dune_lang/dune_env.ml
@@ -199,10 +199,13 @@ let inline_tests_field =
 let env_vars_decode =
   located (repeat (pair string string))
   >>| fun (loc, pairs) ->
+  let pairs = List.map pairs ~f:(fun (var, value) -> Env.Var.of_string var, value) in
   match Env.Map.of_list pairs with
   | Ok vars -> Env.extend Env.empty ~vars
   | Error (k, _, _) ->
-    User_error.raise ~loc [ Pp.textf "Variable %s is specified several times" k ]
+    User_error.raise
+      ~loc
+      [ Pp.textf "Variable %s is specified several times" (Env.Var.to_string k) ]
 ;;
 
 let env_vars_field =

--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -209,7 +209,7 @@ let opam_string_to_slang ~packages_in_solution ~package ~loc opam_string =
 
 let opam_env_update_to_env_update (var, env_op, value_string, _) : _ Action.Env_update.t =
   { Action.Env_update.op = env_op
-  ; var
+  ; var = Env.Var.of_string var
   ; value = String_with_vars.make_text Loc.none value_string
   }
 ;;

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -424,9 +424,9 @@ let make_stderr () = Process.Io.make_stderr ~output_on_success:Swallow ~output_l
 
 let env =
   (* to avoid Git translating its CLI *)
-  Env.add Env.initial ~var:"LC_ALL" ~value:"C"
+  Env.add Env.initial ~var:Env.Var._LC_ALL ~value:"C"
   (* to avoid prmompting for passwords *)
-  |> Env.add ~var:"GIT_TERMINAL_PROMPT" ~value:"0"
+  |> Env.add ~var:(Env.Var.of_string "GIT_TERMINAL_PROMPT") ~value:"0"
 ;;
 
 let git () = Vcs.git_for ~needed_for:"by dune package management to fetch git sources"
@@ -435,7 +435,7 @@ let with_specified_git_dir ~dir env =
   (* prevent Git from walking up the file system to find a potentially
      unrelated git directory, so we disable the walk up by setting
      the directory explicitely. *)
-  Env.add env ~var:"GIT_DIR" ~value:(Path.to_string dir)
+  Env.add env ~var:Env.Var._GIT_DIR ~value:(Path.to_string dir)
 ;;
 
 module Git_error = struct

--- a/src/dune_rules/action_builder.mli
+++ b/src/dune_rules/action_builder.mli
@@ -97,7 +97,7 @@ val paths_matching_unit : loc:Loc.t -> File_selector.t -> unit t
 
 (** [env_var v] records [v] as an environment variable that is read by the
     action produced by the action builder. *)
-val env_var : string -> unit t
+val env_var : Env.Var.t -> unit t
 
 (** Add targets to an action builder, turning a target-less [Action_builder.t]
     into [With_targets.t]. *)

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -212,7 +212,10 @@ end = struct
     let*! value, acc = value env acc in
     let value = Action_builder.memoize ~cutoff:String.equal "env var" value in
     let env =
-      { env with expander = Expander.set_local_env_var env.expander ~var ~value }
+      { env with
+        expander =
+          Expander.set_local_env_var env.expander ~var:(Env.Var.of_string var) ~value
+      }
     in
     let+! f, acc = t env acc in
     let b =

--- a/src/dune_rules/colors.ml
+++ b/src/dune_rules/colors.ml
@@ -9,8 +9,8 @@ let setup_env_for_colors env =
       | None -> Some value
       | Some s -> Some s)
   in
-  let env = set env "OPAMCOLOR" "always" in
-  let env = set env "OCAML_COLOR" "always" in
+  let env = set env (Env.Var.of_string "OPAMCOLOR") "always" in
+  let env = set env (Env.Var.of_string "OCAML_COLOR") "always" in
   env
 ;;
 

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -126,7 +126,7 @@ module Builder = struct
       let f (var, t) =
         let parse ~loc:_ s = s in
         let standard = Env_path.path env |> List.map ~f:Path.to_string in
-        var, Ordered_set_lang.eval t ~parse ~standard ~eq:String.equal
+        Env.Var.of_string var, Ordered_set_lang.eval t ~parse ~standard ~eq:String.equal
       in
       List.map ~f t
     in
@@ -298,6 +298,7 @@ end = struct
       in
       Dune_sexp.Parser.parse_string ~fname:"<opam output>" ~mode:Single s
       |> Dune_sexp.Decoder.(parse (enter (repeat (pair string string))) Univ_map.empty)
+      |> List.map ~f:(fun (var, value) -> Env.Var.of_string var, value)
       |> Env.Map.of_list_multi
       |> Env.Map.mapi ~f:(fun var values ->
         match List.rev values with
@@ -305,7 +306,9 @@ end = struct
         | [ x ] -> x
         | x :: _ ->
           User_warning.emit
-            [ Pp.textf "variable %S present multiple times in the output of:" var
+            [ Pp.textf
+                "variable %S present multiple times in the output of:"
+                (Env.Var.to_string var)
             ; Pp.tag
                 User_message.Style.Details
                 (Pp.text (String.quote_list_for_shell (Path.to_string opam :: args)))
@@ -625,7 +628,7 @@ module Group = struct
         [ Pp.textf
             "opam doesn't set the environment variable %s. I cannot create an opam build \
              context without opam setting this variable."
-            Opam_switch.opam_switch_prefix_var_name
+            (Env.Var.to_string Opam_switch.opam_switch_prefix_var_name)
         ];
     let path =
       match Env.Map.find vars Env_path.var with
@@ -684,7 +687,7 @@ module Group = struct
           | Some _ -> Memo.return builder
           | None ->
             let+ env = builder.env in
-            (match Env.get env "OCAMLFIND_TOOLCHAIN" with
+            (match Env.get env (Env.Var.of_string "OCAMLFIND_TOOLCHAIN") with
              | None -> builder
              | Some name ->
                { builder with

--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -527,7 +527,7 @@ let create_sh_script cram_stanzas ~temp_dir ~setup_scripts (shell : Cram_stanza.
       let user_shell_code_output_file = file ~ext:".output" in
       let+ user_shell_code_output_file_sh_path = sh_path user_shell_code_output_file in
       let build_path_prefix_map_var =
-        Dune_util.Build_path_prefix_map._BUILD_PATH_PREFIX_MAP
+        Dune_util.Build_path_prefix_map._BUILD_PATH_PREFIX_MAP |> Env.Var.to_string
       in
       fprln
         oc
@@ -582,7 +582,7 @@ let create_sh_script cram_stanzas ~temp_dir ~setup_scripts (shell : Cram_stanza.
 let _display_with_bars s = List.iter (String.split_lines s) ~f:(Printf.eprintf "| %s\n")
 
 let make_run_env env ~temp_dir ~cwd =
-  let env = Env.add env ~var:"LC_ALL" ~value:"C" in
+  let env = Env.add env ~var:Env.Var._LC_ALL ~value:"C" in
   let temp_dir = Path.relative temp_dir "tmp" in
   let env =
     Dune_util.Build_path_prefix_map.extend_build_path_prefix_map

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -314,7 +314,7 @@ let rec dep expander : Dep_conf.t -> _ = function
   | Env_var var_sw ->
     Other
       (let* var = Expander.expand_str expander var_sw in
-       let+ () = Action_builder.env_var var in
+       let+ () = Action_builder.env_var (Env.Var.of_string var) in
        [])
   | Sandbox_config _ -> Other (Action_builder.return [])
 

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -668,6 +668,7 @@ let env_macro t source macro_invocation =
       ]
       ~hints:[ Pp.text "the syntax is %{env:VAR=DEFAULT-VALUE}" ]
   | Some (var, default) ->
+    let var = Env.Var.of_string var in
     (match Env.Var.Map.find t.local_env var with
      | Some v -> Deps.With (v >>| string)
      | None ->

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -25,7 +25,7 @@ val make_root
     binaries the action will execute. *)
 val host_context : t -> Context.t Memo.t
 
-val set_local_env_var : t -> var:string -> value:string Action_builder.t -> t
+val set_local_env_var : t -> var:Env.Var.t -> value:string Action_builder.t -> t
 
 val set_scope
   :  t

--- a/src/dune_rules/fdo.ml
+++ b/src/dune_rules/fdo.ml
@@ -49,12 +49,16 @@ let get_flags var =
     Env.get env var |> Option.value ~default:"" |> String.extract_blank_separated_words
   in
   let memo =
-    Memo.create var ~input:(module Context) ~cutoff:(List.equal String.equal) f
+    Memo.create
+      (Env.Var.to_string var)
+      ~input:(module Context)
+      ~cutoff:(List.equal String.equal)
+      f
   in
   Memo.exec memo
 ;;
 
-let ocamlfdo_flags = get_flags "OCAMLFDO_FLAGS"
+let ocamlfdo_flags = get_flags (Env.Var.of_string "OCAMLFDO_FLAGS")
 
 module Mode = struct
   type t =
@@ -70,7 +74,7 @@ module Mode = struct
 
   let default = If_exists
   let all = [ If_exists; Never; Always ]
-  let var = "OCAMLFDO_USE_PROFILE"
+  let var = Env.Var.of_string "OCAMLFDO_USE_PROFILE"
 
   let of_env (env : Env.t) =
     match Env.get env var with
@@ -84,7 +88,7 @@ module Mode = struct
                "Failed to parse environment variable: %s=%s\n\
                 Permitted values: if-exists always never\n\
                 Default: %s"
-               var
+               (Env.Var.to_string var)
                v
                (to_string default)
            ])
@@ -148,7 +152,9 @@ let opt_rule cctx m =
 module Linker_script = struct
   type t = Path.t Memo.t option
 
-  let ocamlfdo_linker_script_flags = get_flags "OCAMLFDO_LINKER_SCRIPT_FLAGS"
+  let ocamlfdo_linker_script_flags =
+    get_flags (Env.Var.of_string "OCAMLFDO_LINKER_SCRIPT_FLAGS")
+  ;;
 
   let linker_script_rule cctx fdo_target_exe =
     let sctx = Compilation_context.super_context cctx in

--- a/src/dune_rules/global.ml
+++ b/src/dune_rules/global.ml
@@ -19,7 +19,7 @@ let init ~capture_outputs =
         behave differently when run inside emacs is Dune itself and we sometimes
         run Dune from inside Dune, for instance in cram tests, so it is
         important to do this. *)
-     Env.remove env ~var:"INSIDE_EMACS")
+     Env.remove env ~var:Env.Var._INSIDE_EMACS)
 ;;
 
 let env () = Fdecl.get env

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -374,7 +374,7 @@ let gen_rules_for_single_file stanza ~sctx ~dir ~expander ~mdx_prog ~mdx_prog_ge
     in
     let open Action_builder.O in
     let action =
-      Action_builder.env_var "MDX_RUN_NON_DETERMINISTIC"
+      Action_builder.env_var (Env.Var.of_string "MDX_RUN_NON_DETERMINISTIC")
       >>> (Action_builder.map mdx_input_dependencies ~f:(fun d -> (), d)
            |> Action_builder.dyn_deps)
       >>> let* executable = executable in

--- a/src/dune_rules/melange/melange_binary.ml
+++ b/src/dune_rules/melange/melange_binary.ml
@@ -29,7 +29,7 @@ let where =
   fun sctx ~loc ~dir ->
     let* env = Super_context.env_node sctx ~dir >>= Env_node.external_env in
     let+ melange_dirs =
-      match Env.get env "MELANGELIB" with
+      match Env.get env (Env.Var.of_string "MELANGELIB") with
       | Some p -> Memo.return (Some p)
       | None ->
         let* melc = melc sctx ~loc ~dir in

--- a/src/dune_rules/odoc/odoc.ml
+++ b/src/dune_rules/odoc/odoc.ml
@@ -349,7 +349,7 @@ let run_odoc sctx ~dir command ~quiet ~flags_for args =
     | None -> Action_builder.return Command.Args.empty
     | Some path -> odoc_base_flags quiet path
   in
-  let deps = Action_builder.env_var "ODOC_SYNTAX" in
+  let deps = Action_builder.env_var (Env.Var.of_string "ODOC_SYNTAX") in
   let open Action_builder.With_targets.O in
   Action_builder.with_no_targets deps
   >>> Command.run_dyn_prog

--- a/src/dune_rules/pkg_config.ml
+++ b/src/dune_rules/pkg_config.ml
@@ -3,7 +3,7 @@ open Memo.O
 
 let pkg_config_binary sctx ~dir =
   let+ env = Super_context.env_node sctx ~dir >>= Env_node.external_env in
-  match Env.get env "PKG_CONFIG" with
+  match Env.get env (Env.Var.of_string "PKG_CONFIG") with
   | None -> "pkg-config"
   | Some s -> s
 ;;
@@ -15,7 +15,7 @@ module Query = struct
 
   let to_args t ~env : _ Command.Args.t list =
     let env_args : _ Command.Args.t =
-      match Env.get env "PKG_CONFIG_ARGN" with
+      match Env.get env (Env.Var.of_string "PKG_CONFIG_ARGN") with
       | Some s -> As (String.split_on_char ~sep:' ' s)
       | None -> Command.Args.empty
     in

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -571,13 +571,14 @@ module Pkg = struct
   let base_env t =
     Env.Map.of_list_exn
       [ Opam_switch.opam_switch_prefix_var_name, [ Value.Path t.paths.target_dir ]
-      ; "CDPATH", [ Value.String "" ]
-      ; "MAKELEVEL", [ Value.String "" ]
-      ; "OPAM_PACKAGE_NAME", [ Value.String (Package.Name.to_string t.info.name) ]
-      ; ( "OPAM_PACKAGE_VERSION"
+      ; Env.Var.of_string "CDPATH", [ Value.String "" ]
+      ; Env.Var.of_string "MAKELEVEL", [ Value.String "" ]
+      ; ( Env.Var.of_string "OPAM_PACKAGE_NAME"
+        , [ Value.String (Package.Name.to_string t.info.name) ] )
+      ; ( Env.Var.of_string "OPAM_PACKAGE_VERSION"
         , [ Value.String (Package_version.to_string t.info.version) ] )
-      ; "OPAMCLI", [ Value.String "2.0" ]
-      ; "OPAMSWITCH", [ Value.String "dune" ]
+      ; Env.Var.of_string "OPAMCLI", [ Value.String "2.0" ]
+      ; Env.Var.of_string "OPAMSWITCH", [ Value.String "dune" ]
       ]
   ;;
 
@@ -1132,7 +1133,7 @@ module Action_expander = struct
       expand action ~expander
     in
     List.fold_left updates ~init:action ~f:(fun action (k, v) ->
-      Action.Setenv (k, v, action))
+      Action.Setenv (Env.Var.to_string k, v, action))
   ;;
 
   module Artifacts_and_deps = struct

--- a/src/dune_rules/rocq/rocq_path.ml
+++ b/src/dune_rules/rocq/rocq_path.ml
@@ -198,7 +198,7 @@ let of_env env =
   let rocqpath =
     (* windows uses ';' *)
     let rocqpath_sep = if Sys.cygwin then ';' else Bin.path_sep in
-    Env.get env "ROCQPATH"
+    Env.get env (Env.Var.of_string "ROCQPATH")
     |> function
     | None -> []
     | Some rocqpath -> Bin.parse_path ~sep:rocqpath_sep rocqpath

--- a/src/dune_rules/run_with_path.ml
+++ b/src/dune_rules/run_with_path.ml
@@ -246,7 +246,7 @@ module Spec = struct
       let env =
         eenv.env
         |> Env.add
-             ~var:"OCAMLFIND_DESTDIR"
+             ~var:(Env.Var.of_string "OCAMLFIND_DESTDIR")
              ~value:(Path.to_absolute_filename ocamlfind_destdir)
         |> Env_path.cons ~dir:dune_folder
       in

--- a/src/dune_rules/sites/site_env.ml
+++ b/src/dune_rules/sites/site_env.ml
@@ -1,6 +1,10 @@
 open Import
 open Memo.O
 
+let dune_dir_locations_env_var =
+  Env.Var.of_string Dune_site_private.dune_dir_locations_env_var
+;;
+
 let dune_sites_env ~default_ocamlpath ~stdlib =
   [ Dune_site_private.dune_ocaml_stdlib_env_var, Path.to_absolute_filename stdlib
   ; ( Dune_site_private.dune_ocaml_hardcoded_env_var
@@ -24,7 +28,7 @@ let add_packages_env context ~base stanzas packages =
   in
   let+ env_dune_dir_locations =
     let init =
-      match Stdune.Env.get base Dune_site_private.dune_dir_locations_env_var with
+      match Stdune.Env.get base dune_dir_locations_env_var with
       | None -> []
       | Some var ->
         (match Dune_site_private.decode_dune_dir_locations var with
@@ -102,6 +106,6 @@ let add_packages_env context ~base stanzas packages =
   else
     Stdune.Env.add
       base
-      ~var:Dune_site_private.dune_dir_locations_env_var
+      ~var:dune_dir_locations_env_var
       ~value:(Dune_site_private.encode_dune_dir_locations env_dune_dir_locations)
 ;;

--- a/src/dune_trace/dune
+++ b/src/dune_trace/dune
@@ -28,7 +28,6 @@
   (names dune_trace_stubs))
  (libraries
   stdune
-  dune_action_trace
   re
   csexp
   bigstringaf

--- a/src/dune_trace/dune_trace.ml
+++ b/src/dune_trace/dune_trace.ml
@@ -53,7 +53,7 @@ let at_exit =
       Option.iter alloc_summary ~f:(Out.emit out);
       Out.emit out (Event.exit ());
       Out.close out;
-      (match Env.(get initial Dune_action_trace.Private.trace_dir_env_var) with
+      (match Env.(get initial Var._DUNE_ACTION_TRACE_DIR) with
        | None -> ()
        | Some dir ->
          let dir = Path.of_string dir in

--- a/src/dune_util/build_path_prefix_map0.ml
+++ b/src/dune_util/build_path_prefix_map0.ml
@@ -1,6 +1,6 @@
 open Stdune
 
-let _BUILD_PATH_PREFIX_MAP = "BUILD_PATH_PREFIX_MAP"
+let _BUILD_PATH_PREFIX_MAP = Env.Var.of_string "BUILD_PATH_PREFIX_MAP"
 
 let extend_build_path_prefix_map env how map =
   let new_rules = Build_path_prefix_map.encode_map map in

--- a/src/dune_util/dune_util.ml
+++ b/src/dune_util/dune_util.ml
@@ -16,7 +16,7 @@ let xdg =
      | Some xdg -> xdg
      | None ->
        let env_map =
-         Env.update Env.initial ~var:"HOME" ~f:(function
+         Env.update Env.initial ~var:(Env.Var.of_string "HOME") ~f:(function
            | Some _ as s -> s
            | None ->
              let uid = Unix.getuid () in
@@ -24,7 +24,7 @@ let xdg =
               | exception Not_found -> None
               | s -> Some s.pw_dir))
        in
-       Xdg.create ~env:(Env.get env_map) ())
+       Xdg.create ~env:(fun var -> Env.get env_map (Env.Var.of_string var)) ())
 ;;
 
 let override_xdg : Xdg.t -> unit =

--- a/src/install/roots.ml
+++ b/src/install/roots.ml
@@ -93,13 +93,15 @@ open Dune_findlib
 
 let ocamlpath = Findlib.Config.ocamlpath_var
 let ocamlfind_ignore_dups_in = Findlib.Config.ocamlfind_ignore_dups_in
+let ocamltop_include_path = Env.Var.of_string "OCAMLTOP_INCLUDE_PATH"
+let manpath = Env.Var.of_string "MANPATH"
 
 let to_env_without_path t ~relative =
   [ Ocaml.Env.caml_ld_library_path, relative t.lib_root "stublibs"
   ; ocamlpath, t.lib_root
-  ; "OCAMLTOP_INCLUDE_PATH", relative t.lib_root "toplevel"
+  ; ocamltop_include_path, relative t.lib_root "toplevel"
   ; ocamlfind_ignore_dups_in, t.lib_root
-  ; "MANPATH", t.man
+  ; manpath, t.man
   ]
 ;;
 
@@ -179,7 +181,7 @@ let%test_module "extend_env_concat_path_vars" =
   (module struct
     let env_of_list bindings =
       List.fold_left bindings ~init:Env.empty ~f:(fun env (var, value) ->
-        Env.add env ~var ~value)
+        Env.add env ~var:(Env.Var.of_string var) ~value)
     ;;
 
     let print_env env = Env.to_unix env |> List.iter ~f:print_endline
@@ -193,7 +195,10 @@ let%test_module "extend_env_concat_path_vars" =
         let a = Env.add Env.empty ~var ~value:"/from/a" in
         let b = Env.add Env.empty ~var ~value:"/from/b" in
         let result = extend_env_concat_path_vars a b in
-        Printf.printf "%s=%s\n" var (Option.value (Env.get result var) ~default:"(none)"));
+        Printf.printf
+          "%s=%s\n"
+          (Env.Var.to_string var)
+          (Option.value (Env.get result var) ~default:"(none)"));
       [%expect
         {|
         CAML_LD_LIBRARY_PATH=/from/b:/from/a

--- a/src/ocaml/env.ml
+++ b/src/ocaml/env.ml
@@ -1,9 +1,9 @@
 open Stdune
 
 let with_color env =
-  Env.update env ~var:"OCAMLPARAM" ~f:(function
+  Env.update env ~var:Env.Var._OCAMLPARAM ~f:(function
     | None -> Some "color=always,_"
     | Some s -> Some ("color=always," ^ s))
 ;;
 
-let caml_ld_library_path = "CAML_LD_LIBRARY_PATH"
+let caml_ld_library_path = Env.Var.of_string "CAML_LD_LIBRARY_PATH"

--- a/src/rpc/where.ml
+++ b/src/rpc/where.ml
@@ -37,7 +37,7 @@ let build_dir =
 ;;
 
 let get () =
-  let env = Env.get Env.initial in
+  let env var = Env.get Env.initial (Env.Var.of_string var) in
   match Where.get ~env ~build_dir:(Lazy.force build_dir) with
   | Ok s -> s
   | Error exn ->

--- a/src/source/opam_switch.ml
+++ b/src/source/opam_switch.ml
@@ -21,4 +21,4 @@ include Repr.Poly (struct
     let repr = repr
   end)
 
-let opam_switch_prefix_var_name = "OPAM_SWITCH_PREFIX"
+let opam_switch_prefix_var_name = Env.Var.of_string "OPAM_SWITCH_PREFIX"

--- a/src/source/workspace.ml
+++ b/src/source/workspace.ml
@@ -561,12 +561,18 @@ module Context = struct
         field_o "fdo" (Dune_lang.Syntax.since syntax (2, 0) >>> map string ~f)
       and+ paths =
         let f l =
-          match Env.Map.of_list (List.map ~f:(fun ((loc, s), _) -> s, loc) l) with
+          match
+            Env.Map.of_list
+              (List.map ~f:(fun ((loc, s), _) -> Env.Var.of_string s, loc) l)
+          with
           | Ok _ -> List.map ~f:(fun ((_, s), x) -> s, x) l
           | Error (var, _, loc) ->
             User_error.raise
               ~loc
-              [ Pp.textf "the variable %S can appear at most once in this stanza." var ]
+              [ Pp.textf
+                  "the variable %S can appear at most once in this stanza."
+                  (Env.Var.to_string var)
+              ]
         in
         field
           "paths"

--- a/test/expect-tests/dune_pkg/encode_decode_tests.ml
+++ b/test/expect-tests/dune_pkg/encode_decode_tests.ml
@@ -266,7 +266,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
             }
         ; exported_env =
             [ { Action.Env_update.op = Eq
-              ; var = "foo"
+              ; var = Env.Var.of_string "foo"
               ; value = String_with_vars.make_text Loc.none "bar"
               }
             ]

--- a/test/expect-tests/dune_pkg/rev_store_fetch_depth/rev_store_fetch_depth_test.ml
+++ b/test/expect-tests/dune_pkg/rev_store_fetch_depth/rev_store_fetch_depth_test.ml
@@ -7,9 +7,11 @@ module Console = Console
 let () =
   let cache_dir = lazy (Temp.create Dir ~prefix:"isolated-cache-" ~suffix:"") in
   let env =
-    Env.update Env.initial ~var:"XDG_CACHE_HOME" ~f:(fun _ ->
-      Some (Path.to_string (Lazy.force cache_dir)))
-    |> Env.get
+    let env =
+      Env.update Env.initial ~var:Env.Var._XDG_CACHE_HOME ~f:(fun _ ->
+        Some (Path.to_string (Lazy.force cache_dir)))
+    in
+    fun var -> Env.get env (Env.Var.of_string var)
   in
   Dune_util.override_xdg (Xdg.create ~env ());
   Config.init String.Map.empty;
@@ -66,8 +68,11 @@ let%expect_test "second fetch uses refs for efficient negotiation (fix #13323)" 
   let unrelated_repo_dir = Temp.create Dir ~prefix:"git-unrelated-" ~suffix:"" in
   let trace_file = Temp.create File ~prefix:"git-trace-" ~suffix:".log" in
   let env =
-    Env.add Env.initial ~var:"GIT_TRACE_PACKET" ~value:(Path.to_string trace_file)
-    |> Env.add ~var:"GIT_PROTOCOL" ~value:"version=2"
+    Env.add
+      Env.initial
+      ~var:(Env.Var.of_string "GIT_TRACE_PACKET")
+      ~value:(Path.to_string trace_file)
+    |> Env.add ~var:(Env.Var.of_string "GIT_PROTOCOL") ~value:"version=2"
   in
   (Dune_scheduler.Scheduler.Run.go
      { concurrency = 2; print_ctrl_c_warning = false; watch_exclusions = [] }

--- a/test/expect-tests/dune_pkg/rev_store_tests.ml
+++ b/test/expect-tests/dune_pkg/rev_store_tests.ml
@@ -8,9 +8,11 @@ module Console = Console
 let () =
   Dune_util.override_xdg
     (let env =
-       Env.update Env.initial ~var:"XDG_CACHE_HOME" ~f:(fun _ ->
-         Some (Path.of_filename_relative_to_initial_cwd ".cache" |> Path.to_string))
-       |> Env.get
+       let env =
+         Env.update Env.initial ~var:Env.Var._XDG_CACHE_HOME ~f:(fun _ ->
+           Some (Path.of_filename_relative_to_initial_cwd ".cache" |> Path.to_string))
+       in
+       fun var -> Env.get env (Env.Var.of_string var)
      in
      Xdg.create ~env ());
   Config.init String.Map.empty;

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -19,7 +19,7 @@ let dune_prog =
 let init_chan ~root_dir =
   let build_dir = Filename.concat root_dir "_build" in
   let once () =
-    let env = Env.get Env.initial in
+    let env var = Env.get Env.initial (Env.Var.of_string var) in
     match Dune_rpc_impl.Where.Where.get ~env ~build_dir with
     | Error exn -> Exn.raise exn
     | Ok None -> Fiber.return None

--- a/test/expect-tests/findlib/findlib_tests.ml
+++ b/test/expect-tests/findlib/findlib_tests.ml
@@ -181,7 +181,7 @@ let conf () =
       ~env:
         (Env.initial
          |> Env.add
-              ~var:"OCAMLFIND_CONF"
+              ~var:Env.Var._OCAMLFIND_CONF
               ~value:
                 (Path.Outside_build_dir.relative db_path "../toolchain"
                  |> Path.Outside_build_dir.to_string))

--- a/test/expect-tests/timer_tests.ml
+++ b/test/expect-tests/timer_tests.ml
@@ -54,7 +54,9 @@ let%expect_test "run process with timeout" =
   Scheduler.Run.go config (fun () ->
     let pid =
       let prog =
-        let path = Env.get Env.initial "PATH" |> Option.value_exn |> Bin.parse_path in
+        let path =
+          Env.get Env.initial Env.Var._PATH |> Option.value_exn |> Bin.parse_path
+        in
         Bin.which ~path "sleep" |> Option.value_exn |> Path.to_string
       in
       Spawn.spawn ~prog ~argv0:prog ~args:(Array.Immutable.of_list [ "100000" ]) ()

--- a/test/expect-tests/vcs/vcs_tests_common.ml
+++ b/test/expect-tests/vcs/vcs_tests_common.ml
@@ -49,7 +49,7 @@ let run (vcs : Vcs.t) args =
           --exec]. *)
        Env.add
          Env.initial
-         ~var:"GIT_DIR"
+         ~var:Env.Var._GIT_DIR
          ~value:(Filename.concat (Path.to_absolute_filename vcs.root) ".git"))
     ~dir:vcs.root
     ~stdout_to:(Process.Io.file Dev_null.path Process.Io.Out)


### PR DESCRIPTION
Make `Env.Var.t` abstract so callers explicitly mark boundaries between arbitrary strings and environment variable names. Keep `Env.Var.of_string` unchecked in this preparatory refactor, add the corresponding conversion and representation functions, and update consumers across the codebase.

Repeated environment variables now use shared `Env.Var` constants. This avoids reconstructing them and prepares for enforcing stronger variable-name invariants in follow-up changes. The refactor is intended to preserve behavior.
