### PR TITLE
fix(stdune): reject NUL bytes in environment variable names

### DIFF
--- a/otherlibs/stdune/src/env.ml
+++ b/otherlibs/stdune/src/env.ml
@@ -20,7 +20,15 @@ module Var = struct
   include Comparable.Make (T)
   include T
 
-  let of_string s = s
+  let of_string s =
+    if String.contains s '\000'
+    then
+      Code_error.raise
+        "Env.Var.of_string: NUL byte in environment variable name"
+        [ "name", Dyn.string s ];
+    s
+  ;;
+
   let to_string t = t
   let repr = Repr.view Repr.string ~to_:to_string
   let temp_dir = of_string (if Sys.win32 then "TEMP" else "TMPDIR")

--- a/otherlibs/stdune/src/env.mli
+++ b/otherlibs/stdune/src/env.mli
@@ -8,7 +8,9 @@ module Var : sig
 
   include Comparable_intf.S with type key := t
 
+  (** Raises a code error if the string contains a NUL byte. *)
   val of_string : string -> t
+
   val to_string : t -> string
   val repr : t Repr.t
   val temp_dir : t

--- a/otherlibs/stdune/test/env_tests.ml
+++ b/otherlibs/stdune/test/env_tests.ml
@@ -3,6 +3,13 @@ open Stdune
 let a = Env.Var.of_string "A"
 let b = Env.Var.of_string "B"
 
+let%expect_test "environment variable names cannot contain NUL bytes" =
+  (match Env.Var.of_string "A\000B" with
+   | _ -> print_endline "accepted"
+   | exception Code_error.E _ -> print_endline "rejected");
+  [%expect {| rejected |}]
+;;
+
 let find_assignment env var =
   Env.to_unix env
   |> List.find_map ~f:(fun assignment ->


### PR DESCRIPTION
Validate environment variable names when constructing `Env.Var.t`, rejecting embedded NUL bytes with a code error. This strengthens the invariant established by making the type abstract and prevents invalid names from reaching environment rendering.
