### PR TITLE
refactor(stdune): render Unix environments in spawn

### DIFF
--- a/otherlibs/stdune/src/env.ml
+++ b/otherlibs/stdune/src/env.ml
@@ -45,68 +45,51 @@ end
 module Set = Var.Set
 module Map = Var.Map
 
-module Binding = struct
-  type t =
-    { value : string
-    ; mutable rendered : string Option.Unboxed.t
-    }
+module Value : sig
+  type t
 
-  let create value = { value; rendered = Option.Unboxed.none }
+  val of_string : string -> t
+  val to_string : t -> string
+end = struct
+  type t = string
 
-  let render t ~var =
-    if Option.Unboxed.is_some t.rendered
-    then Option.Unboxed.value_exn t.rendered
-    else (
-      if String.contains t.value '\000'
-      then
-        Code_error.raise
-          "Env: NUL byte in environment variable value"
-          [ "value", Dyn.string t.value ];
-      let rendered = String.append_with_char var ~sep:'=' t.value in
-      t.rendered <- Option.Unboxed.some rendered;
-      rendered)
+  let of_string value =
+    if String.contains value '\000'
+    then
+      Code_error.raise
+        "Env: NUL byte in environment variable value"
+        [ "value", Dyn.string value ];
+    value
   ;;
+
+  let to_string t = t
 end
 
-(* The use of [mutable] for these caches is safe, since we never call (back) to
-   the memoization framework when computing [unix]. *)
-type t =
-  { vars : Binding.t Map.t
-  ; mutable unix : string list option
-  }
+type t = Value.t Map.t
 
-let equal t { vars; unix = _ } =
-  Map.equal
-    ~equal:(fun { Binding.value = x; _ } { Binding.value = y; _ } -> String.equal x y)
-    t.vars
-    vars
+let equal =
+  Map.equal ~equal:(fun x y -> String.equal (Value.to_string x) (Value.to_string y))
 ;;
 
-let hash { vars; unix = _ } =
-  Map.foldi vars ~init:(Hash.create ()) ~f:(fun var { Binding.value; _ } acc ->
+let hash t =
+  Map.foldi t ~init:(Hash.create ()) ~f:(fun var value acc ->
     let acc = Hash.feed acc (Var.hash var) in
-    Hash.feed acc (String.hash value))
+    Hash.feed acc (String.hash (Value.to_string value)))
   |> Hash.hash
 ;;
 
-let of_bindings vars = { vars; unix = None }
-let of_map vars = Map.map vars ~f:Binding.create |> of_bindings
-let empty = of_bindings Map.empty
-let is_empty t = Map.is_empty t.vars
-let vars t = Var.Set.of_keys t.vars
-let get t k = Option.map (Map.find t.vars k) ~f:(fun { Binding.value; _ } -> value)
+let of_map vars = Map.map vars ~f:Value.of_string
+let empty = Map.empty
+let is_empty = Map.is_empty
+let vars = Set.of_keys
+let get t var = Option.map (Map.find t var) ~f:Value.to_string
 
-let to_unix t =
-  match t.unix with
-  | Some bindings -> bindings
-  | None ->
-    let bindings =
-      Map.foldi t.vars ~init:[] ~f:(fun var binding acc ->
-        Binding.render binding ~var:(Var.to_string var) :: acc)
-    in
-    t.unix <- Some bindings;
-    bindings
+let to_list t =
+  Map.foldi t ~init:[] ~f:(fun var value acc -> (var, Value.to_string value) :: acc)
 ;;
+
+let render (var, value) = String.append_with_char (Var.to_string var) ~sep:'=' value
+let to_unix t = List.map (to_list t) ~f:render
 
 let to_windows_block t =
   match to_unix t with
@@ -138,51 +121,36 @@ let map_of_unix arr =
 
 let initial = of_map (map_of_unix (Unix.environment ()))
 let of_unix u = of_map (map_of_unix u)
-let add t ~var ~value = of_bindings (Map.set t.vars var (Binding.create value))
-let mem t ~var = Map.mem t.vars var
-let remove t ~var = of_bindings (Map.remove t.vars var)
 
-let extend t ~vars =
-  if Map.is_empty vars
-  then t
-  else of_bindings (Map.superpose (Map.map vars ~f:Binding.create) t.vars)
+let add t ~var ~value =
+  Map.update t var ~f:(function
+    | Some old when String.equal value (Value.to_string old) -> Some old
+    | None | Some _ -> Some (Value.of_string value))
 ;;
 
-let extend_env x y =
-  if is_empty y
-  then x
-  else if is_empty x
-  then y
-  else of_bindings (Map.superpose y.vars x.vars)
-;;
-
-let to_dyn t =
-  let open Dyn in
-  Map.to_dyn (fun { Binding.value; _ } -> string value) t.vars
-;;
+let mem t ~var = Map.mem t var
+let remove t ~var = if Map.mem t var then Map.remove t var else t
+let extend t ~vars = if Map.is_empty vars then t else Map.superpose (of_map vars) t
+let extend_env x y = if is_empty y then x else if is_empty x then y else Map.superpose y x
+let to_dyn t = Map.to_dyn (fun value -> Dyn.string (Value.to_string value)) t
 
 let diff x y =
-  Map.merge x.vars y.vars ~f:(fun _k vx vy ->
+  Map.merge x y ~f:(fun _ vx vy ->
     match vy with
     | Some _ -> None
     | None -> vx)
-  |> of_bindings
 ;;
 
 let update t ~var ~f =
-  let old = Option.map (Map.find t.vars var) ~f:(fun { Binding.value; _ } -> value) in
-  match f old with
+  match f (get t var) with
   | None -> remove t ~var
   | Some value -> add t ~var ~value
 ;;
 
 let of_string_map m =
-  of_map
-    (String.Map.foldi
-       ~init:Map.empty
-       ~f:(fun k v acc -> Map.set acc (Var.of_string k) v)
-       m)
+  String.Map.foldi m ~init:Map.empty ~f:(fun k v acc -> Map.set acc (Var.of_string k) v)
+  |> of_map
 ;;
 
-let iter t ~f = Map.iteri t.vars ~f:(fun var { Binding.value; _ } -> f var value)
-let to_map t = Map.map t.vars ~f:(fun { Binding.value; _ } -> value)
+let iter t ~f = Map.iteri t ~f:(fun var value -> f var (Value.to_string value))
+let to_map t = Map.map t ~f:Value.to_string

--- a/otherlibs/stdune/src/env.mli
+++ b/otherlibs/stdune/src/env.mli
@@ -39,6 +39,7 @@ val vars : t -> Var.Set.t
 (** The environment when the process started *)
 val initial : t
 
+val to_list : t -> (Var.t * string) list
 val to_unix : t -> string list
 
 (** Render the environment as a double-NUL-terminated Windows environment block. *)

--- a/otherlibs/stdune/src/spawn.ml
+++ b/otherlibs/stdune/src/spawn.ml
@@ -32,7 +32,7 @@ module Pgid = struct
 end
 
 external spawn_unix_raw
-  :  env:string list option
+  :  env:(Env.Var.t * string) list option
   -> cwd:Working_dir.raw
   -> prog:string
   -> argv0:string
@@ -61,7 +61,7 @@ let spawn_unix
       ~sigprocmask
       ~pdeathsig
   =
-  let env = Option.map env ~f:Env.to_unix in
+  let env = Option.map env ~f:Env.to_list in
   let setpgid = Option.map ~f:Pgid.to_int setpgid in
   let pdeathsig = Signal.to_int pdeathsig in
   spawn_unix_raw

--- a/otherlibs/stdune/src/spawn_stubs.c
+++ b/otherlibs/stdune/src/spawn_stubs.c
@@ -392,13 +392,9 @@ static void raise_subprocess_failure(struct subprocess_failure* failure,
   unix_error(failure->error, failure->function, arg);
 }
 
-/* Convert a [string list] into a NULL terminated array of C
-   strings.
-
-   We don't reuse the [cstringvect] function from [unix_support.h] as
-   it doesn't copy the strings in the array.
-*/
-static char **alloc_string_vect(value v)
+/* Convert a list of [(variable, value)] pairs into a NULL terminated array
+   of C strings. */
+static char **alloc_env_list(value v)
 {
   char **result;
   mlsize_t count, i, full_size;
@@ -408,8 +404,11 @@ static char **alloc_string_vect(value v)
   count = 0;
   full_size = sizeof(char*);
   for (x = v; Is_block(x); x = Field(x, 1)) {
+    value binding = Field(x, 0);
     count++;
-    full_size += sizeof(char*) + caml_string_length(Field(x, 0)) + 1;
+    full_size += sizeof(char*) +
+                 caml_string_length(Field(binding, 0)) +
+                 caml_string_length(Field(binding, 1)) + 2;
   }
 
   /* Allocate the array of pointers followed by the space to copy the
@@ -419,11 +418,18 @@ static char **alloc_string_vect(value v)
 
   ptr = ((char*)result) + (sizeof(char*) * (count + 1));
   for (x = v, i = 0; Is_block(x); x = Field(x, 1), i++) {
-    value v_str = Field(x, 0);
-    mlsize_t len = caml_string_length(v_str) + 1;
-    memcpy(ptr, String_val(v_str), len);
+    value binding = Field(x, 0);
+    value variable = Field(binding, 0);
+    value binding_value = Field(binding, 1);
+    mlsize_t variable_len = caml_string_length(variable);
+    mlsize_t value_len = caml_string_length(binding_value);
     result[i] = ptr;
-    ptr += len;
+    memcpy(ptr, String_val(variable), variable_len);
+    ptr += variable_len;
+    *ptr++ = '=';
+    memcpy(ptr, String_val(binding_value), value_len);
+    ptr += value_len;
+    *ptr++ = '\0';
   }
   result[count] = NULL;
 
@@ -554,7 +560,7 @@ static void init_spawn_info(struct spawn_info *info,
   info->argv = alloc_string_array(v_argv0, v_args);
   info->env =
     Is_block(v_env) ?
-    alloc_string_vect(Field(v_env, 0)) : copy_c_string_array(environ);
+    alloc_env_list(Field(v_env, 0)) : copy_c_string_array(environ);
   info->set_pgid = Is_block(v_setpgid);
   info->pgid =
     Is_block(v_setpgid) ?

--- a/otherlibs/stdune/test/env_tests.ml
+++ b/otherlibs/stdune/test/env_tests.ml
@@ -19,13 +19,15 @@ let find_assignment env var =
   |> Option.value_exn
 ;;
 
-let%expect_test "unchanged assignments are shared between environments" =
+let%expect_test "updating a binding preserves the others" =
   let env = Env.empty |> Env.add ~var:a ~value:"one" |> Env.add ~var:b ~value:"two" in
-  let assignment = find_assignment env "A" in
   let updated = Env.add env ~var:b ~value:"three" in
-  let updated_assignment = find_assignment updated "A" in
-  print_endline (Bool.to_string (assignment == updated_assignment));
-  [%expect {| true |}]
+  print_endline (find_assignment updated "A");
+  print_endline (find_assignment updated "B");
+  [%expect
+    {|
+    A=one
+    B=three |}]
 ;;
 
 let%expect_test "rendering preserves the environment hash" =
@@ -36,10 +38,21 @@ let%expect_test "rendering preserves the environment hash" =
   [%expect {| true |}]
 ;;
 
-let%expect_test "environment values reject NUL bytes when rendered" =
-  let env = Env.add Env.empty ~var:a ~value:"value\000" in
-  (match Env.to_unix env with
+let%expect_test "environment values reject NUL bytes when added" =
+  (match Env.add Env.empty ~var:a ~value:"value\000" with
    | exception Code_error.E _ -> print_endline "rejected"
    | _ -> print_endline "accepted");
   [%expect {| rejected |}]
+;;
+
+let%expect_test "setting an unchanged variable reuses the environment" =
+  let env = Env.empty |> Env.add ~var:a ~value:"one" in
+  let unchanged = Env.add env ~var:a ~value:"one" in
+  let changed = Env.add env ~var:a ~value:"two" in
+  print_endline (Bool.to_string (env == unchanged));
+  print_endline (Bool.to_string (env == changed));
+  [%expect
+    {|
+    true
+    false |}]
 ;;


### PR DESCRIPTION
Store environment entries as validated key/value bindings without caching their Unix rendering. The Unix spawn stub now inserts `=` while copying bindings into its malloc-backed environment block, avoiding intermediate joined strings and cache state in `Env.t`.

`Env.add` uses `Map.update` to retain the existing binding when its value is unchanged, allowing the map—and therefore the environment—to preserve physical identity for no-op additions.
