### PR TITLE
perf(sexp): skip revalidating lexer-produced atoms

### DIFF
--- a/src/dune_sexp/atom.ml
+++ b/src/dune_sexp/atom.ml
@@ -41,6 +41,7 @@ let of_string s =
   else Code_error.raise "Dune_lang.Atom.of_string got invalid atom" [ "atom", String s ]
 ;;
 
+let of_string_unchecked s = A s
 let to_string (A s) = s
 let repr = Repr.view Repr.string ~to_:to_string
 let parse s = if is_valid s then Some (A s) else None

--- a/src/dune_sexp/atom.mli
+++ b/src/dune_sexp/atom.mli
@@ -9,6 +9,10 @@ val non_ascii_error_message : string
 
 val is_valid : string -> bool
 val of_string : string -> t
+
+(** [of_string_unchecked s] requires [is_valid s]. *)
+val of_string_unchecked : string -> t
+
 val to_string : t -> string
 
 (** [parse s] is [Some (a:t)] if [s] can be a valid atom according to [is_valid]

--- a/src/dune_sexp/lexer.mll
+++ b/src/dune_sexp/lexer.mll
@@ -67,7 +67,7 @@ module Template = struct
     | [] | [Text ""] ->
       invalid_dune_or_jbuild lexbuf
     | [Text s] ->
-      Token.Atom (Atom.of_string s)
+      Token.Atom (Atom.of_string_unchecked s)
     | _ ->
       Token.Template
         { quoted


### PR DESCRIPTION
Use an unchecked constructor only for text already accepted by the lexer atom rules. General Atom callers continue to validate their input.