### PR TITLE
perf(engine): avoid rememoizing rule actions at construction

### DIFF
--- a/src/dune_engine/rule.ml
+++ b/src/dune_engine/rule.ml
@@ -98,7 +98,6 @@ include T
 include Comparable.Make (T)
 
 let make ?(mode = Mode.Standard) ?(info = Info.Internal) ~targets action =
-  let action = Action_builder.memoize "Rule.make" action in
   let report_error ?(extra_pp = []) message =
     match info with
     | From_dune_file loc ->


### PR DESCRIPTION
Rule actions are already memoized by build-system execution and reflection. Avoid retaining one redundant Action_builder Memo node and its eager facts for every constructed rule.