### PR TITLE
perf(stdune): reduce map bindings in one traversal

### DIFF
--- a/otherlibs/stdune/src/map.ml
+++ b/otherlibs/stdune/src/map.ml
@@ -141,22 +141,21 @@ module Make (Key : Key) : S with type key = Key.t = struct
 
   let of_list_reduce l ~f =
     List.fold_left l ~init:empty ~f:(fun acc (key, data) ->
-      match find acc key with
-      | None -> set acc key data
-      | Some x -> set acc key (f x data))
+      update acc key ~f:(function
+        | None -> Some data
+        | Some x -> Some (f x data)))
   ;;
 
   let of_list_fold l ~init ~f =
     List.fold_left l ~init:empty ~f:(fun acc (key, data) ->
-      let x = Option.value (find acc key) ~default:init in
-      set acc key (f x data))
+      update acc key ~f:(fun value -> Some (f (Option.value value ~default:init) data)))
   ;;
 
   let of_list_reducei l ~f =
     List.fold_left l ~init:empty ~f:(fun acc (key, data) ->
-      match find acc key with
-      | None -> set acc key data
-      | Some x -> set acc key (f key x data))
+      update acc key ~f:(function
+        | None -> Some data
+        | Some x -> Some (f key x data)))
   ;;
 
   let of_list_multi l =

--- a/otherlibs/stdune/test/map_tests.ml
+++ b/otherlibs/stdune/test/map_tests.ml
@@ -14,3 +14,22 @@ let%expect_test _ =
 map { "a" : [ 1; 2; 3 ]; "b" : [ 1; 2 ] }
 |}]
 ;;
+
+let print_int_map map = String.Map.to_dyn Dyn.int map |> print_dyn
+
+let%expect_test "list reductions preserve input order" =
+  let bindings = [ "a", 1; "b", 2; "a", 3 ] in
+  String.Map.of_list_reduce bindings ~f:(fun before after -> (before * 10) + after)
+  |> print_int_map;
+  String.Map.of_list_reducei bindings ~f:(fun key before after ->
+    String.length key + (before * 10) + after)
+  |> print_int_map;
+  String.Map.of_list_fold bindings ~init:4 ~f:(fun before after -> (before * 10) + after)
+  |> print_int_map;
+  [%expect
+    {|
+    map { "a" : 13; "b" : 2 }
+    map { "a" : 14; "b" : 2 }
+    map { "a" : 413; "b" : 42 }
+    |}]
+;;


### PR DESCRIPTION
Use Map.update for list-reduction constructors so each binding performs one tree descent while preserving duplicate order and reducer semantics.