### PR TITLE
Fix install stanza enabled_if handling for @all

### DIFF
--- a/doc/changes/fixed/15895.md
+++ b/doc/changes/fixed/15895.md
@@ -1,0 +1,2 @@
+- Respect `enabled_if` on `install` stanzas when adding their files and
+  directories to the `@all` alias. (#15895, fixes #15825, @aryemans)

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -3,30 +3,35 @@ open Memo.O
 module Gen_rules = Build_config.Gen_rules
 
 let install_stanza_rules ~ctx_dir ~expander (install_conf : Install_conf.t) =
-  let action =
-    (* XXX we're evaluating these stanzas here and [Install_rules]. Seems a bit
-       sad to do that *)
-    let files_and_dirs =
-      let expand = Expander.No_deps.expand expander ~mode:Single in
-      let+ files_expanded =
-        Install_entry.File.to_file_bindings_expanded
-          install_conf.files
-          ~expand
-          ~dir:ctx_dir
-      and+ dirs_expanded =
-        Install_entry.Dir.to_file_bindings_expanded
-          install_conf.dirs
-          ~expand
-          ~dir:ctx_dir
-          ~relative_dst_path_starts_with_parent_error_when:`Deprecation_warning_from_3_11
+  let* enabled = Expander.eval_blang expander install_conf.enabled_if in
+  if not enabled
+  then Memo.return ()
+  else (
+    let action =
+      (* XXX we're evaluating these stanzas here and [Install_rules]. Seems a bit
+         sad to do that *)
+      let files_and_dirs =
+        let expand = Expander.No_deps.expand expander ~mode:Single in
+        let+ files_expanded =
+          Install_entry.File.to_file_bindings_expanded
+            install_conf.files
+            ~expand
+            ~dir:ctx_dir
+        and+ dirs_expanded =
+          Install_entry.Dir.to_file_bindings_expanded
+            install_conf.dirs
+            ~expand
+            ~dir:ctx_dir
+            ~relative_dst_path_starts_with_parent_error_when:
+              `Deprecation_warning_from_3_11
+        in
+        List.map (files_expanded @ dirs_expanded) ~f:(fun fb ->
+          File_binding.Expanded.src fb |> Path.build)
       in
-      List.map (files_expanded @ dirs_expanded) ~f:(fun fb ->
-        File_binding.Expanded.src fb |> Path.build)
+      let open Action_builder.O in
+      Action_builder.of_memo files_and_dirs >>= Action_builder.paths
     in
-    let open Action_builder.O in
-    Action_builder.of_memo files_and_dirs >>= Action_builder.paths
-  in
-  Rules.Produce.Alias.add_deps (Alias.make Alias0.all ~dir:ctx_dir) action
+    Rules.Produce.Alias.add_deps (Alias.make Alias0.all ~dir:ctx_dir) action)
 ;;
 
 module For_stanza : sig

--- a/test/blackbox-tests/test-cases/install/install-enabled-if.t
+++ b/test/blackbox-tests/test-cases/install/install-enabled-if.t
@@ -31,10 +31,6 @@ Test disabled install stanza in multi-context builds (github issue #15825).
   > EOF
 
   $ dune build
-  Error: No rule found for x (context other)
-  -> required by alias all (context other)
-  -> required by alias default (context other)
-  [1]
 
   $ cat _build/default/x
   x


### PR DESCRIPTION
Fixes #15825.

When an `install` stanza is disabled by `enabled_if`, its files were still added as dependencies of the directory's `@all` alias. This caused multi-context builds to require files in contexts where the install stanza was disabled.

This change evaluates the install stanza's `enabled_if` before adding its files and directories to `@all`.

A regression test covers a two-context build where the install stanza is enabled only in the default context and verifies that the disabled context does not build the installed file.

Tested locally with the focused blackbox test and `./dune.exe build @check`.