### PR TITLE
test: add timeout to RPC client example

### DIFF
--- a/otherlibs/dune-rpc-lwt/examples/rpc_client/test/dune
+++ b/otherlibs/dune-rpc-lwt/examples/rpc_client/test/dune
@@ -1,3 +1,4 @@
 (cram
  (applies_to :whole_subtree)
+ (timeout 60)
  (deps %{bin:dune} ../rpc_client.exe))


### PR DESCRIPTION
The directory-style RPC client cram test currently has no timeout. Add the same
60-second bound used by the main blackbox suite so a failed background watch
build cannot leave the CI job waiting indefinitely.
