### PR TITLE
Add flags to ocamllex and ocamlyacc stanzas

### DIFF
--- a/doc/changes/added/15907.md
+++ b/doc/changes/added/15907.md
@@ -1,0 +1,2 @@
+- Add `(flags ...)` to the `ocamllex` and `ocamlyacc` stanzas to pass custom
+  options to parser generators. (#15907, @rgrinberg)

--- a/doc/reference/dune/ocamllex.rst
+++ b/doc/reference/dune/ocamllex.rst
@@ -18,3 +18,15 @@ To use a different rule mode, use the long form:
     (ocamllex
      (modules <names>)
      (mode    <mode>))
+
+Starting in Dune 3.25, the ``flags`` field passes additional command-line
+arguments to ``ocamllex``. The flags use the
+:doc:`/reference/ordered-set-language` and support
+:doc:`/concepts/variables`. For example, ``-ml`` generates an OCaml-based
+automaton instead of using the built-in automata interpreter:
+
+.. code:: dune
+
+    (ocamllex
+     (modules lexer)
+     (flags -ml))

--- a/doc/reference/dune/ocamlyacc.rst
+++ b/doc/reference/dune/ocamlyacc.rst
@@ -18,3 +18,14 @@ To use a different rule mode, use the long form:
     (ocamlyacc
      (modules <names>)
      (mode    <mode>))
+
+Starting in Dune 3.25, the ``flags`` field passes additional command-line
+arguments to ``ocamlyacc``. The flags use the
+:doc:`/reference/ordered-set-language` and support
+:doc:`/concepts/variables`:
+
+.. code:: dune
+
+    (ocamlyacc
+     (modules parser)
+     (flags -q))

--- a/src/dune_rules/parser_generator_rules.ml
+++ b/src/dune_rules/parser_generator_rules.ml
@@ -19,7 +19,7 @@ let tool =
       args
 ;;
 
-let add_rule sctx ~dir ~mode (loc, m) ~for_ =
+let add_rule sctx ~dir ~mode ~flags ~expander (loc, m) ~for_ =
   let args =
     let files = Module.Source.files m in
     let file = List.hd files in
@@ -27,36 +27,38 @@ let add_rule sctx ~dir ~mode (loc, m) ~for_ =
     match for_ with
     | Parser_generators.Ocamllex _ ->
       let dst = Module.File.path file |> Path.as_in_build_dir_exn in
-      [ Command.Args.As [ "-q"; "-o" ]; Target dst; Command.Args.Dep src ]
+      [ Command.Args.dyn flags; As [ "-q"; "-o" ]; Target dst; Dep src ]
     | Ocamlyacc _ ->
       let targets =
         List.map files ~f:(fun file -> Module.File.path file |> Path.as_in_build_dir_exn)
       in
-      [ Command.Args.Dep src; Hidden_targets targets ]
+      [ Command.Args.dyn flags; Command.Args.Dep src; Hidden_targets targets ]
   in
   let action = tool sctx ~loc ~dir args ~for_ in
   let open Memo.O in
-  let* mode =
-    let* expander = Super_context.expander sctx ~dir in
-    Rule_mode_expand.expand_path ~expander ~dir mode
-  in
+  let* mode = Rule_mode_expand.expand_path ~expander ~dir mode in
   Super_context.add_rule sctx ~dir ~mode ~loc action
 ;;
 
 let gen_rules sctx ~dir_contents ~dir ~for_ =
   let open Memo.O in
-  let ocamllex_or_ocamlyacc, modules_for =
+  let { Parser_generators.mode; flags; _ }, modules_for =
     match for_ with
     | Parser_generators.Ocamllex s -> s, Ml_sources.Parser_generators.Ocamllex s.loc
     | Ocamlyacc s -> s, Ocamlyacc s.loc
   in
   (* NOTE(anmonteiro): Parser generator rules run in the "OCaml module space":
     `Ml_sources` generates `foo.mll` -> `foo.ml`. Melange  *)
-  Dir_contents.ml dir_contents ~for_:Ocaml
-  >>| Ml_sources.Parser_generators.modules ~for_:modules_for
-  >>= fun { deps = _; targets } ->
-  let { Parser_generators.mode; _ } = ocamllex_or_ocamlyacc in
+  let* { deps = _; targets } =
+    Dir_contents.ml dir_contents ~for_:Ocaml
+    >>| Ml_sources.Parser_generators.modules ~for_:modules_for
+  in
+  let* expander = Super_context.expander sctx ~dir in
+  let flags =
+    let standard = Action_builder.return [] in
+    Expander.expand_and_eval_set expander flags ~standard
+  in
   Module_trie.to_map targets
   |> Module_name.Map.values
-  |> Memo.parallel_iter ~f:(add_rule sctx ~dir ~mode ~for_)
+  |> Memo.parallel_iter ~f:(add_rule sctx ~dir ~mode ~flags ~expander ~for_)
 ;;

--- a/src/dune_rules/stanzas/parser_generators.ml
+++ b/src/dune_rules/stanzas/parser_generators.ml
@@ -5,6 +5,7 @@ type t =
   ; modules : Ordered_set_lang.Unexpanded.t
   ; mode : Rule_mode.t
   ; enabled_if : Blang.t
+  ; flags : Ordered_set_lang.Unexpanded.t
   }
 
 type for_ =
@@ -32,13 +33,36 @@ let since_expanded = 3, 22
 
 let decode =
   let open Dune_lang.Decoder in
-  (let+ loc = loc
-   and+ modules = Ordered_set_lang.Unexpanded.decode_since_expanded ~since_expanded in
-   { loc; modules; mode = Standard; enabled_if = Blang.true_ })
-  <|> fields
-        (let+ loc = loc
-         and+ modules = Ordered_set_lang.Unexpanded.field ~since_expanded "modules"
-         and+ mode = Rule_mode_decoder.field
-         and+ enabled_if = Enabled_if.decode ~allowed_vars:Any ~since:(Some (1, 4)) () in
-         { loc; modules; mode; enabled_if })
+  let module Ast = Dune_lang.Ast in
+  let short_form =
+    let+ loc = loc
+    and+ modules = Ordered_set_lang.Unexpanded.decode_since_expanded ~since_expanded in
+    { loc
+    ; modules
+    ; mode = Standard
+    ; enabled_if = Blang.true_
+    ; flags = Ordered_set_lang.Unexpanded.standard
+    }
+  in
+  let long_form =
+    fields
+      (let+ loc = loc
+       and+ modules = Ordered_set_lang.Unexpanded.field ~since_expanded "modules"
+       and+ mode = Rule_mode_decoder.field
+       and+ enabled_if = Enabled_if.decode ~allowed_vars:Any ~since:(Some (1, 4)) ()
+       and+ flags =
+         Ordered_set_lang.Unexpanded.field
+           ~check:(Dune_lang.Syntax.since Stanza.syntax (3, 25))
+           "flags"
+       in
+       { loc; modules; mode; enabled_if; flags })
+  in
+  peek
+  >>= function
+  | Some (Ast.List (_, Ast.Atom (_, Dune_lang.Atom.A field_name) :: _))
+    when List.mem
+           [ "modules"; "mode"; "enabled_if"; "flags" ]
+           field_name
+           ~equal:String.equal -> long_form
+  | _ -> short_form
 ;;

--- a/src/dune_rules/stanzas/parser_generators.mli
+++ b/src/dune_rules/stanzas/parser_generators.mli
@@ -5,6 +5,7 @@ type t =
   ; modules : Ordered_set_lang.Unexpanded.t
   ; mode : Rule_mode.t
   ; enabled_if : Blang.t
+  ; flags : Ordered_set_lang.Unexpanded.t
   }
 
 type for_ =

--- a/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-dynamic-modules.t
+++ b/test/blackbox-tests/test-cases/stanzas/ocamllex/ocamllex-dynamic-modules.t
@@ -49,3 +49,39 @@ Building under dune 3.22 throws an error
   > EOF
 
   $ dune build foo.cma
+
+The `flags` field is available starting in Dune 3.25:
+
+  $ make_dune_project 3.24
+  $ cat >dune <<EOF
+  > (ocamllex
+  >  (modules mod)
+  >  (flags -ml))
+  > (library (name foo))
+  > EOF
+
+  $ dune build foo.cma
+  File "dune", line 3, characters 1-12:
+  3 |  (flags -ml))
+       ^^^^^^^^^^^
+  Error: 'flags' is only available since version 3.25 of the dune language.
+  Please update your dune-project file to have (lang dune 3.25).
+  [1]
+
+Flags support the ordered set language and variable expansion. In particular,
+`-ml` asks `ocamllex` to generate an OCaml-based automaton:
+
+  $ make_dune_project 3.25
+  $ echo '%{read-lines:gen/flag-value}' >gen/flags
+  $ echo -ml >gen/flag-value
+  $ cat >dune <<EOF
+  > (ocamllex
+  >  (modules mod)
+  >  (flags (:include gen/flags)))
+  > (library (name foo))
+  > EOF
+
+  $ dune build foo.cma
+  $ dune trace cat \
+  >   | jq_dune -c 'processesBrief | select(.prog == "ocamllex") | .args'
+  ["-ml","-q","-o","mod.ml","mod.mll"]

--- a/test/blackbox-tests/test-cases/stanzas/ocamlyacc/ocamlyacc.t
+++ b/test/blackbox-tests/test-cases/stanzas/ocamlyacc/ocamlyacc.t
@@ -25,3 +25,19 @@ Test a library that uses a `ocamlyacc` parser.
   > EOF
 
   $ dune build
+
+The `flags` field passes additional arguments to `ocamlyacc`:
+
+  $ make_dune_project 3.25
+  $ cat >dune <<EOF
+  > (library
+  >  (name lib))
+  > (ocamlyacc
+  >  (modules my_parser)
+  >  (flags -q))
+  > EOF
+
+  $ dune build
+  $ dune trace cat \
+  >   | jq_dune -c 'processesBrief | select(.prog == "ocamlyacc") | .args'
+  ["-q","my_parser.mly"]


### PR DESCRIPTION
Add a Dune 3.25-gated `(flags ...)` field to the `ocamllex` and
`ocamlyacc` stanzas. Flags support the ordered set language and variable
expansion before being forwarded to the parser generator.

This allows uses such as `(flags -ml)` to ask `ocamllex` to generate an
OCaml-based automaton. The reference documentation and black-box coverage are
updated for both stanzas.