### PR TITLE
perf(stdune): inline pair equality

### DIFF
--- a/otherlibs/stdune/src/tuple.ml
+++ b/otherlibs/stdune/src/tuple.ml
@@ -2,7 +2,7 @@ module T2 = struct
   type ('a, 'b) t = 'a * 'b
 
   let to_dyn = Dyn.pair
-  let equal f g (x1, y1) (x2, y2) = f x1 x2 && g y1 y2
+  let[@inline always] equal f g (x1, y1) (x2, y2) = f x1 x2 && g y1 y2
 
   let hash f g (a, b) =
     let acc = Hash.create () in


### PR DESCRIPTION
Inline pair equality at call sites while preserving left-to-right short-circuiting and the supplied component equality functions.