### PR TITLE
perf(stdune): inline pair hashing

### DIFF
--- a/otherlibs/stdune/src/tuple.ml
+++ b/otherlibs/stdune/src/tuple.ml
@@ -4,7 +4,7 @@ module T2 = struct
   let to_dyn = Dyn.pair
   let equal f g (x1, y1) (x2, y2) = f x1 x2 && g y1 y2
 
-  let hash f g (a, b) =
+  let[@inline always] hash f g (a, b) =
     let acc = Hash.create () in
     let acc = Hash.feed acc (f a) in
     let acc = Hash.feed acc (g b) in


### PR DESCRIPTION
Inline pair hashing at call sites so concrete component hashers can be specialized while preserving the exact Hash create, feed, and finalization sequence.