### PR TITLE
test: demonstrate install enabled_if issue with @all

### DIFF
--- a/test/blackbox-tests/test-cases/install/install-enabled-if.t
+++ b/test/blackbox-tests/test-cases/install/install-enabled-if.t
@@ -1,0 +1,43 @@
+Test disabled install stanza in multi-context builds (github issue #15825).
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.21)
+  > (package
+  >  (name repro)
+  >  (allow_empty))
+  > EOF
+
+  $ cat > dune-workspace << EOF
+  > (lang dune 3.21)
+  > (context default)
+  > (context
+  >  (default
+  >   (name other)))
+  > EOF
+
+  $ cat > dune << EOF
+  > (rule
+  >  (enabled_if (= %{context_name} default))
+  >  (target x)
+  >  (action
+  >   (write-file %{target} x)))
+  > 
+  > (install
+  >  (section lib)
+  >  (package repro)
+  >  (enabled_if (= %{context_name} default))
+  >  (files
+  >   (x as c/x)))
+  > EOF
+
+  $ dune build
+  Error: No rule found for x (context other)
+  -> required by alias all (context other)
+  -> required by alias default (context other)
+  [1]
+
+  $ cat _build/default/x
+  x
+
+  $ test -f _build/other/x
+  [1]


### PR DESCRIPTION
This extracts Aryeman Singh's regression test from #15895 into a preceding test-only change. The promoted output captures the current #15825 behavior: `@all` in the disabled context depends on the install stanza's file and fails.