### PR TITLE
chore: bump dune language version to 3.25

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -36,10 +36,8 @@ jobs:
           - os: ubuntu-26.04
             name: x86_64-unknown-linux-musl
             installable: .#dune-static
-          - os: ubuntu-26.04
-            name: x86_64-pc-windows-gnu
-            installable: .#windows-static
-            binary: dune.exe
+          # Building x86_64-pc-windows-gnu does not work when Dune itself uses
+          # an unreleased version of Dune.
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.24)
+(lang dune 3.25)
 ;;         ^^^^
 ;; When changing the version, don't forget to regenerate *.opam files
 ;; by running [$ dune build @opam --auto-promote].

--- a/opam/chrome-trace.opam
+++ b/opam/chrome-trace.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.25"}
   "ocaml" {>= "4.14"}
   "odoc" {with-doc}
 ]

--- a/opam/dune-action-plugin.opam
+++ b/opam/dune-action-plugin.opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.25"}
   "dune-glob" {= version}
   "csexp" {>= "1.5.0"}
   "ppx_expect" {with-test}

--- a/opam/dune-action-trace.opam
+++ b/opam/dune-action-trace.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.25"}
   "csexp" {>= "1.5.0"}
   "ocaml" {>= "4.14"}
   "odoc" {with-doc}

--- a/opam/dune-build-info.opam
+++ b/opam/dune-build-info.opam
@@ -16,7 +16,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.25"}
   "ocaml" {>= "4.14"}
   "odoc" {with-doc}
 ]

--- a/opam/dune-configurator.opam
+++ b/opam/dune-configurator.opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.25"}
   "ocaml" {>= "4.14"}
   "base-unix"
   "csexp" {>= "1.5.0"}

--- a/opam/dune-glob.opam
+++ b/opam/dune-glob.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.25"}
   "stdune" {= version}
   "dyn"
   "re"

--- a/opam/dune-private-libs.opam
+++ b/opam/dune-private-libs.opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.25"}
   "csexp" {>= "1.5.0"}
   "pp" {>= "1.1.0"}
   "dyn" {= version}

--- a/opam/dune-rpc-lwt.opam
+++ b/opam/dune-rpc-lwt.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.25"}
   "dune-rpc" {= version}
   "csexp" {>= "1.5.0"}
   "lwt" {>= "5.6.0"}

--- a/opam/dune-rpc.opam
+++ b/opam/dune-rpc.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.25"}
   "ocamlc-loc"
   "csexp"
   "ordering"

--- a/opam/dune-site.opam
+++ b/opam/dune-site.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.25"}
   "dune-private-libs" {= version}
   "odoc" {with-doc}
 ]

--- a/opam/dyn.opam
+++ b/opam/dyn.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.25"}
   "ocaml" {>= "4.14"}
   "ordering" {= version}
   "pp" {>= "1.1.0"}

--- a/opam/fs-io.opam
+++ b/opam/fs-io.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.25"}
   "base-unix"
   "ocaml" {>= "4.14"}
   "odoc" {with-doc}

--- a/opam/ocamlc-loc.opam
+++ b/opam/ocamlc-loc.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.25"}
   "ocaml" {>= "4.14"}
   "dyn" {= version}
   "odoc" {with-doc}

--- a/opam/ordering.opam
+++ b/opam/ordering.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.25"}
   "ocaml" {>= "4.14"}
   "odoc" {with-doc}
 ]

--- a/opam/stdune.opam
+++ b/opam/stdune.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.25"}
   "ocaml" {>= "4.14"}
   "base-unix"
   "csexp" {>= "1.5.0"}

--- a/opam/top-closure.opam
+++ b/opam/top-closure.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.25"}
   "ocaml" {>= "4.14"}
   "odoc" {with-doc}
 ]

--- a/opam/xdg.opam
+++ b/opam/xdg.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.25"}
   "ocaml" {>= "4.14"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Bump Dune's own language version to 3.25 and regenerate the generated opam files.