### PR TITLE
perf(stdune): avoid copying reversed set accumulators

### DIFF
--- a/otherlibs/stdune/src/array.ml
+++ b/otherlibs/stdune/src/array.ml
@@ -54,6 +54,19 @@ let of_list_map l ~f =
       f x)
 ;;
 
+let of_rev_list = function
+  | [] -> [||]
+  | last :: rest ->
+    let array = Stdlib.Array.make (Stdlib.List.length rest + 1) last in
+    let rec fill i = function
+      | [] -> array
+      | x :: rest ->
+        array.(i) <- x;
+        fill (i - 1) rest
+    in
+    fill (Stdlib.Array.length array - 2) rest
+;;
+
 module Immutable = struct
   include T
 
@@ -220,7 +233,7 @@ module Sorted = struct
       let of_sorted_list l =
         let rec loop l acc =
           match l with
-          | [] -> Stdlib.Array.of_list (Stdlib.List.rev acc)
+          | [] -> of_rev_list acc
           | x :: rest ->
             (match acc with
              | y :: _ ->

--- a/otherlibs/stdune/src/array.mli
+++ b/otherlibs/stdune/src/array.mli
@@ -7,6 +7,9 @@ val exists : 'a t -> f:('a -> bool) -> bool
 val fold_right : 'a t -> f:('a -> 'acc -> 'acc) -> init:'acc -> 'acc
 val swap : 'a t -> int -> int -> unit
 
+(** [of_rev_list l] creates an array containing the elements of [l] in reverse order. *)
+val of_rev_list : 'a list -> 'a t
+
 module Immutable : sig
   type 'a t
 

--- a/otherlibs/stdune/test/array_tests.ml
+++ b/otherlibs/stdune/test/array_tests.ml
@@ -8,6 +8,7 @@ module Map = String.Array.Map
 module Set = String.Array.Set
 
 let print_bool b = bool b |> print_dyn
+let print_int_array x = array int x |> print_dyn
 let print_int_option x = option int x |> print_dyn
 let print_map t = Map.to_list t |> list (pair string int) |> print_dyn
 let print_set t = Set.to_list t |> list string |> print_dyn
@@ -36,6 +37,20 @@ let print_unsorted_set_error () =
   match Set.of_sorted_list [ "b"; "a" ] with
   | _ -> print_endline "ok"
   | exception Code_error.E _ -> print_endline "unsorted"
+;;
+
+let%expect_test "array of reversed list" =
+  print_int_array (Array.of_rev_list []);
+  print_int_array (Array.of_rev_list [ 1 ]);
+  print_int_array (Array.of_rev_list [ 1; 2 ]);
+  print_int_array (Array.of_rev_list [ 1; 2; 3 ]);
+  [%expect
+    {|
+    [||]
+    [| 1 |]
+    [| 2;  1 |]
+    [| 3;  2;  1 |]
+    |}]
 ;;
 
 let%expect_test "array-backed map" =


### PR DESCRIPTION
Sorted.Set.of_sorted_list collects deduplicated elements in reverse order.
Converting the accumulator with List.rev followed by Array.of_list
allocates a second list.

Add a generic of_rev_list helper that allocates the result once and fills
it from the end of the reversed input. This preserves ordering validation
and duplicate removal while avoiding the intermediate list.