### PR TITLE
perf: generate lexers as direct OCaml code

### DIFF
--- a/boot/dune
+++ b/boot/dune
@@ -38,7 +38,9 @@
  (action
   (diff libs.ml libs.ml.gen)))
 
-(ocamllex pps)
+(ocamllex
+ (modules pps)
+ (flags -ml))
 
 (executable
  (name duneboot)

--- a/otherlibs/configurator/src/dune
+++ b/otherlibs/configurator/src/dune
@@ -1,4 +1,6 @@
-(ocamllex extract_obj)
+(ocamllex
+ (modules extract_obj)
+ (flags -ml))
 
 (library
  (name configurator)

--- a/otherlibs/dune-glob/src/dune
+++ b/otherlibs/dune-glob/src/dune
@@ -6,4 +6,6 @@
   (:standard -w -50))
  (synopsis "The glob language as understood by dune."))
 
-(ocamllex lexer)
+(ocamllex
+ (modules lexer)
+ (flags -ml))

--- a/otherlibs/dune-private-libs/meta_parser/dune
+++ b/otherlibs/dune-private-libs/meta_parser/dune
@@ -3,4 +3,6 @@
  (public_name dune-private-libs.meta_parser)
  (synopsis "[Internal] findlib META parser"))
 
-(ocamllex meta_lexer)
+(ocamllex
+ (modules meta_lexer)
+ (flags -ml))

--- a/otherlibs/dune-rpc/dune
+++ b/otherlibs/dune-rpc/dune
@@ -4,4 +4,6 @@
  (synopsis "dune rpc client and protocol")
  (libraries dyn ocamlc_loc unix stdune csexp xdg ordering pp))
 
-(ocamllex dbus_address)
+(ocamllex
+ (modules dbus_address)
+ (flags -ml))

--- a/otherlibs/ocamlc-loc/src/dune
+++ b/otherlibs/ocamlc-loc/src/dune
@@ -3,4 +3,6 @@
  (public_name ocamlc-loc)
  (libraries dyn))
 
-(ocamllex lexer)
+(ocamllex
+ (modules lexer)
+ (flags -ml))

--- a/src/dune_lang/dune
+++ b/src/dune_lang/dune
@@ -21,4 +21,6 @@
   dune_section
   (re_export dune_sexp)))
 
-(ocamllex dune_file_script)
+(ocamllex
+ (modules dune_file_script)
+ (flags -ml))

--- a/src/dune_lang/dune_file_script.mll
+++ b/src/dune_lang/dune_file_script.mll
@@ -3,6 +3,10 @@
 
 rule is_script = parse
   | "(* -*- tuareg -*- *)" { true }
+  | eof {
+      (* Keep direct-code generation's entry points mutually recursive. *)
+      not (eof_reached lexbuf)
+    }
   | ""                     { false }
 
 and eof_reached = parse

--- a/src/dune_rules/cram/dune
+++ b/src/dune_rules/cram/dune
@@ -1,1 +1,3 @@
-(ocamllex cram_lexer)
+(ocamllex
+ (modules cram_lexer)
+ (flags -ml))

--- a/src/dune_rules/dune
+++ b/src/dune_rules/dune
@@ -37,7 +37,9 @@
   xdg)
  (synopsis "Internal Dune library, do not use!"))
 
-(ocamllex ocamlobjinfo)
+(ocamllex
+ (modules ocamlobjinfo)
+ (flags -ml))
 
 (rule
  (target assets.ml.gen)

--- a/src/dune_sexp/dune
+++ b/src/dune_sexp/dune
@@ -6,4 +6,6 @@
   (pps ppx_expect))
  (libraries stdune))
 
-(ocamllex lexer versioned_file_first_line)
+(ocamllex
+ (modules lexer versioned_file_first_line)
+ (flags -ml))


### PR DESCRIPTION
Generate all Dune-owned lexers with `ocamllex -ml` via the new `(flags ...)` field, avoiding the table interpreter. The bootstrap generator remains unchanged because it does not consume these stanzas.