### PR TITLE
test(sat): cover the sat/solve trace event and solver stats

### DIFF
--- a/doc/changes/added/15923.md
+++ b/doc/changes/added/15923.md
@@ -1,0 +1,3 @@
+- Added an opt-in `sat` trace category emitting a `sat/solve` event with
+  the SAT solver's stats (variables, clauses, decisions, conflicts) and
+  duration. Enable with `DUNE_TRACE=+sat`. (#15923, @Alizter)

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -948,7 +948,19 @@ module Solver = struct
         in
         find_undecided root_req
       in
-      match Sat.run_solver sat decider with
+      let start = Time.now () in
+      let result = Sat.run_solver sat decider in
+      let stop = Time.now () in
+      Dune_trace.emit Sat (fun () ->
+        let stats = Sat.get_stats sat in
+        Dune_trace.Event.sat_solve
+          ~start
+          ~dur:(Time.diff stop start)
+          ~num_variables:stats.num_variables
+          ~num_clauses:stats.num_clauses
+          ~num_decisions:stats.num_decisions
+          ~num_conflicts:stats.num_conflicts);
+      match result with
       | false -> None
       | true ->
         (* Build the results object *)

--- a/src/dune_trace/category.ml
+++ b/src/dune_trace/category.ml
@@ -25,6 +25,7 @@ type t =
   | Artifact_substitution
   | Thread
   | Runtime
+  | Sat
 
 let all =
   [ Rpc
@@ -51,6 +52,7 @@ let all =
   ; Artifact_substitution
   ; Thread
   ; Runtime
+  ; Sat
   ]
 ;;
 
@@ -79,6 +81,7 @@ let to_string = function
   | Artifact_substitution -> "artifact_subtitution"
   | Thread -> "thread"
   | Runtime -> "runtime"
+  | Sat -> "sat"
 ;;
 
 let of_string =
@@ -119,6 +122,7 @@ module Set = Bit_set.Make (struct
       | Artifact_substitution -> 21
       | Thread -> 22
       | Runtime -> 23
+      | Sat -> 24
     ;;
   end)
 

--- a/src/dune_trace/category.mli
+++ b/src/dune_trace/category.mli
@@ -23,6 +23,7 @@ type t =
   | Artifact_substitution
   | Thread
   | Runtime
+  | Sat
 
 val to_string : t -> string
 val of_string : string -> t option

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -26,6 +26,7 @@ module Category : sig
     | Artifact_substitution
     | Thread
     | Runtime
+    | Sat
 end
 
 module Event : sig
@@ -168,6 +169,15 @@ module Event : sig
   val gc : unit -> t
   val fd_count : unit -> t option
   val spawn_thread : name:string -> t
+
+  val sat_solve
+    :  start:Time.t
+    -> dur:Time.Span.t
+    -> num_variables:int
+    -> num_clauses:int
+    -> num_decisions:int
+    -> num_conflicts:int
+    -> t
 
   module Promote : sig
     val promote : Path.Build.t -> Path.Source.t -> t

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -1079,6 +1079,17 @@ let spawn_thread ~name =
   Event.instant ~args ~name:"spawn_thread" now Thread
 ;;
 
+let sat_solve ~start ~dur ~num_variables ~num_clauses ~num_decisions ~num_conflicts =
+  let args =
+    [ "num_variables", Arg.int num_variables
+    ; "num_clauses", Arg.int num_clauses
+    ; "num_decisions", Arg.int num_decisions
+    ; "num_conflicts", Arg.int num_conflicts
+    ]
+  in
+  Event.complete ~args ~name:"solve" ~start ~dur Sat
+;;
+
 let sandbox name ~start ~stop ~queued loc ~dir =
   let args =
     [ "loc", Arg.string (Loc.to_file_colon_line loc); "dir", Arg.build_path dir ]

--- a/src/sat/sat.ml
+++ b/src/sat/sat.ml
@@ -147,6 +147,15 @@ module Make (User : USER) = struct
     ; mutable set_to_false : bool
     ; conflict_vars : VarID.Hash_set.t
       (* we are finishing up by setting everything else to False *)
+      (* Counters for observability. [num_clauses] counts input clauses
+         added via [at_least_one] / [implies] / [impossible]; the
+         at-most clauses are not counted because they do not carry a
+         problem handle at their construction site (see sat.mli).
+         [num_decisions] and [num_conflicts] are incremented in
+         [run_solver]. *)
+    ; num_clauses : Counter.t
+    ; num_decisions : Counter.t
+    ; num_conflicts : Counter.t
     }
 
   let lit_equal (s1, v1) (s2, v2) = s1 == s2 && v1 == v2
@@ -223,6 +232,9 @@ module Make (User : USER) = struct
     ; toplevel_conflict = false
     ; set_to_false = false
     ; conflict_vars = VarID.Hash_set.create ()
+    ; num_clauses = Counter.create ()
+    ; num_decisions = Counter.create ()
+    ; num_conflicts = Counter.create ()
     }
   ;;
 
@@ -356,7 +368,10 @@ module Make (User : USER) = struct
     done
   ;;
 
-  let impossible problem = problem.toplevel_conflict <- true
+  let impossible problem =
+    Counter.incr problem.num_clauses;
+    problem.toplevel_conflict <- true
+  ;;
 
   (* Call [Clause.propagate lit] when lit becomes True *)
   let watch_lit lit clause =
@@ -626,6 +641,7 @@ module Make (User : USER) = struct
 
   (** Public interface. Only used before the solve starts. *)
   let at_least_one problem ?(reason = "input fact") lits =
+    Counter.incr problem.num_clauses;
     if List.is_empty lits
     then problem.toplevel_conflict <- true
     else if
@@ -910,9 +926,11 @@ module Make (User : USER) = struct
                 ];
             problem.trail_lim <- problem.trail_len :: problem.trail_lim;
             problem.trail_lim_len <- problem.trail_lim_len + 1;
+            Counter.incr problem.num_decisions;
             let r = enqueue problem lit (External "considering") in
             assert r
           | Some conflicting_clause ->
+            Counter.incr problem.num_conflicts;
             if get_decision_level problem = 0
             then (
               if debug then log_debug (Pp.text "FAIL: conflict found at top level");
@@ -960,5 +978,20 @@ module Make (User : USER) = struct
     if value = Undecided
     then Pp.text "undecided!"
     else Pp.hovbox (pp_lit_reason lit ++ Pp.text " => " ++ pp_lit_assignment lit)
+  ;;
+
+  type stats =
+    { num_variables : int
+    ; num_clauses : int
+    ; num_decisions : int
+    ; num_conflicts : int
+    }
+
+  let get_stats problem =
+    { num_variables = List.length problem.vars
+    ; num_clauses = Counter.read problem.num_clauses
+    ; num_decisions = Counter.read problem.num_decisions
+    ; num_conflicts = Counter.read problem.num_conflicts
+    }
   ;;
 end

--- a/src/sat/sat.mli
+++ b/src/sat/sat.mli
@@ -80,4 +80,23 @@ module Make (User : USER) : sig
 
   val get_user_data_for_lit : lit -> User.t
   val explain_reason : lit -> 'tag Pp.t
+
+  (** {2 Observability} *)
+
+  (** Statistics describing a SAT problem and the work done to solve it.
+      [num_variables] and [num_clauses] are structural (the problem size);
+      [num_decisions] and [num_conflicts] are cumulative counters of work
+      performed by the solver. Note that [num_clauses] counts only
+      "at-least-one" / "implies" / "impossible" clauses; the
+      "at-most-{one,n}" clauses (used for conflict-class / mutual-exclusion
+      groupings) are not counted because they do not carry a problem handle
+      at their construction site. *)
+  type stats =
+    { num_variables : int
+    ; num_clauses : int
+    ; num_decisions : int
+    ; num_conflicts : int
+    }
+
+  val get_stats : t -> stats
 end

--- a/test/blackbox-tests/test-cases/pkg/sat-solve-trace.t
+++ b/test/blackbox-tests/test-cases/pkg/sat-solve-trace.t
@@ -1,0 +1,67 @@
+The `sat` trace category emits a complete event for every SAT solve performed
+while generating a lock directory. The events are opt-in: they are only
+emitted when the `sat` category is enabled via `DUNE_TRACE=+sat`.
+
+  $ mkrepo
+  $ mkpkg foo 0.0.1
+  $ mkpkg bar << EOF
+  > depends: [ "foo" ]
+  > EOF
+
+With the `sat` category enabled, solving emits at least one `sat`/`solve`
+event carrying the solver stats:
+
+  $ export DUNE_TRACE=+sat
+  $ solve_project << EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends bar))
+  > EOF
+  Solution for dune.lock:
+  - bar.0.0.1
+  - foo.0.0.1
+
+Assert the shape of the `sat`/`solve` events. The exact counter values and the
+number of events depend on the solver (it may run more than once, e.g. when
+retrying with different `max_avoids`), so only assert sane ranges:
+
+  $ dune trace cat | jq -s '
+  >   [ .[] | select(.cat == "sat" and .name == "solve") ] as $solves
+  > | { has_sat_solve_events: ($solves | length > 0)
+  >   , valid_shape: all($solves[];
+  >       (.args.num_variables | type) == "number"
+  >       and (.args.num_clauses | type) == "number"
+  >       and (.args.num_decisions | type) == "number"
+  >       and (.args.num_conflicts | type) == "number"
+  >       and .args.num_variables >= 1
+  >       and .args.num_clauses >= 1
+  >       and .args.num_decisions >= 0
+  >       and .args.num_conflicts >= 0
+  >       and (.dur | type) == "number")
+  >   }
+  > '
+  {
+    "has_sat_solve_events": true,
+    "valid_shape": true
+  }
+
+The `sat` category is opt-in: without `DUNE_TRACE=+sat`, no `sat` events are
+emitted at all:
+
+  $ unset DUNE_TRACE
+  $ rm -rf "${source_lock_dir}"
+  $ solve_project << EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends bar))
+  > EOF
+  Solution for dune.lock:
+  - bar.0.0.1
+  - foo.0.0.1
+
+  $ dune trace cat | jq -s '[ .[] | select(.cat == "sat") ] | length'
+  0

--- a/test/expect-tests/sat/dune
+++ b/test/expect-tests/sat/dune
@@ -1,0 +1,15 @@
+(library
+ (name dune_sat_unit_tests)
+ (inline_tests)
+ (libraries
+  dune_tests_common
+  stdune
+  sat
+  ;; This is because of the (implicit_transitive_deps false)
+  ;; in dune-project
+  ppx_expect.config
+  ppx_expect.config_types
+  base
+  ppx_inline_test.config)
+ (preprocess
+  (pps ppx_expect)))

--- a/test/expect-tests/sat/sat_tests.ml
+++ b/test/expect-tests/sat/sat_tests.ml
@@ -1,0 +1,138 @@
+open Stdune
+open Dune_tests_common
+
+let () = init ()
+
+module Sat = Sat.Make (struct
+    type t = int
+
+    let pp = Pp.textf "%d"
+  end)
+
+let print_stats p =
+  let open Sat in
+  let st = get_stats p in
+  Format.printf
+    "num_variables=%d num_clauses=%d num_decisions=%d num_conflicts=%d@."
+    st.num_variables
+    st.num_clauses
+    st.num_decisions
+    st.num_conflicts
+;;
+
+let is_some = function
+  | Some _ -> true
+  | None -> false
+;;
+
+let%expect_test "a fresh problem has all-zero stats" =
+  let open Sat in
+  let p = create () in
+  print_stats p;
+  [%expect
+    {|
+    num_variables=0 num_clauses=0 num_decisions=0 num_conflicts=0
+  |}]
+;;
+
+let%expect_test "structural counters track added variables and input clauses" =
+  let open Sat in
+  let p = create () in
+  let a = add_variable p 1 in
+  let b = add_variable p 2 in
+  let c = add_variable p 3 in
+  print_stats p;
+  at_least_one p [ a; b ];
+  implies p b [ c ];
+  print_stats p;
+  impossible p;
+  print_stats p;
+  [%expect
+    {|
+    num_variables=3 num_clauses=0 num_decisions=0 num_conflicts=0
+    num_variables=3 num_clauses=2 num_decisions=0 num_conflicts=0
+    num_variables=3 num_clauses=3 num_decisions=0 num_conflicts=0
+  |}]
+;;
+
+let%expect_test "at-most clauses are not counted in num_clauses" =
+  let open Sat in
+  let p = create () in
+  let a = add_variable p 1 in
+  let b = add_variable p 2 in
+  let c = add_variable p 3 in
+  let amo = at_most_one [ a; b ] in
+  let _am2 = at_most 2 [ a; b; c ] in
+  print_stats p;
+  (* The at-most clauses are real even though they are not counted:
+     nothing is selected yet, and [a] is still undecided. *)
+  print_endline (if is_some (get_selected amo) then "selected" else "unselected");
+  print_endline (if is_some (get_best_undecided amo) then "undecided" else "decided");
+  [%expect
+    {|
+    num_variables=3 num_clauses=0 num_decisions=0 num_conflicts=0
+    unselected
+    undecided
+  |}]
+;;
+
+let%expect_test "run_solver records decisions, and counters are cumulative" =
+  let open Sat in
+  let p = create () in
+  let a = add_variable p 1 in
+  let b = add_variable p 2 in
+  at_least_one p [ a; b ];
+  let amo = at_most_one [ a; b ] in
+  let decide () = get_best_undecided amo in
+  print_endline (string_of_bool (run_solver p decide));
+  print_stats p;
+  (* Re-solving the same (already solved) problem is a no-op: all
+     variables are decided, so no new decisions or conflicts happen. *)
+  print_endline (string_of_bool (run_solver p decide));
+  print_stats p;
+  print_endline (if is_some (get_selected amo) then "selected" else "unselected");
+  [%expect
+    {|
+    true
+    num_variables=2 num_clauses=1 num_decisions=1 num_conflicts=0
+    true
+    num_variables=2 num_clauses=1 num_decisions=1 num_conflicts=0
+    selected
+  |}]
+;;
+
+let%expect_test "impossible problems are rejected before solving" =
+  let open Sat in
+  let p = create () in
+  impossible p;
+  print_stats p;
+  print_endline (string_of_bool (run_solver p (fun () -> None)));
+  print_stats p;
+  [%expect
+    {|
+    num_variables=0 num_clauses=1 num_decisions=0 num_conflicts=0
+    false
+    num_variables=0 num_clauses=1 num_decisions=0 num_conflicts=0
+  |}]
+;;
+
+let%expect_test "run_solver records conflicts on an unsatisfiable problem" =
+  let open Sat in
+  let p = create () in
+  let a = add_variable p 1 in
+  let b = add_variable p 2 in
+  (* (a or b) and (!a or b) and (a or !b) and (!a or !b) is unsatisfiable. *)
+  at_least_one p [ a; b ];
+  at_least_one p [ neg a; b ];
+  at_least_one p [ a; neg b ];
+  at_least_one p [ neg a; neg b ];
+  (* Returning [None] from the decider means: set the remaining variables
+     to [False]. The search then discovers both conflicts. *)
+  print_endline (string_of_bool (run_solver p (fun () -> None)));
+  print_stats p;
+  [%expect
+    {|
+    false
+    num_variables=2 num_clauses=4 num_decisions=1 num_conflicts=2
+  |}]
+;;


### PR DESCRIPTION
Follow-up to #15923: exercises the observability added there.

- `test/blackbox-tests/test-cases/pkg/sat-solve-trace.t` — cram test that solves a small project against a mock opam repository with `DUNE_TRACE=+sat` and asserts `sat`/`solve` complete events are emitted with the expected stats (`num_variables`, `num_clauses`, `num_decisions`, `num_conflicts`, `dur`), and that no such events appear when the category isn't enabled (opt-in contract).
- `test/expect-tests/sat/` — unit tests for `Sat.get_stats` pinning the documented counter semantics: `num_variables` tracks added variables, `num_clauses` counts `at_least_one`/`implies`/`impossible` clauses (at-most clauses excluded), and `num_decisions`/`num_conflicts` are cumulative solver-work counters.

No production code changes.
