### PR TITLE
perf(memo): specialize empty dependency restoration

### DIFF
--- a/src/memo/deps.ml
+++ b/src/memo/deps.ml
@@ -57,6 +57,11 @@ type 'node t = 'node Static.t
 
 let empty = Static.Empty
 
+let is_empty = function
+  | Static.Empty -> true
+  | Singleton _ | Seq _ | Par _ -> false
+;;
+
 module Dynamic = struct
   (* The most recently discovered section is at the head of the list. *)
   type 'node t = 'node Static.t list

--- a/src/memo/deps.mli
+++ b/src/memo/deps.mli
@@ -10,6 +10,7 @@ open! Stdune
 type 'node t
 
 val empty : 'node t
+val is_empty : _ t -> bool
 
 (** Like [t] but supports cheap appending of new dependencies. *)
 module Dynamic : sig

--- a/src/memo/exec.ml
+++ b/src/memo/exec.ml
@@ -62,6 +62,8 @@ let rec restore_from_cache
        errors of cancelled computations, whose deps are inaccurate ([Deps.empty]) anyway,
        so we must not use [Deps.changed_or_not] on them. *)
     Fiber.return Changed_or_not.Changed
+  | (Ok _ | Error { reproducible = true; _ }) when Deps.is_empty node.deps ->
+    Fiber.return Changed_or_not.Unchanged
   | Ok _ | Error { reproducible = true; _ } ->
     (* We cache reproducible errors just like normal values. We assume that all [Memo]
        computations are deterministic, which means if we rerun a computation that


### PR DESCRIPTION
Return Unchanged directly when restoring a cached reproducible value with no dependencies, avoiding entry into the general series-parallel dependency walker.