### PR TITLE
perf(memo): defer dependency execution without closures

### DIFF
--- a/src/memo/exec.ml
+++ b/src/memo/exec.ml
@@ -228,37 +228,38 @@ and consider_and_compute_without_adding_dep
     Computation.read_but_first_check_for_cycles ~phase:Compute compute ~dep_node:node
 ;;
 
-let exec_dep_node : 'i 'o. ('i, 'o) Dep_node.t -> 'o Fiber.t =
+let exec_dep_node_now : 'i 'o. ('i, 'o) Dep_node.t -> 'o Fiber.t =
   fun node ->
-  Fiber.of_thunk (fun () ->
-    (* Doing the check here before creating any fibers, rather than in
-       [consider_and_restore_from_cache_without_adding_dep], is a measurable win. *)
-    if Run.is_current (Dep_node.last_validated_at node)
-    then
+  (* Doing the check here before creating any fibers, rather than in
+     [consider_and_restore_from_cache_without_adding_dep], is a measurable win. *)
+  if Run.is_current (Dep_node.last_validated_at node)
+  then
+    let* () = Deps_collector.add_dep_from_caller node in
+    let stack_frame = Dep_node.T node in
+    Value.get_exn node.value ~map_exn:(fun exn -> Error.extend_stack exn ~stack_frame)
+  else
+    consider_and_restore_from_cache_without_adding_dep node
+    >>= function
+    | Unchanged ->
       let* () = Deps_collector.add_dep_from_caller node in
       let stack_frame = Dep_node.T node in
       Value.get_exn node.value ~map_exn:(fun exn -> Error.extend_stack exn ~stack_frame)
-    else
-      consider_and_restore_from_cache_without_adding_dep node
-      >>= function
-      | Unchanged ->
-        let* () = Deps_collector.add_dep_from_caller node in
-        let stack_frame = Dep_node.T node in
-        Value.get_exn node.value ~map_exn:(fun exn -> Error.extend_stack exn ~stack_frame)
-      | Cancelled { dependency_cycle } ->
-        (* If restoring from cache failed with a cycle error, and the node's function is
-           deterministic (as it should be), then we will hit the same cycle when trying to
-           recompute the result. We therefore reraise the cycle error as is. Note that
-           apart from saving some work, this also helps us work around the limitation of
-           the cycle detection library that can't detect the same cycle twice. *)
-        raise (Cycle_error.E dependency_cycle)
-      | Changed ->
-        consider_and_compute_without_adding_dep node
-        >>= (function
-         | Ok () ->
-           let* () = Deps_collector.add_dep_from_caller node in
-           let stack_frame = Dep_node.T node in
-           Value.get_exn node.value ~map_exn:(fun exn ->
-             Error.extend_stack exn ~stack_frame)
-         | Error dependency_cycle -> raise (Cycle_error.E dependency_cycle)))
+    | Cancelled { dependency_cycle } ->
+      (* If restoring from cache failed with a cycle error, and the node's function is
+         deterministic (as it should be), then we will hit the same cycle when trying to
+         recompute the result. We therefore reraise the cycle error as is. Note that
+         apart from saving some work, this also helps us work around the limitation of
+         the cycle detection library that can't detect the same cycle twice. *)
+      raise (Cycle_error.E dependency_cycle)
+    | Changed ->
+      consider_and_compute_without_adding_dep node
+      >>= (function
+       | Ok () ->
+         let* () = Deps_collector.add_dep_from_caller node in
+         let stack_frame = Dep_node.T node in
+         Value.get_exn node.value ~map_exn:(fun exn ->
+           Error.extend_stack exn ~stack_frame)
+       | Error dependency_cycle -> raise (Cycle_error.E dependency_cycle))
 ;;
+
+let exec_dep_node node = Fiber.of_thunk_apply exec_dep_node_now node


### PR DESCRIPTION
Pass dependency nodes separately to a shared execution function instead of capturing them in thunks. Keep current-run checks deferred until Fiber execution.