### PR TITLE
perf(memo): return successful dependencies directly

### DIFF
--- a/src/memo/deps_collector.ml
+++ b/src/memo/deps_collector.ml
@@ -34,6 +34,15 @@ let add_dep_from_caller dep_node =
   Fiber.Var.get_apply_map var add_dep_to_collector dep_node
 ;;
 
+let add_dep_and_return collector (dep_node, value) =
+  add_dep_to_collector collector dep_node;
+  value
+;;
+
+let add_dep_from_caller_and_return dep_node value =
+  Fiber.Var.get_apply_map var add_dep_and_return (dep_node, value)
+;;
+
 (* A way to run a parallel thread while collecting its dependencies separately. *)
 type run_thread = { run : 'a 'b. f:('b -> 'a Fiber.t) -> 'b -> 'a Fiber.t } [@@unboxed]
 

--- a/src/memo/deps_collector.mli
+++ b/src/memo/deps_collector.mli
@@ -20,6 +20,8 @@ val get : t -> Dep_node.packed Deps.t
 (** Record a dependency on [dep_node] in the active collector, if there is one. *)
 val add_dep_from_caller : ('i, 'o) Dep_node.t -> unit Fiber.t
 
+val add_dep_from_caller_and_return : ('i, 'o) Dep_node.t -> 'a -> 'a Fiber.t
+
 (** A way to run one parallel thread while collecting its dependencies separately. *)
 type run_thread = { run : 'a 'b. f:('b -> 'a Fiber.t) -> 'b -> 'a Fiber.t } [@@unboxed]
 

--- a/src/memo/exec.ml
+++ b/src/memo/exec.ml
@@ -233,17 +233,25 @@ let exec_dep_node_now : 'i 'o. ('i, 'o) Dep_node.t -> 'o Fiber.t =
   (* Doing the check here before creating any fibers, rather than in
      [consider_and_restore_from_cache_without_adding_dep], is a measurable win. *)
   if Run.is_current (Dep_node.last_validated_at node)
-  then
-    let* () = Deps_collector.add_dep_from_caller node in
-    let stack_frame = Dep_node.T node in
-    Value.get_exn node.value ~map_exn:(fun exn -> Error.extend_stack exn ~stack_frame)
+  then (
+    match node.value with
+    | Ok value -> Deps_collector.add_dep_from_caller_and_return node value
+    | Error _ | Uninitialized ->
+      let* () = Deps_collector.add_dep_from_caller node in
+      let stack_frame = Dep_node.T node in
+      Value.get_exn_error node.value ~map_exn:(fun exn ->
+        Error.extend_stack exn ~stack_frame))
   else
     consider_and_restore_from_cache_without_adding_dep node
     >>= function
     | Unchanged ->
-      let* () = Deps_collector.add_dep_from_caller node in
-      let stack_frame = Dep_node.T node in
-      Value.get_exn node.value ~map_exn:(fun exn -> Error.extend_stack exn ~stack_frame)
+      (match node.value with
+       | Ok value -> Deps_collector.add_dep_from_caller_and_return node value
+       | Error _ | Uninitialized ->
+         let* () = Deps_collector.add_dep_from_caller node in
+         let stack_frame = Dep_node.T node in
+         Value.get_exn_error node.value ~map_exn:(fun exn ->
+           Error.extend_stack exn ~stack_frame))
     | Cancelled { dependency_cycle } ->
       (* If restoring from cache failed with a cycle error, and the node's function is
          deterministic (as it should be), then we will hit the same cycle when trying to
@@ -255,10 +263,13 @@ let exec_dep_node_now : 'i 'o. ('i, 'o) Dep_node.t -> 'o Fiber.t =
       consider_and_compute_without_adding_dep node
       >>= (function
        | Ok () ->
-         let* () = Deps_collector.add_dep_from_caller node in
-         let stack_frame = Dep_node.T node in
-         Value.get_exn node.value ~map_exn:(fun exn ->
-           Error.extend_stack exn ~stack_frame)
+         (match node.value with
+          | Ok value -> Deps_collector.add_dep_from_caller_and_return node value
+          | Error _ | Uninitialized ->
+            let* () = Deps_collector.add_dep_from_caller node in
+            let stack_frame = Dep_node.T node in
+            Value.get_exn_error node.value ~map_exn:(fun exn ->
+              Error.extend_stack exn ~stack_frame))
        | Error dependency_cycle -> raise (Cycle_error.E dependency_cycle))
 ;;
 

--- a/src/memo/value.ml
+++ b/src/memo/value.ml
@@ -49,6 +49,17 @@ type 'a t =
   | Uninitialized
   (** [Uninitialized] is the value of a node that has never been computed. *)
 
+let get_exn_error t ~map_exn =
+  match t with
+  | Ok _ -> Code_error.raise "Value.get_exn_error called on a value" []
+  | Error { Collect_errors_monoid.exns; reproducible = _ } ->
+    Fiber.reraise_all
+      (Exn_set.to_list_map exns ~f:(fun (exn : Exn_with_backtrace.t) ->
+         { exn with exn = map_exn exn.exn }))
+  | Uninitialized ->
+    Code_error.raise "Value.get_exn_error called on an uninitialized value" []
+;;
+
 let get_exn t ~map_exn =
   match t with
   | Ok a -> Fiber.return a

--- a/src/memo/value.mli
+++ b/src/memo/value.mli
@@ -28,3 +28,5 @@ type 'a t =
 
 (** Get the value, or reraise the contained errors after remapping each one with [map_exn]. *)
 val get_exn : 'a t -> map_exn:(exn -> exn) -> 'a Fiber.t
+
+val get_exn_error : 'a t -> map_exn:(exn -> exn) -> 'a Fiber.t


### PR DESCRIPTION
Combine dependency recording with returning successful node values and handle cached errors separately. Avoid intermediate Fiber bind and return allocations while preserving error stack extension.