### PR TITLE
perf(memo): thread dependency results without pairs

### DIFF
--- a/src/fiber/src/core.ml
+++ b/src/fiber/src/core.ml
@@ -35,6 +35,7 @@ type _ t =
   | Update_var_t : 'a Var_map.Key.t * ('a -> 'a) * (unit -> 'b t) -> 'b t
   | Get_apply_t : 'a Var_map.Key.t * ('a -> 'b -> 'c t) * 'b -> 'c t
   | Get_apply_map_t : 'a Var_map.Key.t * ('a -> 'b -> 'c) * 'b -> 'c t
+  | Get_apply_map2_t : 'a Var_map.Key.t * ('a -> 'b -> 'c -> 'd) * 'b * 'c -> 'd t
   | Set_apply_t : 'a Var_map.Key.t * 'a * ('b -> 'c t) * 'b -> 'c t
   | Update_apply_t : 'a Var_map.Key.t * ('a -> 'a) * ('b -> 'c t) * 'b -> 'c t
   (* Pair internal operations with their state without allocating a closure. *)
@@ -58,6 +59,7 @@ and 'a continuation =
       -> ('a, 'error) result continuation
   | Apply : ('a -> 'b -> 'c t) * 'b * 'c continuation -> 'a continuation
   | Apply_map : ('a -> 'b -> 'c) * 'b * 'c continuation -> 'a continuation
+  | Apply_map2 : ('a -> 'b -> 'c -> 'd) * 'b * 'c * 'd continuation -> 'a continuation
   | Unwind_to : 'a continuation -> 'a continuation
   | Unwind_map_reduce_to : ('a, 'b) result continuation -> 'a continuation
   | End : unit continuation
@@ -209,6 +211,7 @@ let rec continue : type a. a continuation -> a -> eff =
      | Error _ as error -> continue k error)
   | Apply (f, y, k) -> Run (f x y, k)
   | Apply_map (f, y, k) -> continue k (f x y)
+  | Apply_map2 (f, y, z, k) -> continue k (f x y z)
   | Unwind_to k -> Unwind (k, x)
   | Unwind_map_reduce_to k -> Unwind_map_reduce (k, Ok x)
   | End -> End_of_fiber ()
@@ -339,6 +342,7 @@ let rec eval : type a. a t -> a continuation -> eff =
   | Update_var_t (key, f, body) -> Update_var (key, f, body, k)
   | Get_apply_t (key, f, x) -> Get_var (key, Apply (f, x, k))
   | Get_apply_map_t (key, f, x) -> Get_var (key, Apply_map (f, x, k))
+  | Get_apply_map2_t (key, f, x, y) -> Get_var (key, Apply_map2 (f, x, y, k))
   | Set_apply_t (key, value, f, x) -> Set_var_apply (key, value, f, x, k)
   | Update_apply_t (key, f, body, x) -> Update_var_apply (key, f, body, x, k)
   | Primitive_t (f, x) -> f x k
@@ -533,6 +537,12 @@ module Var = struct
 
   let get_apply_map (key : 'a Var_map.Key.t) (f : 'a -> 'b -> 'c) (x : 'b) : 'c t =
     Get_apply_map_t (key, f, x)
+  ;;
+
+  let get_apply_map2 (key : 'a Var_map.Key.t) (f : 'a -> 'b -> 'c -> 'd) (x : 'b) (y : 'c)
+    : 'd t
+    =
+    Get_apply_map2_t (key, f, x, y)
   ;;
 
   let set_apply (key : 'a Var_map.Key.t) (value : 'a) (f : 'b -> 'c t) (x : 'b) : 'c t =

--- a/src/fiber/src/fiber.mli
+++ b/src/fiber/src/fiber.mli
@@ -190,6 +190,9 @@ module Var : sig
   (** Like [get_apply] but [f] returns a plain value rather than a fiber. *)
   val get_apply_map : 'a t -> ('a -> 'b -> 'c) -> 'b -> 'c fiber
 
+  (** Like [get_apply_map] with two separately threaded arguments. *)
+  val get_apply_map2 : 'a t -> ('a -> 'b -> 'c -> 'd) -> 'b -> 'c -> 'd fiber
+
   (** [set_apply var value f x] sets [var] to [value] during the execution of [f x]. *)
   val set_apply : 'a t -> 'a -> ('b -> 'c fiber) -> 'b -> 'c fiber
 

--- a/src/fiber/src/scheduler.ml
+++ b/src/fiber/src/scheduler.ml
@@ -99,6 +99,7 @@ and exec : type a. context -> a continuation -> a -> Jobs.t -> step' =
      | Error _ as error -> exec ctx k error jobs)
   | Apply (f, y, k) -> exec_fiber_apply2 ctx f x y k jobs
   | Apply_map (f, y, k) -> exec_apply_map ctx f x y k jobs
+  | Apply_map2 (f, y, z, k) -> exec_apply_map2 ctx f x y z k jobs
   | Unwind_to k -> exec ctx.parent k x jobs
   | Unwind_map_reduce_to k -> unwind_map_reduce ctx k (Ok x) jobs
   | End as k -> exec_core_continuation ctx k x jobs
@@ -199,6 +200,22 @@ and exec_apply_map
   match f x y with
   | exception exn -> handle_exception ctx exn jobs
   | z -> exec ctx k z jobs
+
+and exec_apply_map2
+  :  'a 'b 'c 'd.
+     context
+  -> ('a -> 'b -> 'c -> 'd)
+  -> 'a
+  -> 'b
+  -> 'c
+  -> 'd continuation
+  -> Jobs.t
+  -> step'
+  =
+  fun ctx f x y z k jobs ->
+  match f x y z with
+  | exception exn -> handle_exception ctx exn jobs
+  | result -> exec ctx k result jobs
 
 and handle_exception ctx exn jobs =
   let exn = Exn_with_backtrace.capture exn in
@@ -378,6 +395,8 @@ and exec_fiber : type a. context -> a t -> a continuation -> Jobs.t -> step' =
   | Get_apply_t (key, f, x) -> exec ctx (Apply (f, x, k)) (Var_map.get ctx.vars key) jobs
   | Get_apply_map_t (key, f, x) ->
     exec ctx (Apply_map (f, x, k)) (Var_map.get ctx.vars key) jobs
+  | Get_apply_map2_t (key, f, x, y) ->
+    exec ctx (Apply_map2 (f, x, y, k)) (Var_map.get ctx.vars key) jobs
   | Set_apply_t (key, value, f, x) ->
     let ctx = { ctx with parent = ctx; vars = Var_map.set ctx.vars key value } in
     exec_fiber_apply ctx f x (Unwind_to k) jobs

--- a/src/fiber/test/var_tests.ml
+++ b/src/fiber/test/var_tests.ml
@@ -21,18 +21,19 @@ let%expect_test "fiber vars are preserved across yields" =
     () |}]
 ;;
 
-let%expect_test "Var.get_apply and get_apply_map read the var and thread the argument" =
+let%expect_test "Var get_apply variants read the var and thread arguments" =
   let var = Fiber.Var.create 0 in
   let run =
     Fiber.Var.set var 10 (fun () ->
       let* sum = Fiber.Var.get_apply var (fun value x -> Fiber.return (value + x)) 5 in
-      let+ product = Fiber.Var.get_apply_map var (fun value x -> value * x) 5 in
-      printf "get_apply = %d, get_apply_map = %d\n" sum product)
+      let* product = Fiber.Var.get_apply_map var (fun value x -> value * x) 5 in
+      let+ sum3 = Fiber.Var.get_apply_map2 var (fun value x y -> value + x + y) 5 7 in
+      printf "get_apply = %d, get_apply_map = %d, get_apply_map2 = %d\n" sum product sum3)
   in
   test unit run;
   [%expect
     {|
-    get_apply = 15, get_apply_map = 50
+    get_apply = 15, get_apply_map = 50, get_apply_map2 = 22
     () |}]
 ;;
 

--- a/src/memo/deps_collector.ml
+++ b/src/memo/deps_collector.ml
@@ -34,13 +34,13 @@ let add_dep_from_caller dep_node =
   Fiber.Var.get_apply_map var add_dep_to_collector dep_node
 ;;
 
-let add_dep_and_return collector (dep_node, value) =
+let add_dep_and_return collector dep_node value =
   add_dep_to_collector collector dep_node;
   value
 ;;
 
 let add_dep_from_caller_and_return dep_node value =
-  Fiber.Var.get_apply_map var add_dep_and_return (dep_node, value)
+  Fiber.Var.get_apply_map2 var add_dep_and_return dep_node value
 ;;
 
 (* A way to run a parallel thread while collecting its dependencies separately. *)


### PR DESCRIPTION
Add a two-argument Fiber variable map operation so successful dependency recording can pass the node and cached value separately. This removes the transient pair while preserving variable lookup, dependency order, and continuation error handling.