### PR TITLE
perf(memo): bind captured arguments without closures

### DIFF
--- a/src/fiber/src/core.ml
+++ b/src/fiber/src/core.ml
@@ -14,6 +14,7 @@ type _ t =
   | Map2_t : 'a t * ('a -> 'b) * ('b -> 'c) -> 'c t
   | Map3_t : 'a t * ('a -> 'b) * ('b -> 'c) * ('c -> 'd) -> 'd t
   | Bind_t : 'a t * ('a -> 'b t) -> 'b t
+  | Bind_apply_t : 'a t * ('a -> 'b -> 'c t) * 'b -> 'c t
   | Bind_result_t :
       ('a, 'error) result t * ('a -> ('b, 'error) result t)
       -> ('b, 'error) result t
@@ -271,6 +272,7 @@ let rec continue : type a. a continuation -> a -> eff =
 
 let return x = Return_t x
 let bind t ~f = Bind_t (t, f)
+let bind_apply t f x = Bind_apply_t (t, f, x)
 let bind_result t ~f = Bind_result_t (t, f)
 
 let map t ~f =
@@ -310,6 +312,7 @@ let rec eval : type a. a t -> a continuation -> eff =
   | Map2_t (t, f, g) -> eval t (Map2 (f, g, k))
   | Map3_t (t, f, g, h) -> eval t (Map3 (f, g, h, k))
   | Bind_t (t, f) -> eval t (Bind (f, k))
+  | Bind_apply_t (t, f, x) -> eval t (Apply (f, x, k))
   | Bind_result_t (t, f) -> eval t (Bind_result (f, k))
   | Thunk_t f -> eval (f ()) k
   | Thunk_apply_t (f, x) -> eval (f x) k

--- a/src/fiber/src/fiber.mli
+++ b/src/fiber/src/fiber.mli
@@ -54,6 +54,10 @@ end
 val map : 'a t -> f:('a -> 'b) -> 'b t
 val bind : 'a t -> f:('a -> 'b t) -> 'b t
 
+(** [bind_apply t f x] is equivalent to [bind t ~f:(fun y -> f y x)] without allocating
+    the partial application. *)
+val bind_apply : 'a t -> ('a -> 'b -> 'c t) -> 'b -> 'c t
+
 (** Bind a successful result without allocating an intermediate callback for propagating
     errors. *)
 val bind_result

--- a/src/fiber/src/scheduler.ml
+++ b/src/fiber/src/scheduler.ml
@@ -344,6 +344,7 @@ and exec_fiber : type a. context -> a t -> a continuation -> Jobs.t -> step' =
   | Map2_t (t, f, g) -> exec_fiber ctx t (Map2 (f, g, k)) jobs
   | Map3_t (t, f, g, h) -> exec_fiber ctx t (Map3 (f, g, h, k)) jobs
   | Bind_t (t, f) -> exec_fiber ctx t (Bind (f, k)) jobs
+  | Bind_apply_t (t, f, x) -> exec_fiber ctx t (Apply (f, x, k)) jobs
   | Bind_result_t (t, f) -> exec_fiber ctx t (Bind_result (f, k)) jobs
   | Thunk_t f -> exec_fiber_thunk ctx f k jobs
   | Thunk_apply_t (f, x) -> exec_fiber_apply ctx f x k jobs

--- a/src/fiber/test/fiber_tests.ml
+++ b/src/fiber/test/fiber_tests.ml
@@ -54,6 +54,25 @@ let%expect_test "of_thunk_apply fibers are lazy and reusable" =
     12 |}]
 ;;
 
+let%expect_test "bind_apply threads its argument" =
+  let fiber =
+    Fiber.bind_apply
+      (Fiber.return 10)
+      (fun result argument ->
+         printfn "callback %d %d" result argument;
+         Fiber.return (result + argument))
+      5
+  in
+  test int fiber;
+  test int fiber;
+  [%expect
+    {|
+    callback 10 5
+    15
+    callback 10 5
+    15 |}]
+;;
+
 let%expect_test "map chains preserve callback order and exceptions" =
   let chain ~length ~raise_at =
     List.init length ~f:(fun i -> i + 1)

--- a/src/memo/exec.ml
+++ b/src/memo/exec.ml
@@ -228,49 +228,54 @@ and consider_and_compute_without_adding_dep
     Computation.read_but_first_check_for_cycles ~phase:Compute compute ~dep_node:node
 ;;
 
-let exec_dep_node_now : 'i 'o. ('i, 'o) Dep_node.t -> 'o Fiber.t =
+let add_dep_from_caller_and_get_value : type i o. (i, o) Dep_node.t -> o Fiber.t =
+  fun node ->
+  match node.value with
+  | Ok value -> Deps_collector.add_dep_from_caller_and_return node value
+  | Error _ | Uninitialized ->
+    let* () = Deps_collector.add_dep_from_caller node in
+    let stack_frame = Dep_node.T node in
+    Value.get_exn_error node.value ~map_exn:(fun exn ->
+      Error.extend_stack exn ~stack_frame)
+;;
+
+let after_compute
+  : type i o. (unit, Cycle_error.t) result -> (i, o) Dep_node.t -> o Fiber.t
+  =
+  fun result node ->
+  match result with
+  | Ok () -> add_dep_from_caller_and_get_value node
+  | Error dependency_cycle -> raise (Cycle_error.E dependency_cycle)
+;;
+
+let after_restore
+  : type i o. Cycle_error.t Changed_or_not.t -> (i, o) Dep_node.t -> o Fiber.t
+  =
+  fun result node ->
+  match result with
+  | Unchanged -> add_dep_from_caller_and_get_value node
+  | Cancelled { dependency_cycle } ->
+    (* If restoring from cache failed with a cycle error, and the node's function is
+       deterministic (as it should be), then we will hit the same cycle when trying to
+       recompute the result. We therefore reraise the cycle error as is. Note that apart
+       from saving some work, this also helps us work around the limitation of the cycle
+       detection library that can't detect the same cycle twice. *)
+    raise (Cycle_error.E dependency_cycle)
+  | Changed ->
+    Fiber.bind_apply (consider_and_compute_without_adding_dep node) after_compute node
+;;
+
+let exec_dep_node_now : type i o. (i, o) Dep_node.t -> o Fiber.t =
   fun node ->
   (* Doing the check here before creating any fibers, rather than in
      [consider_and_restore_from_cache_without_adding_dep], is a measurable win. *)
   if Run.is_current (Dep_node.last_validated_at node)
-  then (
-    match node.value with
-    | Ok value -> Deps_collector.add_dep_from_caller_and_return node value
-    | Error _ | Uninitialized ->
-      let* () = Deps_collector.add_dep_from_caller node in
-      let stack_frame = Dep_node.T node in
-      Value.get_exn_error node.value ~map_exn:(fun exn ->
-        Error.extend_stack exn ~stack_frame))
+  then add_dep_from_caller_and_get_value node
   else
-    consider_and_restore_from_cache_without_adding_dep node
-    >>= function
-    | Unchanged ->
-      (match node.value with
-       | Ok value -> Deps_collector.add_dep_from_caller_and_return node value
-       | Error _ | Uninitialized ->
-         let* () = Deps_collector.add_dep_from_caller node in
-         let stack_frame = Dep_node.T node in
-         Value.get_exn_error node.value ~map_exn:(fun exn ->
-           Error.extend_stack exn ~stack_frame))
-    | Cancelled { dependency_cycle } ->
-      (* If restoring from cache failed with a cycle error, and the node's function is
-         deterministic (as it should be), then we will hit the same cycle when trying to
-         recompute the result. We therefore reraise the cycle error as is. Note that
-         apart from saving some work, this also helps us work around the limitation of
-         the cycle detection library that can't detect the same cycle twice. *)
-      raise (Cycle_error.E dependency_cycle)
-    | Changed ->
-      consider_and_compute_without_adding_dep node
-      >>= (function
-       | Ok () ->
-         (match node.value with
-          | Ok value -> Deps_collector.add_dep_from_caller_and_return node value
-          | Error _ | Uninitialized ->
-            let* () = Deps_collector.add_dep_from_caller node in
-            let stack_frame = Dep_node.T node in
-            Value.get_exn_error node.value ~map_exn:(fun exn ->
-              Error.extend_stack exn ~stack_frame))
-       | Error dependency_cycle -> raise (Cycle_error.E dependency_cycle))
+    Fiber.bind_apply
+      (consider_and_restore_from_cache_without_adding_dep node)
+      after_restore
+      node
 ;;
 
 let exec_dep_node node = Fiber.of_thunk_apply exec_dep_node_now node


### PR DESCRIPTION
Add Fiber.bind_apply to thread a separately stored argument into a bind continuation. Use it for dependency restoration and recomputation so Memo can hoist the callbacks instead of capturing the dependency node in closures. Preserve dependency recording, cycle propagation, and cached-error stack extension.