### PR TITLE
perf(memo): inline Fiber map construction

### DIFF
--- a/src/fiber/src/core.ml
+++ b/src/fiber/src/core.ml
@@ -276,7 +276,7 @@ let return x = Return_t x
 let bind t ~f = Bind_t (t, f)
 let bind_result t ~f = Bind_result_t (t, f)
 
-let map t ~f =
+let[@inline] map t ~f =
   match t with
   | Map_t (t, g) -> Map2_t (t, g, f)
   | Map2_t (t, g, h) -> Map3_t (t, g, h, f)


### PR DESCRIPTION
Inline the small map-constructor fusion dispatch at Memo call sites, retaining the existing Map/Map2/Map3 representation and callback order.