### PR TITLE
perf(memo): dispatch immediate Fiber callback results directly

### DIFF
--- a/src/fiber/src/scheduler.ml
+++ b/src/fiber/src/scheduler.ml
@@ -483,6 +483,7 @@ and exec_fiber_apply
   fun ctx f x k jobs ->
   match f x with
   | exception exn -> handle_exception ctx exn jobs
+  | Return_t y -> exec ctx k y jobs
   | t -> exec_fiber ctx t k jobs
 
 and exec_fiber_apply2


### PR DESCRIPTION
Handle Return_t directly after applying a Fiber callback instead of entering the general fiber-node dispatcher. Preserve exception handling, continuation order, and all non-immediate node behavior.