### PR TITLE
perf(memo): execute Fiber bind continuations directly

### DIFF
--- a/src/fiber/src/scheduler.ml
+++ b/src/fiber/src/scheduler.ml
@@ -101,11 +101,19 @@ and exec : type a. context -> a continuation -> a -> Jobs.t -> step' =
     (match h (g (f x)) with
      | exception exn -> handle_exception ctx exn jobs
      | y -> exec ctx k y jobs)
-  | Bind (f, k) -> exec_fiber_apply ctx f x k jobs
+  | Bind (f, k) ->
+    (match f x with
+     | exception exn -> handle_exception ctx exn jobs
+     | Return_t y -> exec ctx k y jobs
+     | t -> exec_fiber ctx t k jobs)
   | Bind_result (f, k) ->
     (match x with
-     | Ok x -> exec_fiber_apply ctx f x k jobs
-     | Error _ as error -> exec ctx k error jobs)
+     | Error _ as error -> exec ctx k error jobs
+     | Ok x ->
+       (match f x with
+        | exception exn -> handle_exception ctx exn jobs
+        | Return_t y -> exec ctx k y jobs
+        | t -> exec_fiber ctx t k jobs))
   | Apply (f, y, k) -> exec_fiber_apply2 ctx f x y k jobs
   | Apply_map (f, y, k) ->
     (match f x y with


### PR DESCRIPTION
Apply Bind and successful Bind_result callbacks directly in the continuation dispatcher, including the immediate-result fast path. Preserve callback exception capture, result-error propagation, and continuation order.