### PR TITLE
perf(boot): compile lexers with -ml

### DIFF
--- a/boot/bootstrap.ml
+++ b/boot/bootstrap.ml
@@ -127,7 +127,7 @@ let () =
       let ocamllex = Filename.concat bin_dir "ocamllex" in
       compiler, ocamllex, Some "--secondary", Some lib_dir)
   in
-  exit_if_non_zero (runf "%s -q -o %s %s" ocamllex (pps ^ ".ml") (pps ^ ".mll"));
+  exit_if_non_zero (runf "%s -ml -q -o %s %s" ocamllex (pps ^ ".ml") (pps ^ ".mll"));
   let script =
     let fname, out = Filename.open_temp_file duneboot "main" in
     script out;

--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -1139,7 +1139,7 @@ let insert_header fn ~header =
 
 let copy_lexer ~header src dst =
   let dst = Filename.remove_extension dst ^ ".ml" in
-  let+ () = Process.run Config.ocamllex [ "-q"; "-o"; dst; src ] in
+  let+ () = Process.run Config.ocamllex [ "-ml"; "-q"; "-o"; dst; src ] in
   insert_header dst ~header
 ;;
 

--- a/test/blackbox-tests/test-cases/boot/cycle.t
+++ b/test/blackbox-tests/test-cases/boot/cycle.t
@@ -19,7 +19,7 @@ Testing cycle detection in bootstrap.
   $ create_dune a <<EOF
   > open A
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   cycle:
   - a__B.ml

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-ambiguous.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-ambiguous.t
@@ -31,6 +31,6 @@ it picks up the closest one.
   > module M1 = A.Bar.Baz
   > let () = Printf.printf "Hello from %s\n" M1.exported
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from the correct module!

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-no-group-intf.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-no-group-intf.t
@@ -19,7 +19,7 @@ Testing the bootstrap of a wrapped include subdirs qualified.
   > module M2 = A.B.X
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from wrapped a/b/x.ml
   Hello from bootstrapped binary!

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-unwrapped.t
@@ -34,7 +34,7 @@ Testing the bootstrap of an unwrapped include subdirs qualified.
   > module M3 = B.C
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from unwrapped a/b/c/c.ml
   Hello from unwrapped a/b/b.ml

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-wrapped.t
@@ -31,7 +31,7 @@ Testing the bootstrap of a wrapped include subdirs qualified.
   > module M4 = A.B.C
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from wrapped a/b/c/c.ml
   Hello from wrapped a/b/b.ml

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-unwrapped.t
@@ -30,7 +30,7 @@ Testing the bootstrap of an unwrapped include subdirs unqualified.
   > module M3 = C
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from unwrapped a/b/b.ml
   Hello from unwrapped a/b/c/c.ml

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-wrapped.t
@@ -30,7 +30,7 @@ Testing the bootstrap of a wrapped include subdirs unqualified.
   > module M4 = A.C
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from wrapped a/b/b.ml
   Hello from wrapped a/b/c/c.ml

--- a/test/blackbox-tests/test-cases/boot/ppx-expect-test.t
+++ b/test/blackbox-tests/test-cases/boot/ppx-expect-test.t
@@ -32,7 +32,7 @@ Testing that the bootstrap preprocessor strips let%expect_test blocks.
   $ create_dune a <<EOF
   > let () = Printf.printf "Hello, x = %d" A.x
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   x = 42
   Hello, x = 42

--- a/test/blackbox-tests/test-cases/boot/ppx-test-module.t
+++ b/test/blackbox-tests/test-cases/boot/ppx-test-module.t
@@ -42,7 +42,7 @@ Testing that the bootstrap preprocessor strips let%test_module blocks.
   $ create_dune a <<EOF
   > let () = Printf.printf "Hello, x = %d" A.x
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   x = 42
   Hello, x = 42

--- a/test/blackbox-tests/test-cases/boot/singleton-unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/singleton-unwrapped.t
@@ -19,7 +19,7 @@ Testing the bootstrap of singleton unwrapped libraries.
   > open B
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from singleton unwrapped a/b.ml
   Hello from bootstrapped binary!

--- a/test/blackbox-tests/test-cases/boot/singleton-wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/singleton-wrapped.t
@@ -18,7 +18,7 @@ Testing the bootstrap of singleton wrapped libraries.
   > open A
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from singleton wrapped a/a.ml
   Hello from bootstrapped binary!

--- a/test/blackbox-tests/test-cases/boot/unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/unwrapped.t
@@ -25,7 +25,7 @@ Testing the bootstrap of unwrapped libraries.
   > open B
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from unwrapped a/a.ml
   Hello from unwrapped a/b.ml

--- a/test/blackbox-tests/test-cases/boot/wrapped-no-interface.t
+++ b/test/blackbox-tests/test-cases/boot/wrapped-no-interface.t
@@ -21,7 +21,7 @@ Testing the bootstrap of wrapped libraries without interface moodule.
   > open Root
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from wrapped non-interface module a/b.ml
   Hello from bootstrapped binary!

--- a/test/blackbox-tests/test-cases/boot/wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/wrapped.t
@@ -26,7 +26,7 @@ Testing the bootstrap of wrapped libraries.
   > open B
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from wrapped module a/b.ml
   Hello from wrapped interface module a/a.ml


### PR DESCRIPTION
Compile the bootstrap preprocessor and lexer sources with ocamllex's `-ml` option. This makes bootstrap-generated lexers use the faster code-based automaton, consistent with Dune's regular lexer builds.