### PR TITLE
fix(melange): stage installed emission dependencies

### DIFF
--- a/doc/changes/fixed/15949.md
+++ b/doc/changes/fixed/15949.md
@@ -1,0 +1,3 @@
+- Fix Melange emission with installed libraries whose `.cmj` and `.cmi` files
+  are stored in the `melange` object directory (#15949, fixes #14820,
+  @anmonteiro)

--- a/src/dune_rules/obj_dir.ml
+++ b/src/dune_rules/obj_dir.ml
@@ -153,7 +153,15 @@ module External = struct
   let dir t = t.public_dir.ocaml
   let obj_dir t = t.public_dir.ocaml
   let odoc_dir t = t.public_dir.ocaml
-  let all_obj_dirs t ~mode:_ = [ t.public_dir.ocaml ]
+
+  let all_obj_dirs t ~(mode : Lib_mode.t) =
+    match mode with
+    | Ocaml _ -> [ t.public_dir.ocaml ]
+    | Melange ->
+      [ t.public_dir.melange; public_cmi_melange_dir t ]
+      |> Path.Set.of_list
+      |> Path.Set.to_list
+  ;;
 
   let all_cmis { public_dir; private_dir; public_cmi_dir } =
     List.filter_opt

--- a/test/blackbox-tests/test-cases/melange/emit-installed-melange-object-dir.t
+++ b/test/blackbox-tests/test-cases/melange/emit-installed-melange-object-dir.t
@@ -58,5 +58,5 @@ files above.
   >    | "\(.predicate) \(.dir_kind) \(.dir)"]
   >   | sort[]
   > ' deps.json
-  *.cmi External $TESTCASE_ROOT/prefix/lib/repro/foo
-  *.cmj External $TESTCASE_ROOT/prefix/lib/repro/foo
+  *.cmi External $TESTCASE_ROOT/prefix/lib/repro/foo/melange
+  *.cmj External $TESTCASE_ROOT/prefix/lib/repro/foo/melange

--- a/test/blackbox-tests/test-cases/melange/emit-installed-private-module.t
+++ b/test/blackbox-tests/test-cases/melange/emit-installed-private-module.t
@@ -57,7 +57,7 @@ stage the installed Melange object dirs rather than only the entry module's
   $ write_melange_repro_foo_consumer
 
   $ OCAMLPATH=$PWD/prefix/lib:$OCAMLPATH dune rules --format=json --deps --root app --display=quiet dist/node_modules/repro.foo/foo_map.js > deps.json
-  $ jq_dune -r '.[] | depsGlobEntriesWithPredicate("*.cmj") | select(.dir | endswith("/repro/foo")) | "\(.dir_kind) \(.dir)"' deps.json
-  External $TESTCASE_ROOT/prefix/lib/repro/foo
-  $ jq_dune -r '.[] | depsGlobEntriesWithPredicate("*.cmi") | select(.dir | endswith("/repro/foo")) | "\(.dir_kind) \(.dir)"' deps.json
-  External $TESTCASE_ROOT/prefix/lib/repro/foo
+  $ jq_dune -r '.[] | depsGlobEntriesWithPredicate("*.cmj") | select(.dir | endswith("/repro/foo/melange")) | "\(.dir_kind) \(.dir)"' deps.json
+  External $TESTCASE_ROOT/prefix/lib/repro/foo/melange
+  $ jq_dune -r '.[] | depsGlobEntriesWithPredicate("*.cmi") | select(.dir | endswith("/repro/foo/melange")) | "\(.dir_kind) \(.dir)"' deps.json
+  External $TESTCASE_ROOT/prefix/lib/repro/foo/melange


### PR DESCRIPTION
Stages installed Melange object dependencies during JS emission.

Fixes #14820. Regression test added in #15900.