### PR TITLE
perf(rules): reuse dependency deduplication tables

### DIFF
--- a/otherlibs/stdune/src/hashtbl.ml
+++ b/otherlibs/stdune/src/hashtbl.ml
@@ -28,6 +28,19 @@ struct
       x
   ;;
 
+  let dedupe_by ~key =
+    let seen = create 32 in
+    Staged.stage (fun list ->
+      clear seen;
+      List.filter list ~f:(fun x ->
+        let key = key x in
+        if mem seen key
+        then false
+        else (
+          set seen key ();
+          true)))
+  ;;
+
   let foldi t ~init ~f = fold t ~init ~f:(fun ~key ~data acc -> f key data acc)
   let fold t ~init ~f = foldi t ~init ~f:(fun _ x -> f x)
 

--- a/otherlibs/stdune/src/hashtbl_intf.ml
+++ b/otherlibs/stdune/src/hashtbl_intf.ml
@@ -15,6 +15,13 @@ module type S = sig
   val find : 'a t -> key -> 'a option
   val find_exn : 'a t -> key -> 'a
   val find_or_add : 'a t -> key -> f:(key -> 'a) -> 'a
+
+  (** [dedupe_by ~key] returns a staged function that removes elements with
+      duplicate keys from a list while preserving the first occurrence of every
+      key. Unstage the function once and reuse it. It reuses a mutable table and
+      must not be called concurrently or reentrantly. *)
+  val dedupe_by : key:('a -> key) -> ('a list -> 'a list) Staged.t
+
   val fold : 'a t -> init:'b -> f:('a -> 'b -> 'b) -> 'b
   val foldi : 'a t -> init:'b -> f:(key -> 'a -> 'b -> 'b) -> 'b
   val of_list_exn : (key * 'a) list -> 'a t

--- a/otherlibs/stdune/test/string_tests.ml
+++ b/otherlibs/stdune/test/string_tests.ml
@@ -219,3 +219,17 @@ let%expect_test "split_lines preserves carriage returns outside CRLF" =
     [ "first"; "second" ]
     |}]
 ;;
+
+let%expect_test "table dedupe_by preserves first occurrences across calls" =
+  let dedupe = String.Table.dedupe_by ~key:fst |> Staged.unstage in
+  let print values = dedupe values |> list (pair string int) |> print_dyn in
+  print [];
+  print [ "a", 1; "b", 2; "a", 3; "c", 4; "b", 5 ];
+  print [ "c", 6; "a", 7; "c", 8 ];
+  [%expect
+    {|
+    []
+    [ ("a", 1); ("b", 2); ("c", 4) ]
+    [ ("c", 6); ("a", 7) ]
+    |}]
+;;

--- a/src/dune_rules/dep_graph.ml
+++ b/src/dune_rules/dep_graph.ml
@@ -71,18 +71,10 @@ module Ml_kind = struct
   let dummy m = Ml_kind.Dict.make_both (dummy m)
 
   let for_module_compilation ~modules ({ impl; intf } : t) =
-    let dedupe_modules modules =
-      let _, modules =
-        List.fold_left
-          modules
-          ~init:(Module_name.Unique.Set.empty, [])
-          ~f:(fun (seen, acc) module_ ->
-            let obj_name = Module.obj_name module_ in
-            if Module_name.Unique.Set.mem seen obj_name
-            then seen, acc
-            else Module_name.Unique.Set.add seen obj_name, module_ :: acc)
-      in
-      List.rev modules
+    let dedupe_modules =
+      String.Table.dedupe_by ~key:(fun module_ ->
+        Module.obj_name module_ |> Module_name.Unique.to_string)
+      |> Staged.unstage
     in
     let merge_impl_and_intf_deps obj_name impl_deps =
       let intf_deps = Module_name.Unique.Map.find_exn intf.per_module obj_name in


### PR DESCRIPTION
Add Hashtbl.Make.dedupe_by, which returns a staged stable-deduplication
function backed by a table cleared and reused between calls. Use the
String.Table instance to deduplicate module dependencies by unique object
name.

This preserves first-occurrence order while avoiding persistent set nodes
and a reversed accumulator. Cover key projection, ordering, and table reuse
with unit tests.