### PR TITLE
perf(stdune): parse valid local paths directly

### DIFF
--- a/otherlibs/stdune/src/path0.ml
+++ b/otherlibs/stdune/src/path0.ml
@@ -76,11 +76,11 @@ module Local_gen = struct
     let relative_result t components =
       let rec loop t components =
         match components with
-        | [] -> Result.Ok t
+        | [] -> Ok t
         | "." :: rest -> loop t rest
         | ".." :: rest ->
           (match parent t with
-           | None -> Result.Error `Outside_the_workspace
+           | None -> Error `Outside_the_workspace
            | Some parent -> loop parent rest)
         | fn :: rest ->
           if is_root t
@@ -162,23 +162,31 @@ module Local_gen = struct
     in
     fun s ->
       let len = String.length s in
-      len = 0 || before_slash s (len - 1)
+      len > 0 && before_slash s (len - 1)
   ;;
 
+  let is_valid s = is_root s || is_canonicalized s
+
   let parse_string_result s =
-    match s with
-    | "" | "." -> Result.Ok root
-    | _ when is_canonicalized s -> Result.Ok s
-    | _ -> relative_result root s
+    if is_valid s
+    then Ok s
+    else if String.is_empty s
+    then Ok root
+    else relative_result root s
   ;;
 
   let parse_string_exn s =
-    match parse_string_result s with
-    | Ok t -> t
-    | Error `Outside_the_workspace ->
-      Code_error.raise
-        "Local.parse_string_exn: path outside the workspace"
-        [ "s", String s ]
+    if is_valid s
+    then s
+    else if String.is_empty s
+    then root
+    else (
+      match relative_result root s with
+      | Ok t -> t
+      | Error `Outside_the_workspace ->
+        Code_error.raise
+          "Local.parse_string_exn: path outside the workspace"
+          [ "s", String s ])
   ;;
 
   let of_string s = parse_string_exn s

--- a/otherlibs/stdune/test/path_tests.ml
+++ b/otherlibs/stdune/test/path_tests.ml
@@ -29,6 +29,17 @@ let external_basename s =
   | exception Code_error.E _ -> print_endline "invalid"
 ;;
 
+let local_of_string s =
+  match Path.Local.of_string s with
+  | path ->
+    printfn
+      "%S -> %S%s"
+      s
+      (Path.Local.to_string path)
+      (if Path.Local.is_root path then " (root)" else "")
+  | exception User_error.E _ -> printfn "%S -> outside workspace" s
+;;
+
 let descendant p ~of_ = Dyn.option Path.to_dyn (Path.descendant p ~of_) |> print_dyn
 let is_descendant p ~of_ = Dyn.bool (Path.is_descendant p ~of_) |> print_dyn
 
@@ -50,6 +61,37 @@ let drop_build_context p =
 ;;
 
 let local_part p = Path.local_part p |> Path.Local.to_dyn |> print_dyn
+
+let%expect_test "local path parsing produces canonical representations" =
+  List.iter
+    [ ""
+    ; "."
+    ; "foo"
+    ; "foo/bar"
+    ; "./foo"
+    ; "foo/./bar"
+    ; "foo//bar/"
+    ; "foo/../bar"
+    ; "foo/.."
+    ; ".."
+    ; "../foo"
+    ]
+    ~f:local_of_string;
+  [%expect
+    {|
+    "" -> "." (root)
+    "." -> "." (root)
+    "foo" -> "foo"
+    "foo/bar" -> "foo/bar"
+    "./foo" -> "foo"
+    "foo/./bar" -> "foo/bar"
+    "foo//bar/" -> "foo/bar"
+    "foo/../bar" -> "bar"
+    "foo/.." -> "." (root)
+    ".." -> outside workspace
+    "../foo" -> outside workspace
+    |}]
+;;
 
 let%expect_test _ =
   let p = Path.(relative root) "foo" in


### PR DESCRIPTION
Share an is_valid predicate between the result-returning and
exception-raising local-path parsers. Handle valid path representations
and the empty root alias directly in parse_string_exn instead of wrapping
them in Ok only to immediately unwrap them.

This preserves normalization and error handling for non-canonical inputs
while removing the result allocation from the common path.