### PR TITLE
test(pkg): observe sat/solve event with stats in existing solver tests

### DIFF
--- a/test/blackbox-tests/dune.jq
+++ b/test/blackbox-tests/dune.jq
@@ -34,6 +34,8 @@ def inlineTestProcesses:
     processesBrief
   | select(.prog == "inline-test-runner.bc");
 
+def satSolveEvents: select(.cat == "sat" and .name == "solve");
+
 def targetsMatchingFilter(f):
     processes
   | select(.args | targets | any(f))

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-selection.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-selection.t
@@ -73,9 +73,16 @@ Generate all lockdirs:
   $ dune pkg lock dune.macos.lock
   Solution for dune.macos.lock:
   - macos-only.0.0.1
-  $ dune pkg lock dune.linux.lock
+  $ DUNE_TRACE=+sat dune pkg lock dune.linux.lock
   Solution for dune.linux.lock:
   - linux-only.0.0.1
+
+The trace file is reset per dune invocation, so the assertion below
+covers only the last pkg lock above (one SAT engine run, non-portable).
+
+  $ dune trace cat \
+  > | jq -s 'include "dune"; [ .[] | satSolveEvents ] | length'
+  1
 
 Demonstrate that the correct lockdir is being chosen by building packages that
 are only dependent on on certain systems.

--- a/test/blackbox-tests/test-cases/pkg/lockdir-load-dedup.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-load-dedup.t
@@ -17,9 +17,16 @@ the same lock dir.
 
   $ make_dune_project 3.23
 
-  $ dune build @check
+  $ DUNE_TRACE=+sat dune build @check
 
 Both contexts share the default lock dir. Check how many times it is loaded:
 
   $ dune trace cat | jq -s '[ .[] | select(.name == "load_lock_dir") ] | length'
   1
+
+The build path uses an already-generated lockdir, so the SAT engine
+should not run at all. With Sat tracing enabled, the count is zero.
+
+  $ dune trace cat \
+  > | jq -s 'include "dune"; [ .[] | satSolveEvents ] | length'
+  0

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
@@ -17,11 +17,18 @@ Create a package that writes a different value to some files depending on the os
 
   $ make_portable_lockdirs_project
 
-  $ dune pkg lock
+  $ DUNE_TRACE=+sat dune pkg lock
   Solution for dune.lock
   
   Dependencies common to all supported platforms:
   - foo.0.0.1
+
+The portable lock directory is solved independently for each of the four
+platforms.
+
+  $ dune trace cat \
+  > | jq -s 'include "dune"; [ .[] | satSolveEvents ] | length'
+  4
 
   $ cat ${default_lock_dir}/lock.dune
   (lang package 0.1)

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-no-solution.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-no-solution.t
@@ -27,7 +27,7 @@ Depend on a pair of packages which can't be coinstalled:
   > EOF
 
 Solver error when solving fails with the same error on all platforms:
-  $ dune pkg lock
+  $ DUNE_TRACE=+sat dune pkg lock
   Error:
   Unable to solve dependencies while generating lock directory: dune.lock
   
@@ -44,6 +44,12 @@ Solver error when solving fails with the same error on all platforms:
       Rejected candidates:
         c.0.2: Incompatible with restriction: = 0.1
   [1]
+
+Each of the four platform solves retries twice before reporting the failure.
+
+  $ dune trace cat \
+  > | jq -s 'include "dune"; [ .[] | satSolveEvents ] | length'
+  12
 
 Modify the "a" package so the solver error is different on different platforms:
   $ mkpkg a <<EOF

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
@@ -27,7 +27,7 @@ Define a package bar which conditionally depends on different versions of foo:
 
   $ make_x_depends_bar_project
 
-  $ dune pkg lock
+  $ DUNE_TRACE=+sat dune pkg lock
   Solution for dune.lock
   
   Dependencies common to all supported platforms:
@@ -46,6 +46,13 @@ Define a package bar which conditionally depends on different versions of foo:
   
   arch = x86_64; os = macos:
   - foo.2
+
+The portable lock directory is solved independently for each of the four
+platforms.
+
+  $ dune trace cat \
+  > | jq -s 'include "dune"; [ .[] | satSolveEvents ] | length'
+  4
 
 Build the project as if we were on linux and confirm that version 1 of foo was built:
   $ export DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11

--- a/test/blackbox-tests/test-cases/pkg/sat-solve-trace.t
+++ b/test/blackbox-tests/test-cases/pkg/sat-solve-trace.t
@@ -27,8 +27,8 @@ Assert the shape of the `sat`/`solve` events. The exact counter values and the
 number of events depend on the solver (it may run more than once, e.g. when
 retrying with different `max_avoids`), so only assert sane ranges:
 
-  $ dune trace cat | jq -s '
-  >   [ .[] | select(.cat == "sat" and .name == "solve") ] as $solves
+  $ dune trace cat | jq -s 'include "dune";
+  >   [ .[] | satSolveEvents ] as $solves
   > | { has_sat_solve_events: ($solves | length > 0)
   >   , valid_shape: all($solves[];
   >       (.args.num_variables | type) == "number"


### PR DESCRIPTION
Assert SAT solve invocation counts in existing package solver tests without coupling them to exact conflict statistics.

Tests: affected package cram tests; `@fmt`; `@check`.