### PR TITLE
test(pkg): cover portable lock dir solver invariants

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-dedup-manifest-errors.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-dedup-manifest-errors.t
@@ -33,6 +33,19 @@ Create the package "foo" with an opam file that creates a circular dep with the 
   depends on the package "x" which is in the workspace.
   [1]
 
+Create the package "foo" with a dependency on the workspace package "x" that
+only applies on macos. Platform-conditional dependencies must be validated,
+and the error must be reported only once:
+  $ mkpkg foo <<EOF
+  > depends: [ "x" { os = "macos" } ]
+  > EOF
+
+  $ dune pkg lock
+  Error: Dune does not support packages outside the workspace depending on
+  packages in the workspace. The package "foo" is not in the workspace but it
+  depends on the package "x" which is in the workspace.
+  [1]
+
 Create the package "foo" with an invalid variable interpolation:
   $ mkpkg foo <<EOF
   > build: [ "./configure" "--prefix=%{prefix" ]

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-no-solution.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-no-solution.t
@@ -51,6 +51,9 @@ Each of the four platform solves retries twice before reporting the failure.
   > | jq -s 'include "dune"; [ .[] | satSolveEvents ] | length'
   12
 
+No partial lock directory is written:
+  $ test ! -e dune.lock
+
 Modify the "a" package so the solver error is different on different platforms:
   $ mkpkg a <<EOF
   > depends: [

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-older-common-version.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-older-common-version.t
@@ -1,0 +1,72 @@
+When one platform can only use an older version of a package while another
+platform prefers a newer version, the current per-platform solver selects a
+different version for each platform.
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Define 2 versions of the package foo that write their version number to a file
+during their build so we can validate which version was built. The newer
+version is only available on linux:
+  $ mkpkg foo 1 <<EOF
+  > build: [
+  >   ["mkdir" "-p" share "%{lib}%/%{name}%"]
+  >   ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
+  >   ["sh" "-c" "echo %{version}% > %{share}%/version"]
+  > ]
+  > EOF
+  $ mkpkg foo 2 <<EOF
+  > available: os = "linux"
+  > build: [
+  >   ["mkdir" "-p" share "%{lib}%/%{name}%"]
+  >   ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
+  >   ["sh" "-c" "echo %{version}% > %{share}%/version"]
+  > ]
+  > EOF
+
+Define a package bar which depends on foo without a version constraint:
+  $ mkpkg bar <<EOF
+  > build: [
+  >   ["mkdir" "-p" share "%{lib}%/%{name}%"]
+  >   ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
+  > ]
+  > depends: [ "foo" ]
+  > EOF
+
+  $ make_x_depends_bar_project
+
+Linux prefers foo.2 while macos can only install foo.1. The current
+per-platform solver selects each platform's preferred version:
+  $ dune pkg lock
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
+  - bar.0.0.1
+  
+  Additionally, some packages will only be built on specific platforms.
+  
+  arch = arm64; os = linux:
+  - foo.2
+  
+  arch = arm64; os = macos:
+  - foo.1
+  
+  arch = x86_64; os = linux:
+  - foo.2
+  
+  arch = x86_64; os = macos:
+  - foo.1
+
+Build the project as if we were on linux and confirm that version 2 of foo was built:
+  $ export DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11
+  $ dune build
+  $ cat $pkg_root/$(dune pkg print-digest foo)/target/share/version
+  2
+
+  $ dune clean
+
+Build the project as if we were on macos and confirm that version 1 of foo was built:
+  $ export DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew DUNE_CONFIG__OS_VERSION=15.3.1
+  $ dune build
+  $ cat $pkg_root/$(dune pkg print-digest foo)/target/share/version
+  1


### PR DESCRIPTION
Adds coverage for portable lock directory behavior that the upcoming solver changes must preserve or intentionally change:

- A failed platform-set solve must not leave a partial lock directory.
- A platform-conditional manifest error must be reported once rather than once per platform.
- Independent platform solves currently select different versions of the same package. This records the before-state so later commits can first reject the inconsistent result and then select one common version. Both platform results are built to verify the selected versions rather than relying only on lock-directory output.

SAT invocation counts are already covered by existing trace-based tests and are updated by the single-solve implementation commit. These tests focus on solver outcomes instead.

Tests: affected portable-lockdir cram tests; `@fmt`; `@check`.