### PR TITLE
test(deps): expose delayed named package validation

### DIFF
--- a/test/blackbox-tests/test-cases/depend-on/named-binding-with-package-error.t
+++ b/test/blackbox-tests/test-cases/depend-on/named-binding-with-package-error.t
@@ -4,6 +4,17 @@ empty path list, which is rarely what the user intended.
 
   $ make_mypkg_lib_project
 
+The restriction is currently not checked when the rule is disabled:
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (target out)
+  >  (enabled_if false)
+  >  (deps (:pkg (package mypkg)))
+  >  (action (echo unused)))
+  > EOF
+  $ dune build
+
   $ cat >dune <<'EOF'
   > (rule
   >  (deps (:pkg (package mypkg)))


### PR DESCRIPTION
Document that a named package dependency in a disabled rule is currently accepted because dependency validation only happens when its action builder is evaluated.

This captures the existing behavior before moving structural dependency validation into stanza decoding in a follow-up.