### PR TITLE
fix(deps): validate named package bindings while decoding

### DIFF
--- a/doc/changes/fixed/15966.md
+++ b/doc/changes/fixed/15966.md
@@ -1,0 +1,2 @@
+- Reject package dependencies in named dependency bindings while decoding
+  dependency fields, including for disabled stanzas. (#15966, @rgrinberg)

--- a/src/dune_lang/dep_conf.ml
+++ b/src/dune_lang/dep_conf.ml
@@ -151,6 +151,25 @@ let decode files =
 let decode_no_files = decode `Forbid
 let decode = decode `Allow
 
+let decode_bindings =
+  let+ bindings = Bindings.decode decode in
+  Bindings.fold bindings ~init:() ~f:(fun binding () ->
+    match binding with
+    | Bindings.Unnamed _ -> ()
+    | Named (name, deps) ->
+      List.iter deps ~f:(function
+        | Package package ->
+          User_error.raise
+            ~loc:(String_with_vars.loc package)
+            ~hints:[ Pp.text "Place the (package ...) entry in the deps list directly." ]
+            [ Pp.textf
+                "(package ...) is not supported inside a named dependency binding (:%s)."
+                name
+            ]
+        | _ -> ()));
+  bindings
+;;
+
 let command_line_parser ~stanza_version =
   Syntax.set
     Stanza.syntax

--- a/src/dune_lang/dep_conf.mli
+++ b/src/dune_lang/dep_conf.mli
@@ -52,5 +52,6 @@ val repr : t Repr.t
 include Conv.S with type t := t
 
 val decode_no_files : t Decoder.t
+val decode_bindings : t Bindings.t Decoder.t
 val command_line_parser : stanza_version:Syntax.Version.t -> t Decoder.t
 val to_dyn : t Dyn.builder

--- a/src/dune_lang/stanzas/alias_conf.ml
+++ b/src/dune_lang/stanzas/alias_conf.ml
@@ -19,7 +19,7 @@ include Stanza.Make (struct
 let decode =
   let open Decoder in
   fields
-    (let* deps = field "deps" (Bindings.decode Dep_conf.decode) ~default:Bindings.empty in
+    (let* deps = field "deps" Dep_conf.decode_bindings ~default:Bindings.empty in
      String_with_vars.add_user_vars_to_decoding_env
        (Bindings.var_names deps)
        (let+ name = field "name" Alias.decode

--- a/src/dune_rules/cram/cram_stanza.ml
+++ b/src/dune_rules/cram/cram_stanza.ml
@@ -104,7 +104,7 @@ let decode =
   fields
     (let+ applies_to = field "applies_to" decode_applies_to ~default:default_applies_to
      and+ alias = field_o "alias" Dune_lang.Alias.decode
-     and+ deps = field_o "deps" (Bindings.decode Dep_conf.decode)
+     and+ deps = field_o "deps" Dep_conf.decode_bindings
      and+ enabled_if = Enabled_if.decode ~allowed_vars:Any ~since:None ()
      and+ locks = Locks.field ~check:(Dune_lang.Syntax.since Stanza.syntax (2, 9)) ()
      and+ package =

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -86,7 +86,7 @@ let expand_include =
       (String_with_vars.set_decoding_env
          (* CR-someday rgrinberg: this environment looks fishy *)
          (Pform.Env.initial ~stanza:Stanza.latest_version ~extensions:[])
-         (Bindings.decode Dep_conf.decode))
+         Dep_conf.decode_bindings)
   in
   fun ~dir ~project s ->
     Path.Build.relative dir s

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -243,7 +243,7 @@ let decode =
        field
          "deps"
          ~default:Bindings.empty
-         (Dune_lang.Syntax.since syntax (0, 2) >>> Bindings.decode Dep_conf.decode)
+         (Dune_lang.Syntax.since syntax (0, 2) >>> Dep_conf.decode_bindings)
      and+ preludes = field ~default:[] "preludes" (repeat Prelude.decode)
      and+ libraries =
        field

--- a/src/dune_rules/stanzas/rule_conf.ml
+++ b/src/dune_rules/stanzas/rule_conf.ml
@@ -100,7 +100,7 @@ let directory_targets_extension =
 let long_form ~loc =
   fields
   @@
-  let* deps = field "deps" (Bindings.decode Dep_conf.decode) ~default:Bindings.empty in
+  let* deps = field "deps" Dep_conf.decode_bindings ~default:Bindings.empty in
   let* project = Dune_project.get_exn () in
   let allow_directory_targets =
     Dune_project.dune_version project >= (3, 24)

--- a/src/dune_rules/stanzas/tests.ml
+++ b/src/dune_rules/stanzas/tests.ml
@@ -19,7 +19,7 @@ include Stanza.Make (struct
 let gen_parse names =
   let* () = Dune_lang.Syntax.since Stanza.syntax (1, 0) in
   fields
-    (let* deps = field "deps" (Bindings.decode Dep_conf.decode) ~default:Bindings.empty in
+    (let* deps = field "deps" Dep_conf.decode_bindings ~default:Bindings.empty in
      String_with_vars.add_user_vars_to_decoding_env
        (Bindings.var_names deps)
        (let* dune_version = Dune_lang.Syntax.get_exn Stanza.syntax in

--- a/test/blackbox-tests/test-cases/depend-on/named-binding-with-package-error.t
+++ b/test/blackbox-tests/test-cases/depend-on/named-binding-with-package-error.t
@@ -4,7 +4,7 @@ empty path list, which is rarely what the user intended.
 
   $ make_mypkg_lib_project
 
-The restriction is currently not checked when the rule is disabled:
+The restriction is checked even when the rule is disabled:
 
   $ cat >dune <<'EOF'
   > (rule
@@ -14,6 +14,13 @@ The restriction is currently not checked when the rule is disabled:
   >  (action (echo unused)))
   > EOF
   $ dune build
+  File "dune", line 4, characters 22-27:
+  4 |  (deps (:pkg (package mypkg)))
+                            ^^^^^
+  Error: (package ...) is not supported inside a named dependency binding
+  (:pkg).
+  Hint: Place the (package ...) entry in the deps list directly.
+  [1]
 
   $ cat >dune <<'EOF'
   > (rule


### PR DESCRIPTION
Reject package dependencies inside named dependency bindings while decoding dependency fields, rather than waiting until their action builders are evaluated. Structural errors are now reported even for disabled stanzas.

Follow-up to #15965.