### PR TITLE
refactor(melange): combine installed emission object globs

### DIFF
--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -287,18 +287,12 @@ let make_same_lib_emission_deps =
 ;;
 
 let make_external_lib_emission_deps =
-  let cmj_glob = Glob.of_string_exn Loc.none "*.cmj" in
-  let cmi_glob = Glob.of_string_exn Loc.none "*.cmi" in
-  let deps_of_glob ~dirs glob =
-    List.map dirs ~f:(fun dir -> Dep.file_selector (File_selector.of_glob ~dir glob))
-    |> Dep.Set.of_list
-  in
+  let obj_glob = Glob.of_string_exn Loc.none "*{.cmi,.cmj}" in
   fun ~obj_dir ->
-    let melange_obj_dirs = Obj_dir.all_obj_dirs obj_dir ~mode:Melange in
     let deps =
-      Dep.Set.union
-        (deps_of_glob ~dirs:melange_obj_dirs cmj_glob)
-        (deps_of_glob ~dirs:melange_obj_dirs cmi_glob)
+      Obj_dir.all_obj_dirs obj_dir ~mode:Melange
+      |> List.map ~f:(fun dir -> Dep.file_selector (File_selector.of_glob ~dir obj_glob))
+      |> Dep.Set.of_list
     in
     fun _module_ -> Action_builder.return deps
 ;;

--- a/test/blackbox-tests/test-cases/melange/emit-installed-melange-object-dir.t
+++ b/test/blackbox-tests/test-cases/melange/emit-installed-melange-object-dir.t
@@ -52,11 +52,12 @@ files above.
 
   $ jq_dune -r --arg lib_dir "$PWD/prefix/lib/repro/foo" '
   >   [.[] | depGlobEntries
-  >    | select(.predicate == "*.cmj" or .predicate == "*.cmi")
+  >    | select(.predicate == "*.cmj"
+  >             or .predicate == "*.cmi"
+  >             or .predicate == "*{.cmi,.cmj}")
   >    | select(.dir_kind == "External")
   >    | select(.dir == $lib_dir or .dir == ($lib_dir + "/melange"))
   >    | "\(.predicate) \(.dir_kind) \(.dir)"]
   >   | sort[]
   > ' deps.json
-  *.cmi External $TESTCASE_ROOT/prefix/lib/repro/foo/melange
-  *.cmj External $TESTCASE_ROOT/prefix/lib/repro/foo/melange
+  *{.cmi,.cmj} External $TESTCASE_ROOT/prefix/lib/repro/foo/melange

--- a/test/blackbox-tests/test-cases/melange/emit-installed-private-module.t
+++ b/test/blackbox-tests/test-cases/melange/emit-installed-private-module.t
@@ -57,7 +57,5 @@ stage the installed Melange object dirs rather than only the entry module's
   $ write_melange_repro_foo_consumer
 
   $ OCAMLPATH=$PWD/prefix/lib:$OCAMLPATH dune rules --format=json --deps --root app --display=quiet dist/node_modules/repro.foo/foo_map.js > deps.json
-  $ jq_dune -r '.[] | depsGlobEntriesWithPredicate("*.cmj") | select(.dir | endswith("/repro/foo/melange")) | "\(.dir_kind) \(.dir)"' deps.json
-  External $TESTCASE_ROOT/prefix/lib/repro/foo/melange
-  $ jq_dune -r '.[] | depsGlobEntriesWithPredicate("*.cmi") | select(.dir | endswith("/repro/foo/melange")) | "\(.dir_kind) \(.dir)"' deps.json
+  $ jq_dune -r '.[] | depsGlobEntriesWithPredicate("*{.cmi,.cmj}") | select(.dir | endswith("/repro/foo/melange")) | "\(.dir_kind) \(.dir)"' deps.json
   External $TESTCASE_ROOT/prefix/lib/repro/foo/melange


### PR DESCRIPTION
Combine installed Melange CMI and CMJ emission dependencies into one file selector.

Follow-up to #15967.