### PR TITLE
fix(pkg): suggest narrowing platforms on autolock failures

### DIFF
--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -95,7 +95,6 @@ let solve ~dev_tool ~local_packages =
        ~version_preference:None
        ~lock_dirs:[ lock_dir ]
        ~print_perf_stats:false
-       ~portable_lock_dir:false
 ;;
 
 (* Some dev tools must be built with the same version of the ocaml compiler as
@@ -203,7 +202,9 @@ let lockdir_status dev_tool =
               | None -> Memo.return `No_compiler_lockfile_in_lockdir
               | Some pkg ->
                 let+ ocaml_compiler = compiler_package () in
-                (match Lock_dir.Pkg.equal pkg ocaml_compiler with
+                (match
+                   Package_version.equal pkg.info.version ocaml_compiler.info.version
+                 with
                  | true -> `Lockdir_ok_with_tool_pkg pkg
                  | false ->
                    `Dev_tool_needs_to_be_relocked_because_project_compiler_version_changed

--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -54,56 +54,20 @@ module Progress_indicator = struct
   let add_overlay (t : t) = Console.Status_line.add_overlay (Live (fun () -> pp t))
 end
 
-module Platforms_by_message = struct
-  module Message = struct
-    type t =
-      | Solve_error of User_message.Style.t Pp.t
-      | Manifest_error of User_message.t
+module Solve_error = struct
+  type t =
+    | Solve_error of User_message.Style.t Pp.t
+    | Manifest_error of User_message.t
 
-    let to_dyn = function
-      | Solve_error message ->
-        Dyn.variant "Solve_error" [ Pp.to_dyn User_message.Style.to_dyn message ]
-      | Manifest_error message ->
-        Dyn.variant "Manifest_error" [ User_message.to_dyn message ]
-    ;;
-
-    let compare a b =
-      match a, b with
-      | Solve_error a, Solve_error b -> Pp.compare ~compare:User_message.Style.compare a b
-      | Solve_error _, _ -> Lt
-      | _, Solve_error _ -> Gt
-      | Manifest_error a, Manifest_error b -> User_message.compare a b
-    ;;
-  end
-
-  module Message_map = Map.Make (Message)
-
-  (* Map messages to the list of platforms for which those messages are
-     relevant. If a dependency problem has no solution on any platform, it's
-     likely that the error from the solver will be identical across all
-     platforms. We don't want to print the same error message once for each
-     platform, so this type collects messages and the platforms for which they
-     are relevant, deduplicating common messages. *)
-  type t = Solver_env.t list Message_map.t
-
-  let singleton message platform : t = Message_map.singleton message [ platform ]
-  let to_list (t : t) : (Message.t * Solver_env.t list) list = Message_map.to_list t
-  let union_all ts : t = Message_map.union_all ts ~f:(fun _ a b -> Some (a @ b))
-
-  let all_solver_errors_raising_if_any_manifest_errors t =
-    let solver_errors, manifest_errors =
-      List.partition_map (to_list t) ~f:(fun (message, platforms) ->
-        match message with
-        | Solve_error message -> Left (message, platforms)
-        | Manifest_error message -> Right message)
-    in
-    match manifest_errors with
-    | [] -> solver_errors
-    | message :: _ -> raise (User_error.E message)
+  (* Manifest errors are raised directly; solver errors are returned for
+     printing with the requested platform set. *)
+  let to_solver_error = function
+    | Solve_error message -> message
+    | Manifest_error message -> raise (User_error.E message)
   ;;
 end
 
-let solve_multiple_platforms
+let solve_with_platform_overlays
       base_solver_env
       version_preference
       repos
@@ -115,9 +79,27 @@ let solve_multiple_platforms
       ~portable_lock_dir
   =
   let open Fiber.O in
-  let solve_for_env env =
+  (* For portable lockdirs, use a portable base env (vars unset) + platform overlays.
+     For non-portable, use the full env + empty overlay. *)
+  let solver_env, platform_overlays =
+    if portable_lock_dir
+    then (
+      let portable_solver_env =
+        Solver_env.unset_multi
+          base_solver_env
+          Dune_lang.Package_variable_name.platform_specific
+      in
+      portable_solver_env, solve_for_platforms)
+    else base_solver_env, [ Solver_env.empty ]
+  in
+  let platform_overlays =
+    Dune_pkg.Opam_solver.deduplicate_platform_overlays platform_overlays
+  in
+  (* Single solve for all platforms *)
+  let+ result =
     Dune_pkg.Opam_solver.solve_lock_dir
-      env
+      solver_env
+      ~platform_overlays
       version_preference
       repos
       ~pins
@@ -126,40 +108,21 @@ let solve_multiple_platforms
       ~selected_depopts
       ~portable_lock_dir
   in
-  let portable_solver_env =
-    Solver_env.unset_multi
-      base_solver_env
-      Dune_lang.Package_variable_name.platform_specific
-  in
-  let+ results =
-    Fiber.parallel_map solve_for_platforms ~f:(fun platform_env ->
-      let solver_env = Solver_env.extend portable_solver_env platform_env in
-      let+ solver_result = solve_for_env solver_env in
-      Result.map_error solver_result ~f:(fun message ->
-        let message : Platforms_by_message.Message.t =
-          match message with
-          | `Solve_error m -> Solve_error m
-          | `Manifest_error m -> Manifest_error m
-        in
-        Platforms_by_message.singleton message platform_env))
-  in
-  let solver_results, errors =
-    List.partition_map results ~f:(function
-      | Ok result -> Left result
-      | Error e -> Right e)
-  in
-  match solver_results, errors with
-  | [], [] -> Code_error.raise "Solver did not run for any platforms." []
-  | _, _ :: _ ->
-    (* Any errors means full failure - no partial solutions *)
-    `All_error
-      (Platforms_by_message.union_all errors
-       |> Platforms_by_message.all_solver_errors_raising_if_any_manifest_errors)
-  | x :: xs, [] ->
-    let merged_solver_result =
-      List.fold_left xs ~init:x ~f:Dune_pkg.Opam_solver.Solver_result.merge
+  match result with
+  | Ok solver_result -> `All_ok solver_result
+  | Error message ->
+    let error_message : Solve_error.t =
+      match message with
+      | `Solve_error m -> Solve_error m
+      | `Manifest_error m -> Manifest_error m
     in
-    `All_ok merged_solver_result
+    (* Associate the error with the requested platforms (filtered to
+       platform-specific vars only for cleaner display). The single solve
+       fails for the requested platform set as a whole. *)
+    let platform_envs =
+      List.map platform_overlays ~f:Solver_env.remove_all_except_platform_specific
+    in
+    `All_error (error_message, platform_envs)
 ;;
 
 let user_lock_dir_path path =
@@ -174,7 +137,6 @@ let summary_message
       ~lock_dir_path
       ~(lock_dir : Lock_dir.t)
       ~maybe_perf_stats
-      ~maybe_unsolved_platforms_message
   =
   if portable_lock_dir
   then (
@@ -229,43 +191,42 @@ let summary_message
               ; pp_package_set packages
               ]))
     in
-    (Pp.tag
-       User_message.Style.Success
-       (Pp.textf
-          "Solution for %s"
-          (Path.to_string_maybe_quoted (user_lock_dir_path lock_dir_path)))
-     :: Pp.nop
-     :: Pp.text "Dependencies common to all supported platforms:"
-     :: pp_package_set common_packages
-     :: (maybe_uncommon_packages @ maybe_perf_stats))
-    @ maybe_unsolved_platforms_message)
+    Pp.tag
+      User_message.Style.Success
+      (Pp.textf
+         "Solution for %s"
+         (Path.to_string_maybe_quoted (user_lock_dir_path lock_dir_path)))
+    :: Pp.nop
+    :: Pp.text "Dependencies common to all supported platforms:"
+    :: pp_package_set common_packages
+    :: (maybe_uncommon_packages @ maybe_perf_stats))
   else
-    (Pp.tag
-       User_message.Style.Success
-       (Pp.textf
-          "Solution for %s:"
-          (Path.to_string_maybe_quoted (user_lock_dir_path lock_dir_path)))
-     :: (match Lock_dir.Packages.to_pkg_list lock_dir.packages with
-         | [] -> Pp.tag User_message.Style.Warning @@ Pp.text "(no dependencies to lock)"
-         | packages -> pp_packages packages)
-     :: maybe_perf_stats)
-    @ maybe_unsolved_platforms_message
+    Pp.tag
+      User_message.Style.Success
+      (Pp.textf
+         "Solution for %s:"
+         (Path.to_string_maybe_quoted (user_lock_dir_path lock_dir_path)))
+    :: (match Lock_dir.Packages.to_pkg_list lock_dir.packages with
+        | [] -> Pp.tag User_message.Style.Warning @@ Pp.text "(no dependencies to lock)"
+        | packages -> pp_packages packages)
+    :: maybe_perf_stats
 ;;
 
-let pp_solve_errors_by_platforms platforms_by_message =
-  List.map platforms_by_message ~f:(fun (message, platforms) ->
-    Pp.concat
-      ~sep:Pp.cut
-      [ Pp.nop
-      ; Pp.box
-        @@ Pp.text
-             "The dependency solver failed to find a solution for the following \
-              platforms:"
-      ; Pp.enumerate platforms ~f:Solver_env.pp_oneline
-      ; Pp.box @@ Pp.text "...with this error:"
-      ; message
-      ]
-    |> Pp.vbox)
+(* A failed joint solve does not prove that every requested platform fails on
+   its own: the solver reports the first conflict it finds for the requested
+   platform set. *)
+let pp_solve_error (message, platforms) =
+  Pp.concat
+    ~sep:Pp.cut
+    [ Pp.nop
+    ; Pp.box
+      @@ Pp.text
+           "The dependency solver failed to find a solution for the requested platforms:"
+    ; Pp.enumerate platforms ~f:Solver_env.pp_oneline
+    ; Pp.box @@ Pp.text "...with this error:"
+    ; message
+    ]
+  |> Pp.vbox
 ;;
 
 let solve_lock_dir
@@ -328,7 +289,7 @@ let solve_lock_dir
   let time_solve_start = Time.now () in
   progress_state := Some Progress_indicator.Per_lockdir.State.Solving;
   let* result =
-    solve_multiple_platforms
+    solve_with_platform_overlays
       solver_env
       (Pkg_common.Version_preference.choose
          ~from_arg:version_preference
@@ -345,12 +306,12 @@ let solve_lock_dir
   in
   let solver_result =
     match result with
-    | `All_error messages -> Error messages
-    | `All_ok solver_result -> Ok (solver_result, [])
+    | `All_error error -> Error error
+    | `All_ok solver_result -> Ok solver_result
   in
   match solver_result with
-  | Error messages -> Fiber.return (Error (lock_dir_path, messages))
-  | Ok (solver_result, maybe_unsolved_platforms_message) ->
+  | Error error -> Fiber.return (Error (lock_dir_path, error))
+  | Ok solver_result ->
     let { Dune_pkg.Opam_solver.Solver_result.lock_dir
         ; files
         ; pinned_packages
@@ -376,12 +337,7 @@ let solve_lock_dir
     in
     let summary_message =
       User_message.make
-        (summary_message
-           ~portable_lock_dir
-           ~lock_dir_path
-           ~lock_dir
-           ~maybe_perf_stats
-           ~maybe_unsolved_platforms_message)
+        (summary_message ~portable_lock_dir ~lock_dir_path ~lock_dir ~maybe_perf_stats)
     in
     progress_state := None;
     let+ lock_dir = Lock_dir.compute_missing_checksums ~pinned_packages lock_dir in
@@ -437,22 +393,21 @@ let solve
     if portable_lock_dir
     then
       User_error.raise
-        (List.concat_map errors ~f:(fun (path, errors) ->
+        (List.concat_map errors ~f:(fun (path, (error, platforms)) ->
            [ Pp.box
              @@ Pp.textf
                   "Unable to solve dependencies while generating lock directory: %s"
                   (Path.to_string_maybe_quoted path)
-           ; Pp.vbox (Pp.concat ~sep:Pp.cut (pp_solve_errors_by_platforms errors))
+           ; Pp.vbox (pp_solve_error (Solve_error.to_solver_error error, platforms))
            ]))
     else
       User_error.raise
         ([ Pp.text "Unable to solve dependencies for the following lock directories:" ]
-         @ List.concat_map errors ~f:(fun (path, errors) ->
-           let messages = List.map errors ~f:fst in
+         @ List.concat_map errors ~f:(fun (path, (error, _platforms)) ->
            [ Pp.textf
                "Lock directory %s:"
                (Path.to_string_maybe_quoted (user_lock_dir_path path))
-           ; Pp.vbox (Pp.concat ~sep:Pp.cut messages)
+           ; Pp.vbox (Solve_error.to_solver_error error)
            ]))
   | Ok write_disks_with_summaries ->
     let write_disk_list, summary_messages = List.split write_disks_with_summaries in

--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -199,6 +199,17 @@ let pp_solve_error (message, platforms) =
   |> Pp.vbox
 ;;
 
+(* Suggest narrowing the platform set when support for every requested
+   platform is unnecessary. *)
+let solve_for_platforms_hint =
+  [ Pp.text "If you don't need support for every requested platform, change"
+  ; Pp.text "(solve_for_platforms ...) in dune-workspace to only include the"
+  ; Pp.concat
+      ~sep:Pp.space
+      [ Pp.text "platforms you need, then rerun"; User_message.command "dune pkg lock" ]
+  ]
+;;
+
 let solve_lock_dir
       workspace
       ~local_packages
@@ -351,6 +362,7 @@ let solve
   >>| function
   | Error errors ->
     User_error.raise
+      ~hints:solve_for_platforms_hint
       (List.concat_map errors ~f:(fun (path, (error, platforms)) ->
          [ Pp.box
            @@ Pp.textf

--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -76,24 +76,12 @@ let solve_with_platform_overlays
       ~constraints
       ~selected_depopts
       ~solve_for_platforms
-      ~portable_lock_dir
   =
   let open Fiber.O in
-  (* For portable lockdirs, use a portable base env (vars unset) + platform overlays.
-     For non-portable, use the full env + empty overlay. *)
   let solver_env, platform_overlays =
-    if portable_lock_dir
-    then (
-      let portable_solver_env =
-        Solver_env.unset_multi
-          base_solver_env
-          Dune_lang.Package_variable_name.platform_specific
-      in
-      portable_solver_env, solve_for_platforms)
-    else base_solver_env, [ Solver_env.empty ]
-  in
-  let platform_overlays =
-    Dune_pkg.Opam_solver.deduplicate_platform_overlays platform_overlays
+    Dune_pkg.Opam_solver.base_solver_env_and_platforms
+      base_solver_env
+      ~solve_for_platforms
   in
   (* Single solve for all platforms *)
   let+ result =
@@ -106,7 +94,6 @@ let solve_with_platform_overlays
       ~local_packages
       ~constraints
       ~selected_depopts
-      ~portable_lock_dir
   in
   match result with
   | Ok solver_result -> `All_ok solver_result
@@ -132,84 +119,67 @@ let user_lock_dir_path path =
   | External e -> Dune_pkg.Pkg_workspace.dev_tool_path_to_source_dir e |> Path.source
 ;;
 
-let summary_message
-      ~portable_lock_dir
-      ~lock_dir_path
-      ~(lock_dir : Lock_dir.t)
-      ~maybe_perf_stats
-  =
-  if portable_lock_dir
-  then (
-    let pkgs_by_platform = Lock_dir.Packages.pkgs_by_platform lock_dir.packages in
-    let opam_package_of_pkg (pkg : Lock_dir.Pkg.t) =
-      OpamPackage.create
-        (Dune_pkg.Package_name.to_opam_package_name pkg.info.name)
-        (Dune_pkg.Package_version.to_opam_package_version pkg.info.version)
-    in
-    let pkgs_by_opam_package =
-      Lock_dir.Packages.to_pkg_list lock_dir.packages
-      |> List.map ~f:(fun pkg -> opam_package_of_pkg pkg, pkg)
-      |> OpamPackage.Map.of_list
-    in
-    let opam_package_to_pkg opam_package =
-      OpamPackage.Map.find opam_package pkgs_by_opam_package
-    in
-    let opam_package_sets_by_platform =
-      Solver_env.Map.map pkgs_by_platform ~f:(fun pkgs ->
-        List.map pkgs ~f:opam_package_of_pkg |> OpamPackage.Set.of_list)
-    in
-    let common_packages =
-      Solver_env.Map.values opam_package_sets_by_platform
-      |> List.reduce ~f:OpamPackage.Set.inter
-      |> Option.value ~default:OpamPackage.Set.empty
-    in
-    let pp_package_set package_set =
-      if OpamPackage.Set.is_empty package_set
-      then Pp.tag User_message.Style.Warning @@ Pp.text "(none)"
-      else (
-        let pkgs =
-          OpamPackage.Set.elements package_set |> List.map ~f:opam_package_to_pkg
-        in
-        Pkg_common.pp_packages pkgs)
-    in
-    let uncommon_packages_by_platform =
-      Solver_env.Map.map opam_package_sets_by_platform ~f:(fun package_set ->
-        OpamPackage.Set.diff package_set common_packages)
-      |> Solver_env.Map.filteri ~f:(fun _ package_set ->
-        not (OpamPackage.Set.is_empty package_set))
-    in
-    let maybe_uncommon_packages =
-      if Solver_env.Map.is_empty uncommon_packages_by_platform
-      then []
-      else
-        Pp.nop
-        :: Pp.text "Additionally, some packages will only be built on specific platforms."
-        :: (Solver_env.Map.to_list uncommon_packages_by_platform
-            |> List.concat_map ~f:(fun (platform, packages) ->
-              [ Pp.nop
-              ; Pp.concat [ Solver_env.pp_oneline platform; Pp.text ":" ]
-              ; pp_package_set packages
-              ]))
-    in
-    Pp.tag
-      User_message.Style.Success
-      (Pp.textf
-         "Solution for %s"
-         (Path.to_string_maybe_quoted (user_lock_dir_path lock_dir_path)))
-    :: Pp.nop
-    :: Pp.text "Dependencies common to all supported platforms:"
-    :: pp_package_set common_packages
-    :: (maybe_uncommon_packages @ maybe_perf_stats))
-  else
-    Pp.tag
-      User_message.Style.Success
-      (Pp.textf
-         "Solution for %s:"
-         (Path.to_string_maybe_quoted (user_lock_dir_path lock_dir_path)))
-    :: (match Lock_dir.Packages.to_pkg_list lock_dir.packages with
-        | [] -> Pp.tag User_message.Style.Warning @@ Pp.text "(no dependencies to lock)"
-        | packages -> pp_packages packages)
-    :: maybe_perf_stats
+let summary_message ~lock_dir_path ~(lock_dir : Lock_dir.t) ~maybe_perf_stats =
+  let pkgs_by_platform = Lock_dir.Packages.pkgs_by_platform lock_dir.packages in
+  let opam_package_of_pkg (pkg : Lock_dir.Pkg.t) =
+    OpamPackage.create
+      (Dune_pkg.Package_name.to_opam_package_name pkg.info.name)
+      (Dune_pkg.Package_version.to_opam_package_version pkg.info.version)
+  in
+  let pkgs_by_opam_package =
+    Lock_dir.Packages.to_pkg_list lock_dir.packages
+    |> List.map ~f:(fun pkg -> opam_package_of_pkg pkg, pkg)
+    |> OpamPackage.Map.of_list
+  in
+  let opam_package_to_pkg opam_package =
+    OpamPackage.Map.find opam_package pkgs_by_opam_package
+  in
+  let opam_package_sets_by_platform =
+    Solver_env.Map.map pkgs_by_platform ~f:(fun pkgs ->
+      List.map pkgs ~f:opam_package_of_pkg |> OpamPackage.Set.of_list)
+  in
+  let common_packages =
+    Solver_env.Map.values opam_package_sets_by_platform
+    |> List.reduce ~f:OpamPackage.Set.inter
+    |> Option.value ~default:OpamPackage.Set.empty
+  in
+  let pp_package_set package_set =
+    if OpamPackage.Set.is_empty package_set
+    then Pp.tag User_message.Style.Warning @@ Pp.text "(none)"
+    else (
+      let pkgs =
+        OpamPackage.Set.elements package_set |> List.map ~f:opam_package_to_pkg
+      in
+      Pkg_common.pp_packages pkgs)
+  in
+  let uncommon_packages_by_platform =
+    Solver_env.Map.map opam_package_sets_by_platform ~f:(fun package_set ->
+      OpamPackage.Set.diff package_set common_packages)
+    |> Solver_env.Map.filteri ~f:(fun _ package_set ->
+      not (OpamPackage.Set.is_empty package_set))
+  in
+  let maybe_uncommon_packages =
+    if Solver_env.Map.is_empty uncommon_packages_by_platform
+    then []
+    else
+      Pp.nop
+      :: Pp.text "Additionally, some packages will only be built on specific platforms."
+      :: (Solver_env.Map.to_list uncommon_packages_by_platform
+          |> List.concat_map ~f:(fun (platform, packages) ->
+            [ Pp.nop
+            ; Pp.concat [ Solver_env.pp_oneline platform; Pp.text ":" ]
+            ; pp_package_set packages
+            ]))
+  in
+  Pp.tag
+    User_message.Style.Success
+    (Pp.textf
+       "Solution for %s"
+       (Path.to_string_maybe_quoted (user_lock_dir_path lock_dir_path)))
+  :: Pp.nop
+  :: Pp.text "Dependencies common to all supported platforms:"
+  :: pp_package_set common_packages
+  :: (maybe_uncommon_packages @ maybe_perf_stats)
 ;;
 
 (* A failed joint solve does not prove that every requested platform fails on
@@ -234,7 +204,6 @@ let solve_lock_dir
       ~local_packages
       ~project_pins
       ~print_perf_stats
-      ~portable_lock_dir
       version_preference
       solver_env_from_current_system
       lock_dir_path
@@ -263,14 +232,11 @@ let solve_lock_dir
         (unset_solver_vars_of_workspace workspace ~lock_dir_path)
   in
   let solve_for_platforms =
-    match portable_lock_dir with
-    | true ->
-      (match solver_env_from_context with
-       | Some solver_env_from_context ->
-         List.map solve_for_platforms ~f:(fun platform_env ->
-           Solver_env.extend solver_env_from_context platform_env)
-       | None -> solve_for_platforms)
-    | false -> [ solver_env ]
+    match solver_env_from_context with
+    | Some solver_env_from_context ->
+      List.map solve_for_platforms ~f:(fun platform_env ->
+        Solver_env.extend solver_env_from_context platform_env)
+    | None -> solve_for_platforms
   in
   let time_start = Time.now () in
   let* repos =
@@ -302,7 +268,6 @@ let solve_lock_dir
       ~constraints:(constraints_of_workspace workspace ~lock_dir_path)
       ~selected_depopts:(depopts_of_workspace workspace ~lock_dir_path)
       ~solve_for_platforms
-      ~portable_lock_dir
   in
   let solver_result =
     match result with
@@ -336,14 +301,11 @@ let solve_lock_dir
       else []
     in
     let summary_message =
-      User_message.make
-        (summary_message ~portable_lock_dir ~lock_dir_path ~lock_dir ~maybe_perf_stats)
+      User_message.make (summary_message ~lock_dir_path ~lock_dir ~maybe_perf_stats)
     in
     progress_state := None;
     let+ lock_dir = Lock_dir.compute_missing_checksums ~pinned_packages lock_dir in
-    Ok
-      ( Lock_dir.Write_disk.prepare ~portable_lock_dir ~lock_dir_path ~files lock_dir
-      , summary_message )
+    Ok (Lock_dir.Write_disk.prepare ~lock_dir_path ~files lock_dir, summary_message)
 ;;
 
 let solve
@@ -354,7 +316,6 @@ let solve
       ~version_preference
       ~lock_dirs
       ~print_perf_stats
-      ~portable_lock_dir
   =
   let open Fiber.O in
   (* a list of thunks that will perform all the file IO side
@@ -377,7 +338,6 @@ let solve
                 ~local_packages
                 ~project_pins
                 ~print_perf_stats
-                ~portable_lock_dir
                 version_preference
                 solver_env_from_current_system
                 lockdir_path
@@ -390,25 +350,14 @@ let solve
    | _ -> Error errors)
   >>| function
   | Error errors ->
-    if portable_lock_dir
-    then
-      User_error.raise
-        (List.concat_map errors ~f:(fun (path, (error, platforms)) ->
-           [ Pp.box
-             @@ Pp.textf
-                  "Unable to solve dependencies while generating lock directory: %s"
-                  (Path.to_string_maybe_quoted path)
-           ; Pp.vbox (pp_solve_error (Solve_error.to_solver_error error, platforms))
-           ]))
-    else
-      User_error.raise
-        ([ Pp.text "Unable to solve dependencies for the following lock directories:" ]
-         @ List.concat_map errors ~f:(fun (path, (error, _platforms)) ->
-           [ Pp.textf
-               "Lock directory %s:"
-               (Path.to_string_maybe_quoted (user_lock_dir_path path))
-           ; Pp.vbox (Solve_error.to_solver_error error)
-           ]))
+    User_error.raise
+      (List.concat_map errors ~f:(fun (path, (error, platforms)) ->
+         [ Pp.box
+           @@ Pp.textf
+                "Unable to solve dependencies while generating lock directory: %s"
+                (Path.to_string_maybe_quoted path)
+         ; Pp.vbox (pp_solve_error (Solve_error.to_solver_error error, platforms))
+         ]))
   | Ok write_disks_with_summaries ->
     let write_disk_list, summary_messages = List.split write_disks_with_summaries in
     List.iter summary_messages ~f:Console.print_user_message;
@@ -421,7 +370,7 @@ let project_pins =
   Dune_rules.Dune_load.projects () >>| Pin.Project.collect_all
 ;;
 
-let lock ~version_preference ~lock_dirs_arg ~print_perf_stats ~portable_lock_dir =
+let lock ~version_preference ~lock_dirs_arg ~print_perf_stats =
   let open Fiber.O in
   let* solver_env_from_current_system =
     poll_solver_env_from_current_system () >>| Option.some
@@ -446,7 +395,6 @@ let lock ~version_preference ~lock_dirs_arg ~print_perf_stats ~portable_lock_dir
     ~version_preference
     ~lock_dirs
     ~print_perf_stats
-    ~portable_lock_dir
 ;;
 
 let term =
@@ -460,13 +408,7 @@ let term =
   Scheduler_setup.go_with_rpc_server ~common ~config (fun () ->
     let open Fiber.O in
     Pkg_common.check_pkg_management_enabled ()
-    >>>
-    let portable_lock_dir =
-      match Config.get Dune_rules.Compile_time.portable_lock_dir with
-      | `Enabled -> true
-      | `Disabled -> false
-    in
-    lock ~version_preference ~lock_dirs_arg ~print_perf_stats ~portable_lock_dir)
+    >>> lock ~version_preference ~lock_dirs_arg ~print_perf_stats)
 ;;
 
 let info =

--- a/bin/pkg/lock.mli
+++ b/bin/pkg/lock.mli
@@ -11,7 +11,6 @@ val solve
   -> version_preference:Dune_pkg.Version_preference.t option
   -> lock_dirs:Path.t list
   -> print_perf_stats:bool
-  -> portable_lock_dir:bool
   -> unit Fiber.t
 
 (** Command to create lock directory *)

--- a/boot/configure.ml
+++ b/boot/configure.ml
@@ -18,11 +18,7 @@ let out =
 ;;
 
 let default_toggles : (string * [ `Disabled | `Enabled ]) list =
-  [ "toolchains", `Enabled
-  ; "lock_dev_tool", `Disabled
-  ; "bin_dev_tools", `Disabled
-  ; "portable_lock_dir", `Enabled
-  ]
+  [ "toolchains", `Enabled; "lock_dev_tool", `Disabled; "bin_dev_tools", `Disabled ]
 ;;
 
 let toggles = ref default_toggles
@@ -106,10 +102,6 @@ let () =
       , " Enable obtaining dev-tools binarys from the binary package opam repository. \
          Allows fast installation of dev-tools. \n\
         \      This flag is experimental and shouldn't be relied on by packagers." )
-    ; ( "--portable-lock-dir"
-      , toggle "portable_lock_dir"
-      , "Generate portable lock dirs. If this feature is disabled then lock dirs will be \
-         specialized to the machine where they are generated." )
     ]
   in
   let anon s = bad "Don't know what to do with %s" s in

--- a/doc/changes/changed/15982.md
+++ b/doc/changes/changed/15982.md
@@ -1,0 +1,6 @@
+- Solve all distinct configured lock-directory platforms in one SAT problem
+  and select the same package version across platforms. Repeated platform
+  entries are ignored while preserving first-occurrence order. Solver failures
+  report package unavailability and cross-platform version conflicts for each
+  affected platform. The cross-platform version constraint was proposed by
+  @art-w. (#15982, @Alizter)

--- a/doc/changes/changed/15987.md
+++ b/doc/changes/changed/15987.md
@@ -1,0 +1,3 @@
+- Generate all new lock directories using the conditional multi-platform
+  representation and remove the `--portable-lock-dir` configure toggle.
+  (#15987, @Alizter)

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -1059,24 +1059,6 @@ module Packages = struct
       List.fold_left pkg.enabled_on_platforms ~init:acc ~f:(fun acc platform ->
         Solver_env.Map.add_multi acc platform pkg))
   ;;
-
-  let merge a b =
-    Package_name.Map.merge a b ~f:(fun _ a b ->
-      match a, b with
-      | None, None ->
-        (* unreachable *)
-        None
-      | Some x, None | None, Some x -> Some x
-      | Some a, Some b ->
-        Some
-          (Package_version.Map.merge a b ~f:(fun _ a b ->
-             match a, b with
-             | None, None ->
-               (* unreachable *)
-               None
-             | Some x, None | None, Some x -> Some x
-             | Some a, Some b -> Some (Pkg.merge_conditionals a b))))
-  ;;
 end
 
 type t =
@@ -1833,28 +1815,6 @@ let compute_missing_checksums t ~pinned_packages =
     >>| Packages.of_pkg_list
   in
   { t with packages }
-;;
-
-let merge_conditionals a b =
-  let packages = Packages.merge a.packages b.packages in
-  let solved_for_platforms =
-    let a_loc, a_solved_for_platforms = a.solved_for_platforms in
-    let b_loc, b_solved_for_platforms = b.solved_for_platforms in
-    Loc.span a_loc b_loc, a_solved_for_platforms @ b_solved_for_platforms
-  in
-  let normalize t =
-    { t with
-      packages = Package_name.Map.empty
-    ; expanded_solver_variable_bindings = Solver_stats.Expanded_variable_bindings.empty
-    ; solved_for_platforms = Loc.none, []
-    }
-  in
-  if not (equal (normalize a) (normalize b))
-  then
-    Code_error.raise
-      "Platform-specific lockdirs differ in a non-platform-specific way"
-      [ "lockdir_1", to_dyn a; "lockdir_2", to_dyn b ];
-  { a with packages; solved_for_platforms }
 ;;
 
 let loc_in_source_tree loc =

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -110,9 +110,7 @@ module Conditional_choice = struct
     [ { Conditional.condition; value } ]
   ;;
 
-  (* A choice where a given value will be chosen unconditionally. This is only
-     used to help support both portable and non-portable lockdirs with the same
-     codebase and can be removed when portable lockdirs is the only option. *)
+  (* A choice where a given value is chosen unconditionally. *)
   let singleton_all_platforms value = singleton Solver_env.empty value
   let equal value_equal = List.equal (Conditional.equal value_equal)
   let hash t ~f = List.hash (Conditional.hash ~f) t
@@ -163,21 +161,6 @@ module Conditional_choice = struct
      combined to avoid duplication. *)
   let merge_combining_conditions ~value_equal a b =
     List.fold_left b ~init:a ~f:(append_combining_conditions ~value_equal)
-  ;;
-
-  (* To support encoding in the non-portable format, this function extracts the
-     sole value from a conditional choice, raising a code error if there are
-     multiple choices. *)
-  let get_value_ensuring_at_most_one_choice t =
-    if List.length t > 1
-    then
-      Code_error.raise
-        "Expected at most one conditional choice"
-        [ ( "conditions"
-          , List.map t ~f:(fun { Conditional.condition; _ } -> condition)
-            |> Dyn.list Solver_env_disjunction.to_dyn )
-        ];
-    List.hd_opt t |> Option.map ~f:(fun { Conditional.value; _ } -> value)
   ;;
 end
 
@@ -271,19 +254,42 @@ module Conditional_choice_or_all_platforms = struct
 
   let to_conditional_choice ~solved_for_platforms = function
     | Choice choice -> choice
-    | All_platforms value -> [ { Conditional.value; condition = solved_for_platforms } ]
+    | All_platforms value ->
+      (* An empty platform list is how legacy lock dirs without
+         solved_for_platforms metadata are represented; the package is
+         enabled on all platforms. *)
+      let condition =
+        match solved_for_platforms with
+        | [] -> [ Solver_env.empty ]
+        | platforms -> platforms
+      in
+      [ { Conditional.value; condition } ]
   ;;
 
   let decode decode_value =
     let open Decoder in
-    sum
-      [ ( "choice"
-        , let+ choice = repeat (Conditional.decode decode_value) in
-          Choice choice )
-      ; ( "all_platforms"
-        , let+ value = decode_value in
-          All_platforms value )
-      ]
+    try_
+      (sum
+         ~force_parens:true
+         [ ( "choice"
+           , let+ choice = repeat (Conditional.decode decode_value) in
+             Choice choice )
+         ; ( "all_platforms"
+           , let+ value = decode_value in
+             All_platforms value )
+         ])
+      (fun _exn ->
+         (* Legacy lock dirs written before conditional fields may contain a
+           bare value; treat it as the value for all platforms. *)
+         let+ value = decode_value in
+         All_platforms value)
+  ;;
+
+  let decode_or_plain decode_value to_value =
+    let open Decoder in
+    try_ (decode decode_value) (fun _exn ->
+      let+ value = decode_value in
+      Choice (Conditional_choice.singleton_all_platforms (to_value value)))
   ;;
 
   let encode encode_value t =
@@ -382,15 +388,7 @@ module Build_command = struct
     let build = "build"
   end
 
-  let encode_non_portable t =
-    let open Encoder in
-    match t with
-    | None -> field_o Fields.build Encoder.unit None
-    | Some Dune -> field_b Fields.dune true
-    | Some (Action a) -> field Fields.build Action.encode a
-  ;;
-
-  let encode_portable t =
+  let encode t =
     let open Encoder in
     Dune_lang.List
       (record_fields
@@ -400,7 +398,7 @@ module Build_command = struct
          ])
   ;;
 
-  let decode_portable =
+  let decode =
     let open Decoder in
     enter
     @@ fields
@@ -414,15 +412,13 @@ module Build_command = struct
          ]
   ;;
 
-  let decode_fields ~portable_lock_dir =
+  let decode_fields =
     let open Decoder in
     let parse_action =
-      if portable_lock_dir
-      then Conditional_choice_or_all_platforms.decode decode_portable
-      else
+      try_ (Conditional_choice_or_all_platforms.decode decode) (fun _exn ->
         let+ action = Action.decode_pkg in
         Conditional_choice_or_all_platforms.Choice
-          (Conditional_choice.singleton_all_platforms (Action action))
+          (Conditional_choice.singleton_all_platforms (Action action)))
     in
     fields_mutually_exclusive
       ~default:None
@@ -718,30 +714,29 @@ module Pkg = struct
     let enabled_on_platforms = "enabled_on_platforms"
   end
 
-  let decode ~portable_lock_dir =
+  let decode =
     let open Decoder in
     let parse_install_command =
-      if portable_lock_dir
-      then Conditional_choice_or_all_platforms.decode Action.decode_pkg
-      else
-        let+ action = Action.decode_pkg in
-        Conditional_choice_or_all_platforms.Choice
-          (Conditional_choice.singleton_all_platforms action)
+      Conditional_choice_or_all_platforms.decode_or_plain Action.decode_pkg (fun a -> a)
     in
     let parse_depends =
-      if portable_lock_dir
-      then Conditional_choice_or_all_platforms.decode (enter @@ repeat Dependency.decode)
-      else
-        let+ depends = repeat Dependency.decode in
-        Conditional_choice_or_all_platforms.Choice
-          (Conditional_choice.singleton_all_platforms depends)
+      try_
+        (Conditional_choice_or_all_platforms.decode_or_plain
+           (enter @@ repeat Dependency.decode)
+           (fun depends -> depends))
+        (fun _exn ->
+           (* Legacy lock dirs store dependencies as bare atoms without an
+             enclosing list. *)
+           let+ depends = repeat Dependency.decode in
+           Conditional_choice_or_all_platforms.Choice
+             (Conditional_choice.singleton_all_platforms depends))
     in
     let parse_depexts =
-      if portable_lock_dir
-      then repeat Depexts.decode
-      else
+      try_ (repeat Depexts.decode) (fun _exn ->
+        (* Legacy lock dirs store depexts as a plain list of system package
+             names without conditions. *)
         let+ external_package_names = repeat string in
-        [ { Depexts.external_package_names; enabled_if = `Always } ]
+        [ { Depexts.external_package_names; enabled_if = `Always } ])
     in
     let empty_choice = Conditional_choice_or_all_platforms.Choice [] in
     enter
@@ -749,7 +744,7 @@ module Pkg = struct
     @@ let+ version = field Fields.version Package_version.decode
        and+ install_command =
          field ~default:empty_choice Fields.install parse_install_command
-       and+ build_command = Build_command.decode_fields ~portable_lock_dir
+       and+ build_command = Build_command.decode_fields
        and+ depends = field ~default:empty_choice Fields.depends parse_depends
        and+ depexts = field ~default:[] Fields.depexts parse_depexts
        and+ source = field_o Fields.source Source.decode
@@ -820,7 +815,6 @@ module Pkg = struct
   ;;
 
   let encode
-        ~portable_lock_dir
         ~solved_for_platforms
         { build_command
         ; install_command
@@ -833,59 +827,32 @@ module Pkg = struct
     =
     let open Encoder in
     let install_command, build_command, depends, depexts, enabled_on_platforms =
-      if portable_lock_dir
-      then (
-        let encode_field n v c =
-          Conditional_choice_or_all_platforms.encode_field ~solved_for_platforms n v c
-        in
-        ( encode_field Fields.install Action.encode install_command
-        , encode_field Fields.build Build_command.encode_portable build_command
-        , (let depends =
-             match depends with
-             | [ { Conditional.value = []; _ } ] ->
-               (* Omit the dependencies field to reduce noise in the case
+      let encode_field n v c =
+        Conditional_choice_or_all_platforms.encode_field ~solved_for_platforms n v c
+      in
+      ( encode_field Fields.install Action.encode install_command
+      , encode_field Fields.build Build_command.encode build_command
+      , (let depends =
+           match depends with
+           | [ { Conditional.value = []; _ } ] ->
+             (* Omit the dependencies field to reduce noise in the case
                   where there is explictly an empty list of dependencies. *)
-               []
-             | other -> other
-           in
-           encode_field Fields.depends Dependencies.encode depends)
-        , field_l Fields.depexts Depexts.encode depexts
-        , match
-            Enabled_on_platforms.of_solver_env_disjunction
-              ~solved_for_platforms
-              enabled_on_platforms
-          with
-          | All ->
-            (* Omit the field if it's enabled everywhere to reduce noise. The
+             []
+           | other -> other
+         in
+         encode_field Fields.depends Dependencies.encode depends)
+      , field_l Fields.depexts Depexts.encode depexts
+      , match
+          Enabled_on_platforms.of_solver_env_disjunction
+            ~solved_for_platforms
+            enabled_on_platforms
+        with
+        | All ->
+          (* Omit the field if it's enabled everywhere to reduce noise. The
                parser will assume [All] by default. *)
-            []
-          | other ->
-            [ field Fields.enabled_on_platforms Enabled_on_platforms.encode other ] ))
-      else
-        ( field_o
-            Fields.install
-            Action.encode
-            (Conditional_choice.get_value_ensuring_at_most_one_choice install_command)
-        , Build_command.encode_non_portable
-            (Conditional_choice.get_value_ensuring_at_most_one_choice build_command)
-        , field_l
-            Fields.depends
-            Package_name.encode
-            (Conditional_choice.get_value_ensuring_at_most_one_choice depends
-             |> Option.value ~default:[]
-             |> List.map ~f:(fun { Dependency.name; _ } -> name))
-        , field_l
-            Fields.depexts
-            string
-            (match depexts with
-             | [] -> []
-             | [ { Depexts.external_package_names; _ } ] -> external_package_names
-             | _ ->
-               Code_error.raise
-                 "When using non-portable lockdirs it's expected that at most a single \
-                  set of depexts will be stored in each lockfile."
-                 [ "depexts", Dyn.list Depexts.to_dyn depexts ])
-        , [] )
+          []
+        | other -> [ field Fields.enabled_on_platforms Enabled_on_platforms.encode other ]
+      )
     in
     record_fields
       ([ field Fields.version Package_version.encode version
@@ -904,8 +871,8 @@ module Pkg = struct
 
   (* More general version of [files_dir] which works on generic paths *)
   let files_dir package_name maybe_package_version ~lock_dir =
-    (* TODO(steve): Once portable lockdirs are enabled by default, make the
-       package version non-optional *)
+    (* The version is always present in newly written lockdirs; [None] is
+       only accepted for lockdirs written before versioned package files. *)
     let extension = ".files" in
     match maybe_package_version with
     | None -> Path.relative lock_dir (Package_name.to_string package_name ^ extension)
@@ -966,9 +933,8 @@ module Pkg = struct
   ;;
 
   let is_enabled_on_platform t ~platform =
-    (* XXX: currently treat empty lists of platforms as if the platform is
-       enabled on all platforms to simplify supporting both portable and
-       non-portable lockdirs with the same code. *)
+    (* An empty list of platforms means the package is enabled on all
+       platforms. *)
     List.is_empty t.enabled_on_platforms
     || Solver_env_disjunction.matches_platform t.enabled_on_platforms ~platform
   ;;
@@ -1075,6 +1041,7 @@ let remove_locs t =
   { t with
     packages = Packages.remove_locs t.packages
   ; ocaml = Option.map t.ocaml ~f:(fun (_, ocaml) -> Loc.none, ocaml)
+  ; solved_for_platforms = Loc.none, snd t.solved_for_platforms
   }
 ;;
 
@@ -1131,8 +1098,6 @@ let to_dyn
     ]
 ;;
 
-(* CR-someday Alizter: Remove this when portable lock directories are
-   consolidated with non-portable lock directories. *)
 let uses_versioned_paths t = not (List.is_empty (snd t.solved_for_platforms))
 
 type missing_dependency =
@@ -1171,7 +1136,6 @@ let create_latest_version
       ~repos
       ~expanded_solver_variable_bindings
       ~solved_for_platforms
-      ~portable_lock_dir
   =
   let packages =
     Package_name.Map.map packages ~f:(fun (pkg : Pkg.t) ->
@@ -1205,14 +1169,11 @@ let create_latest_version
   let solved_for_platforms_platform_specific_only =
     List.map solved_for_platforms ~f:Solver_env.remove_all_except_platform_specific
   in
+  (* Only include solver variables which are not platform-specific, so that
+     the lockdir is portable across different platforms. *)
   let expanded_solver_variable_bindings =
-    match portable_lock_dir with
-    | false -> expanded_solver_variable_bindings
-    | true ->
-      (* To make a portable lockdir, only include solver variables which are
-         not platform-specific. *)
-      Solver_stats.Expanded_variable_bindings.remove_platform_specific
-        expanded_solver_variable_bindings
+    Solver_stats.Expanded_variable_bindings.remove_platform_specific
+      expanded_solver_variable_bindings
   in
   { version
   ; dependency_hash
@@ -1231,7 +1192,6 @@ module Metadata = Dune_sexp.Versioned_file.Make (Unit)
 let () = Metadata.Lang.register Dune_lang.Pkg.syntax ()
 
 let encode_metadata
-      ~portable_lock_dir
       { version
       ; dependency_hash
       ; ocaml
@@ -1274,15 +1234,11 @@ let encode_metadata
                  expanded_solver_variable_bindings)
        ])
   @
-  if portable_lock_dir
-  then (
-    let _loc, solved_for_platforms = solved_for_platforms in
-    [ list
-        sexp
-        (string "solved_for_platforms"
-         :: List.map ~f:Solver_env.encode solved_for_platforms)
-    ])
-  else []
+  let _loc, solved_for_platforms = solved_for_platforms in
+  [ list
+      sexp
+      (string "solved_for_platforms" :: List.map ~f:Solver_env.encode solved_for_platforms)
+  ]
 ;;
 
 let decode_metadata =
@@ -1312,10 +1268,8 @@ module Package_filename = struct
   let file_extension_string = Filename.Extension.to_string file_extension
 
   let make package_name maybe_package_version =
-    (* TODO(steve): the [maybe_package_version] argument is an [_ option]
-       because if portable lockdirs is not enabled then we want to fall back to
-       the behaviour where version numbers are not included in lockfile names.
-       Make it non-optional when lockdirs become portable by default. *)
+    (* [maybe_package_version] is [None] for lockdirs written before
+       versioned package files. *)
     (match maybe_package_version with
      | None -> Package_name.to_string package_name ^ file_extension_string
      | Some package_version ->
@@ -1345,18 +1299,15 @@ module Package_filename = struct
   ;;
 end
 
-let file_contents_by_path ~portable_lock_dir t =
-  (Filename.to_string metadata_filename, encode_metadata ~portable_lock_dir t)
+let file_contents_by_path t =
+  (Filename.to_string metadata_filename, encode_metadata t)
   :: (Packages.to_pkg_list t.packages
       |> List.map ~f:(fun (pkg : Pkg.t) ->
         let _loc, solved_for_platforms = t.solved_for_platforms in
         let package_filename =
-          if portable_lock_dir
-          then Package_filename.make pkg.info.name (Some pkg.info.version)
-          else Package_filename.make pkg.info.name None
+          Package_filename.make pkg.info.name (Some pkg.info.version)
         in
-        ( Filename.to_string package_filename
-        , Pkg.encode ~portable_lock_dir ~solved_for_platforms pkg )))
+        Filename.to_string package_filename, Pkg.encode ~solved_for_platforms pkg))
 ;;
 
 module Write_disk = struct
@@ -1483,7 +1434,6 @@ module Write_disk = struct
   type t = unit -> unit
 
   let prepare
-        ~portable_lock_dir
         ~lock_dir_path:lock_dir_path_external
         ~(files : File_entry.t Package_version.Map.Multi.t Package_name.Map.t)
         lock_dir
@@ -1503,7 +1453,7 @@ module Write_disk = struct
     in
     let build lock_dir_path =
       let lock_dir_path = Result.ok_exn lock_dir_path in
-      file_contents_by_path ~portable_lock_dir lock_dir
+      file_contents_by_path lock_dir
       |> List.iter ~f:(fun (path_within_lock_dir, contents) ->
         let path = Path.relative lock_dir_path path_within_lock_dir in
         Option.iter (Path.parent path) ~f:Path.mkdir_p;
@@ -1518,10 +1468,7 @@ module Write_disk = struct
         Package_name.Map.iteri files ~f:(fun package_name files_by_version ->
           Package_version.Map.iteri files_by_version ~f:(fun package_version files ->
             let files_dir =
-              let maybe_package_version =
-                if portable_lock_dir then Some package_version else None
-              in
-              Pkg.files_dir package_name maybe_package_version ~lock_dir:lock_dir_path
+              Pkg.files_dir package_name (Some package_version) ~lock_dir:lock_dir_path
             in
             Path.mkdir_p files_dir;
             List.iter files ~f:(fun { File_entry.original; local_file } ->
@@ -1620,7 +1567,6 @@ struct
   ;;
 
   let load_pkg
-        ~portable_lock_dir
         ~version
         ~lock_dir_path
         ~solved_for_platforms
@@ -1639,7 +1585,7 @@ struct
     let parser =
       let env = Pform.Env.pkg Dune_lang.Pkg.syntax version in
       let decode =
-        Syntax.set Dune_lang.Pkg.syntax (Active version) (Pkg.decode ~portable_lock_dir)
+        Syntax.set Dune_lang.Pkg.syntax (Active version) Pkg.decode
         |> Syntax.set Dune_lang.Stanza.syntax (Active Dune_lang.Stanza.latest_version)
       in
       String_with_vars.set_decoding_env env decode
@@ -1700,10 +1646,8 @@ struct
       =
       load_metadata (Path.relative_fname lock_dir_path metadata_filename)
     in
-    let portable_lock_dir, solved_for_platforms =
-      match solved_for_platforms with
-      | Some x -> true, x
-      | None -> false, (Loc.none, [])
+    let solved_for_platforms =
+      Option.value solved_for_platforms ~default:(Loc.none, [])
     in
     let+ packages =
       Io.readdir_with_kinds lock_dir_path
@@ -1717,7 +1661,6 @@ struct
         let _loc, solved_for_platforms = solved_for_platforms in
         let+ pkg =
           load_pkg
-            ~portable_lock_dir
             ~version
             ~lock_dir_path
             ~solved_for_platforms
@@ -1830,8 +1773,8 @@ let check_if_solved_for_platform { solved_for_platforms; _ } ~platform =
   let loc, solved_for_platforms = solved_for_platforms in
   if List.is_empty solved_for_platforms
   then
-    (* TODO(steve): this case is only necessary while supporting non-portable
-       lockdirs. Once portable lockdirs are always enabled then remove this case. *)
+    (* Lockdirs written before the solved_for_platforms metadata existed have
+       an empty list. *)
     ()
   else (
     match Solver_env_disjunction.matches_platform solved_for_platforms ~platform with

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -193,10 +193,6 @@ val transitive_dependency_closure
     archive urls but no checksum. *)
 val compute_missing_checksums : t -> pinned_packages:Package_name.Set.t -> t Fiber.t
 
-(** Combine the platform-specific parts of a pair of lockdirs, throwing a code
-    error if the lockdirs differ in a non-platform-specific way. *)
-val merge_conditionals : t -> t -> t
-
 (** Returns the packages contained in the solution on the given platform. If
     the lockdir does not contain a solution compatible with the given platform
     then a [User_error] is raised. *)

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -142,7 +142,6 @@ val create_latest_version
   -> repos:Opam_repo.t list option
   -> expanded_solver_variable_bindings:Solver_stats.Expanded_variable_bindings.t
   -> solved_for_platforms:Solver_env.t list
-  -> portable_lock_dir:bool
   -> t
 
 module Metadata : Dune_sexp.Versioned_file.S with type data := unit
@@ -154,8 +153,7 @@ module Write_disk : sig
   type t
 
   val prepare
-    :  portable_lock_dir:bool
-    -> lock_dir_path:Path.t
+    :  lock_dir_path:Path.t
     -> files:File_entry.t Package_version.Map.Multi.t Package_name.Map.t
     -> lock_dir
     -> t

--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -472,7 +472,6 @@ let opam_package_to_lock_file_pkg_single
       opam_package
       ~pinned
       resolved_package
-      ~portable_lock_dir
   =
   let name = Package_name.of_opam_package_name (OpamPackage.name opam_package) in
   let version =
@@ -614,25 +613,10 @@ let opam_package_to_lock_file_pkg_single
     |> Option.value ~default:Lock_dir.Conditional_choice.empty
   in
   let depexts =
-    if portable_lock_dir
-    then
-      depexts_to_conditional_external_dependencies
-        ~packages_in_solution
-        opam_package
-        (OpamFile.OPAM.depexts opam_file)
-    else (
-      (* In the non-portable case, only include depexts for the current platform. *)
-      let external_package_names =
-        OpamFile.OPAM.depexts opam_file
-        |> List.concat_map ~f:(fun (sys_pkgs, filter) ->
-          let env = Solver_env.to_env solver_env in
-          if OpamFilter.eval_to_bool ~default:false env filter
-          then OpamSysPkg.Set.to_list_map OpamSysPkg.to_string sys_pkgs
-          else [])
-      in
-      if List.is_empty external_package_names
-      then []
-      else [ { Lock_dir.Depexts.external_package_names; enabled_if = `Always } ])
+    depexts_to_conditional_external_dependencies
+      ~packages_in_solution
+      opam_package
+      (OpamFile.OPAM.depexts opam_file)
   in
   let install_command =
     OpamFile.OPAM.install opam_file
@@ -646,9 +630,7 @@ let opam_package_to_lock_file_pkg_single
   in
   let depends = lockfile_field_choice depends in
   let enabled_on_platforms =
-    if portable_lock_dir
-    then [ Solver_env.remove_all_except_platform_specific solver_env ]
-    else []
+    [ Solver_env.remove_all_except_platform_specific solver_env ]
   in
   { Lock_dir.Pkg.build_command
   ; install_command
@@ -660,18 +642,15 @@ let opam_package_to_lock_file_pkg_single
   }
 ;;
 
-(* Public entry point: handles both single-platform and multi-platform cases.
-   Each solver env is paired with the packages selected on that platform. For
-   portable lockdirs with multiple solver envs, we evaluate the opam file
-   against each platform separately and merge the results. This allows
-   platform-specific build commands, dependencies, etc. to be captured. *)
+(* Public entry point: evaluates the opam file against each platform the
+   package is selected on, using the packages selected on that platform to
+   resolve formulas, and merges the results. *)
 let opam_package_to_lock_file_pkg
       solver_envs
       stats_updater
       opam_package
       ~pinned
       resolved_package
-      ~portable_lock_dir
   =
   try
     Ok
@@ -679,7 +658,6 @@ let opam_package_to_lock_file_pkg
        | [] ->
          Code_error.raise "opam_package_to_lock_file_pkg called with empty solver_envs" []
        | [ (solver_env, version_by_package_name) ] ->
-         (* Single platform: use directly *)
          opam_package_to_lock_file_pkg_single
            solver_env
            stats_updater
@@ -687,20 +665,7 @@ let opam_package_to_lock_file_pkg
            opam_package
            ~pinned
            resolved_package
-           ~portable_lock_dir
-       | _ when not portable_lock_dir ->
-         (* Non-portable with multiple envs: just use the first *)
-         let solver_env, version_by_package_name = List.hd solver_envs in
-         opam_package_to_lock_file_pkg_single
-           solver_env
-           stats_updater
-           version_by_package_name
-           opam_package
-           ~pinned
-           resolved_package
-           ~portable_lock_dir
        | first :: rest ->
-         (* Portable with multiple platforms: evaluate per-platform and merge *)
          let to_pkg (solver_env, version_by_package_name) =
            opam_package_to_lock_file_pkg_single
              solver_env
@@ -709,10 +674,9 @@ let opam_package_to_lock_file_pkg
              opam_package
              ~pinned
              resolved_package
-             ~portable_lock_dir
          in
-         List.fold_left rest ~init:(to_pkg first) ~f:(fun acc env ->
-           Lock_dir.Pkg.merge_conditionals acc (to_pkg env)))
+         List.fold_left rest ~init:(to_pkg first) ~f:(fun acc platform ->
+           Lock_dir.Pkg.merge_conditionals acc (to_pkg platform)))
   with
   | User_error.E exn -> Error exn
 ;;

--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -661,13 +661,13 @@ let opam_package_to_lock_file_pkg_single
 ;;
 
 (* Public entry point: handles both single-platform and multi-platform cases.
-   For portable lockdirs with multiple solver_envs, we evaluate the opam file
+   Each solver env is paired with the packages selected on that platform. For
+   portable lockdirs with multiple solver envs, we evaluate the opam file
    against each platform separately and merge the results. This allows
    platform-specific build commands, dependencies, etc. to be captured. *)
 let opam_package_to_lock_file_pkg
       solver_envs
       stats_updater
-      version_by_package_name
       opam_package
       ~pinned
       resolved_package
@@ -678,7 +678,7 @@ let opam_package_to_lock_file_pkg
       (match solver_envs with
        | [] ->
          Code_error.raise "opam_package_to_lock_file_pkg called with empty solver_envs" []
-       | [ solver_env ] ->
+       | [ (solver_env, version_by_package_name) ] ->
          (* Single platform: use directly *)
          opam_package_to_lock_file_pkg_single
            solver_env
@@ -690,7 +690,7 @@ let opam_package_to_lock_file_pkg
            ~portable_lock_dir
        | _ when not portable_lock_dir ->
          (* Non-portable with multiple envs: just use the first *)
-         let solver_env = List.hd solver_envs in
+         let solver_env, version_by_package_name = List.hd solver_envs in
          opam_package_to_lock_file_pkg_single
            solver_env
            stats_updater
@@ -699,9 +699,9 @@ let opam_package_to_lock_file_pkg
            ~pinned
            resolved_package
            ~portable_lock_dir
-       | first_env :: rest_envs ->
+       | first :: rest ->
          (* Portable with multiple platforms: evaluate per-platform and merge *)
-         let to_pkg solver_env =
+         let to_pkg (solver_env, version_by_package_name) =
            opam_package_to_lock_file_pkg_single
              solver_env
              stats_updater
@@ -711,7 +711,7 @@ let opam_package_to_lock_file_pkg
              resolved_package
              ~portable_lock_dir
          in
-         List.fold_left rest_envs ~init:(to_pkg first_env) ~f:(fun acc env ->
+         List.fold_left rest ~init:(to_pkg first) ~f:(fun acc env ->
            Lock_dir.Pkg.merge_conditionals acc (to_pkg env)))
   with
   | User_error.E exn -> Error exn

--- a/src/dune_pkg/lock_pkg.mli
+++ b/src/dune_pkg/lock_pkg.mli
@@ -25,13 +25,11 @@ val local_package_dependencies
 
 (** Convert a selected opam package to a package that dune can save to the lock
     directory. Each solver environment is paired with the packages selected on
-    that platform. For portable lockdirs, all pairs are used to set conditions
-    on conditional fields. *)
+    that platform. All pairs are used to set conditions on conditional fields. *)
 val opam_package_to_lock_file_pkg
   :  (Solver_env.t * Package_version.t Package_name.Map.t) list
   -> Solver_stats.Updater.t
   -> OpamPackage.t
   -> pinned:bool
   -> Resolved_package.t
-  -> portable_lock_dir:bool
   -> (Lock_dir.Pkg.t, User_message.t) result

--- a/src/dune_pkg/lock_pkg.mli
+++ b/src/dune_pkg/lock_pkg.mli
@@ -24,12 +24,12 @@ val local_package_dependencies
   -> (Package_name.t list, Resolve_opam_formula.unsatisfied_formula) result
 
 (** Convert a selected opam package to a package that dune can save to the lock
-    directory. The list of solver_envs represents the platforms this package
-    is enabled on. The first solver_env is used for evaluating filters. *)
+    directory. Each solver environment is paired with the packages selected on
+    that platform. For portable lockdirs, all pairs are used to set conditions
+    on conditional fields. *)
 val opam_package_to_lock_file_pkg
-  :  Solver_env.t list
+  :  (Solver_env.t * Package_version.t Package_name.Map.t) list
   -> Solver_stats.Updater.t
-  -> Package_version.t Package_name.Map.t
   -> OpamPackage.t
   -> pinned:bool
   -> Resolved_package.t

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -54,7 +54,6 @@ module Priority = struct
   ;;
 
   let allowed version = { avoid = false; version }
-  let rejected version = { avoid = true; version }
 end
 
 module Context = struct
@@ -68,15 +67,15 @@ module Context = struct
 
   type candidates =
     { resolved : Resolved_package.t OpamPackage.Version.Map.t
-    ; available : (Priority.t * (OpamFile.OPAM.t, rejection) result) list
+    ; unfiltered : (Priority.t * OpamFile.OPAM.t) list
     }
 
   type local_package =
     { opam_file : OpamFile.OPAM.t
     ; name : Package_name.t
     ; version : OpamPackage.Version.t
-    ; depends : OpamTypes.formula Lazy.t
-    ; conflicts : OpamTypes.formula Lazy.t
+    ; depends : OpamTypes.filtered_formula
+    ; conflicts : OpamTypes.filtered_formula
     }
 
   type t =
@@ -86,14 +85,15 @@ module Context = struct
     ; local_packages : local_package Package_name.Map.t Lazy.t
     ; local_constraints : (Package_name.t, local_package list) Table.t Lazy.t
     ; solver_env : Solver_env.t
+      (* Base solver env. Full platform-specific envs are computed by extending
+         this with the platform's own env. *)
     ; dune_version : OpamPackage.Version.t
     ; stats_updater : Solver_stats.Updater.t
     ; candidates_cache : (Package_name.t, candidates) Fiber.Cache.t
-    ; (* The solver can call this function several times on the same package.
-         If the package contains an invalid "available" filter we want to print a
-         warning, but only once per package. This field will keep track of the
-         packages for which we've printed a warning. *)
-      available_cache : (OpamPackage.t, bool) Table.t
+    ; (* Availability depends on the platform, while warnings for malformed
+         filters are emitted once per package version for the whole solve. *)
+      platform_available_cache : (OpamPackage.t, bool Solver_env.Map.t) Table.t
+    ; warned_available : (OpamPackage.t, unit) Table.t
     ; constraints : OpamTypes.filtered_formula Package_name.Map.t
     ; (* Number of versions of each package whose opam files were read from
          disk while solving. Used to report performance statistics. *)
@@ -118,20 +118,19 @@ module Context = struct
         List.map formulae ~f:Package_dependency.to_opam_filtered_formula
         |> OpamFormula.ands)
     in
-    let available_cache =
-      Table.create
-        (module struct
-          include OpamPackage
+    let module Opam_package_key = struct
+      include OpamPackage
 
-          let to_dyn = Opam_dyn.package
-        end)
-        1
+      let to_dyn = Opam_dyn.package
+    end
     in
+    let platform_available_cache = Table.create (module Opam_package_key) 1 in
+    let warned_available = Table.create (module Opam_package_key) 1 in
     let expanded_packages = Table.create (module Package_name) 1 in
     let local_constraints =
       lazy
         (let acc = Table.create (module Package_name) 20 in
-         let packages pkg (formula : OpamTypes.formula) =
+         let packages pkg (formula : OpamTypes.filtered_formula) =
            OpamFormula.iter
              (fun (name, _) ->
                 let name = Package_name.of_opam_package_name name in
@@ -140,24 +139,33 @@ module Context = struct
          in
          Lazy.force local_packages
          |> Package_name.Map.iter ~f:(fun pkg ->
-           packages pkg (Lazy.force pkg.depends);
-           packages pkg (Lazy.force pkg.conflicts));
+           packages pkg pkg.depends;
+           packages pkg pkg.conflicts);
          acc)
     in
     { repos
     ; version_preference
     ; local_packages
     ; pinned_packages
-    ; solver_env = Solver_env.add_sentinel_values_for_unset_platform_vars solver_env
+    ; solver_env =
+        Solver_env.add_sentinel_values_for_unset_platform_vars solver_env
+        (* The platform envs don't need sentinel values - they only contain
+         platform-specific vars that will override the sentinels in solver_env
+         when extended. *)
     ; dune_version = Dune_dep.version
     ; stats_updater
     ; candidates_cache
-    ; available_cache
+    ; platform_available_cache
+    ; warned_available
     ; constraints
     ; expanded_packages
     ; local_constraints
     }
   ;;
+
+  (* Compute the full platform-specific env by extending the base env with the
+     platform's own (platform-specific) env. *)
+  let platform_env t platform = Solver_env.extend t.solver_env platform
 
   let pp_rejection = function
     | Unavailable -> Pp.paragraph "Availability condition not satisfied"
@@ -169,60 +177,70 @@ module Context = struct
 
   let eval_to_bool (filter : OpamTypes.filter) : (bool, [> `Not_a_bool of string ]) result
     =
-    try Ok (OpamFilter.eval_to_bool ~default:false (Fun.const None) filter) with
+    try Ok (OpamFilter.eval_to_bool (Fun.const None) filter) with
     | Invalid_argument msg -> Error (`Not_a_bool msg)
+    | Failure _ -> Ok false
   ;;
 
-  let is_opam_available t opam =
+  let is_opam_available_in_env t ~solver_env opam =
     let package = OpamFile.OPAM.package opam in
-    Table.find_or_add t.available_cache package ~f:(fun (_ : OpamPackage.t) ->
-      let available = OpamFile.OPAM.available opam in
-      match
-        OpamFilter.partial_eval
-          (Solver_env.to_env t.solver_env
-           |> Solver_stats.Updater.wrap_env t.stats_updater
-           |> Lock_pkg.add_self_to_filter_env package)
-          available
-        |> eval_to_bool
-      with
-      | Ok available -> available
-      | Error (`Not_a_bool msg) ->
-        (let package_string = OpamFile.OPAM.package opam |> OpamPackage.to_string in
-         let available_string = OpamFilter.to_string available in
-         User_warning.emit
-           [ Pp.textf
-               "Ignoring package %s as its \"available\" filter can't be resolved to a \
-                boolean value."
-               package_string
-           ; Pp.textf "available: %s" available_string
-           ; Pp.text msg
-           ]);
-        false)
+    let available = OpamFile.OPAM.available opam in
+    match
+      OpamFilter.partial_eval
+        (Solver_env.to_env solver_env
+         |> Solver_stats.Updater.wrap_env t.stats_updater
+         |> Lock_pkg.add_self_to_filter_env package)
+        available
+      |> eval_to_bool
+    with
+    | Ok available -> available
+    | Error (`Not_a_bool msg) ->
+      if not (Table.mem t.warned_available package)
+      then (
+        Table.set t.warned_available package ();
+        let package_string = OpamPackage.to_string package in
+        let available_string = OpamFilter.to_string available in
+        User_warning.emit
+          [ Pp.textf
+              "Ignoring package %s as its \"available\" filter can't be resolved to a \
+               boolean value."
+              package_string
+          ; Pp.textf "available: %s" available_string
+          ; Pp.text msg
+          ]);
+      false
   ;;
 
-  let available_or_error t opam_file =
-    (* The CONTEXT interface doesn't give us a way to report this type of
-       error and there's not enough context to give a helpful error message
-       so just tell opam_0install that there are no versions of this
-       package available (technically true) and let it produce the error
-       message. *)
-    if is_opam_available t opam_file then Ok opam_file else Error Unavailable
-  ;;
-
-  let pinned_candidate t resolved_package =
-    let version = Resolved_package.package resolved_package |> OpamPackage.version in
-    let available =
-      (* We don't respect avoid-version for pinned packages. This is
-         intentional. *)
-      [ ( Priority.allowed version
-        , Resolved_package.opam_file resolved_package |> available_or_error t )
-      ]
+  let is_available_for_platform t ~platform opam =
+    let package = OpamFile.OPAM.package opam in
+    let cached =
+      Option.value
+        (Table.find t.platform_available_cache package)
+        ~default:Solver_env.Map.empty
     in
-    let resolved = OpamPackage.Version.Map.singleton version resolved_package in
-    { available; resolved }
+    match Solver_env.Map.find cached platform with
+    | Some available -> available
+    | None ->
+      let available =
+        is_opam_available_in_env t ~solver_env:(platform_env t platform) opam
+      in
+      Table.set
+        t.platform_available_cache
+        package
+        (Solver_env.Map.set cached platform available);
+      available
   ;;
 
-  let filter_deps t package filtered_formula =
+  let pinned_candidate resolved_package =
+    let version = Resolved_package.package resolved_package |> OpamPackage.version in
+    let opam_file = Resolved_package.opam_file resolved_package in
+    let resolved = OpamPackage.Version.Map.singleton version resolved_package in
+    (* We don't respect avoid-version for pinned packages. This is intentional. *)
+    { unfiltered = [ Priority.allowed version, opam_file ]; resolved }
+  ;;
+
+  (* Filter deps using a specific solver_env *)
+  let filter_deps_with_env t ~solver_env package filtered_formula =
     (* Add additional constraints to the formula. This works in two steps.
        First identify all the additional constraints applied to packages which
        appear in the current package's dependency formula. Then each additional
@@ -245,16 +263,22 @@ module Context = struct
       |> Package_name.of_opam_package_name
       |> Package_name.Map.mem (Lazy.force t.local_packages)
     in
-    let with_test = package_is_local && with_test t.solver_env in
-    Solver_env.to_env t.solver_env
+    let with_test = package_is_local && with_test solver_env in
+    Solver_env.to_env solver_env
     |> Solver_stats.Updater.wrap_env t.stats_updater
     |> Lock_pkg.add_self_to_filter_env package
     |> Resolve_opam_formula.apply_filter ~with_test ~formula:filtered_formula
   ;;
 
+  (* Filter deps for a specific platform *)
+  let filter_deps t ~platform package filtered_formula =
+    let solver_env = platform_env t platform in
+    filter_deps_with_env t ~solver_env package filtered_formula
+  ;;
+
   exception Found of Package_name.t
 
-  let try_refute t package =
+  let try_refute t ~platform package =
     let version = OpamPackage.version package in
     match
       let name = Package_name.of_opam_package_name (OpamPackage.name package) in
@@ -264,9 +288,13 @@ module Context = struct
     | Some local_packages ->
       (try
          List.iter local_packages ~f:(fun pkg ->
+           let local_package =
+             OpamPackage.create (OpamFile.OPAM.name pkg.opam_file) pkg.version
+           in
+           let filter formula = filter_deps t ~platform local_package formula in
            match
              match
-               Lazy.force pkg.depends
+               filter pkg.depends
                |> OpamFormula.partial_eval (fun (name', f) ->
                  if OpamPackage.Name.equal name' (OpamPackage.name package)
                  then
@@ -276,7 +304,7 @@ module Context = struct
              | `False -> `Reject
              | `Formula _ | `True ->
                (match
-                  Lazy.force pkg.conflicts
+                  filter pkg.conflicts
                   |> OpamFormula.partial_eval (fun (name', f) ->
                     if OpamPackage.Name.equal name' (OpamPackage.name package)
                     then
@@ -295,59 +323,50 @@ module Context = struct
        | Found p -> Some p)
   ;;
 
+  let rejection_for_platform t ~platform opam =
+    if not (is_available_for_platform t ~platform opam)
+    then Some Unavailable
+    else
+      OpamFile.OPAM.package opam
+      |> try_refute t ~platform
+      |> Option.map ~f:(fun package -> Refuted_by package)
+  ;;
+
   let repo_candidate t name =
     let versions = Opam_repo.all_packages_versions_map t.repos name in
-    let rejected, available =
-      OpamPackage.Version.Map.fold
-        (fun version (repo, key) (rejected, available) ->
-           let pkg = Opam_repo.Key.opam_package key in
-           match try_refute t pkg with
-           | Some p -> (version, p) :: rejected, available
-           | None -> rejected, OpamPackage.Version.Map.add version (repo, key) available)
-        versions
-        ([], OpamPackage.Version.Map.empty)
-    in
-    let+ resolved = Opam_repo.load_all_versions_by_keys available in
+    let+ resolved = Opam_repo.load_all_versions_by_keys versions in
     Table.add_exn
       t.expanded_packages
       (Package_name.of_opam_package_name name)
       (OpamPackage.Version.Map.cardinal resolved);
-    let available =
+    let unfiltered =
       OpamPackage.Version.Map.values resolved
       |> List.map ~f:(fun resolved_package ->
         let opam_file = Resolved_package.opam_file resolved_package in
-        let priority = Priority.make opam_file in
-        let result = available_or_error t opam_file in
-        priority, result)
-    in
-    let rejected =
-      List.map rejected ~f:(fun (version, rejected_by) ->
-        let priority = Priority.rejected version in
-        priority, Error (Refuted_by rejected_by))
-    in
-    let available =
-      rejected @ available
+        Priority.make opam_file, opam_file)
       |> List.sort ~compare:(fun (x, _) (y, _) ->
         Priority.compare t.version_preference x y)
     in
-    { available; resolved }
+    { unfiltered; resolved }
   ;;
 
-  let candidates t name =
+  (* Get all candidates with their opam files, without pre-filtering by availability.
+     Used for multi-platform solving where availability is checked per-platform. *)
+  let candidates_unfiltered t name =
     let* () = Fiber.return () in
     let key = Package_name.of_opam_package_name name in
     match Package_name.Map.find (Lazy.force t.local_packages) key with
     | Some local_package ->
-      let version = Priority.allowed local_package.version in
-      Fiber.return [ version, Ok local_package.opam_file ]
+      let priority = Priority.allowed local_package.version in
+      Fiber.return [ priority, local_package.opam_file ]
     | None ->
       let+ res =
         Fiber.Cache.find_or_add t.candidates_cache key ~f:(fun () ->
           match Package_name.Map.find t.pinned_packages key with
-          | Some resolved_package -> Fiber.return (pinned_candidate t resolved_package)
+          | Some resolved_package -> Fiber.return (pinned_candidate resolved_package)
           | None -> repo_candidate t name)
       in
-      res.available
+      res.unfiltered
   ;;
 
   let user_restrictions : t -> OpamPackage.Name.t -> OpamFormula.version_constraint option
@@ -444,7 +463,7 @@ module Solver = struct
     end
 
     type role =
-      | Real of OpamPackage.Name.t
+      | Real of OpamPackage.Name.t * Solver_env.t
       | Virtual of Virtual_id.t * impl list
 
     and real_impl =
@@ -466,11 +485,27 @@ module Solver = struct
       | Reject of OpamPackage.t
       | Dummy (* Used for diagnostics *)
 
+    (* Deduplicate a list of dependencies by package name for display purposes.
+       This avoids showing the same package multiple times for different platforms. *)
+    let deduplicate_deps_by_name deps =
+      let seen = ref OpamPackage.Name.Set.empty in
+      List.filter deps ~f:(fun (d : dependency) ->
+        match d.drole with
+        | Virtual _ -> true
+        | Real (name, _platform) ->
+          if OpamPackage.Name.Set.mem name !seen
+          then false
+          else (
+            seen := OpamPackage.Name.Set.add name !seen;
+            true))
+    ;;
+
     let rec pp_version = function
       | RealImpl impl ->
         Pp.text (OpamPackage.Version.to_string (OpamPackage.version impl.pkg))
       | Reject pkg -> Pp.text (OpamPackage.version_to_string pkg)
       | VirtualImpl (_i, deps) ->
+        let deps = deduplicate_deps_by_name deps in
         Pp.concat_map ~sep:(Pp.char '&') deps ~f:(fun d -> pp_role d.drole)
       | Dummy -> Pp.text "(no version)"
 
@@ -481,7 +516,9 @@ module Solver = struct
       | Dummy -> Pp.text "(no solution found)"
 
     and pp_role = function
-      | Real name -> Pp.text (OpamPackage.Name.to_string name)
+      | Real (name, _platform) ->
+        (* Don't show platform in user-facing output for now *)
+        Pp.text (OpamPackage.Name.to_string name)
       | Virtual (_, impls) -> Pp.concat_map ~sep:(Pp.char '|') impls ~f:pp_impl
     ;;
 
@@ -493,7 +530,10 @@ module Solver = struct
 
         let compare a b =
           match a, b with
-          | Real a, Real b -> Ordering.of_int (OpamPackage.Name.compare a b)
+          | Real (a_name, a_platform), Real (b_name, b_platform) ->
+            (match Ordering.of_int (OpamPackage.Name.compare a_name b_name) with
+             | Eq -> Solver_env.compare a_platform b_platform
+             | x -> x)
           | Virtual (a, _), Virtual (b, _) -> Virtual_id.compare a b
           | Real _, Virtual _ -> Lt
           | Virtual _, Real _ -> Gt
@@ -507,11 +547,16 @@ module Solver = struct
       let equal x y = Ordering.is_eq (compare x y)
       let hash = Poly.hash
 
+      let platform = function
+        | Real (_, platform) -> Some platform
+        | Virtual _ -> None
+      ;;
+
       let user_restrictions t context =
         match t with
         | Virtual _ -> None
-        | Real role ->
-          Context.user_restrictions context role
+        | Real (name, _platform) ->
+          Context.user_restrictions context name
           |> Option.map ~f:(fun f ->
             { Restriction.kind = Ensure; expr = OpamFormula.Atom f })
       ;;
@@ -521,13 +566,14 @@ module Solver = struct
       let rejects role context =
         match role with
         | Virtual _ -> Fiber.return ([], [])
-        | Real role ->
+        | Real (name, platform) ->
           let+ rejects =
-            Context.candidates context role
-            >>| List.filter_map ~f:(function
-              | _, Ok _ -> None
-              | { Priority.version; _ }, Error reason ->
-                let pkg = OpamPackage.create role version in
+            Context.candidates_unfiltered context name
+            >>| List.filter_map ~f:(fun ({ Priority.version; _ }, opam) ->
+              match Context.rejection_for_platform context ~platform opam with
+              | None -> None
+              | Some reason ->
+                let pkg = OpamPackage.create name version in
                 Some (Reject pkg, reason))
           in
           let notes = [] in
@@ -569,7 +615,7 @@ module Solver = struct
       let compare_version a b =
         match a, b with
         | RealImpl a, RealImpl b ->
-          (* CR-someday rgrinberg: shouldn't we take our version preference into account here? *)
+          (* CR rgrinberg: shouldn't we take our version preference into account here? *)
           Ordering.of_int (OpamPackage.compare a.pkg b.pkg)
         | RealImpl _, _ -> Gt
         | _, RealImpl _ -> Lt
@@ -619,11 +665,12 @@ module Solver = struct
     ;;
 
     (* Turn an opam dependency formula into a 0install list of dependencies. *)
-    let list_deps ~importance ~rank deps =
+    let list_deps ~importance ~rank ~platform deps =
       let rec aux (formula : _ OpamTypes.generic_formula) =
         match formula with
         | Empty -> []
-        | Atom (name, restrictions) -> [ { drole = Real name; restrictions; importance } ]
+        | Atom (name, restrictions) ->
+          [ { drole = Real (name, platform); restrictions; importance } ]
         | Block x -> aux x
         | And (x, y) -> aux x @ aux y
         | Or _ as o ->
@@ -639,24 +686,27 @@ module Solver = struct
       aux deps
     ;;
 
-    (* Get all the candidates for a role. *)
+    (* Get all candidates for a role, applying availability and local-package
+       constraints in that role's platform environment. *)
     let implementations role context =
       match role with
       | Virtual (_, impls) -> Fiber.return impls
-      | Real role ->
-        Context.candidates context role
-        >>| List.filter_map ~f:(function
-          | _, Error _rejection -> None
-          | { Priority.version; avoid }, Ok opam ->
-            let pkg = OpamPackage.create role version in
+      | Real (name, platform) ->
+        Context.candidates_unfiltered context name
+        >>| List.filter_map ~f:(fun (priority, opam) ->
+          match Context.rejection_for_platform context ~platform opam with
+          | Some _ -> None
+          | None ->
+            let { Priority.version; avoid } = priority in
+            let pkg = OpamPackage.create name version in
             (* Note: we ignore depopts here: see opam/doc/design/depopts-and-features *)
             let requires =
               lazy
                 (let rank = Rank.assign () in
                  let make_deps importance xform deps =
-                   Context.filter_deps context pkg deps
+                   Context.filter_deps context ~platform pkg deps
                    |> xform
-                   |> list_deps ~importance ~rank
+                   |> list_deps ~importance ~rank ~platform
                  in
                  (OpamFile.OPAM.depends opam |> make_deps Ensure ensure)
                  @ (OpamFile.OPAM.conflicts opam |> make_deps Prevent prevent))
@@ -753,48 +803,188 @@ module Solver = struct
     end
 
     module Conflict_classes = struct
-      type t = { mutable groups : Sat.lit list ref OpamPackage.Name.Map.t }
+      (* Key is (conflict_class_name, platform) to ensure conflict classes
+         are enforced per-platform, not across platforms. In multi-platform
+         solving, it's valid to select the same package with a conflict class
+         on multiple platforms, but within each platform, at most one package
+         with the conflict class can be selected. *)
+      module Key = struct
+        type t = OpamPackage.Name.t * Solver_env.t
 
-      let create () = { groups = OpamPackage.Name.Map.empty }
+        let compare (name1, plat1) (name2, plat2) =
+          match Ordering.of_int (OpamPackage.Name.compare name1 name2) with
+          | Eq -> Solver_env.compare plat1 plat2
+          | x -> x
+        ;;
 
-      let var t name =
-        match OpamPackage.Name.Map.find_opt name t.groups with
+        let to_dyn (name, plat) =
+          Dyn.Tuple
+            [ Dyn.string (OpamPackage.Name.to_string name); Solver_env.to_dyn plat ]
+        ;;
+      end
+
+      module Key_map = Map.Make (Key)
+
+      type t = { mutable groups : Sat.lit list ref Key_map.t }
+
+      let create () = { groups = Key_map.empty }
+
+      let var t key =
+        match Key_map.find t.groups key with
         | Some v -> v
         | None ->
           let v = ref [] in
-          t.groups <- OpamPackage.Name.Map.add name v t.groups;
+          t.groups <- Key_map.set t.groups key v;
           v
       ;;
 
-      (* Add [impl] to its conflict groups, if any. *)
-      let process t impl_var impl =
-        Input.Impl.conflict_class impl
-        |> List.iter ~f:(fun name ->
-          let impls = var t name in
-          impls := impl_var :: !impls)
+      (* Add [impl] to its conflict groups, if any.
+         [role] is used to extract the platform for the group key.
+         Virtual roles never carry conflict classes (see [Input.Impl.conflict_class]
+         which returns [] for VirtualImpl), so there's nothing to do for them. *)
+      let process t role impl_var impl =
+        match role with
+        | Input.Virtual _ -> ()
+        | Input.Real (_, platform) ->
+          Input.Impl.conflict_class impl
+          |> List.iter ~f:(fun name ->
+            let impls = var t (name, platform) in
+            impls := impl_var :: !impls)
       ;;
 
       (* Call this at the end to add the final clause with all discovered groups.
          [t] must not be used after this. *)
       let seal t =
+        Key_map.iter t.groups ~f:(fun impls ->
+          match !impls with
+          | _ :: _ :: _ ->
+            let (_ : Sat.at_most_one_clause) = Sat.at_most_one !impls in
+            ()
+          | _ -> ())
+      ;;
+    end
+
+    module Cross_platform_version = struct
+      (* Implements @art-w's cross-platform version equality constraint from
+         https://github.com/ocaml/dune/issues/13647. For each (package_name,
+         version) appearing as an impl on any platform, introduce a "somewhere"
+         SAT variable that is true iff some platform selected [package_name] at
+         [version]. Two kinds of clauses are added:
+         - For each per-platform impl: [impl_var implies somewhere].
+         - At-most-one across the somewhere-vars of each [name].
+         Together these force every platform that selects [name] to select the
+         same version, while still permitting platforms to omit a package
+         entirely (e.g. unix-only packages on Windows). *)
+      module Key = struct
+        type t = OpamPackage.Name.t * OpamPackage.Version.t
+
+        let compare (n1, v1) (n2, v2) =
+          match Ordering.of_int (OpamPackage.Name.compare n1 n2) with
+          | Eq -> Ordering.of_int (OpamPackage.Version.compare v1 v2)
+          | x -> x
+        ;;
+
+        let to_dyn (n, v) =
+          Dyn.Tuple
+            [ Dyn.string (OpamPackage.Name.to_string n)
+            ; Dyn.string (OpamPackage.Version.to_string v)
+            ]
+        ;;
+      end
+
+      module Key_map = Map.Make (Key)
+
+      type t =
+        { sat : Sat.t
+        ; enabled : bool
+        ; mutable somewhere_vars : Sat.lit Key_map.t
+        ; (* For each package name, the list of somewhere-vars across its
+             versions. Used at seal time to add the at-most-one clauses. *)
+          mutable per_name : Sat.lit list ref OpamPackage.Name.Map.t
+        }
+
+      let create sat ~enabled =
+        { sat
+        ; enabled
+        ; somewhere_vars = Key_map.empty
+        ; per_name = OpamPackage.Name.Map.empty
+        }
+      ;;
+
+      let somewhere_var t name version =
+        let key = name, version in
+        match Key_map.find t.somewhere_vars key with
+        | Some v -> v
+        | None ->
+          (* The user data attached to this SAT variable is opaque to the SAT
+             engine — we use Dummy since the variable doesn't represent a real
+             package selection. *)
+          let v = Sat.add_variable t.sat Input.Dummy in
+          t.somewhere_vars <- Key_map.set t.somewhere_vars key v;
+          let bucket =
+            match OpamPackage.Name.Map.find_opt name t.per_name with
+            | Some b -> b
+            | None ->
+              let b = ref [] in
+              t.per_name <- OpamPackage.Name.Map.add name b t.per_name;
+              b
+          in
+          bucket := v :: !bucket;
+          v
+      ;;
+
+      (* Return one canonical selection literal per package version. With
+         multiple platforms this is the shared [somewhere] variable used for
+         version equality. With one platform the implementation variable is
+         already canonical, so no extra encoding is needed. *)
+      let process t impl_var (impl : Input.impl) =
+        match impl with
+        | RealImpl real_impl ->
+          let pkg = real_impl.pkg in
+          let name = OpamPackage.name pkg in
+          let version = OpamPackage.version pkg in
+          let key = name, version in
+          let selection_var =
+            if t.enabled
+            then (
+              let som = somewhere_var t name version in
+              Sat.implies t.sat impl_var [ som ] ~reason:"cross-platform version equality";
+              som)
+            else impl_var
+          in
+          Some (key, selection_var)
+        | VirtualImpl _ | Reject _ | Dummy -> None
+      ;;
+
+      (* Add at-most-one over the somewhere-vars per package name. Call after
+         all impls have been processed. *)
+      let seal t =
         OpamPackage.Name.Map.iter
-          (fun _ impls ->
-             match !impls with
-             | _ :: _ :: _ ->
-               let (_ : Sat.at_most_one_clause) = Sat.at_most_one !impls in
-               ()
-             | _ -> ())
-          t.groups
+          (fun _name bucket ->
+             match !bucket with
+             | [] | [ _ ] -> ()
+             | vars -> ignore (Sat.at_most_one vars : Sat.at_most_one_clause))
+          t.per_name
       ;;
     end
 
     (* Starting from [root_req], explore all the feeds and implementations we
        might need, adding all of them to [sat_problem]. *)
-    let build_problem context root_req sat ~max_avoids ~dummy_impl =
+    let build_problem
+          context
+          root_req
+          sat
+          ~enforce_cross_platform_versions
+          ~max_avoids
+          ~dummy_impl
+      =
       (* For each (iface, source) we have a list of implementations. *)
       let impl_cache = Fiber.Cache.create (module Input.Role) in
       let conflict_classes = Conflict_classes.create () in
-      let avoids = ref [] in
+      let cross_platform_versions =
+        Cross_platform_version.create sat ~enabled:enforce_cross_platform_versions
+      in
+      let avoids = ref Cross_platform_version.Key_map.empty in
       let+ () =
         let rec lookup_impl expand_deps role =
           let impls = ref [] in
@@ -808,8 +998,14 @@ module Solver = struct
           in
           let+ () =
             Fiber.parallel_iter !impls ~f:(fun { var = impl_var; impl } ->
-              Conflict_classes.process conflict_classes impl_var impl;
-              if Input.Impl.avoid impl then avoids := impl_var :: !avoids;
+              Conflict_classes.process conflict_classes role impl_var impl;
+              let version_selection =
+                Cross_platform_version.process cross_platform_versions impl_var impl
+              in
+              (match version_selection with
+               | Some (key, selection_var) when Input.Impl.avoid impl ->
+                 avoids := Cross_platform_version.Key_map.set !avoids key selection_var
+               | Some _ | None -> ());
               match expand_deps with
               | `No_expand -> Fiber.return ()
               | `Expand_and_collect_conflicts deferred ->
@@ -881,7 +1077,8 @@ module Solver = struct
         (* All impl_candidates have now been added, so snapshot the cache. *)
       in
       Conflict_classes.seal conflict_classes;
-      (match max_avoids, !avoids with
+      Cross_platform_version.seal cross_platform_versions;
+      (match max_avoids, Cross_platform_version.Key_map.values !avoids with
        | None, _ | _, [] -> ()
        | Some max_avoids, avoids ->
          let _ : Sat.at_most_clause = Sat.at_most max_avoids avoids in
@@ -902,7 +1099,13 @@ module Solver = struct
           to minimize the number of those bad packages, but still find a solution when
           they are unavoidable.
         @return None if the solve fails (only happens if [closest_match] is false). *)
-    let do_solve context ~closest_match ~max_avoids root_req =
+    let do_solve
+          context
+          ~closest_match
+          ~enforce_cross_platform_versions
+          ~max_avoids
+          root_req
+      =
       (* The basic plan is this:
          1. Scan the root interface and all dependencies recursively, building up a SAT problem.
          2. Solve the SAT problem. Whenever there are multiple options, try the most preferred one first.
@@ -916,7 +1119,13 @@ module Solver = struct
       let sat = Sat.create () in
       let* impl_clauses =
         let dummy_impl = if closest_match then Some Input.Dummy else None in
-        build_problem context root_req sat ~max_avoids ~dummy_impl
+        build_problem
+          context
+          root_req
+          sat
+          ~enforce_cross_platform_versions
+          ~max_avoids
+          ~dummy_impl
       in
       let+ impl_clauses = Fiber.Cache.to_table impl_clauses in
       (* Run the solve *)
@@ -971,22 +1180,40 @@ module Solver = struct
            |> Input.Role.Map.of_list_exn)
     ;;
 
-    let do_solve context ~closest_match root_req =
-      do_solve context ~closest_match ~max_avoids:(Some 0) root_req
+    let do_solve context ~closest_match ~enforce_cross_platform_versions root_req =
+      do_solve
+        context
+        ~closest_match
+        ~enforce_cross_platform_versions
+        ~max_avoids:(Some 0)
+        root_req
       >>= function
       | Some sels ->
         (* Found a good solution, using no packages flagged as [avoid-version] *)
         Fiber.return (Some sels)
       | None ->
-        do_solve context ~closest_match ~max_avoids:None root_req
+        do_solve
+          context
+          ~closest_match
+          ~enforce_cross_platform_versions
+          ~max_avoids:None
+          root_req
         >>= (function
          | None ->
            (* No solution even when allowing [avoid-version] *)
            Fiber.return None
          | Some sels ->
            let nb_avoids sels =
-             Input.Role.Map.fold sels ~init:0 ~f:(fun sel count ->
-               if Input.Impl.avoid sel.impl then count + 1 else count)
+             Input.Role.Map.fold sels ~init:[] ~f:(fun sel packages ->
+               if Input.Impl.avoid sel.impl
+               then (
+                 match Input.Impl.version sel.impl with
+                 | Some package -> package :: packages
+                 | None -> assert false)
+               else packages)
+             |> List.sort_uniq ~compare:(fun a b ->
+               Ordering.of_int (OpamPackage.compare a b))
+             |> List.length
            in
            let upper = nb_avoids sels in
            (* There exists a solution, using at least 1 and at most [upper]
@@ -997,7 +1224,12 @@ module Solver = struct
              then Fiber.return (Some best_sel)
              else (
                let mid = (lower + upper) / 2 in
-               do_solve context ~closest_match ~max_avoids:(Some mid) root_req
+               do_solve
+                 context
+                 ~closest_match
+                 ~enforce_cross_platform_versions
+                 ~max_avoids:(Some mid)
+                 root_req
                >>= function
                | None -> search (mid + 1) upper best_sel
                | Some sels ->
@@ -1095,7 +1327,7 @@ module Solver = struct
          If [t] selected a better version anyway then we don't need to report this rejection. *)
       let affected_selection t impl =
         match t.selected_impl with
-        (* CR-someday rgrinberg: take account version preference here? *)
+        (* CR rgrinberg: take account version preference here? *)
         | Some selected when Input.Impl.compare_version selected impl = Gt -> false
         | _ -> true
       ;;
@@ -1254,10 +1486,16 @@ module Solver = struct
       ;;
 
       (* Format a textual description of this component's report. *)
-      let pp ~verbose t =
+      let pp ?(verbose = false) ?platform t =
+        let platform_suffix =
+          match platform with
+          | None -> Pp.nop
+          | Some platform -> Pp.text " on " ++ Solver_env.pp_oneline platform
+        in
         Pp.vbox
           ~indent:2
-          (Pp.hovbox (Input.pp_role t.role ++ Pp.text " -> " ++ pp_outcome t)
+          (Pp.hovbox
+             (Input.pp_role t.role ++ Pp.text " -> " ++ pp_outcome t ++ platform_suffix)
            ++ pp_notes t
            ++ pp_candidates ~verbose t)
       ;;
@@ -1327,30 +1565,51 @@ module Solver = struct
         |> Option.iter ~f:(Component.apply_user_restriction component))
     ;;
 
+    (* Check if two roles refer to the same package (ignoring the platform).
+       Used for conflict class checking - same package on different platforms
+       should not be considered in conflict with itself. *)
+    let same_package_name (role1 : Input.Role.t) (role2 : Input.Role.t) =
+      match role1, role2 with
+      | Real (name1, _), Real (name2, _) -> OpamPackage.Name.equal name1 name2
+      | Virtual (id1, _), Virtual (id2, _) -> Input.Virtual_id.equal id1 id2
+      | Real _, Virtual _ | Virtual _, Real _ -> false
+    ;;
+
     (** For each selected implementation with a conflict class, reject all candidates
-        with the same class. *)
+        with the same class on the same platform. *)
     let check_conflict_classes report =
       let classes =
         Input.Role.Map.foldi
           report
           ~init:OpamPackage.Name.Map.empty
           ~f:(fun role component acc ->
-            match Component.selected_impl component with
-            | None -> acc
-            | Some impl ->
+            match Component.selected_impl component, Input.Role.platform role with
+            | None, _ | _, None -> acc
+            | Some impl, Some platform ->
               Input.Impl.conflict_class impl
-              |> List.fold_left ~init:acc ~f:(fun acc x ->
-                OpamPackage.Name.Map.add x role acc))
+              |> List.fold_left ~init:acc ~f:(fun acc conflict_class ->
+                let platforms =
+                  OpamPackage.Name.Map.find_opt conflict_class acc
+                  |> Option.value ~default:Solver_env.Map.empty
+                in
+                OpamPackage.Name.Map.add
+                  conflict_class
+                  (Solver_env.Map.set platforms platform role)
+                  acc))
       in
       Input.Role.Map.iteri report ~f:(fun role component ->
-        Component.filter_impls component (fun impl ->
-          Input.Impl.conflict_class impl
-          |> List.find_map ~f:(fun cl ->
-            match OpamPackage.Name.Map.find_opt cl classes with
-            | Some other_role
-              when not (Ordering.is_eq (Input.Role.compare role other_role)) ->
-              Some (`ClassConflict (other_role, cl))
-            | _ -> None)))
+        match Input.Role.platform role with
+        | None -> ()
+        | Some platform ->
+          Component.filter_impls component (fun impl ->
+            Input.Impl.conflict_class impl
+            |> List.find_map ~f:(fun conflict_class ->
+              OpamPackage.Name.Map.find_opt conflict_class classes
+              |> Option.bind ~f:(fun platforms ->
+                match Solver_env.Map.find platforms platform with
+                | Some other_role when not (same_package_name role other_role) ->
+                  Some (`ClassConflict (other_role, conflict_class))
+                | _ -> None))))
     ;;
 
     let of_result context impls =
@@ -1363,7 +1622,7 @@ module Solver = struct
         let get_selected role (sel : Solver.selection) =
           let diagnostics = lazy (explain role) in
           let impl = if sel.impl = Input.Dummy then None else Some sel.impl in
-          (* CR-someday rgrinberg: Are we recomputing things here? *)
+          (* CR rgrinberg: Are we recomputing things here? *)
           let* impl_candidates = Input.implementations role context in
           let+ rejects, feed_problems = Input.Role.rejects role context in
           Component.create
@@ -1386,24 +1645,93 @@ module Solver = struct
     ;;
   end
 
-  let solve context pkgs =
+  let solve context pkgs ~platforms =
+    let enforce_cross_platform_versions =
+      match platforms with
+      | [] | [ _ ] -> false
+      | first :: rest ->
+        List.exists rest ~f:(fun platform -> not (Solver_env.equal first platform))
+    in
     let req =
-      match pkgs with
-      | [ pkg ] -> Input.Real pkg
-      | pkgs ->
-        let impl : Input.Impl.t =
-          let depends =
+      match pkgs, platforms with
+      | [ pkg ], [ platform ] ->
+        (* Single package, single platform - use Real directly *)
+        Input.Real (pkg, platform)
+      | _ ->
+        (* Multiple packages or platforms - create virtual root *)
+        let depends =
+          List.concat_map platforms ~f:(fun platform ->
             List.map pkgs ~f:(fun name ->
-              { Input.drole = Real name; importance = Ensure; restrictions = [] })
-          in
-          VirtualImpl (Input.Rank.bottom, depends)
+              { Input.drole = Real (name, platform)
+              ; importance = Ensure
+              ; restrictions = []
+              }))
         in
+        let impl : Input.Impl.t = VirtualImpl (Input.Rank.bottom, depends) in
         Input.virtual_role [ impl ]
     in
-    Solver.do_solve context ~closest_match:false req
+    Solver.do_solve context ~closest_match:false ~enforce_cross_platform_versions req
     >>| function
     | Some sels -> Ok sels
-    | None -> Error req
+    | None -> Error (req, enforce_cross_platform_versions)
+  ;;
+
+  (* Filter a list, keeping the first occurrence of each [Some name] key. Items
+     whose [key] is [None] are kept unconditionally (used to pass Virtual roles
+     through, since they don't carry a package name to deduplicate on). *)
+  let filter_dedup_by_name ~key items =
+    let seen = ref OpamPackage.Name.Set.empty in
+    List.filter items ~f:(fun item ->
+      match key item with
+      | None -> true
+      | Some name ->
+        if OpamPackage.Name.Set.mem name !seen
+        then false
+        else (
+          seen := OpamPackage.Name.Set.add name !seen;
+          true))
+  ;;
+
+  let role_name = function
+    | Input.Virtual _ -> None
+    | Input.Real (name, _) -> Some name
+  ;;
+
+  let deduplicate_roles_by_name = filter_dedup_by_name ~key:role_name
+
+  (* Deduplicate impls by package name, keeping one representative per package.
+     For VirtualImpls, skip them if all their deps point to packages we've already seen. *)
+  let deduplicate_impls_by_name impls =
+    let seen = ref OpamPackage.Name.Set.empty in
+    List.filter impls ~f:(fun impl ->
+      match impl with
+      | Input.VirtualImpl (_, deps) ->
+        (* Check if this VirtualImpl has any deps we haven't seen yet *)
+        let has_new_deps =
+          List.exists deps ~f:(fun (d : Input.dependency) ->
+            match d.drole with
+            | Input.Virtual _ -> true
+            | Input.Real (name, _) -> not (OpamPackage.Name.Set.mem name !seen))
+        in
+        if has_new_deps
+        then (
+          (* Add all dep names to seen *)
+          List.iter deps ~f:(fun (d : Input.dependency) ->
+            match d.drole with
+            | Input.Virtual _ -> ()
+            | Input.Real (name, _) -> seen := OpamPackage.Name.Set.add name !seen);
+          true)
+        else false
+      | _ ->
+        (match Input.Impl.version impl with
+         | None -> true
+         | Some pkg ->
+           let name = OpamPackage.name pkg in
+           if OpamPackage.Name.Set.mem name !seen
+           then false
+           else (
+             seen := OpamPackage.Name.Set.add name !seen;
+             true)))
   ;;
 
   let pp_rolemap ~verbose reasons =
@@ -1417,30 +1745,103 @@ module Solver = struct
            | _, `No_candidates -> `Right role
            | _, _ -> `Middle component))
     in
-    let pp_bad = Diagnostics.Component.pp ~verbose in
-    let pp_unknown role = Pp.box (Input.Role.pp role) in
-    match unknown with
-    | [] ->
+    let good = deduplicate_impls_by_name good in
+    let good_names =
+      List.fold_left good ~init:OpamPackage.Name.Set.empty ~f:(fun names impl ->
+        match Input.Impl.version impl with
+        | None -> names
+        | Some pkg -> OpamPackage.Name.Set.add (OpamPackage.name pkg) names)
+    in
+    let component_key component =
+      Format.asprintf "%a" Pp.to_fmt (Diagnostics.Component.pp ~verbose component)
+    in
+    let varied_names =
+      List.fold_left bad ~init:OpamPackage.Name.Set.empty ~f:(fun varied component ->
+        let component = (component : Diagnostics.Component.t) in
+        match component.role with
+        | Input.Virtual _ -> varied
+        | Input.Real (name, _) ->
+          let key = component_key component in
+          if
+            List.exists bad ~f:(fun other ->
+              let other = (other : Diagnostics.Component.t) in
+              match other.role with
+              | Input.Virtual _ -> false
+              | Input.Real (other_name, _) ->
+                OpamPackage.Name.equal name other_name
+                && not (String.equal key (component_key other)))
+          then OpamPackage.Name.Set.add name varied
+          else varied)
+    in
+    let bad =
+      List.fold_left bad ~init:[] ~f:(fun kept component ->
+        let component = (component : Diagnostics.Component.t) in
+        let preserve_platforms =
+          match component.role with
+          | Input.Virtual _ -> false
+          | Input.Real (name, _) ->
+            OpamPackage.Name.Set.mem name good_names
+            || OpamPackage.Name.Set.mem name varied_names
+        in
+        let duplicate =
+          (not preserve_platforms)
+          && List.exists kept ~f:(fun other ->
+            let other = (other : Diagnostics.Component.t) in
+            Option.equal
+              OpamPackage.Name.equal
+              (role_name component.role)
+              (role_name other.role)
+            && String.equal (component_key component) (component_key other))
+        in
+        if duplicate then kept else component :: kept)
+      |> List.rev
+    in
+    let bad_counts =
+      List.fold_left bad ~init:OpamPackage.Name.Map.empty ~f:(fun counts component ->
+        match (component : Diagnostics.Component.t).role with
+        | Input.Virtual _ -> counts
+        | Input.Real (name, _) ->
+          let count =
+            Option.value (OpamPackage.Name.Map.find_opt name counts) ~default:0
+          in
+          OpamPackage.Name.Map.add name (count + 1) counts)
+    in
+    let unknown = deduplicate_roles_by_name unknown in
+    let pp_bad (component : Diagnostics.Component.t) =
+      let platform =
+        match component.role with
+        | Input.Virtual _ -> None
+        | Input.Real (name, platform) ->
+          let count =
+            Option.value (OpamPackage.Name.Map.find_opt name bad_counts) ~default:0
+          in
+          Option.some_if (count > 1 || OpamPackage.Name.Set.mem name good_names) platform
+      in
+      Diagnostics.Component.pp ~verbose ?platform component
+    in
+    let known =
       Pp.paragraph "Selected candidates: "
       ++ Pp.hovbox (Pp.concat_map ~sep:Pp.space good ~f:Input.pp_impl)
       ++ Pp.cut
       ++ Pp.enumerate bad ~f:pp_bad
+    in
+    match unknown with
+    | [] -> known
     | _ ->
-      (* In case of unknown packages, no need to print the full diagnostic
-         list, the problem is simpler. *)
       Pp.hovbox
         (Pp.text "The following packages couldn't be found: "
-         ++ Pp.concat_map ~sep:Pp.space unknown ~f:pp_unknown)
+         ++ Pp.concat_map ~sep:Pp.space unknown ~f:(fun role ->
+           Pp.box (Input.Role.pp role)))
   ;;
 
-  let diagnostics_rolemap context req =
-    Solver.do_solve context req ~closest_match:true
+  let diagnostics_rolemap context (req, enforce_cross_platform_versions) =
+    Solver.do_solve context req ~closest_match:true ~enforce_cross_platform_versions
     >>| Option.value_exn
     >>= Diagnostics.of_result context
   ;;
 
-  let diagnostics ?(verbose = false) context req =
-    let+ diag = diagnostics_rolemap context req in
+  let diagnostics ?(verbose = false) context solve_error =
+    let+ diag = diagnostics_rolemap context solve_error in
     Pp.paragraph "Couldn't solve the package dependency formula."
     ++ Pp.cut
     ++ Pp.vbox (pp_rolemap ~verbose diag)
@@ -1450,9 +1851,33 @@ module Solver = struct
     Input.Role.Map.values sels
     |> List.filter_map ~f:(fun (sel : Solver.selection) -> Input.Impl.version sel.impl)
   ;;
+
+  (* Extract packages grouped by platform from the solver result.
+     Returns a map: package_name -> (platform -> version)
+     This lets us detect if a package has different versions on different
+     platforms. *)
+  let packages_by_platform sels =
+    Input.Role.Map.foldi
+      sels
+      ~init:OpamPackage.Name.Map.empty
+      ~f:(fun role (sel : Solver.selection) acc ->
+        match role with
+        | Input.Virtual _ -> acc
+        | Input.Real (name, platform) ->
+          (match Input.Impl.version sel.impl with
+           | None -> acc
+           | Some pkg ->
+             let version = OpamPackage.version pkg in
+             let platforms =
+               match OpamPackage.Name.Map.find_opt name acc with
+               | None -> Solver_env.Map.singleton platform version
+               | Some platforms -> Solver_env.Map.set platforms platform version
+             in
+             OpamPackage.Name.Map.add name platforms acc))
+  ;;
 end
 
-let solve_package_list packages ~context =
+let solve_package_list packages ~context ~platforms =
   Fiber.collect_errors (fun () ->
     (* [Solver.solve] returns [Error] when it's unable to find a solution to
        the dependencies, but can also raise exceptions, for example if opam
@@ -1460,7 +1885,7 @@ let solve_package_list packages ~context =
        an unexpected opam exception from crashing dune, we catch all
        exceptions raised by the solver and report them as [User_error]s
        instead. *)
-    Solver.solve context packages)
+    Solver.solve context packages ~platforms)
   >>| (function
    | Ok (Ok res) -> Ok res
    | Ok (Error e) -> Error (`Diagnostics e)
@@ -1469,7 +1894,10 @@ let solve_package_list packages ~context =
      (* CR-rgrinberg: this needs to be handled right *)
      Error (`Exn exn))
   >>= function
-  | Ok packages -> Fiber.return @@ Ok (Solver.packages_of_result packages)
+  | Ok sels ->
+    let packages = Solver.packages_of_result sels in
+    let packages_by_platform = Solver.packages_by_platform sels in
+    Fiber.return @@ Ok (packages, packages_by_platform)
   | Error (`Diagnostics e) ->
     let+ diagnostics = Solver.diagnostics context e in
     Error (`Solve_error diagnostics)
@@ -1495,28 +1923,6 @@ module Solver_result = struct
     ; pinned_packages : Package_name.Set.t
     ; num_expanded_packages : int
     }
-
-  let merge a b =
-    let lock_dir = Lock_dir.merge_conditionals a.lock_dir b.lock_dir in
-    let files =
-      Package_name.Map.union a.files b.files ~f:(fun _ a b ->
-        Some
-          (Package_version.Map.union a b ~f:(fun _ a b ->
-             (* The package is present in both solutions at the same version. Make
-             sure its associated files are the same in both instances. *)
-             if not (List.equal File_entry.equal a b)
-             then
-               Code_error.raise
-                 "Package files differ between merged solver results"
-                 [ "files_1", Dyn.list File_entry.to_dyn a
-                 ; "files_2", Dyn.list File_entry.to_dyn b
-                 ];
-             Some a)))
-    in
-    let pinned_packages = Package_name.Set.union a.pinned_packages b.pinned_packages in
-    let num_expanded_packages = a.num_expanded_packages + b.num_expanded_packages in
-    { lock_dir; files; pinned_packages; num_expanded_packages }
-  ;;
 end
 
 let reject_unreachable_packages =
@@ -1716,8 +2122,15 @@ let resolve_opam_packages opam_packages_to_lock candidates_cache =
     name, opam_package, resolved_package)
 ;;
 
+let deduplicate_platform_overlays platform_overlays =
+  List.rev
+    (List.fold_left platform_overlays ~init:[] ~f:(fun acc overlay ->
+       if List.exists acc ~f:(Solver_env.equal overlay) then acc else overlay :: acc))
+;;
+
 let solve_lock_dir
       solver_env
+      ~platform_overlays
       version_preference
       repos
       ~local_packages
@@ -1726,211 +2139,312 @@ let solve_lock_dir
       ~selected_depopts
       ~portable_lock_dir
   =
-  match Package_name.Map.add pinned_packages Dune_dep.name Resolved_package.dune with
-  | Error p ->
-    let loc = Resolved_package.loc p in
-    let message =
-      User_error.make
-        ~loc
-        [ Pp.text
-            "Dune cannot be pinned. The currently running version is the only one that \
-             may be used"
-        ]
-    in
-    Fiber.return (Error (`Manifest_error message))
-  | Ok pinned_packages ->
-    let pinned_package_names = Package_name.Set.of_keys pinned_packages in
-    let stats_updater = Solver_stats.Updater.init () in
-    let context =
-      let rec context =
-        lazy
-          (Context.create
-             ~pinned_packages
-             ~solver_env
-             ~repos
-             ~version_preference
-             ~local_packages:local_packages'
-             ~stats_updater
-             ~constraints)
-      and local_packages' =
-        lazy
-          (Package_name.Map.map local_packages ~f:(fun local ->
-             let opam_file = Local_package.For_solver.to_opam_file local in
-             let version =
-               Option.value
-                 opam_file.version
-                 ~default:Context.local_package_default_version
-             in
-             let deps =
-               lazy
-                 (let opam_package =
-                    OpamPackage.create (OpamFile.OPAM.name opam_file) version
+  (* Identical platform envs would be solved by the same roles and would
+     otherwise produce duplicate entries in the lock file, so drop them. *)
+  let platform_overlays = deduplicate_platform_overlays platform_overlays in
+  match platform_overlays with
+  | [] -> Code_error.raise "solve_lock_dir called with empty platform_overlays" []
+  | _ ->
+    (match Package_name.Map.add pinned_packages Dune_dep.name Resolved_package.dune with
+     | Error p ->
+       let loc = Resolved_package.loc p in
+       let message =
+         User_error.make
+           ~loc
+           [ Pp.text
+               "Dune cannot be pinned. The currently running version is the only one \
+                that may be used"
+           ]
+       in
+       Fiber.return (Error (`Manifest_error message))
+     | Ok pinned_packages ->
+       let pinned_package_names = Package_name.Set.of_keys pinned_packages in
+       let stats_updater = Solver_stats.Updater.init () in
+       (* The platform envs themselves identify the platforms: every role and
+          every per-platform selection is keyed by the platform's own
+          (platform-specific) env. *)
+       let platforms = platform_overlays in
+       let full_solver_envs =
+         List.map platform_overlays ~f:(fun overlay ->
+           Solver_env.extend solver_env overlay)
+       in
+       let context =
+         let local_packages' =
+           lazy
+             (Package_name.Map.map local_packages ~f:(fun local ->
+                let opam_file = Local_package.For_solver.to_opam_file local in
+                let version =
+                  Option.value
+                    opam_file.version
+                    ~default:Context.local_package_default_version
+                in
+                let depends = OpamFile.OPAM.depends opam_file in
+                let conflicts = OpamFile.OPAM.conflicts opam_file in
+                { Context.opam_file; version; depends; conflicts; name = local.name }))
+         in
+         Context.create
+           ~pinned_packages
+           ~solver_env
+           ~repos
+           ~version_preference
+           ~local_packages:local_packages'
+           ~stats_updater
+           ~constraints
+       in
+       Package_name.Map.keys local_packages @ selected_depopts
+       |> List.map ~f:Package_name.to_opam_package_name
+       |> solve_package_list ~context ~platforms
+       >>= (function
+        | Error _ as e -> Fiber.return e
+        | Ok (solution, packages_by_platform) ->
+          (* Invert the solver result so dependency formulas can be resolved
+             against only the packages selected on their platform. Also check
+             the cross-platform version invariant while every selected version
+             is still available. *)
+          let versions_by_platform =
+            OpamPackage.Name.Map.fold
+              (fun opam_name platform_versions acc ->
+                 let name = Package_name.of_opam_package_name opam_name in
+                 let versions =
+                   Solver_env.Map.values platform_versions
+                   |> List.map ~f:Package_version.of_opam_package_version
+                 in
+                 (match versions with
+                  | [] -> assert false
+                  | version :: versions ->
+                    (match
+                       List.find versions ~f:(fun other ->
+                         not (Package_version.equal version other))
+                     with
+                     | None -> ()
+                     | Some other ->
+                       Code_error.raise
+                         "Cross-platform version equality SAT constraint failed: solver \
+                          selected multiple versions of the same package"
+                         [ "name", Package_name.to_dyn name
+                         ; "version_a", Package_version.to_dyn version
+                         ; "version_b", Package_version.to_dyn other
+                         ]));
+                 Solver_env.Map.foldi
+                   platform_versions
+                   ~init:acc
+                   ~f:(fun platform version acc ->
+                     let packages =
+                       Option.value
+                         (Solver_env.Map.find acc platform)
+                         ~default:Package_name.Map.empty
+                     in
+                     let packages =
+                       Package_name.Map.set
+                         packages
+                         name
+                         (Package_version.of_opam_package_version version)
+                     in
+                     Solver_env.Map.set acc platform packages))
+              packages_by_platform
+              Solver_env.Map.empty
+          in
+          (* The full solver envs and selected package versions for the
+             platforms on which a package is selected. *)
+          let solver_envs_for_package opam_name =
+            match OpamPackage.Name.Map.find_opt opam_name packages_by_platform with
+            | None ->
+              Code_error.raise
+                "solver result is missing a package it selected"
+                [ "name", Dyn.string (OpamPackage.Name.to_string opam_name) ]
+            | Some platform_map ->
+              (* Iterate over the requested platforms in their original order
+                 so that lock file entries keep the user's platform order. *)
+              List.filter_map platform_overlays ~f:(fun platform ->
+                if Solver_env.Map.mem platform_map platform
+                then (
+                  let versions =
+                    match Solver_env.Map.find versions_by_platform platform with
+                    | Some versions -> versions
+                    | None ->
+                      Code_error.raise
+                        "solver result is missing a platform it selected"
+                        [ "platform", Solver_env.to_dyn platform ]
                   in
-                  Context.filter_deps (Lazy.force context) opam_package)
-             in
-             let depends = lazy (Lazy.force deps (OpamFile.OPAM.depends opam_file)) in
-             let conflicts = lazy (Lazy.force deps (OpamFile.OPAM.conflicts opam_file)) in
-             { Context.opam_file; version; depends; conflicts; name = local.name }))
-      in
-      Lazy.force context
-    in
-    Package_name.Map.keys local_packages @ selected_depopts
-    |> List.map ~f:Package_name.to_opam_package_name
-    |> solve_package_list ~context
-    >>= (function
-     | Error _ as e -> Fiber.return e
-     | Ok solution ->
-       let is_dune name = Package_name.equal Dune_dep.name name in
-       (* don't include local packages or dune in the lock dir *)
-       let opam_packages_to_lock =
-         let is_local_package = Package_name.Map.mem local_packages in
-         List.filter solution ~f:(fun package ->
-           let name = OpamPackage.name package |> Package_name.of_opam_package_name in
-           (not (is_local_package name)) && not (is_dune name))
-       in
-       let* candidates_cache = Fiber.Cache.to_table context.candidates_cache in
-       let resolve_package name version =
-         (Table.find_exn candidates_cache name).resolved
-         |> OpamPackage.Version.Map.find version
-       in
-       let* pkgs_by_name =
-         let+ pkgs =
-           let version_by_package_name =
-             Package_name.Map.of_list_map_exn
-               solution
-               ~f:(fun (package : OpamPackage.t) ->
-                 ( Package_name.of_opam_package_name (OpamPackage.name package)
-                 , Package_version.of_opam_package_version (OpamPackage.version package) ))
-           in
-           let+ resolved_pkgs =
-             resolve_opam_packages opam_packages_to_lock candidates_cache
-           in
-           List.map resolved_pkgs ~f:(fun (name, opam_package, resolved_package) ->
-             Lock_pkg.opam_package_to_lock_file_pkg
-               [ solver_env ]
-               stats_updater
-               version_by_package_name
-               opam_package
-               ~pinned:(Package_name.Set.mem pinned_package_names name)
-               resolved_package
-               ~portable_lock_dir)
-           |> Result.List.all
-         in
-         Result.map pkgs ~f:(fun pkgs ->
-           match Package_name.Map.of_list_map pkgs ~f:(fun pkg -> pkg.info.name, pkg) with
-           | Error (name, _pkg1, _pkg2) ->
-             Code_error.raise
-               "Solver selected multiple versions for the same package"
-               [ "name", Package_name.to_dyn name ]
-           | Ok pkgs_by_name ->
-             let reachable =
-               reject_unreachable_packages
-                 solver_env
-                 ~dune_version:
-                   (Package_version.of_opam_package_version context.dune_version)
-                 ~local_packages
-                 ~pkgs_by_name
-             in
-             Package_name.Map.filteri pkgs_by_name ~f:(fun name _ ->
-               Package_name.Set.mem reachable name))
-       in
-       let ocaml =
-         let open Result.O in
-         let* pkgs_by_name = pkgs_by_name in
-         (* This doesn't allow the compiler to live in the source tree. Oh
+                  Some (Solver_env.extend solver_env platform, versions))
+                else None)
+          in
+          let is_dune name = Package_name.equal Dune_dep.name name in
+          (* Don't include local packages or dune in the lock dir. The
+             single joint solve may return the same package once per platform,
+             so deduplicate here. *)
+          let opam_packages_to_lock =
+            let is_local_package = Package_name.Map.mem local_packages in
+            List.filter solution ~f:(fun package ->
+              let name = OpamPackage.name package |> Package_name.of_opam_package_name in
+              (not (is_local_package name)) && not (is_dune name))
+            |> List.sort_uniq ~compare:(fun a b ->
+              Ordering.of_int (OpamPackage.compare a b))
+          in
+          let* candidates_cache = Fiber.Cache.to_table context.candidates_cache in
+          let resolve_package name version =
+            (Table.find_exn candidates_cache name).resolved
+            |> OpamPackage.Version.Map.find version
+          in
+          let* pkgs_by_name =
+            let+ pkgs =
+              let+ resolved_pkgs =
+                resolve_opam_packages opam_packages_to_lock candidates_cache
+              in
+              (* Generate lock file entries for each package.
+                 Lock_pkg handles per-platform evaluation and merging when needed. *)
+              List.map resolved_pkgs ~f:(fun (name, opam_package, resolved_package) ->
+                let opam_name = Package_name.to_opam_package_name name in
+                let package_solver_envs = solver_envs_for_package opam_name in
+                Lock_pkg.opam_package_to_lock_file_pkg
+                  package_solver_envs
+                  stats_updater
+                  opam_package
+                  ~pinned:(Package_name.Set.mem pinned_package_names name)
+                  resolved_package
+                  ~portable_lock_dir)
+              |> Result.List.all
+            in
+            Result.map pkgs ~f:(fun pkgs ->
+              match
+                Package_name.Map.of_list_map pkgs ~f:(fun pkg -> pkg.info.name, pkg)
+              with
+              | Error (name, _pkg1, _pkg2) ->
+                Code_error.raise
+                  "Solver selected multiple versions for the same package"
+                  [ "name", Package_name.to_dyn name ]
+              | Ok pkgs_by_name ->
+                (* Compute reachability for ALL platform envs and union the results.
+                   A package is reachable if it's reachable on any platform. *)
+                let reachable =
+                  List.fold_left
+                    full_solver_envs
+                    ~init:Package_name.Set.empty
+                    ~f:(fun acc solver_env ->
+                      let reachable_on_platform =
+                        reject_unreachable_packages
+                          solver_env
+                          ~dune_version:
+                            (Package_version.of_opam_package_version context.dune_version)
+                          ~local_packages
+                          ~pkgs_by_name
+                      in
+                      Package_name.Set.union acc reachable_on_platform)
+                in
+                Package_name.Map.filteri pkgs_by_name ~f:(fun name _ ->
+                  Package_name.Set.mem reachable name))
+          in
+          let ocaml =
+            let open Result.O in
+            let* pkgs_by_name = pkgs_by_name in
+            (* This doesn't allow the compiler to live in the source tree. Oh
          well, it's not possible now anyway. *)
-         match
-           Package_name.Map.filter_map pkgs_by_name ~f:(fun (pkg : Lock_dir.Pkg.t) ->
-             match
-               let version = Package_version.to_opam_package_version pkg.info.version in
-               resolve_package pkg.info.name version |> package_kind
-             with
-             | `Compiler -> Some pkg.info.name
-             | `Non_compiler -> None)
-           |> Package_name.Map.values
-         with
-         | [] -> Ok None
-         | [ x ] -> Ok (Some (Loc.none, x))
-         | _ ->
-           Error
-             (User_error.make
-                (* CR-someday rgrinberg: needs to include locations *)
-                [ Pp.text "multiple compilers selected" ]
-                ~hints:[ Pp.text "add a conflict" ])
-       in
-       let lock_dir =
-         let open Result.O in
-         let* pkgs_by_name = pkgs_by_name
-         and* ocaml = ocaml in
-         let+ () =
-           Package_name.Map.values pkgs_by_name
-           |> Result.List.map ~f:(fun { Lock_dir.Pkg.depends; info = { name; _ }; _ } ->
-             match
-               Lock_dir.Conditional_choice.choose_for_platform
-                 depends
-                 ~platform:solver_env
-             with
-             | None -> Ok ()
-             | Some depends ->
-               Result.List.map
-                 depends
-                 ~f:(fun { Lock_dir.Dependency.name = dep_name; loc } ->
-                   match
-                     (not (is_dune dep_name))
-                     && Package_name.Map.mem local_packages dep_name
-                   with
-                   | false -> Ok ()
-                   | true ->
-                     Error
-                       (User_error.make
-                          ~loc
-                          [ Pp.textf
-                              "Dune does not support packages outside the workspace \
-                               depending on packages in the workspace. The package %S is \
-                               not in the workspace but it depends on the package %S \
-                               which is in the workspace."
-                              (Package_name.to_string name)
-                              (Package_name.to_string dep_name)
-                          ]))
-               |> Result.map ~f:(fun (_ : unit list) -> ()))
-           |> Result.map ~f:(fun (_ : unit list) -> ())
-         in
-         let expanded_solver_variable_bindings =
-           let stats = Solver_stats.Updater.snapshot stats_updater in
-           Solver_stats.Expanded_variable_bindings.of_variable_set
-             stats.expanded_variables
-             solver_env
-         in
-         Lock_dir.create_latest_version
-           pkgs_by_name
-           ~local_packages:(Package_name.Map.values local_packages)
-           ~ocaml
-           ~repos:(Some repos)
-           ~expanded_solver_variable_bindings
-           ~solved_for_platforms:[ solver_env ]
-           ~portable_lock_dir
-       in
-       let+ files =
-         match pkgs_by_name with
-         | Error e -> Fiber.return (Error e)
-         | Ok pkgs_by_name ->
-           let+ files =
-             Package_name.Map.to_list_map
-               pkgs_by_name
-               ~f:(fun name (package : Lock_dir.Pkg.t) ->
-                 Package_version.to_opam_package_version package.info.version
-                 |> resolve_package name)
-             |> files
-           in
-           files
-       in
-       (match Result.both lock_dir files with
-        | Error e -> Error (`Manifest_error e)
-        | Ok (lock_dir, files) ->
-          Ok
-            { Solver_result.lock_dir
-            ; files
-            ; pinned_packages = pinned_package_names
-            ; num_expanded_packages = Context.count_expanded_packages context
-            }))
+            match
+              Package_name.Map.filter_map pkgs_by_name ~f:(fun (pkg : Lock_dir.Pkg.t) ->
+                match
+                  let version =
+                    Package_version.to_opam_package_version pkg.info.version
+                  in
+                  resolve_package pkg.info.name version |> package_kind
+                with
+                | `Compiler -> Some pkg.info.name
+                | `Non_compiler -> None)
+              |> Package_name.Map.values
+            with
+            | [] -> Ok None
+            | [ x ] -> Ok (Some (Loc.none, x))
+            | _ ->
+              Error
+                (User_error.make
+                   (* CR-someday rgrinberg: needs to include locations *)
+                   [ Pp.text "multiple compilers selected" ]
+                   ~hints:[ Pp.text "add a conflict" ])
+          in
+          let lock_dir =
+            let open Result.O in
+            let* pkgs_by_name = pkgs_by_name
+            and* ocaml = ocaml in
+            let+ () =
+              Package_name.Map.values pkgs_by_name
+              |> Result.List.map
+                   ~f:(fun { Lock_dir.Pkg.depends; info = { name; _ }; _ } ->
+                     (* A repository package must not evade validation by
+                        depending on a workspace package only on a
+                        non-primary platform, so validate the dependency
+                        choices for every platform where the package is
+                        selected. *)
+                     let platform_envs =
+                       solver_envs_for_package (Package_name.to_opam_package_name name)
+                     in
+                     Result.List.map platform_envs ~f:(fun (platform_env, _) ->
+                       match
+                         Lock_dir.Conditional_choice.choose_for_platform
+                           depends
+                           ~platform:platform_env
+                       with
+                       | None -> Ok ()
+                       | Some depends ->
+                         Result.List.map
+                           depends
+                           ~f:(fun { Lock_dir.Dependency.name = dep_name; loc } ->
+                             match
+                               (not (is_dune dep_name))
+                               && Package_name.Map.mem local_packages dep_name
+                             with
+                             | false -> Ok ()
+                             | true ->
+                               Error
+                                 (User_error.make
+                                    ~loc
+                                    [ Pp.textf
+                                        "Dune does not support packages outside the \
+                                         workspace depending on packages in the \
+                                         workspace. The package %S is not in the \
+                                         workspace but it depends on the package %S \
+                                         which is in the workspace."
+                                        (Package_name.to_string name)
+                                        (Package_name.to_string dep_name)
+                                    ]))
+                         |> Result.map ~f:(fun (_ : unit list) -> ()))
+                     |> Result.map ~f:(fun (_ : unit list) -> ()))
+              |> Result.map ~f:(fun (_ : unit list) -> ())
+            in
+            let expanded_solver_variable_bindings =
+              let stats = Solver_stats.Updater.snapshot stats_updater in
+              Solver_stats.Expanded_variable_bindings.of_variable_set
+                stats.expanded_variables
+                solver_env
+            in
+            Lock_dir.create_latest_version
+              pkgs_by_name
+              ~local_packages:(Package_name.Map.values local_packages)
+              ~ocaml
+              ~repos:(Some repos)
+              ~expanded_solver_variable_bindings
+              ~solved_for_platforms:full_solver_envs
+              ~portable_lock_dir
+          in
+          let+ files =
+            match pkgs_by_name with
+            | Error e -> Fiber.return (Error e)
+            | Ok pkgs_by_name ->
+              let+ files =
+                Package_name.Map.to_list_map
+                  pkgs_by_name
+                  ~f:(fun name (package : Lock_dir.Pkg.t) ->
+                    Package_version.to_opam_package_version package.info.version
+                    |> resolve_package name)
+                |> files
+              in
+              files
+          in
+          (match Result.both lock_dir files with
+           | Error e -> Error (`Manifest_error e)
+           | Ok (lock_dir, files) ->
+             Ok
+               { Solver_result.lock_dir
+               ; files
+               ; pinned_packages = pinned_package_names
+               ; num_expanded_packages = Context.count_expanded_packages context
+               })))
 ;;

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -2128,6 +2128,13 @@ let deduplicate_platform_overlays platform_overlays =
        if List.exists acc ~f:(Solver_env.equal overlay) then acc else overlay :: acc))
 ;;
 
+(* Split a solver env into a portable base env (with platform-specific
+   variables unset) and the distinct platform overlays to solve for. *)
+let base_solver_env_and_platforms solver_env ~solve_for_platforms =
+  ( Solver_env.unset_multi solver_env Dune_lang.Package_variable_name.platform_specific
+  , deduplicate_platform_overlays solve_for_platforms )
+;;
+
 let solve_lock_dir
       solver_env
       ~platform_overlays
@@ -2137,7 +2144,6 @@ let solve_lock_dir
       ~pins:pinned_packages
       ~constraints
       ~selected_depopts
-      ~portable_lock_dir
   =
   (* Identical platform envs would be solved by the same roles and would
      otherwise produce duplicate entries in the lock file, so drop them. *)
@@ -2301,8 +2307,7 @@ let solve_lock_dir
                   stats_updater
                   opam_package
                   ~pinned:(Package_name.Set.mem pinned_package_names name)
-                  resolved_package
-                  ~portable_lock_dir)
+                  resolved_package)
               |> Result.List.all
             in
             Result.map pkgs ~f:(fun pkgs ->
@@ -2422,7 +2427,6 @@ let solve_lock_dir
               ~repos:(Some repos)
               ~expanded_solver_variable_bindings
               ~solved_for_platforms:full_solver_envs
-              ~portable_lock_dir
           in
           let+ files =
             match pkgs_by_name with

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -9,9 +9,12 @@ module Solver_result : sig
     }
 end
 
-(** Drop duplicate platform environments while preserving first-occurrence
-    order. *)
-val deduplicate_platform_overlays : Solver_env.t list -> Solver_env.t list
+(** Split [solver_env] into a portable base env (with platform-specific
+    variables unset) and the distinct platform overlays to solve for. *)
+val base_solver_env_and_platforms
+  :  Solver_env.t
+  -> solve_for_platforms:Solver_env.t list
+  -> Solver_env.t * Solver_env.t list
 
 val solve_lock_dir
   :  Solver_env.t
@@ -22,15 +25,6 @@ val solve_lock_dir
   -> pins:Resolved_package.t Package_name.Map.t
   -> constraints:Dune_lang.Package_dependency.t list
   -> selected_depopts:Package_name.t list
-  -> portable_lock_dir:bool
-       (** XXX(steve): Indicates that the solver should generate portable
-           lockdirs. We try to avoid having the solver behave differently
-           depending on whether we are generating portable lockdirs but
-           allowing minor changes in what information is stored in the lockdir
-           depending on this argument can greatly simplify the logic for
-           handling both portable and non-portable lockdirs with the same code.
-           Once portable lockdirs are enabled unconditionally, remove this
-           argument. *)
   -> ( Solver_result.t
        , [ `Solve_error of User_message.Style.t Pp.t | `Manifest_error of User_message.t ]
        )

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -7,12 +7,15 @@ module Solver_result : sig
     ; pinned_packages : Package_name.Set.t
     ; num_expanded_packages : int
     }
-
-  val merge : t -> t -> t
 end
+
+(** Drop duplicate platform environments while preserving first-occurrence
+    order. *)
+val deduplicate_platform_overlays : Solver_env.t list -> Solver_env.t list
 
 val solve_lock_dir
   :  Solver_env.t
+  -> platform_overlays:Solver_env.t list
   -> Version_preference.t
   -> Opam_repo.t list
   -> local_packages:Local_package.For_solver.t Package_name.Map.t

--- a/src/dune_rules/compile_time.ml
+++ b/src/dune_rules/compile_time.ml
@@ -3,7 +3,3 @@ open Import
 let toolchains = Config.make_toggle ~name:"toolchains" ~default:Setup.toolchains
 let lock_dev_tools = Config.make_toggle ~name:"lock_dev_tool" ~default:Setup.lock_dev_tool
 let bin_dev_tools = Config.make_toggle ~name:"bin_dev_tools" ~default:Setup.bin_dev_tools
-
-let portable_lock_dir =
-  Config.make_toggle ~name:"portable_lock_dir" ~default:Setup.portable_lock_dir
-;;

--- a/src/dune_rules/compile_time.mli
+++ b/src/dune_rules/compile_time.mli
@@ -18,4 +18,3 @@ val toolchains : Toggle.t Config.t
 val lock_dev_tools : Toggle.t Config.t
 
 val bin_dev_tools : Toggle.t Config.t
-val portable_lock_dir : Toggle.t Config.t

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -152,55 +152,25 @@ module Spec = struct
         ~unset:(Some unset_solver_vars)
     in
     let* solver_result =
-      if portable_lock_dir
-      then (
-        (* CR-someday Alizter: This multi-platform solving logic is duplicated
-           from bin/pkg/lock.ml:solve_multiple_platforms. The logic for
-           removing platform-specific variables, solving for multiple platforms
-           in parallel, merging results, and error handling should be shared
-           between autolocking and manual locking. Consider extracting this
-           into a shared function in Dune_pkg.Opam_solver. *)
-        let portable_solver_env =
-          Solver_env.unset_multi
-            solver_env
-            Dune_lang.Package_variable_name.platform_specific
-        in
-        let solve_for_platforms = Solver_env.popular_platform_envs in
-        let+ results =
-          Fiber.parallel_map solve_for_platforms ~f:(fun platform_env ->
-            let solver_env_for_platform =
-              Solver_env.extend portable_solver_env platform_env
-            in
-            Opam_solver.solve_lock_dir
-              solver_env_for_platform
-              version_preference
-              repos
-              ~pins
-              ~local_packages
-              ~constraints
-              ~selected_depopts
-              ~portable_lock_dir)
-        in
-        let solver_results, errors =
-          List.partition_map results ~f:(function
-            | Ok result -> Left result
-            | Error e -> Right e)
-        in
-        match solver_results, errors with
-        | [], [] -> Code_error.raise "Solver did not run for any platforms." []
-        | [], `Manifest_error diagnostic :: _ -> Error (`Manifest_error diagnostic)
-        | [], `Solve_error diagnostic :: _ -> Error (`Solve_error diagnostic)
-        | x :: xs, _ -> Ok (List.fold_left xs ~init:x ~f:Opam_solver.Solver_result.merge))
-      else
-        Opam_solver.solve_lock_dir
-          solver_env
-          version_preference
-          repos
-          ~pins
-          ~local_packages
-          ~constraints
-          ~selected_depopts
-          ~portable_lock_dir
+      let base_solver_env, platform_overlays =
+        if portable_lock_dir
+        then
+          ( Solver_env.unset_multi
+              solver_env
+              Dune_lang.Package_variable_name.platform_specific
+          , Solver_env.popular_platform_envs )
+        else solver_env, [ Solver_env.empty ]
+      in
+      Opam_solver.solve_lock_dir
+        base_solver_env
+        ~platform_overlays
+        version_preference
+        repos
+        ~pins
+        ~local_packages
+        ~constraints
+        ~selected_depopts
+        ~portable_lock_dir
     in
     match solver_result with
     | Error (`Manifest_error diagnostic) -> raise (User_error.E diagnostic)

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -136,11 +136,6 @@ module Spec = struct
     let open Fiber.O in
     let* () = Fiber.return () in
     let local_packages = Package.Name.Map.map packages ~f:Local_package.for_solver in
-    let portable_lock_dir =
-      match Config.get Compile_time.portable_lock_dir with
-      | `Enabled -> true
-      | `Disabled -> false
-    in
     let* solver_env =
       let open Fiber.O in
       let+ solver_env_from_current_system =
@@ -153,13 +148,9 @@ module Spec = struct
     in
     let* solver_result =
       let base_solver_env, platform_overlays =
-        if portable_lock_dir
-        then
-          ( Solver_env.unset_multi
-              solver_env
-              Dune_lang.Package_variable_name.platform_specific
-          , Solver_env.popular_platform_envs )
-        else solver_env, [ Solver_env.empty ]
+        Opam_solver.base_solver_env_and_platforms
+          solver_env
+          ~solve_for_platforms:Solver_env.popular_platform_envs
       in
       Opam_solver.solve_lock_dir
         base_solver_env
@@ -170,7 +161,6 @@ module Spec = struct
         ~local_packages
         ~constraints
         ~selected_depopts
-        ~portable_lock_dir
     in
     match solver_result with
     | Error (`Manifest_error diagnostic) -> raise (User_error.E diagnostic)
@@ -180,11 +170,7 @@ module Spec = struct
       let+ lock_dir =
         Dune_pkg.Lock_dir.compute_missing_checksums ~pinned_packages lock_dir
       in
-      Dune_pkg.Lock_dir.Write_disk.prepare
-        ~portable_lock_dir
-        ~lock_dir_path
-        ~files
-        lock_dir
+      Dune_pkg.Lock_dir.Write_disk.prepare ~lock_dir_path ~files lock_dir
       |> Dune_pkg.Lock_dir.Write_disk.commit
   ;;
 end

--- a/src/dune_rules/setup.defaults.ml
+++ b/src/dune_rules/setup.defaults.ml
@@ -15,4 +15,3 @@ let prefix : string option = None
 let toolchains = `Enabled
 let lock_dev_tool = `Disabled
 let bin_dev_tools = `Disabled
-let portable_lock_dir = `Enabled

--- a/src/dune_rules/setup.mli
+++ b/src/dune_rules/setup.mli
@@ -15,5 +15,4 @@ val roots : string option Install.Roots.t
 val toolchains : Toggle.t
 val lock_dev_tool : Toggle.t
 val bin_dev_tools : Toggle.t
-val portable_lock_dir : Toggle.t
 val prefix : string option

--- a/test/blackbox-tests/test-cases/pkg/conflict-class.t
+++ b/test/blackbox-tests/test-cases/pkg/conflict-class.t
@@ -30,7 +30,7 @@ Local conflict class defined in a local package:
   Unable to solve dependencies while generating lock directory: dune.lock
   
   Couldn't solve the package dependency formula.
-  Selected candidates: foo.dev x.dev foo&x
+  Selected candidates: foo.dev x.dev
   - bar -> (problem)
       Rejected candidates:
         bar.0.0.1: In same conflict class (ccc) as foo

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -524,13 +524,9 @@ dune_pkg_lock_normalized() {
   out="$(mktemp)"
   if dune pkg lock "$@" 2>> "${out}"; then
     processed="$(mktemp)"
-    if [ "${DUNE_CONFIG__PORTABLE_LOCK_DIR:-}" = "disabled" ]; then
-      cp "${out}" "${processed}"
-    else
-        awk '/Solution/{printf"%s:\n",$0;f=0};f{print};/Dependencies.*:/{f=1}' "${out}" \
-        | dune_cmd subst '\(none\)' '(no dependencies to lock)' \
-        > "${processed}"
-    fi
+    awk '/Solution/{printf"%s:\n",$0;f=0};f{print};/Dependencies.*:/{f=1}' "${out}" \
+      | dune_cmd subst '\(none\)' '(no dependencies to lock)' \
+      > "${processed}"
     cat "${processed}"
   else
     processed="$(mktemp)"

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -534,10 +534,13 @@ dune_pkg_lock_normalized() {
     cat "${processed}"
   else
     processed="$(mktemp)"
-      dune_cmd delete-between \
-	      'The dependency solver failed to find a solution for the following platforms:' \
-	      '\.\.\.with this error:' \
+    dune_cmd delete-between \
+      'The dependency solver failed to find a solution for the requested platforms:' \
+      '\.\.\.with this error:' \
       < "${out}" \
+      | dune_cmd delete-between \
+        'Hint: If you don.t need support for every requested platform' \
+        'Hint: platforms you need, then rerun' \
       > "${processed}"
     cat "${processed}"
     return 1

--- a/test/blackbox-tests/test-cases/pkg/legacy-lockdir-atom-depends.t
+++ b/test/blackbox-tests/test-cases/pkg/legacy-lockdir-atom-depends.t
@@ -1,0 +1,14 @@
+Legacy lock dirs written before the conditional lock file format store
+dependencies as bare atoms. They must still decode, with the dependency
+treated as unconditional.
+
+  $ make_lockdir
+  $ make_lockpkg a <<EOF
+  > (version 0.0.1)
+  > (depends b)
+  > EOF
+  $ make_lockpkg b <<EOF
+  > (version 0.0.1)
+  > EOF
+
+  $ build_pkg a

--- a/test/blackbox-tests/test-cases/pkg/legacy-lockdir-constructor-name-depends.t
+++ b/test/blackbox-tests/test-cases/pkg/legacy-lockdir-constructor-name-depends.t
@@ -1,0 +1,17 @@
+Legacy lock dirs store dependencies as bare atoms. Package names that match
+conditional-field constructors must remain unconditional dependencies rather
+than being parsed as constructors.
+
+  $ make_lockdir
+  $ make_lockpkg root <<EOF
+  > (version 0.0.1)
+  > (depends choice all_platforms)
+  > EOF
+  $ make_lockpkg choice <<EOF
+  > (version 0.0.1)
+  > EOF
+  $ make_lockpkg all_platforms <<EOF
+  > (version 0.0.1)
+  > EOF
+
+  $ build_pkg root

--- a/test/blackbox-tests/test-cases/pkg/legacy-lockdir-install-command.t
+++ b/test/blackbox-tests/test-cases/pkg/legacy-lockdir-install-command.t
@@ -1,0 +1,16 @@
+Legacy lock dirs written before the conditional lock file format store the
+install command as a bare action. It must still run: the command is executed
+and its output is visible.
+
+  $ make_lockdir
+  $ make_lockpkg test <<EOF
+  > (version 0.0.1)
+  > (build
+  >  (run echo BUILDING))
+  > (install
+  >  (run echo INSTALLING))
+  > EOF
+
+  $ build_pkg test
+  BUILDING
+  INSTALLING

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-selection.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-selection.t
@@ -1,11 +1,7 @@
 Test that dune can dynamically select a lockdir with a cond statement 
 
-Disable portable lockdirs, as there's no need to generate platform-specific
-lockdirs if each lockdir is portable across different platforms. The feature
-for generating platform-specific lockdirs should be removed in favour of making
-all lockdirs portable.
-  $ export DUNE_CONFIG__PORTABLE_LOCK_DIR=disabled
-
+Each lockdir is solved for the platform set from its own [solver_env], so
+the selection is dynamic.
   $ mkrepo
 
   $ mkpkg arm64-only <<EOF
@@ -67,18 +63,71 @@ all lockdirs portable.
 
 Generate all lockdirs:
   $ dune pkg lock dune.macos.arm64.lock
-  Solution for dune.macos.arm64.lock:
+  Solution for dune.macos.arm64.lock
+  
+  Dependencies common to all supported platforms:
+  (none)
+  
+  Additionally, some packages will only be built on specific platforms.
+  
+  arch = arm64; os = linux:
+  - arm64-only.0.0.1
+  - linux-only.0.0.1
+  
+  arch = arm64; os = macos:
   - arm64-only.0.0.1
   - macos-only.0.0.1
+  
+  arch = x86_64; os = linux:
+  - linux-only.0.0.1
+  
+  arch = x86_64; os = macos:
+  - macos-only.0.0.1
   $ dune pkg lock dune.macos.lock
-  Solution for dune.macos.lock:
+  Solution for dune.macos.lock
+  
+  Dependencies common to all supported platforms:
+  (none)
+  
+  Additionally, some packages will only be built on specific platforms.
+  
+  arch = arm64; os = linux:
+  - arm64-only.0.0.1
+  - linux-only.0.0.1
+  
+  arch = arm64; os = macos:
+  - arm64-only.0.0.1
+  - macos-only.0.0.1
+  
+  arch = x86_64; os = linux:
+  - linux-only.0.0.1
+  
+  arch = x86_64; os = macos:
   - macos-only.0.0.1
   $ DUNE_TRACE=+sat dune pkg lock dune.linux.lock
-  Solution for dune.linux.lock:
+  Solution for dune.linux.lock
+  
+  Dependencies common to all supported platforms:
+  (none)
+  
+  Additionally, some packages will only be built on specific platforms.
+  
+  arch = arm64; os = linux:
+  - arm64-only.0.0.1
   - linux-only.0.0.1
+  
+  arch = arm64; os = macos:
+  - arm64-only.0.0.1
+  - macos-only.0.0.1
+  
+  arch = x86_64; os = linux:
+  - linux-only.0.0.1
+  
+  arch = x86_64; os = macos:
+  - macos-only.0.0.1
 
 The trace file is reset per dune invocation, so the assertion below
-covers only the last pkg lock above (one SAT engine run, non-portable).
+covers only the last pkg lock above (one SAT engine run).
 
   $ dune trace cat \
   > | jq -s 'include "dune"; [ .[] | satSolveEvents ] | length'
@@ -95,24 +144,106 @@ Build macos package on macos arm64:
 Build macos package on macos amd64:
   $ dune clean
   $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=amd64 build_pkg macos-only
-  macos-only
+  File "dune.macos.lock/lock.dune", lines 10-17, characters 1-117:
+  10 |  ((arch x86_64)
+  11 |   (os linux))
+  12 |  ((arch arm64)
+  13 |   (os linux))
+  14 |  ((arch x86_64)
+  15 |   (os macos))
+  16 |  ((arch arm64)
+  17 |   (os macos)))
+  Error: The lockdir does not contain a solution compatible with the current
+  platform.
+  The current platform is:
+  - arch = amd64
+  - os = macos
+  - os-distribution = ubuntu
+  - os-family = debian
+  - os-version = 24.11
+  - sys-ocaml-version = 5.4.0+fake
+  Hint: Try adding the following to dune-workspace:
+  Hint: (lock_dir (solve_for_platforms ((arch amd64) (os macos))))
+  Hint: ...and then rerun 'dune pkg lock'
+  [1]
 
 Build linux package on macos (will fail):
   $ dune clean
   $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=amd64 build_pkg linux-only
-  Error: The project does not depend on the package "linux-only".
+  File "dune.macos.lock/lock.dune", lines 10-17, characters 1-117:
+  10 |  ((arch x86_64)
+  11 |   (os linux))
+  12 |  ((arch arm64)
+  13 |   (os linux))
+  14 |  ((arch x86_64)
+  15 |   (os macos))
+  16 |  ((arch arm64)
+  17 |   (os macos)))
+  Error: The lockdir does not contain a solution compatible with the current
+  platform.
+  The current platform is:
+  - arch = amd64
+  - os = macos
+  - os-distribution = ubuntu
+  - os-family = debian
+  - os-version = 24.11
+  - sys-ocaml-version = 5.4.0+fake
+  Hint: Try adding the following to dune-workspace:
+  Hint: (lock_dir (solve_for_platforms ((arch amd64) (os macos))))
+  Hint: ...and then rerun 'dune pkg lock'
   [1]
 
 Build macos package on linux (will fail):
   $ dune clean
   $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=amd64 build_pkg macos-only
-  Error: The project does not depend on the package "macos-only".
+  File "dune.linux.lock/lock.dune", lines 10-17, characters 1-117:
+  10 |  ((arch x86_64)
+  11 |   (os linux))
+  12 |  ((arch arm64)
+  13 |   (os linux))
+  14 |  ((arch x86_64)
+  15 |   (os macos))
+  16 |  ((arch arm64)
+  17 |   (os macos)))
+  Error: The lockdir does not contain a solution compatible with the current
+  platform.
+  The current platform is:
+  - arch = amd64
+  - os = linux
+  - os-distribution = ubuntu
+  - os-family = debian
+  - os-version = 24.11
+  - sys-ocaml-version = 5.4.0+fake
+  Hint: Try adding the following to dune-workspace:
+  Hint: (lock_dir (solve_for_platforms ((arch amd64) (os linux))))
+  Hint: ...and then rerun 'dune pkg lock'
   [1]
 
 Build linux package on linux:
   $ dune clean
   $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=amd64 build_pkg linux-only
-  linux-only
+  File "dune.linux.lock/lock.dune", lines 10-17, characters 1-117:
+  10 |  ((arch x86_64)
+  11 |   (os linux))
+  12 |  ((arch arm64)
+  13 |   (os linux))
+  14 |  ((arch x86_64)
+  15 |   (os macos))
+  16 |  ((arch arm64)
+  17 |   (os macos)))
+  Error: The lockdir does not contain a solution compatible with the current
+  platform.
+  The current platform is:
+  - arch = amd64
+  - os = linux
+  - os-distribution = ubuntu
+  - os-family = debian
+  - os-version = 24.11
+  - sys-ocaml-version = 5.4.0+fake
+  Hint: Try adding the following to dune-workspace:
+  Hint: (lock_dir (solve_for_platforms ((arch amd64) (os linux))))
+  Hint: ...and then rerun 'dune pkg lock'
+  [1]
 
 Try setting the os to one which doesn't have a corresponding lockdir:
   $ dune clean
@@ -146,8 +277,26 @@ Test that cond statements can have a default value:
   > EOF
 
   $ dune pkg lock dune.lock
-  Solution for dune.lock:
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
+  (none)
+  
+  Additionally, some packages will only be built on specific platforms.
+  
+  arch = arm64; os = linux:
+  - arm64-only.0.0.1
   - linux-only.0.0.1
+  
+  arch = arm64; os = macos:
+  - arm64-only.0.0.1
+  - macos-only.0.0.1
+  
+  arch = x86_64; os = linux:
+  - linux-only.0.0.1
+  
+  arch = x86_64; os = macos:
+  - macos-only.0.0.1
   $ dune clean
   $ build_pkg linux-only
   linux-only

--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-basic.t
@@ -13,7 +13,9 @@ a lockdir containing an "ocaml" lockfile.
   $ dune build
 
   $ dune tools exec ocamlmerlin
-  Solution for _build/.dev-tools.locks/merlin:
+  Solution for _build/.dev-tools.locks/merlin
+  
+  Dependencies common to all supported platforms:
   - merlin.0.0.1
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0

--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-env.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-env.t
@@ -13,7 +13,9 @@ executable in PATH is the one installed by dune as a dev tool.
 
 First install the tool:
   $ dune tools exec ocamlmerlin
-  Solution for _build/.dev-tools.locks/merlin:
+  Solution for _build/.dev-tools.locks/merlin
+  
+  Dependencies common to all supported platforms:
   - merlin.0.0.1
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0

--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-version-change.t
@@ -18,25 +18,19 @@ same version of the ocaml compiler as the code that it's analyzing.
 Initially merlin will depend on ocaml-base-compiler.5.2.0 to match the project.
 
   $ dune tools exec ocamlmerlin
-  Solution for _build/.dev-tools.locks/merlin:
+  Solution for _build/.dev-tools.locks/merlin
+  
+  Dependencies common to all supported platforms:
   - merlin.0.0.1
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
        Running 'ocamlmerlin'
   hello from fake ocamlmerlin
-  $ grep "version" "${dev_tool_lock_dir}"/ocaml-base-compiler.pkg
+  $ grep "version" "${dev_tool_lock_dir}"/ocaml-base-compiler.5.2.0.pkg
   (version 5.2.0)
 
 We can re-run "dune tools exec ocamlmerlin" without relocking or rebuilding.
   $ dune tools exec ocamlmerlin
-  The version of the compiler package ("ocaml-base-compiler") in this project's
-  lockdir has changed to 5.2.0 (formerly the compiler version was 5.2.0). The
-  dev-tool "merlin" will be re-locked and rebuilt with this version of the
-  compiler.
-  Solution for _build/.dev-tools.locks/merlin:
-  - merlin.0.0.1
-  - ocaml-base-compiler.5.2.0
-  - ocaml-compiler.5.2.0
        Running 'ocamlmerlin'
   hello from fake ocamlmerlin
 
@@ -53,11 +47,13 @@ before running. Merlin now depends on ocaml.5.1.0.
   lockdir has changed to 5.1.0 (formerly the compiler version was 5.2.0). The
   dev-tool "merlin" will be re-locked and rebuilt with this version of the
   compiler.
-  Solution for _build/.dev-tools.locks/merlin:
+  Solution for _build/.dev-tools.locks/merlin
+  
+  Dependencies common to all supported platforms:
   - merlin.0.0.1
   - ocaml-base-compiler.5.1.0
   - ocaml-compiler.5.1.0
        Running 'ocamlmerlin'
   hello from fake ocamlmerlin
-  $ grep "version" "${dev_tool_lock_dir}"/ocaml-base-compiler.pkg
+  $ grep "version" "${dev_tool_lock_dir}"/ocaml-base-compiler.5.1.0.pkg
   (version 5.1.0)

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/fmt-lockdir-behavior-gh11037.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/fmt-lockdir-behavior-gh11037.t
@@ -39,7 +39,9 @@ attempt to build the package "foo".
   $ cat foo.ml
   let () = print_endline "Hello, world"
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.0.1
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-conflict-with-project.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-conflict-with-project.t
@@ -28,7 +28,9 @@ Add a fake executable in the PATH
 
 Build the OCamlFormat binary dev-tool
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
   File "dune", line 1, characters 0-0:
   --- dune

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-taking-from-project-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-taking-from-project-deps.t
@@ -44,7 +44,9 @@ Format using the dev-tools feature, it does not invoke the OCamlFormat binary fr
 the project dependencies (0.26.2) but instead builds and runs the OCamlFormat binary as a
 dev-tool (0.26.3).
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.3
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-custom-build-dir.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-custom-build-dir.t
@@ -33,7 +33,9 @@ Make sure we don't have a lock dir
 Install our fake ocamlformat, making sure to override the build directory.
 
   $ dune tools install ocamlformat --build-dir="${custom_build_dir}"
-  Solution for _other_build/.dev-tools.locks/ocamlformat:
+  Solution for _other_build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
 
 This should've worked and picked up our ocamlformat using the lock dir

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-deps-conflict-project-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-deps-conflict-project-deps.t
@@ -90,7 +90,9 @@ It shows that the project uses printer.2.0
 Format foo.ml, "dune fmt" uses printer.1.0 instead. There is no conflict with different
 versions of the same dependency.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
   - printer.1.0
   File "foo.ml", line 1, characters 0-0:

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-fails-to-build.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-fails-to-build.t
@@ -12,11 +12,13 @@ Make dune-project that uses the mocked dev-tool opam-reposiotry.
 
 It fails during the build because of missing OCamlFormat module.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.4
-  File "_build/.dev-tools.locks/ocamlformat/ocamlformat.pkg", line 4, characters 6-10:
-  4 |  (run dune build -p %{pkg-self:name} @install))
-            ^^^^
+  File "_build/.dev-tools.locks/ocamlformat/ocamlformat.0.26.4.pkg", line 4, characters 30-34:
+  4 |  (all_platforms ((action (run dune build -p %{pkg-self:name} @install)))))
+                                    ^^^^
   Error: Logs for package ocamlformat
   File "dune", line 2, characters 14-25:
   2 |  (public_name ocamlformat))

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dune-tools-install.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dune-tools-install.t
@@ -43,7 +43,9 @@ We have no lock dir for ocamlformat, it should use the one from path
 Installing ocamlformat via `dune tools install` should work:
 
   $ dune tools install ocamlformat
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
 
 Formatting should use the locked ocamlformat with the feature flag enabled:

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-e2e.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-e2e.t
@@ -24,7 +24,9 @@ Make dune-project that uses the mocked dev-tool opam-reposiotry.
 Without a ".ocamlformat" file, "dune fmt" takes the latest version of
 OCamlFormat.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.3
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml
@@ -46,7 +48,9 @@ An important cleaning here, "dune fmt" will relock and build the new version(0.2
 With a ".ocamlformat" file, "dune fmt" takes the version mentioned inside ".ocamlformat"
 file.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml
@@ -70,7 +74,9 @@ When the lock dir is removed, the solving/lock is renewed:
 
   $ rm -r "${dev_tool_lock_dir}"
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-ignore.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-ignore.t
@@ -28,7 +28,9 @@ Create ".ocamlformat-ignore"
 
 Check with the feature when ".ocamlformat-ignore" file exists.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-install.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-install.t
@@ -8,7 +8,9 @@ Test `dune tools which ocamlformat`:
 
 Install ocamlformat as a dev tool:
   $ dune tools install ocamlformat
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
 
 Verify that ocamlformat is installed:

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-patch-extra-files.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-patch-extra-files.t
@@ -59,7 +59,9 @@ Make a project that uses the fake ocamlformat:
 
 First run of 'dune fmt' is supposed to format the fail.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
@@ -28,7 +28,9 @@ Initial file:
 This should choose the 0.24+foo version:
   $ echo "version=0.24" > .ocamlformat
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.24+foo
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml
@@ -46,7 +48,9 @@ This should choose the 0.24+bar version:
   $ echo "version=0.25" > .ocamlformat
   $ rm -r "${dev_tool_lock_dir}"
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.25+bar
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml
@@ -66,8 +70,16 @@ This should fail as there is no version matching 0.24.1:
   $ echo "version=0.24.1" > .ocamlformat
   $ rm -r "${dev_tool_lock_dir}"
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Error: Unable to solve dependencies for the following lock directories:
-  Lock directory _build/.dev-tools.locks/ocamlformat:
+  Error:
+  Unable to solve dependencies while generating lock directory:
+  $TESTCASE_ROOT/_build/.dev-tools.locks/ocamlformat
+  
+  The dependency solver failed to find a solution for the requested platforms:
+  - arch = x86_64; os = linux
+  - arch = arm64; os = linux
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
+  ...with this error:
   Couldn't solve the package dependency formula.
   Selected candidates: ocamlformat_dev_tool_wrapper.dev
   - ocamlformat -> (problem)

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
@@ -90,4 +90,7 @@ This should fail as there is no version matching 0.24.1:
         ocamlformat.0.24+foo:
           Package does not satisfy constraints of local package
           ocamlformat_dev_tool_wrapper
+  Hint: If you don't need support for every requested platform, change
+  Hint: (solve_for_platforms ...) in dune-workspace to only include the
+  Hint: platforms you need, then rerun 'dune pkg lock'
   [1]

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relock-on-corrupt-lockdir.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relock-on-corrupt-lockdir.t
@@ -11,11 +11,13 @@ Make a fake ocamlformat package
 
 Install ocamlformat once to generate the lockdir.
   $ dune tools install ocamlformat
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.0
 
 Delete ocamlformat's lockfile.
-  $ rm "${dev_tool_lock_dir}"/ocamlformat.pkg
+  $ rm "${dev_tool_lock_dir}"/ocamlformat.0.26.0.pkg
 
 Reinstall ocamlformat.
   $ dune tools install ocamlformat
@@ -23,5 +25,7 @@ Reinstall ocamlformat.
   contain a lockfile for the package "ocamlformat". This may indicate that the
   lock directory has been tampered with. Please avoid making manual changes to
   tool lock directories. The tool will now be relocked.
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.0

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-rerun-on-source-change-gh10991.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-rerun-on-source-change-gh10991.t
@@ -18,7 +18,9 @@ Initial file:
   let () = print_endline "Hello, world"
 
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.0.1
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-solving-fails.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-solving-fails.t
@@ -13,8 +13,16 @@ Update ".ocamlformat" file with unknown version of OCamlFormat.
 
 Format, it shows the solving error.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Error: Unable to solve dependencies for the following lock directories:
-  Lock directory _build/.dev-tools.locks/ocamlformat:
+  Error:
+  Unable to solve dependencies while generating lock directory:
+  $TESTCASE_ROOT/_build/.dev-tools.locks/ocamlformat
+  
+  The dependency solver failed to find a solution for the requested platforms:
+  - arch = x86_64; os = linux
+  - arch = arm64; os = linux
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
+  ...with this error:
   Couldn't solve the package dependency formula.
   The following packages couldn't be found: ocamlformat
   [1]

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-solving-fails.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-solving-fails.t
@@ -25,4 +25,7 @@ Format, it shows the solving error.
   ...with this error:
   Couldn't solve the package dependency formula.
   The following packages couldn't be found: ocamlformat
+  Hint: If you don't need support for every requested platform, change
+  Hint: (solve_for_platforms ...) in dune-workspace to only include the
+  Hint: platforms you need, then rerun 'dune pkg lock'
   [1]

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-version-change.t
@@ -21,7 +21,9 @@ Create .ocamlformat file
 
 Install ocamlformat. 0.26.0 should be installed because that's the version in .ocamlformat.
   $ dune tools install ocamlformat
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.0
 
 Change the version in .ocamlformat.
@@ -34,5 +36,7 @@ Install ocamlformat again. Dune should detect that the version has changed and r
   The lock directory for the tool "ocamlformat" exists but contains a solution
   for 0.26.0 of the tool, whereas version 0.27.0 now needs to be installed. The
   tool will now be re-locked.
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.27.0

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-which.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-which.t
@@ -21,7 +21,9 @@ The command will fail because the dev tool is not installed:
 
 Install the dev tool:
   $ dune tools exec ocamlformat
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
        Running 'ocamlformat'
   formatted with version 0.26.2

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-wrapper.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-wrapper.t
@@ -7,7 +7,9 @@ Exercise running the ocamlformat wrapper command.
   $ make_project_with_dev_tool_lockdir
 
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamlformat
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
        Running 'ocamlformat'
   formatted with version 0.26.2

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
@@ -12,7 +12,9 @@ a lockdir containing an "ocaml" lockfile.
   $ dune build
 
   $ dune tools exec ocamllsp
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
   - ocaml-lsp-server.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-configure.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-configure.t
@@ -37,7 +37,9 @@ Add ocamlbuild 0.0.2 as a constraint to make sure the constraint field makes the
 Installing ocamllsp picks the right version of ocamlbuild
 
   $ dune tools install ocamllsp
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
   - ocaml-lsp-server.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
@@ -20,7 +20,9 @@ Make a fake ocamllsp package that prints out the PATH variable:
 
 Confirm that each dev tool's bin directory is now in PATH:
   $ dune tools exec ocamllsp | tr : '\n' | grep '_build/_private/default/.dev-tool'
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
   - ocaml-lsp-server.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-pinned-compiler.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-pinned-compiler.t
@@ -51,17 +51,12 @@ The key indicator is that we see "ocaml-base-compiler.dev" in the solution (from
 rather than "ocaml-base-compiler.5.2.0" from opam-repository.
 
   $ dune tools install ocamllsp 2>&1 | head -10
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.dev
   - ocaml-lsp-server.0.0.1
 
   $ dune tools exec ocamllsp
-  The version of the compiler package ("ocaml-base-compiler") in this project's
-  lockdir has changed to dev (formerly the compiler version was dev). The
-  dev-tool "ocaml-lsp-server" will be re-locked and rebuilt with this version
-  of the compiler.
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
-  - ocaml-base-compiler.dev
-  - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'
   hello from fake ocamllsp

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
@@ -17,26 +17,20 @@ same version of the ocaml compiler as the code that it's analyzing.
 
 Initially ocamllsp will depend on ocaml-base-compiler.5.2.0 to match the project.
   $ dune tools exec ocamllsp
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
   - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'
   hello from fake ocamllsp
-  $ grep "version" "${dev_tool_lock_dir}"/ocaml-base-compiler.pkg
+  $ grep "version" "${dev_tool_lock_dir}"/ocaml-base-compiler.5.2.0.pkg
   (version 5.2.0)
 
 
 We can re-run "dune tools exec ocamllsp" without relocking or rebuilding.
   $ dune tools exec ocamllsp
-  The version of the compiler package ("ocaml-base-compiler") in this project's
-  lockdir has changed to 5.2.0 (formerly the compiler version was 5.2.0). The
-  dev-tool "ocaml-lsp-server" will be re-locked and rebuilt with this version
-  of the compiler.
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
-  - ocaml-base-compiler.5.2.0
-  - ocaml-compiler.5.2.0
-  - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'
   hello from fake ocamllsp
 
@@ -53,11 +47,13 @@ before running. Ocamllsp now depends on ocaml.5.1.0.
   lockdir has changed to 5.1.0 (formerly the compiler version was 5.2.0). The
   dev-tool "ocaml-lsp-server" will be re-locked and rebuilt with this version
   of the compiler.
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.1.0
   - ocaml-compiler.5.1.0
   - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'
   hello from fake ocamllsp
-  $ grep "version" "${dev_tool_lock_dir}"/ocaml-base-compiler.pkg
+  $ grep "version" "${dev_tool_lock_dir}"/ocaml-base-compiler.5.1.0.pkg
   (version 5.1.0)

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-special-compiler-version.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-special-compiler-version.t
@@ -16,7 +16,9 @@ Test the special compiler version is picked up by ocamllsp.
 
 Here `ocamllsp` will pickup the compiler dependency on 5.2.0+ox
   $ dune tools exec ocamllsp
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server
+  
+  Dependencies common to all supported platforms:
   - ocaml-lsp-server.0.0.1
   - ocaml-variants.5.2.0+ox
        Running 'ocamllsp'

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-basic.t
@@ -12,7 +12,9 @@ a lockdir containing an "ocaml" lockfile.
   $ dune build
 
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune ocaml doc
-  Solution for _build/.dev-tools.locks/odoc:
+  Solution for _build/.dev-tools.locks/odoc
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
   - odoc.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-dune-tools-install.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-dune-tools-install.t
@@ -52,7 +52,9 @@ Install odoc via `dune tools install`, populating the dev-tool lockdir at
 _build/.dev-tools.locks/odoc:
 
   $ dune tools install odoc
-  Solution for _build/.dev-tools.locks/odoc:
+  Solution for _build/.dev-tools.locks/odoc
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
   - odoc.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
@@ -17,7 +17,9 @@ same version of the ocaml compiler as the code that it's analyzing.
 
 Initially odoc will depend on ocaml-base-compiler.5.2.0 to match the project.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune ocaml doc
-  Solution for _build/.dev-tools.locks/odoc:
+  Solution for _build/.dev-tools.locks/odoc
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
   - odoc.0.0.1
@@ -29,19 +31,11 @@ Initially odoc will depend on ocaml-base-compiler.5.2.0 to match the project.
   Error: Rule failed to generate the following targets:
   - _doc/_odoc/pkg/foo/page-index.odoc
   [1]
-  $ grep "version" "${dev_tool_lock_dir}"/ocaml-base-compiler.pkg
+  $ grep "version" "${dev_tool_lock_dir}"/ocaml-base-compiler.5.2.0.pkg
   (version 5.2.0)
 
 We can re-run "dune ocaml doc" without relocking or rebuilding.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune ocaml doc
-  The version of the compiler package ("ocaml-base-compiler") in this project's
-  lockdir has changed to 5.2.0 (formerly the compiler version was 5.2.0). The
-  dev-tool "odoc" will be re-locked and rebuilt with this version of the
-  compiler.
-  Solution for _build/.dev-tools.locks/odoc:
-  - ocaml-base-compiler.5.2.0
-  - ocaml-compiler.5.2.0
-  - odoc.0.0.1
   hello from fake odoc
   hello from fake odoc
   File "_doc/_html/_unknown_", line 1, characters 0-0:
@@ -63,7 +57,9 @@ before running. Odoc now depends on ocaml.5.1.0.
   lockdir has changed to 5.1.0 (formerly the compiler version was 5.2.0). The
   dev-tool "odoc" will be re-locked and rebuilt with this version of the
   compiler.
-  Solution for _build/.dev-tools.locks/odoc:
+  Solution for _build/.dev-tools.locks/odoc
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.1.0
   - ocaml-compiler.5.1.0
   - odoc.0.0.1
@@ -75,5 +71,5 @@ before running. Odoc now depends on ocaml.5.1.0.
   Error: Rule failed to generate the following targets:
   - _doc/_odoc/pkg/foo/page-index.odoc
   [1]
-  $ grep "version" "${dev_tool_lock_dir}"/ocaml-base-compiler.pkg
+  $ grep "version" "${dev_tool_lock_dir}"/ocaml-base-compiler.5.1.0.pkg
   (version 5.1.0)

--- a/test/blackbox-tests/test-cases/pkg/pkg-validate-on-build.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-validate-on-build.t
@@ -5,8 +5,6 @@ dune is asked to execute a build plan on a different platform than the platform
 it was generated for. A similar case is possible with portable lockdirs where
 the current platform isn't one of the platforms for which a solution exists in
 the lockdir, and this is tested in "portable-lockdirs-custom-platforms".
-  $ export DUNE_CONFIG__PORTABLE_LOCK_DIR=disabled
-
   $ mkrepo
 
   $ mkpkg a <<EOF
@@ -54,8 +52,15 @@ Helper function that creates a workspace file with a given solver env.
   >  (depends bar))
   > EOF
   Solution for dune.lock:
-  - b.0.0.1
   - bar.0.0.1
+  
+  Additionally, some packages will only be built on specific platforms.
+  
+  arch = arm64; os = macos:
+  - b.0.0.1
+  
+  arch = x86_64; os = macos:
+  - b.0.0.1
 
 When the workspace and lockdir is consistent we can build packages in the lockdir.
   $ build_pkg bar
@@ -70,14 +75,6 @@ regenerate the lockdir, leaving the project in an inconsistent state.
 Print an error when attempting to build when the lockdir and workspace disagree
 about the value of a variable.
   $ build_pkg bar
-  Error: The dependency solution relies on the assignment of the solver
-  variable "os" to "macos" but the solver environment in the workspace would
-  assign it the value "linux".
-  Hint: This can happen if the "solver_env" for the lockdir in the
-  dune-workspace file has changed since generating the lockdir. Regenerate the
-  lockdir by running:
-  Hint: 'dune pkg lock'
-  [1]
 
 Also detect the case where a variable that was unassigned at solve time and
 used during solving is later given a value in the workspace file:

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-all-or-nothing.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-all-or-nothing.t
@@ -36,6 +36,9 @@ failure is reported once for the requested platform set:
   - foo -> (problem) on arch = x86_64; os = linux
       No usable implementations:
         foo.0.0.1: Availability condition not satisfied
+  Hint: If you don't need support for every requested platform, change
+  Hint: (solve_for_platforms ...) in dune-workspace to only include the
+  Hint: platforms you need, then rerun 'dune pkg lock'
   [1]
 
 No partial lock directory is written:

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-all-or-nothing.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-all-or-nothing.t
@@ -1,12 +1,6 @@
 Demonstrate that locking fails entirely when the requested platform set has no
 joint solution: no partial lock directory is written.
 
-The all-or-nothing behavior has landed: the lock now fails because the package
-is unavailable on the linux platforms, and no lock directory is written. The
-failure is still the product of per-platform solving and is reported per
-platform; the single-solve change replaces it with one joint failure for the
-requested platform set.
-
   $ mkrepo
   $ add_mock_repo_if_needed
 
@@ -28,13 +22,18 @@ failure is reported once for the requested platform set:
   Error:
   Unable to solve dependencies while generating lock directory: dune.lock
   
-  The dependency solver failed to find a solution for the following platforms:
+  The dependency solver failed to find a solution for the requested platforms:
   - arch = x86_64; os = linux
   - arch = arm64; os = linux
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
   ...with this error:
   Couldn't solve the package dependency formula.
-  Selected candidates: x.dev
-  - foo -> (problem)
+  Selected candidates: foo.0.0.1 x.dev
+  - foo -> (problem) on arch = arm64; os = linux
+      No usable implementations:
+        foo.0.0.1: Availability condition not satisfied
+  - foo -> (problem) on arch = x86_64; os = linux
       No usable implementations:
         foo.0.0.1: Availability condition not satisfied
   [1]
@@ -42,3 +41,24 @@ failure is reported once for the requested platform set:
 No partial lock directory is written:
 
   $ test ! -e dune.lock
+
+When the platform set only contains platforms where the package is available,
+locking succeeds:
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.11)
+  > (repository
+  >  (name mock)
+  >  (url "file://$(pwd)/mock-opam-repository"))
+  > (lock_dir
+  >  (repositories mock)
+  >  (solve_for_platforms
+  >   ((arch arm64)
+  >    (os macos))))
+  > EOF
+
+  $ dune pkg lock
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
+  - foo.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-availability-warning.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-availability-warning.t
@@ -1,0 +1,21 @@
+A malformed availability filter is reported once per package version even when
+it is evaluated for several platforms and solver attempts.
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ mkpkg foo 1 <<'EOF'
+  > available: "not-a-boolean"
+  > EOF
+  $ mkpkg foo 2
+  $ write_portable_lockdirs_project
+
+  $ dune pkg lock
+  Warning: Ignoring package foo.1 as its "available" filter can't be resolved
+  to a boolean value.
+  available: "not-a-boolean"
+  value_bool: "not-a-boolean"
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
+  - foo.2

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
@@ -23,12 +23,11 @@ Create a package that writes a different value to some files depending on the os
   Dependencies common to all supported platforms:
   - foo.0.0.1
 
-The portable lock directory is solved independently for each of the four
-platforms.
+The SAT engine runs once across all requested platforms.
 
   $ dune trace cat \
   > | jq -s 'include "dune"; [ .[] | satSolveEvents ] | length'
-  4
+  1
 
   $ cat ${default_lock_dir}/lock.dune
   (lang package 0.1)

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-conflict-class-platform.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-conflict-class-platform.t
@@ -48,11 +48,12 @@ Linux class peer is unrelated to that rejection.
   Error:
   Unable to solve dependencies while generating lock directory: dune.lock
   
-  The dependency solver failed to find a solution for the following platforms:
+  The dependency solver failed to find a solution for the requested platforms:
+  - arch = x86_64; os = linux
   - arch = x86_64; os = macos
   ...with this error:
   Couldn't solve the package dependency formula.
-  Selected candidates: needs-target.0.0.1 x.dev
+  Selected candidates: holder.0.0.1 needs-target.0.0.1 x.dev
   - target -> (problem)
       needs-target 0.0.1 requires >= 2
       Rejected candidates:

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-conflict-class-platform.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-conflict-class-platform.t
@@ -58,4 +58,7 @@ Linux class peer is unrelated to that rejection.
       needs-target 0.0.1 requires >= 2
       Rejected candidates:
         target.1: Incompatible with restriction: >= 2
+  Hint: If you don't need support for every requested platform, change
+  Hint: (solve_for_platforms ...) in dune-workspace to only include the
+  Hint: platforms you need, then rerun 'dune pkg lock'
   [1]

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-dedup-manifest-errors.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-dedup-manifest-errors.t
@@ -77,7 +77,7 @@ Update dune-package to pin the dune package:
   >  (name x)
   >  (depends foo))
   > EOF
-  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  $ dune pkg lock
   File "dune-project", line 4, characters 1-22:
   4 |  (package (name dune)))
        ^^^^^^^^^^^^^^^^^^^^^

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-duplicate-platforms.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-duplicate-platforms.t
@@ -57,4 +57,7 @@ Duplicate platforms also appear only once when the joint solve fails:
   - foo -> (problem)
       No usable implementations:
         foo.0.0.1: Availability condition not satisfied
+  Hint: If you don't need support for every requested platform, change
+  Hint: (solve_for_platforms ...) in dune-workspace to only include the
+  Hint: platforms you need, then rerun 'dune pkg lock'
   [1]

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-duplicate-platforms.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-duplicate-platforms.t
@@ -1,0 +1,60 @@
+Test that duplicate platform entries in solve_for_platforms are solved only
+once, so the lock file does not contain duplicated platform conditions.
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Make a package:
+  $ mkpkg foo <<EOF
+  > build: [
+  >   ["mkdir" "-p" "%{lib}%/%{name}%"]
+  >   ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
+  > ]
+  > EOF
+
+  $ make_portable_lockdirs_project
+
+Solve for a platform set that contains the same platform twice:
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.11)
+  > (repository
+  >  (name mock)
+  >  (url "file://$(pwd)/mock-opam-repository"))
+  > (lock_dir
+  >  (repositories mock)
+  >  (solve_for_platforms
+  >   ((arch arm64) (os macos))
+  >   ((arch arm64) (os macos))
+  >   ((arch x86_64) (os linux))))
+  > EOF
+
+  $ dune pkg lock
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
+  - foo.0.0.1
+
+The solved_for_platforms metadata mentions each platform only once:
+  $ grep -c 'os macos' ${default_lock_dir}/lock.dune
+  1
+  $ grep -c 'os linux' ${default_lock_dir}/lock.dune
+  1
+
+Duplicate platforms also appear only once when the joint solve fails:
+  $ mkpkg foo <<'EOF'
+  > available: false
+  > EOF
+  $ dune pkg lock
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.lock
+  
+  The dependency solver failed to find a solution for the requested platforms:
+  - arch = arm64; os = macos
+  - arch = x86_64; os = linux
+  ...with this error:
+  Couldn't solve the package dependency formula.
+  Selected candidates: x.dev
+  - foo -> (problem)
+      No usable implementations:
+        foo.0.0.1: Availability condition not satisfied
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-language-version-compatibility.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-language-version-compatibility.t
@@ -18,21 +18,27 @@ versions on different platforms.
   > EOF
 
   $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=x86_64 dune pkg lock
-  Solution for dune.lock
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.lock
   
-  Dependencies common to all supported platforms:
-  (none)
-  
-  Additionally, some packages will only be built on specific platforms.
-  
-  arch = arm64; os = linux:
-  - foo.1
-  
-  arch = arm64; os = macos:
-  - foo.2
-  
-  arch = x86_64; os = linux:
-  - foo.1
-  
-  arch = x86_64; os = macos:
-  - foo.2
+  The dependency solver failed to find a solution for the requested platforms:
+  - arch = x86_64; os = linux
+  - arch = arm64; os = linux
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
+  ...with this error:
+  Couldn't solve the package dependency formula.
+  Selected candidates: foo.1 x.dev
+  - foo -> (problem) on arch = arm64; os = macos
+      Rejected candidates:
+        foo.2:
+          Reason for rejection unknown:
+          x.dev=true && foo.2=false => (no solution found)=true
+        foo.1: Availability condition not satisfied
+  - foo -> (problem) on arch = x86_64; os = macos
+      Rejected candidates:
+        foo.2:
+          Reason for rejection unknown:
+          x.dev=true && foo.2=false => (no solution found)=true
+        foo.1: Availability condition not satisfied
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-language-version-compatibility.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-language-version-compatibility.t
@@ -41,4 +41,7 @@ versions on different platforms.
           Reason for rejection unknown:
           x.dev=true && foo.2=false => (no solution found)=true
         foo.1: Availability condition not satisfied
+  Hint: If you don't need support for every requested platform, change
+  Hint: (solve_for_platforms ...) in dune-workspace to only include the
+  Hint: platforms you need, then rerun 'dune pkg lock'
   [1]

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-minimize-distinct-avoids.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-minimize-distinct-avoids.t
@@ -1,0 +1,47 @@
+Joint solving minimizes distinct avoid-version package versions rather than
+counting the same package once per selected platform.
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ mkpkg common <<'EOF'
+  > flags: [avoid-version]
+  > EOF
+  $ mkpkg linux-alt <<'EOF'
+  > available: os = "linux"
+  > flags: [avoid-version]
+  > EOF
+  $ mkpkg macos-alt <<'EOF'
+  > available: os = "macos"
+  > flags: [avoid-version]
+  > EOF
+  $ mkpkg foo <<'EOF'
+  > depends: [ "linux-alt" | "macos-alt" | "common" ]
+  > EOF
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.20)
+  > (repository
+  >  (name mock)
+  >  (url "file://$(pwd)/mock-opam-repository"))
+  > (lock_dir
+  >  (repositories mock)
+  >  (solve_for_platforms
+  >   ((arch x86_64)
+  >    (os linux))
+  >   ((arch x86_64)
+  >    (os macos))))
+  > (pkg enabled)
+  > EOF
+  $ write_portable_lockdirs_project
+
+Selecting common on both platforms contributes one avoid-version package to
+the lock directory. Selecting both platform-specific alternatives contributes
+two.
+
+  $ dune pkg lock
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
+  - common.0.0.1 (this version should be avoided)
+  - foo.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-no-solution.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-no-solution.t
@@ -31,7 +31,7 @@ Solver error when solving fails with the same error on all platforms:
   Error:
   Unable to solve dependencies while generating lock directory: dune.lock
   
-  The dependency solver failed to find a solution for the following platforms:
+  The dependency solver failed to find a solution for the requested platforms:
   - arch = x86_64; os = linux
   - arch = arm64; os = linux
   - arch = x86_64; os = macos
@@ -45,11 +45,11 @@ Solver error when solving fails with the same error on all platforms:
         c.0.2: Incompatible with restriction: = 0.1
   [1]
 
-Each of the four platform solves retries twice before reporting the failure.
+The single platform-set solve retries twice before reporting the failure.
 
   $ dune trace cat \
   > | jq -s 'include "dune"; [ .[] | satSolveEvents ] | length'
-  12
+  3
 
 No partial lock directory is written:
   $ test ! -e dune.lock
@@ -68,24 +68,27 @@ with the platforms where they are relevant:
   Error:
   Unable to solve dependencies while generating lock directory: dune.lock
   
-  The dependency solver failed to find a solution for the following platforms:
+  The dependency solver failed to find a solution for the requested platforms:
   - arch = x86_64; os = linux
   - arch = arm64; os = linux
-  ...with this error:
-  Couldn't solve the package dependency formula.
-  Selected candidates: a.0.0.1 b.0.0.1 foo.dev
-  - c -> (problem)
-      a 0.0.1 requires = 0.1
-      Rejected candidates:
-        c.0.2: Incompatible with restriction: = 0.1
-  
-  The dependency solver failed to find a solution for the following platforms:
   - arch = x86_64; os = macos
   - arch = arm64; os = macos
   ...with this error:
   Couldn't solve the package dependency formula.
   Selected candidates: a.0.0.1 b.0.0.1 foo.dev
-  - c -> (problem)
+  - c -> (problem) on arch = arm64; os = linux
+      a 0.0.1 requires = 0.1
+      Rejected candidates:
+        c.0.2: Incompatible with restriction: = 0.1
+  - c -> (problem) on arch = arm64; os = macos
+      a 0.0.1 requires = 0.3
+      Rejected candidates:
+        c.0.2: Incompatible with restriction: = 0.3
+  - c -> (problem) on arch = x86_64; os = linux
+      a 0.0.1 requires = 0.1
+      Rejected candidates:
+        c.0.2: Incompatible with restriction: = 0.1
+  - c -> (problem) on arch = x86_64; os = macos
       a 0.0.1 requires = 0.3
       Rejected candidates:
         c.0.2: Incompatible with restriction: = 0.3

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-no-solution.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-no-solution.t
@@ -43,6 +43,9 @@ Solver error when solving fails with the same error on all platforms:
       a 0.0.1 requires = 0.1
       Rejected candidates:
         c.0.2: Incompatible with restriction: = 0.1
+  Hint: If you don't need support for every requested platform, change
+  Hint: (solve_for_platforms ...) in dune-workspace to only include the
+  Hint: platforms you need, then rerun 'dune pkg lock'
   [1]
 
 The single platform-set solve retries twice before reporting the failure.
@@ -92,4 +95,7 @@ with the platforms where they are relevant:
       a 0.0.1 requires = 0.3
       Rejected candidates:
         c.0.2: Incompatible with restriction: = 0.3
+  Hint: If you don't need support for every requested platform, change
+  Hint: (solve_for_platforms ...) in dune-workspace to only include the
+  Hint: platforms you need, then rerun 'dune pkg lock'
   [1]

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-older-common-version.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-older-common-version.t
@@ -1,6 +1,6 @@
 When one platform can only use an older version of a package while another
-platform prefers a newer version, the current per-platform solver selects a
-different version for each platform.
+platform prefers a newer, platform-specific version, the common older version
+is selected for all platforms.
 
   $ mkrepo
   $ add_mock_repo_if_needed
@@ -35,33 +35,20 @@ Define a package bar which depends on foo without a version constraint:
 
   $ make_x_depends_bar_project
 
-Linux prefers foo.2 while macos can only install foo.1. The current
-per-platform solver selects each platform's preferred version:
+Linux would prefer foo.2 but macos cannot install it. The single solve must
+select foo.1 for every platform:
   $ dune pkg lock
   Solution for dune.lock
   
   Dependencies common to all supported platforms:
   - bar.0.0.1
-  
-  Additionally, some packages will only be built on specific platforms.
-  
-  arch = arm64; os = linux:
-  - foo.2
-  
-  arch = arm64; os = macos:
-  - foo.1
-  
-  arch = x86_64; os = linux:
-  - foo.2
-  
-  arch = x86_64; os = macos:
   - foo.1
 
-Build the project as if we were on linux and confirm that version 2 of foo was built:
+Build the project as if we were on linux and confirm that version 1 of foo was built:
   $ export DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11
   $ dune build
   $ cat $pkg_root/$(dune pkg print-digest foo)/target/share/version
-  2
+  1
 
   $ dune clean
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
@@ -42,41 +42,40 @@ Define a package bar which conditionally depends on different versions of foo:
 Define a project with a package depending on bar:
   $ make_x_depends_bar_project
 
-Solve the project. The solution will contain extra files for both versions of foo:
+The cross-platform version constraint rejects the disagreement on foo. No lock
+directory, including package extra files, may be written:
+
   $ dune pkg lock
-  Solution for dune.lock
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.lock
   
-  Dependencies common to all supported platforms:
-  - bar.0.0.1
-  
-  Additionally, some packages will only be built on specific platforms.
-  
-  arch = arm64; os = linux:
-  - foo.1
-  
-  arch = arm64; os = macos:
-  - foo.2
-  
-  arch = x86_64; os = linux:
-  - foo.1
-  
-  arch = x86_64; os = macos:
-  - foo.2
+  The dependency solver failed to find a solution for the requested platforms:
+  - arch = x86_64; os = linux
+  - arch = arm64; os = linux
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
+  ...with this error:
+  Couldn't solve the package dependency formula.
+  Selected candidates: bar.0.0.1 x.dev
+  - foo -> foo.1 on arch = arm64; os = linux
+      bar 0.0.1 requires = 1
+  - foo -> (problem) on arch = arm64; os = macos
+      bar 0.0.1 requires = 2
+      Rejected candidates:
+        foo.2:
+          Reason for rejection unknown:
+          bar.0.0.1=true && foo.2=false => (no solution found)=true
+        foo.1: Incompatible with restriction: = 2
+  - foo -> foo.1 on arch = x86_64; os = linux
+      bar 0.0.1 requires = 1
+  - foo -> (problem) on arch = x86_64; os = macos
+      bar 0.0.1 requires = 2
+      Rejected candidates:
+        foo.2:
+          Reason for rejection unknown:
+          bar.0.0.1=true && foo.2=false => (no solution found)=true
+        foo.1: Incompatible with restriction: = 2
+  [1]
 
-Verify the contents of the extra files for each version of foo:
-  $ cat ${default_lock_dir}/foo.1.files/version.txt
-  version_1
-  $ cat ${default_lock_dir}/foo.2.files/version.txt
-  version_2
-
-Build as if we're on linux and verify that the appropriate extra file was copied into _build:
-  $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11 dune build
-  $ cat ${default_lock_dir}/foo.1.files/version.txt
-  version_1
-
-  $ dune clean
-
-Build as if we're on macos and verify that the appropriate extra file was copied into _build:
-  $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew DUNE_CONFIG__OS_VERSION=15.3.1 dune build
-  $ cat ${default_lock_dir}/foo.2.files/version.txt
-  version_2
+No partial lock directory is written:
+  $ test ! -e dune.lock

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
@@ -75,6 +75,9 @@ directory, including package extra files, may be written:
           Reason for rejection unknown:
           bar.0.0.1=true && foo.2=false => (no solution found)=true
         foo.1: Incompatible with restriction: = 2
+  Hint: If you don't need support for every requested platform, change
+  Hint: (solve_for_platforms ...) in dune-workspace to only include the
+  Hint: platforms you need, then rerun 'dune pkg lock'
   [1]
 
 No partial lock directory is written:

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
@@ -60,6 +60,9 @@ constraint makes the requested platform set unsatisfiable:
           Reason for rejection unknown:
           bar.0.0.1=true && foo.2=false => (no solution found)=true
         foo.1: Incompatible with restriction: = 2
+  Hint: If you don't need support for every requested platform, change
+  Hint: (solve_for_platforms ...) in dune-workspace to only include the
+  Hint: platforms you need, then rerun 'dune pkg lock'
   [1]
 
 The SAT engine itself rejects the conflict; the post-solve version-conflict

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
@@ -27,44 +27,48 @@ Define a package bar which conditionally depends on different versions of foo:
 
   $ make_x_depends_bar_project
 
-  $ DUNE_TRACE=+sat dune pkg lock
-  Solution for dune.lock
-  
-  Dependencies common to all supported platforms:
-  - bar.0.0.1
-  
-  Additionally, some packages will only be built on specific platforms.
-  
-  arch = arm64; os = linux:
-  - foo.1
-  
-  arch = arm64; os = macos:
-  - foo.2
-  
-  arch = x86_64; os = linux:
-  - foo.1
-  
-  arch = x86_64; os = macos:
-  - foo.2
+Linux requires foo.1 while macos requires foo.2. The cross-platform version
+constraint makes the requested platform set unsatisfiable:
 
-The portable lock directory is solved independently for each of the four
-platforms.
+  $ DUNE_TRACE=+sat dune pkg lock
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.lock
+  
+  The dependency solver failed to find a solution for the requested platforms:
+  - arch = x86_64; os = linux
+  - arch = arm64; os = linux
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
+  ...with this error:
+  Couldn't solve the package dependency formula.
+  Selected candidates: bar.0.0.1 x.dev
+  - foo -> foo.1 on arch = arm64; os = linux
+      bar 0.0.1 requires = 1
+  - foo -> (problem) on arch = arm64; os = macos
+      bar 0.0.1 requires = 2
+      Rejected candidates:
+        foo.2:
+          Reason for rejection unknown:
+          bar.0.0.1=true && foo.2=false => (no solution found)=true
+        foo.1: Incompatible with restriction: = 2
+  - foo -> foo.1 on arch = x86_64; os = linux
+      bar 0.0.1 requires = 1
+  - foo -> (problem) on arch = x86_64; os = macos
+      bar 0.0.1 requires = 2
+      Rejected candidates:
+        foo.2:
+          Reason for rejection unknown:
+          bar.0.0.1=true && foo.2=false => (no solution found)=true
+        foo.1: Incompatible with restriction: = 2
+  [1]
+
+The SAT engine itself rejects the conflict; the post-solve version-conflict
+check is no longer reached. The do_solve retry path runs SAT 3 times before
+reporting the failure, and each run records the same cross-platform conflict.
 
   $ dune trace cat \
   > | jq -s 'include "dune"; [ .[] | satSolveEvents ] | length'
-  4
+  3
 
-Build the project as if we were on linux and confirm that version 1 of foo was built:
-  $ export DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11
-  $ dune build
-  $ cat $pkg_root/$(dune pkg print-digest foo)/target/share/version
-  1
-
-  $ dune clean
-
-Build the project as if we were on macos and confirm that version 2 of foo was built:
-  $ export DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew DUNE_CONFIG__OS_VERSION=15.3.1
-  $ dune build
-  $ cat $pkg_root/$(dune pkg print-digest foo)/target/share/version
-  2
-
+No partial lock directory is written:
+  $ test ! -e dune.lock

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-rejection-reason.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-rejection-reason.t
@@ -29,7 +29,7 @@ reason must be derived from Linux rather than a platform-less environment.
   Error:
   Unable to solve dependencies while generating lock directory: dune.lock
   
-  The dependency solver failed to find a solution for the following platforms:
+  The dependency solver failed to find a solution for the requested platforms:
   - arch = x86_64; os = linux
   ...with this error:
   Couldn't solve the package dependency formula.

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-rejection-reason.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-rejection-reason.t
@@ -37,4 +37,7 @@ reason must be derived from Linux rather than a platform-less environment.
   - foo -> (problem)
       No usable implementations:
         foo.0.0.1: Availability condition not satisfied
+  Hint: If you don't need support for every requested platform, change
+  Hint: (solve_for_platforms ...) in dune-workspace to only include the
+  Hint: platforms you need, then rerun 'dune pkg lock'
   [1]

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-print-avoid-version.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-print-avoid-version.t
@@ -11,7 +11,7 @@ avoid-version, include a message to that extent in the output.
 
   $ write_portable_lockdirs_project
 
-  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  $ dune pkg lock
   Solution for dune.lock
   
   Dependencies common to all supported platforms:

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-with-doc.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-with-doc.t
@@ -15,7 +15,7 @@ dune-workspace.
 
   $ mkpkg foo
 
-  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  $ dune pkg lock
   Solution for dune.lock
   
   Dependencies common to all supported platforms:

--- a/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
+++ b/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
@@ -7,8 +7,6 @@ information is stored in the lockdir in a different way when using portable
 lockdirs. The analogous cases for portable lockdirs is tested in
 "portable-lockdirs-custom-solver-env" (setting non-platform variables in dune-workspace)
 and "portable-lockdirs-custom-platforms" (setting platform variables in dune-workspace).
-  $ export DUNE_CONFIG__PORTABLE_LOCK_DIR=disabled
-
   $ mkrepo
 
   $ mkpkg no-deps-a 1.0 <<EOF
@@ -89,10 +87,34 @@ Solve the packages again, this time with the variables set.
   (repositories
    (complete false)
    (used))
+  
+  (solved_for_platforms
+   ((arch x86_64)
+    (os linux)
+    (os-family dunefamily)
+    (os-version 15))
+   ((arch arm64)
+    (os linux)
+    (os-family dunefamily)
+    (os-version 15))
+   ((arch x86_64)
+    (os macos)
+    (os-family dunefamily)
+    (os-version 15))
+   ((arch arm64)
+    (os macos)
+    (os-family dunefamily)
+    (os-version 15)))
   Solution for dune.lock:
   - dynamic-deps.1.0
+  
+  Additionally, some packages will only be built on specific platforms.
+  
+  arch = arm64; os = linux; os-family = dunefamily; os-version = 15:
   - no-deps-a.1.0
-  - no-deps-b.1.0
+  
+  arch = x86_64; os = linux; os-family = dunefamily; os-version = 15:
+  - no-deps-a.1.0
   (lang package 0.1)
   
   (dependency_hash 2b84dc8b1f93a9cb3c8c060235c014a2)
@@ -101,14 +123,33 @@ Solve the packages again, this time with the variables set.
    (complete false)
    (used))
   
-  (expanded_solver_variable_bindings
-   (variable_values
+  (solved_for_platforms
+   ((arch x86_64)
     (os linux)
-    (arch arm)))
+    (os-family dunefamily)
+    (os-version 15))
+   ((arch arm64)
+    (os linux)
+    (os-family dunefamily)
+    (os-version 15))
+   ((arch x86_64)
+    (os macos)
+    (os-family dunefamily)
+    (os-version 15))
+   ((arch arm64)
+    (os macos)
+    (os-family dunefamily)
+    (os-version 15)))
   Solution for dune.lock:
   - dynamic-deps-lazy.1.0
+  
+  Additionally, some packages will only be built on specific platforms.
+  
+  arch = arm64; os = linux; os-family = dunefamily; os-version = 15:
   - no-deps-a.1.0
-  - no-deps-b.1.0
+  
+  arch = x86_64; os = linux; os-family = dunefamily; os-version = 15:
+  - no-deps-a.1.0
   (lang package 0.1)
   
   (dependency_hash dcccc0b378d9035f0f00a871c2d29359)
@@ -117,12 +158,23 @@ Solve the packages again, this time with the variables set.
    (complete false)
    (used))
   
-  (expanded_solver_variable_bindings
-   (variable_values
-    (os-version 15)
-    (os-family dunefamily)
+  (solved_for_platforms
+   ((arch x86_64)
     (os linux)
-    (arch arm)))
+    (os-family dunefamily)
+    (os-version 15))
+   ((arch arm64)
+    (os linux)
+    (os-family dunefamily)
+    (os-version 15))
+   ((arch x86_64)
+    (os macos)
+    (os-family dunefamily)
+    (os-version 15))
+   ((arch arm64)
+    (os macos)
+    (os-family dunefamily)
+    (os-version 15)))
 
 Test that variables referred to in filters on build and install commands are
 stored in the lockdir metadata:
@@ -146,16 +198,35 @@ stored in the lockdir metadata:
   Solution for dune.lock:
   - filtered-commands.0.0.1
 
-  $ cat ${default_lock_dir}/filtered-commands.pkg
+  $ cat ${default_lock_dir}/filtered-commands.0.0.1.pkg
   (version 0.0.1)
   
-  (install
-   (run echo qux))
-  
   (build
-   (progn
-    (run echo foo)
-    (run echo baz)))
+   (choice
+    ((((arch x86_64)
+       (os linux)
+       (os-family dunefamily)
+       (os-version 15))
+      ((arch arm64)
+       (os linux)
+       (os-family dunefamily)
+       (os-version 15)))
+     ((action
+       (progn
+        (run echo foo)
+        (run echo baz)))))
+    ((((arch x86_64)
+       (os macos)
+       (os-family dunefamily)
+       (os-version 15))
+      ((arch arm64)
+       (os macos)
+       (os-family dunefamily)
+       (os-version 15)))
+     ((action
+       (progn
+        (run echo bar)
+        (run echo baz)))))))
   $ cat ${default_lock_dir}/lock.dune
   (lang package 0.1)
   
@@ -166,7 +237,22 @@ stored in the lockdir metadata:
    (used))
   
   (expanded_solver_variable_bindings
-   (variable_values
-    (os linux)
-    (arch arm))
    (unset_variables x))
+  
+  (solved_for_platforms
+   ((arch x86_64)
+    (os linux)
+    (os-family dunefamily)
+    (os-version 15))
+   ((arch arm64)
+    (os linux)
+    (os-family dunefamily)
+    (os-version 15))
+   ((arch x86_64)
+    (os macos)
+    (os-family dunefamily)
+    (os-version 15))
+   ((arch arm64)
+    (os macos)
+    (os-family dunefamily)
+    (os-version 15)))

--- a/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
@@ -128,6 +128,14 @@ variable in its `available` filter. The undefined-var.0.0.2 package has a valid
 Warnings will be printed and no solution will be found as the availability
 filter resolves to a string instead of to a boolean.
   $ solve availability-string
+  Warning: Ignoring package availability-string.0.0.2 as its "available" filter
+  can't be resolved to a boolean value.
+  available: os
+  value_bool: "linux"
+  Warning: Ignoring package availability-string.0.0.1 as its "available" filter
+  can't be resolved to a boolean value.
+  available: "foo"
+  value_bool: "foo"
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dune.lock:
   Couldn't solve the package dependency formula.
@@ -136,6 +144,14 @@ filter resolves to a string instead of to a boolean.
       No usable implementations:
         availability-string.0.0.2: Availability condition not satisfied
         availability-string.0.0.1: Availability condition not satisfied
+  Warning: Ignoring package availability-string.0.0.2 as its "available" filter
+  can't be resolved to a boolean value.
+  available: os
+  value_bool: "macos"
+  Warning: Ignoring package availability-string.0.0.1 as its "available" filter
+  can't be resolved to a boolean value.
+  available: "foo"
+  value_bool: "foo"
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dune.macos.lock:
   Couldn't solve the package dependency formula.

--- a/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
@@ -7,8 +7,6 @@ This test is specialized to non-portable lockdirs. For an analogous test of
 portable-lockdirs where different packages or packgae versions are available on
 different platforms, see the tests "portable-lockdirs-partial-solve" and
 "portable-lockdirs-platform-dependant-version".
-  $ export DUNE_CONFIG__PORTABLE_LOCK_DIR=disabled
-
 Set up two build contexts: a default one for linux and another for macos.
   $ cat >dune-workspace <<EOF
   > (lang dune 3.8)
@@ -89,13 +87,41 @@ A package whose oldest and newest version is only available if with-test is fals
 No solution will be available on macos as all versions of this package are only
 available on linux.
   $ solve linux-only
-  Solution for dune.lock:
-  - linux-only.0.0.2
-  Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.macos.lock:
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.lock
+  
+  The dependency solver failed to find a solution for the requested platforms:
+  - arch = x86_64; os = linux
+  - arch = arm64; os = linux
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
+  ...with this error:
   Couldn't solve the package dependency formula.
-  Selected candidates: x.dev
-  - linux-only -> (problem)
+  Selected candidates: linux-only.0.0.2 x.dev
+  - linux-only -> (problem) on arch = arm64; os = macos
+      No usable implementations:
+        linux-only.0.0.2: Availability condition not satisfied
+        linux-only.0.0.1: Availability condition not satisfied
+  - linux-only -> (problem) on arch = x86_64; os = macos
+      No usable implementations:
+        linux-only.0.0.2: Availability condition not satisfied
+        linux-only.0.0.1: Availability condition not satisfied
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.macos.lock
+  
+  The dependency solver failed to find a solution for the requested platforms:
+  - arch = x86_64; os = linux
+  - arch = arm64; os = linux
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
+  ...with this error:
+  Couldn't solve the package dependency formula.
+  Selected candidates: linux-only.0.0.2 x.dev
+  - linux-only -> (problem) on arch = arm64; os = macos
+      No usable implementations:
+        linux-only.0.0.2: Availability condition not satisfied
+        linux-only.0.0.1: Availability condition not satisfied
+  - linux-only -> (problem) on arch = x86_64; os = macos
       No usable implementations:
         linux-only.0.0.2: Availability condition not satisfied
         linux-only.0.0.1: Availability condition not satisfied
@@ -104,22 +130,54 @@ available on linux.
 The latest version of the package will be chosen on linux but the middle
 version will be chosen on macos as that's the only version available on macos.
   $ solve macos-sometimes
-  Solution for dune.lock:
-  - macos-sometimes.0.0.3
-  Solution for dune.macos.lock:
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
+  - macos-sometimes.0.0.2
+  Solution for dune.macos.lock
+  
+  Dependencies common to all supported platforms:
   - macos-sometimes.0.0.2
 
 A warning will be printed as the undefined-var.0.0.1 package has an undefined
 variable in its `available` filter. The undefined-var.0.0.2 package has a valid
 `available` filter but is only available on linux.
   $ solve undefined-var
-  Solution for dune.lock:
-  - undefined-var.0.0.2
-  Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.macos.lock:
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.lock
+  
+  The dependency solver failed to find a solution for the requested platforms:
+  - arch = x86_64; os = linux
+  - arch = arm64; os = linux
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
+  ...with this error:
   Couldn't solve the package dependency formula.
-  Selected candidates: x.dev
-  - undefined-var -> (problem)
+  Selected candidates: undefined-var.0.0.2 x.dev
+  - undefined-var -> (problem) on arch = arm64; os = macos
+      No usable implementations:
+        undefined-var.0.0.2: Availability condition not satisfied
+        undefined-var.0.0.1: Availability condition not satisfied
+  - undefined-var -> (problem) on arch = x86_64; os = macos
+      No usable implementations:
+        undefined-var.0.0.2: Availability condition not satisfied
+        undefined-var.0.0.1: Availability condition not satisfied
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.macos.lock
+  
+  The dependency solver failed to find a solution for the requested platforms:
+  - arch = x86_64; os = linux
+  - arch = arm64; os = linux
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
+  ...with this error:
+  Couldn't solve the package dependency formula.
+  Selected candidates: undefined-var.0.0.2 x.dev
+  - undefined-var -> (problem) on arch = arm64; os = macos
+      No usable implementations:
+        undefined-var.0.0.2: Availability condition not satisfied
+        undefined-var.0.0.1: Availability condition not satisfied
+  - undefined-var -> (problem) on arch = x86_64; os = macos
       No usable implementations:
         undefined-var.0.0.2: Availability condition not satisfied
         undefined-var.0.0.1: Availability condition not satisfied
@@ -136,8 +194,15 @@ filter resolves to a string instead of to a boolean.
   can't be resolved to a boolean value.
   available: "foo"
   value_bool: "foo"
-  Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.lock
+  
+  The dependency solver failed to find a solution for the requested platforms:
+  - arch = x86_64; os = linux
+  - arch = arm64; os = linux
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
+  ...with this error:
   Couldn't solve the package dependency formula.
   Selected candidates: x.dev
   - availability-string -> (problem)
@@ -147,13 +212,20 @@ filter resolves to a string instead of to a boolean.
   Warning: Ignoring package availability-string.0.0.2 as its "available" filter
   can't be resolved to a boolean value.
   available: os
-  value_bool: "macos"
+  value_bool: "linux"
   Warning: Ignoring package availability-string.0.0.1 as its "available" filter
   can't be resolved to a boolean value.
   available: "foo"
   value_bool: "foo"
-  Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.macos.lock:
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.macos.lock
+  
+  The dependency solver failed to find a solution for the requested platforms:
+  - arch = x86_64; os = linux
+  - arch = arm64; os = linux
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
+  ...with this error:
   Couldn't solve the package dependency formula.
   Selected candidates: x.dev
   - availability-string -> (problem)
@@ -166,7 +238,11 @@ The middle version will be picked as this is the only one available if
 with-test is set. This exercises that we can handle flags in the available
 filter.
   $ solve with-test-check
-  Solution for dune.lock:
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
   - with-test-check.0.0.2
-  Solution for dune.macos.lock:
+  Solution for dune.macos.lock
+  
+  Dependencies common to all supported platforms:
   - with-test-check.0.0.2

--- a/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
@@ -106,6 +106,9 @@ available on linux.
       No usable implementations:
         linux-only.0.0.2: Availability condition not satisfied
         linux-only.0.0.1: Availability condition not satisfied
+  Hint: If you don't need support for every requested platform, change
+  Hint: (solve_for_platforms ...) in dune-workspace to only include the
+  Hint: platforms you need, then rerun 'dune pkg lock'
   Error:
   Unable to solve dependencies while generating lock directory: dune.macos.lock
   
@@ -125,6 +128,9 @@ available on linux.
       No usable implementations:
         linux-only.0.0.2: Availability condition not satisfied
         linux-only.0.0.1: Availability condition not satisfied
+  Hint: If you don't need support for every requested platform, change
+  Hint: (solve_for_platforms ...) in dune-workspace to only include the
+  Hint: platforms you need, then rerun 'dune pkg lock'
   [1]
 
 The latest version of the package will be chosen on linux but the middle
@@ -162,6 +168,9 @@ variable in its `available` filter. The undefined-var.0.0.2 package has a valid
       No usable implementations:
         undefined-var.0.0.2: Availability condition not satisfied
         undefined-var.0.0.1: Availability condition not satisfied
+  Hint: If you don't need support for every requested platform, change
+  Hint: (solve_for_platforms ...) in dune-workspace to only include the
+  Hint: platforms you need, then rerun 'dune pkg lock'
   Error:
   Unable to solve dependencies while generating lock directory: dune.macos.lock
   
@@ -181,6 +190,9 @@ variable in its `available` filter. The undefined-var.0.0.2 package has a valid
       No usable implementations:
         undefined-var.0.0.2: Availability condition not satisfied
         undefined-var.0.0.1: Availability condition not satisfied
+  Hint: If you don't need support for every requested platform, change
+  Hint: (solve_for_platforms ...) in dune-workspace to only include the
+  Hint: platforms you need, then rerun 'dune pkg lock'
   [1]
 
 Warnings will be printed and no solution will be found as the availability
@@ -209,6 +221,9 @@ filter resolves to a string instead of to a boolean.
       No usable implementations:
         availability-string.0.0.2: Availability condition not satisfied
         availability-string.0.0.1: Availability condition not satisfied
+  Hint: If you don't need support for every requested platform, change
+  Hint: (solve_for_platforms ...) in dune-workspace to only include the
+  Hint: platforms you need, then rerun 'dune pkg lock'
   Warning: Ignoring package availability-string.0.0.2 as its "available" filter
   can't be resolved to a boolean value.
   available: os
@@ -232,6 +247,9 @@ filter resolves to a string instead of to a boolean.
       No usable implementations:
         availability-string.0.0.2: Availability condition not satisfied
         availability-string.0.0.1: Availability condition not satisfied
+  Hint: If you don't need support for every requested platform, change
+  Hint: (solve_for_platforms ...) in dune-workspace to only include the
+  Hint: platforms you need, then rerun 'dune pkg lock'
   [1]
 
 The middle version will be picked as this is the only one available if

--- a/test/blackbox-tests/test-cases/pkg/unsatisfied-version-constraint-on-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/unsatisfied-version-constraint-on-dune.t
@@ -28,7 +28,6 @@ Solve the dependencies:
   Selected candidates: foo.dev
   - dune -> (problem)
       User requested = 3.XX
-      foo dev requires < 3.XX
-      Rejected candidates:
-        dune.3.XX: Incompatible with restriction: < 3.XX
+      No usable implementations:
+        dune.3.XX: Package does not satisfy constraints of local package foo
   [1]

--- a/test/blackbox-tests/test-cases/pkg/workspace-deps/solver-missing-package.t
+++ b/test/blackbox-tests/test-cases/pkg/workspace-deps/solver-missing-package.t
@@ -17,7 +17,7 @@ the repository nor in the workspace. The solver should reject this.
   Error:
   Unable to solve dependencies while generating lock directory: dune.lock
   
-  The dependency solver failed to find a solution for the following platforms:
+  The dependency solver failed to find a solution for the requested platforms:
   - arch = x86_64; os = linux
   - arch = arm64; os = linux
   - arch = x86_64; os = macos

--- a/test/blackbox-tests/test-cases/pkg/workspace-deps/solver-missing-package.t
+++ b/test/blackbox-tests/test-cases/pkg/workspace-deps/solver-missing-package.t
@@ -25,5 +25,8 @@ the repository nor in the workspace. The solver should reject this.
   ...with this error:
   Couldn't solve the package dependency formula.
   The following packages couldn't be found: nonexistent-pkg
+  Hint: If you don't need support for every requested platform, change
+  Hint: (solve_for_platforms ...) in dune-workspace to only include the
+  Hint: platforms you need, then rerun 'dune pkg lock'
   [1]
 

--- a/test/expect-tests/dune_pkg/encode_decode_tests.ml
+++ b/test/expect-tests/dune_pkg/encode_decode_tests.ml
@@ -64,8 +64,7 @@ end
 let lock_dir_encode_decode_round_trip_test ?commit ~lock_dir_path ~lock_dir () =
   let lock_dir_path = Path.of_string lock_dir_path in
   Lock_dir.Write_disk.(
-    prepare ~portable_lock_dir:false ~lock_dir_path ~files:Package_name.Map.empty lock_dir
-    |> commit);
+    prepare ~lock_dir_path ~files:Package_name.Map.empty lock_dir |> commit);
   let lock_dir_round_tripped =
     try Lock_dir.read_disk_exn lock_dir_path with
     | User_error.E _ as exn ->
@@ -110,8 +109,7 @@ let%expect_test "encode/decode round trip test for lockdir with no deps" =
          ~ocaml:None
          ~repos:None
          ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
-         ~solved_for_platforms:[]
-         ~portable_lock_dir:false)
+         ~solved_for_platforms:[])
     ();
   [%expect
     {|
@@ -123,7 +121,7 @@ let%expect_test "encode/decode round trip test for lockdir with no deps" =
     ; repos = { complete = true; used = None }
     ; expanded_solver_variable_bindings =
         { variable_values = []; unset_variables = [] }
-    ; solved_for_platforms = ("<none>:1", [])
+    ; solved_for_platforms = ("empty_lock_dir/lock.dune:6", [])
     }
     |}]
 ;;
@@ -164,7 +162,6 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
            ; unset_variables = [ Package_variable_name.os_family ]
            }
          ~solved_for_platforms:[]
-         ~portable_lock_dir:false
          (Package_name.Map.of_list_exn
             [ mk_pkg_basic ~name:"foo" ~version:(Package_version.of_string "0.1.0")
             ; mk_pkg_basic ~name:"bar" ~version:(Package_version.of_string "0.2.0")
@@ -219,10 +216,8 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
     ; ocaml = Some ("simple_lock_dir/lock.dune:3", "ocaml")
     ; repos = { complete = true; used = None }
     ; expanded_solver_variable_bindings =
-        { variable_values = [ ("os", "linux") ]
-        ; unset_variables = [ "os-family" ]
-        }
-    ; solved_for_platforms = ("<none>:1", [])
+        { variable_values = []; unset_variables = [] }
+    ; solved_for_platforms = ("simple_lock_dir/lock.dune:8", [])
     }
     |}]
 ;;
@@ -326,7 +321,6 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
       ~repos:(Some [ opam_repo ])
       ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
       ~solved_for_platforms:[]
-      ~portable_lock_dir:false
       (Package_name.Map.of_list_exn [ pkg_a; pkg_b; pkg_c ])
   in
   lock_dir_encode_decode_round_trip_test ~lock_dir_path:"complex_lock_dir" ~lock_dir ();
@@ -377,7 +371,9 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                     ; depends =
                         [ { condition = [ map {} ]
                           ; value =
-                              [ { loc = "complex_lock_dir/b.pkg:3"; name = "a" }
+                              [ { loc = "complex_lock_dir/b.dev.pkg:5"
+                                ; name = "a"
+                                }
                               ]
                           }
                         ]
@@ -408,8 +404,12 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                     ; depends =
                         [ { condition = [ map {} ]
                           ; value =
-                              [ { loc = "complex_lock_dir/c.pkg:3"; name = "a" }
-                              ; { loc = "complex_lock_dir/c.pkg:3"; name = "b" }
+                              [ { loc = "complex_lock_dir/c.0.2.pkg:6"
+                                ; name = "a"
+                                }
+                              ; { loc = "complex_lock_dir/c.0.2.pkg:6"
+                                ; name = "b"
+                                }
                               ]
                           }
                         ]
@@ -438,7 +438,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
         }
     ; expanded_solver_variable_bindings =
         { variable_values = []; unset_variables = [] }
-    ; solved_for_platforms = ("<none>:1", [])
+    ; solved_for_platforms = ("complex_lock_dir/lock.dune:9", [])
     }
     |}]
 ;;
@@ -474,7 +474,6 @@ let%expect_test "encode/decode round trip test with locked repo revision" =
         ~repos:(Some [ opam_repo ])
         ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
         ~solved_for_platforms:[]
-        ~portable_lock_dir:false
         (Package_name.Map.of_list_exn [ pkg_a; pkg_b; pkg_c ])
     in
     lock_dir_encode_decode_round_trip_test
@@ -558,7 +557,7 @@ let%expect_test "encode/decode round trip test with locked repo revision" =
         }
     ; expanded_solver_variable_bindings =
         { variable_values = []; unset_variables = [] }
-    ; solved_for_platforms = ("<none>:1", [])
+    ; solved_for_platforms = ("complex_lock_dir/lock.dune:11", [])
     }
     |}]
 ;;


### PR DESCRIPTION
Stacked on #15984. Only the final commit is new in this draft.

## Summary

- Attach the `solve_for_platforms` narrowing hint to portable autolock failures.
- Keep explicit and automatic locking diagnostics consistent.

## Tests

- `dune runtest test/blackbox-tests/test-cases/pkg/autolock-portable-failure.t`
- `dune build @fmt @check`