### PR TITLE
refactor(pkg): retire portable lock directory mode

### DIFF
--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -347,7 +347,7 @@ let project_pins =
   Dune_rules.Dune_load.projects () >>| Pin.Project.collect_all
 ;;
 
-let lock ~version_preference ~lock_dirs_arg ~print_perf_stats ~portable_lock_dir =
+let lock ~version_preference ~lock_dirs_arg ~print_perf_stats =
   let open Fiber.O in
   let* solver_env_from_current_system =
     poll_solver_env_from_current_system () >>| Option.some
@@ -372,7 +372,7 @@ let lock ~version_preference ~lock_dirs_arg ~print_perf_stats ~portable_lock_dir
     ~version_preference
     ~lock_dirs
     ~print_perf_stats
-    ~portable_lock_dir
+    ~portable_lock_dir:true
 ;;
 
 let term =
@@ -386,13 +386,7 @@ let term =
   Scheduler_setup.go_with_rpc_server ~common ~config (fun () ->
     let open Fiber.O in
     Pkg_common.error_if_pkg_management_disabled ()
-    >>>
-    let portable_lock_dir =
-      match Config.get Dune_rules.Compile_time.portable_lock_dir with
-      | `Enabled -> true
-      | `Disabled -> false
-    in
-    lock ~version_preference ~lock_dirs_arg ~print_perf_stats ~portable_lock_dir)
+    >>> lock ~version_preference ~lock_dirs_arg ~print_perf_stats)
 ;;
 
 let info =

--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -61,84 +61,68 @@ let user_lock_dir_path path =
   | External e -> Dune_pkg.Pkg_workspace.dev_tool_path_to_source_dir e |> Path.source
 ;;
 
-let summary_message
-      ~portable_lock_dir
-      ~lock_dir_path
-      ~(lock_dir : Lock_dir.t)
-      ~maybe_perf_stats
-  =
-  if portable_lock_dir
-  then (
-    let pkgs_by_platform = Lock_dir.Packages.pkgs_by_platform lock_dir.packages in
-    let opam_package_of_pkg (pkg : Lock_dir.Pkg.t) =
-      OpamPackage.create
-        (Dune_pkg.Package_name.to_opam_package_name pkg.info.name)
-        (Dune_pkg.Package_version.to_opam_package_version pkg.info.version)
-    in
-    let pkgs_by_opam_package =
-      Lock_dir.Packages.to_pkg_list lock_dir.packages
-      |> List.map ~f:(fun pkg -> opam_package_of_pkg pkg, pkg)
-      |> OpamPackage.Map.of_list
-    in
-    let opam_package_to_pkg opam_package =
-      OpamPackage.Map.find opam_package pkgs_by_opam_package
-    in
-    let opam_package_sets_by_platform =
-      Solver_env.Map.map pkgs_by_platform ~f:(fun pkgs ->
-        List.map pkgs ~f:opam_package_of_pkg |> OpamPackage.Set.of_list)
-    in
-    let common_packages =
-      Solver_env.Map.values opam_package_sets_by_platform
-      |> List.reduce ~f:OpamPackage.Set.inter
-      |> Option.value ~default:OpamPackage.Set.empty
-    in
-    let pp_package_set package_set =
-      if OpamPackage.Set.is_empty package_set
-      then Pp.tag User_message.Style.Warning @@ Pp.text "(none)"
-      else (
-        let pkgs =
-          OpamPackage.Set.elements package_set |> List.map ~f:opam_package_to_pkg
-        in
-        Pkg_common.pp_packages pkgs)
-    in
-    let uncommon_packages_by_platform =
-      Solver_env.Map.map opam_package_sets_by_platform ~f:(fun package_set ->
-        OpamPackage.Set.diff package_set common_packages)
-      |> Solver_env.Map.filteri ~f:(fun _ package_set ->
-        not (OpamPackage.Set.is_empty package_set))
-    in
-    let maybe_uncommon_packages =
-      if Solver_env.Map.is_empty uncommon_packages_by_platform
-      then []
-      else
-        Pp.nop
-        :: Pp.text "Additionally, some packages will only be built on specific platforms."
-        :: (Solver_env.Map.to_list uncommon_packages_by_platform
-            |> List.concat_map ~f:(fun (platform, packages) ->
-              [ Pp.nop
-              ; Pp.concat [ Solver_env.pp_oneline platform; Pp.text ":" ]
-              ; pp_package_set packages
-              ]))
-    in
-    Pp.tag
-      User_message.Style.Success
-      (Pp.textf
-         "Solution for %s"
-         (Path.to_string_maybe_quoted (user_lock_dir_path lock_dir_path)))
-    :: Pp.nop
-    :: Pp.text "Dependencies common to all supported platforms:"
-    :: pp_package_set common_packages
-    :: (maybe_uncommon_packages @ maybe_perf_stats))
-  else
-    Pp.tag
-      User_message.Style.Success
-      (Pp.textf
-         "Solution for %s:"
-         (Path.to_string_maybe_quoted (user_lock_dir_path lock_dir_path)))
-    :: (match Lock_dir.Packages.to_pkg_list lock_dir.packages with
-        | [] -> Pp.tag User_message.Style.Warning @@ Pp.text "(no dependencies to lock)"
-        | packages -> pp_packages packages)
-    :: maybe_perf_stats
+let summary_message ~lock_dir_path ~(lock_dir : Lock_dir.t) ~maybe_perf_stats =
+  let pkgs_by_platform = Lock_dir.Packages.pkgs_by_platform lock_dir.packages in
+  let opam_package_of_pkg (pkg : Lock_dir.Pkg.t) =
+    OpamPackage.create
+      (Dune_pkg.Package_name.to_opam_package_name pkg.info.name)
+      (Dune_pkg.Package_version.to_opam_package_version pkg.info.version)
+  in
+  let pkgs_by_opam_package =
+    Lock_dir.Packages.to_pkg_list lock_dir.packages
+    |> List.map ~f:(fun pkg -> opam_package_of_pkg pkg, pkg)
+    |> OpamPackage.Map.of_list
+  in
+  let opam_package_to_pkg opam_package =
+    OpamPackage.Map.find opam_package pkgs_by_opam_package
+  in
+  let opam_package_sets_by_platform =
+    Solver_env.Map.map pkgs_by_platform ~f:(fun pkgs ->
+      List.map pkgs ~f:opam_package_of_pkg |> OpamPackage.Set.of_list)
+  in
+  let common_packages =
+    Solver_env.Map.values opam_package_sets_by_platform
+    |> List.reduce ~f:OpamPackage.Set.inter
+    |> Option.value ~default:
+         (OpamPackage.Map.keys pkgs_by_opam_package |> OpamPackage.Set.of_list)
+  in
+  let pp_package_set package_set =
+    if OpamPackage.Set.is_empty package_set
+    then Pp.tag User_message.Style.Warning @@ Pp.text "(none)"
+    else (
+      let pkgs =
+        OpamPackage.Set.elements package_set |> List.map ~f:opam_package_to_pkg
+      in
+      pp_packages pkgs)
+  in
+  let uncommon_packages_by_platform =
+    Solver_env.Map.map opam_package_sets_by_platform ~f:(fun package_set ->
+      OpamPackage.Set.diff package_set common_packages)
+    |> Solver_env.Map.filteri ~f:(fun _ package_set ->
+      not (OpamPackage.Set.is_empty package_set))
+  in
+  let maybe_uncommon_packages =
+    if Solver_env.Map.is_empty uncommon_packages_by_platform
+    then []
+    else
+      Pp.nop
+      :: Pp.text "Additionally, some packages will only be built on specific platforms."
+      :: (Solver_env.Map.to_list uncommon_packages_by_platform
+          |> List.concat_map ~f:(fun (platform, packages) ->
+            [ Pp.nop
+            ; Pp.concat [ Solver_env.pp_oneline platform; Pp.text ":" ]
+            ; pp_package_set packages
+            ]))
+  in
+  Pp.tag
+    User_message.Style.Success
+    (Pp.textf
+       "Solution for %s"
+       (Path.to_string_maybe_quoted (user_lock_dir_path lock_dir_path)))
+  :: Pp.nop
+  :: Pp.text "Dependencies common to all supported platforms:"
+  :: pp_package_set common_packages
+  :: (maybe_uncommon_packages @ maybe_perf_stats)
 ;;
 
 (* A failed joint solve does not prove that every requested platform fails on
@@ -272,7 +256,7 @@ let solve_lock_dir
     in
     let summary_message =
       User_message.make
-        (summary_message ~portable_lock_dir ~lock_dir_path ~lock_dir ~maybe_perf_stats)
+        (summary_message ~lock_dir_path ~lock_dir ~maybe_perf_stats)
     in
     progress_state := None;
     let+ lock_dir = Lock_dir.compute_missing_checksums ~pinned_packages lock_dir in

--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -237,6 +237,7 @@ let solve_lock_dir
         (Package_name.Map.map local_packages ~f:Dune_pkg.Local_package.for_solver)
       ~constraints:(constraints_of_workspace workspace ~lock_dir_path)
       ~selected_depopts:(depopts_of_workspace workspace ~lock_dir_path)
+      ~package_paths:(Lock_dir.Package_paths.for_writing ~portable_lock_dir)
       ~portable_lock_dir
   in
   match result with

--- a/boot/configure.ml
+++ b/boot/configure.ml
@@ -18,11 +18,7 @@ let out =
 ;;
 
 let default_toggles : (string * [ `Disabled | `Enabled ]) list =
-  [ "toolchains", `Enabled
-  ; "lock_dev_tool", `Disabled
-  ; "bin_dev_tools", `Disabled
-  ; "portable_lock_dir", `Enabled
-  ]
+  [ "toolchains", `Enabled; "lock_dev_tool", `Disabled; "bin_dev_tools", `Disabled ]
 ;;
 
 let toggles = ref default_toggles
@@ -106,10 +102,6 @@ let () =
       , " Enable obtaining dev-tools binarys from the binary package opam repository. \
          Allows fast installation of dev-tools. \n\
         \      This flag is experimental and shouldn't be relied on by packagers." )
-    ; ( "--portable-lock-dir"
-      , toggle "portable_lock_dir"
-      , "Generate portable lock dirs. If this feature is disabled then lock dirs will be \
-         specialized to the machine where they are generated." )
     ]
   in
   let anon s = bad "Don't know what to do with %s" s in

--- a/doc/changes/changed/15987.md
+++ b/doc/changes/changed/15987.md
@@ -1,0 +1,3 @@
+- Remove the `--portable-lock-dir` configure option. Project lock directories
+  now always use the multi-platform format; older lock directories remain
+  readable. (#15987, @Alizter)

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -1055,6 +1055,55 @@ module Packages = struct
   ;;
 end
 
+module Package_paths = struct
+  type t =
+    | Versioned
+    | Unversioned
+
+  let equal = Poly.equal
+
+  let to_dyn = function
+    | Versioned -> Dyn.variant "Versioned" []
+    | Unversioned -> Dyn.variant "Unversioned" []
+  ;;
+
+  let versioned = function
+    | Versioned -> true
+    | Unversioned -> false
+  ;;
+
+  let env_var = Env.Var.of_string "DUNE_PKG_VERSIONED_LOCK_DIR_PATHS"
+
+  let for_writing ~portable_lock_dir =
+    match Env.get Env.initial env_var with
+    | None -> if portable_lock_dir then Versioned else Unversioned
+    | Some "enabled" -> Versioned
+    | Some "disabled" -> Unversioned
+    | Some value ->
+      User_error.raise
+        [ Pp.textf "Invalid value %S for %s." value (Env.Var.to_string env_var) ]
+        ~hints:[ Pp.text "Expected \"enabled\" or \"disabled\"." ]
+  ;;
+
+  let infer ~lock_dir_path ~default package_versions =
+    let has_versioned, has_unversioned =
+      List.fold_left package_versions ~init:(false, false) ~f:(fun (v, u) -> function
+        | Some _ -> true, u
+        | None -> v, true)
+    in
+    match has_versioned, has_unversioned with
+    | true, false -> Versioned
+    | false, true -> Unversioned
+    | false, false -> default
+    | true, true ->
+      User_error.raise
+        [ Pp.textf
+            "Lock directory %s mixes versioned and unversioned package paths."
+            (Path.to_string_maybe_quoted lock_dir_path)
+        ]
+  ;;
+end
+
 type t =
   { version : Syntax.Version.t
   ; dependency_hash : (Loc.t * Local_package.Dependency_hash.t) option
@@ -1063,6 +1112,7 @@ type t =
   ; repos : Repositories.t
   ; expanded_solver_variable_bindings : Solver_stats.Expanded_variable_bindings.t
   ; solved_for_platforms : Loc.t * Solver_env.t list
+  ; package_paths : Package_paths.t
   }
 
 let remove_locs t =
@@ -1080,6 +1130,7 @@ let equal
       ; repos
       ; expanded_solver_variable_bindings
       ; solved_for_platforms
+      ; package_paths
       }
       t
   =
@@ -1097,6 +1148,7 @@ let equal
   && (Tuple.T2.equal Loc.equal (List.equal Solver_env.equal))
        solved_for_platforms
        t.solved_for_platforms
+  && Package_paths.equal package_paths t.package_paths
 ;;
 
 let to_dyn
@@ -1107,6 +1159,7 @@ let to_dyn
       ; repos
       ; expanded_solver_variable_bindings
       ; solved_for_platforms
+      ; package_paths
       }
   =
   Dyn.record
@@ -1122,12 +1175,11 @@ let to_dyn
       , Solver_stats.Expanded_variable_bindings.to_dyn expanded_solver_variable_bindings )
     ; ( "solved_for_platforms"
       , Tuple.T2.to_dyn Loc.to_dyn_hum (Dyn.list Solver_env.to_dyn) solved_for_platforms )
+    ; "package_paths", Package_paths.to_dyn package_paths
     ]
 ;;
 
-(* CR-someday Alizter: Remove this when portable lock directories are
-   consolidated with non-portable lock directories. *)
-let uses_versioned_paths t = not (List.is_empty (snd t.solved_for_platforms))
+let uses_versioned_paths t = Package_paths.versioned t.package_paths
 
 type missing_dependency =
   { dependant_package : Pkg.t
@@ -1165,6 +1217,7 @@ let create_latest_version
       ~repos
       ~expanded_solver_variable_bindings
       ~solved_for_platforms
+      ~package_paths
       ~portable_lock_dir
   =
   let packages =
@@ -1215,6 +1268,7 @@ let create_latest_version
   ; repos = { complete; used }
   ; expanded_solver_variable_bindings
   ; solved_for_platforms = Loc.none, solved_for_platforms_platform_specific_only
+  ; package_paths
   }
 ;;
 
@@ -1233,6 +1287,7 @@ let encode_metadata
       ; packages = _
       ; expanded_solver_variable_bindings
       ; solved_for_platforms
+      ; package_paths = _
       }
   =
   let open Encoder in
@@ -1338,11 +1393,8 @@ let file_contents_by_path ~portable_lock_dir t =
   :: (Packages.to_pkg_list t.packages
       |> List.map ~f:(fun (pkg : Pkg.t) ->
         let _loc, solved_for_platforms = t.solved_for_platforms in
-        let package_filename =
-          if portable_lock_dir
-          then Package_filename.make pkg.info.name (Some pkg.info.version)
-          else Package_filename.make pkg.info.name None
-        in
+        let package_version = Option.some_if (uses_versioned_paths t) pkg.info.version in
+        let package_filename = Package_filename.make pkg.info.name package_version in
         ( Filename.to_string package_filename
         , Pkg.encode ~portable_lock_dir ~solved_for_platforms pkg )))
 ;;
@@ -1505,11 +1557,11 @@ module Write_disk = struct
         Format.asprintf "%a" Pp.to_fmt pp |> Io.write_file path;
         Package_name.Map.iteri files ~f:(fun package_name files_by_version ->
           Package_version.Map.iteri files_by_version ~f:(fun package_version files ->
+            let package_version =
+              Option.some_if (uses_versioned_paths lock_dir) package_version
+            in
             let files_dir =
-              let maybe_package_version =
-                if portable_lock_dir then Some package_version else None
-              in
-              Pkg.files_dir package_name maybe_package_version ~lock_dir:lock_dir_path
+              Pkg.files_dir package_name package_version ~lock_dir:lock_dir_path
             in
             Path.mkdir_p files_dir;
             List.iter files ~f:(fun { File_entry.original; local_file } ->
@@ -1693,7 +1745,7 @@ struct
       | Some x -> true, x
       | None -> false, (Loc.none, [])
     in
-    let+ packages =
+    let* package_filenames =
       Io.readdir_with_kinds lock_dir_path
       >>| List.filter_map ~f:(fun (name, (kind : Unix.file_kind)) ->
         match kind with
@@ -1701,7 +1753,15 @@ struct
         | _ ->
           (* TODO *)
           None)
-      >>= Io.parallel_map ~f:(fun (package_name, maybe_package_version) ->
+    in
+    let package_paths =
+      let default =
+        if portable_lock_dir then Package_paths.Versioned else Package_paths.Unversioned
+      in
+      List.map package_filenames ~f:snd |> Package_paths.infer ~lock_dir_path ~default
+    in
+    let+ packages =
+      Io.parallel_map package_filenames ~f:(fun (package_name, maybe_package_version) ->
         let _loc, solved_for_platforms = solved_for_platforms in
         let+ pkg =
           load_pkg
@@ -1725,6 +1785,7 @@ struct
         ; repos
         ; expanded_solver_variable_bindings
         ; solved_for_platforms
+        ; package_paths
         })
     in
     Option.iter (Dune_trace.global ()) ~f:(fun trace -> Dune_trace.Out.finish trace event);

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -110,9 +110,7 @@ module Conditional_choice = struct
     [ { Conditional.condition; value } ]
   ;;
 
-  (* A choice where a given value will be chosen unconditionally. This is only
-     used to help support both portable and non-portable lockdirs with the same
-     codebase and can be removed when portable lockdirs is the only option. *)
+  (* A choice where a given value is chosen unconditionally. *)
   let singleton_all_platforms value = singleton Solver_env.empty value
   let equal value_equal = List.equal (Conditional.equal value_equal)
   let hash t ~f = List.hash (Conditional.hash ~f) t
@@ -163,21 +161,6 @@ module Conditional_choice = struct
      combined to avoid duplication. *)
   let merge_combining_conditions ~value_equal a b =
     List.fold_left b ~init:a ~f:(append_combining_conditions ~value_equal)
-  ;;
-
-  (* To support encoding in the non-portable format, this function extracts the
-     sole value from a conditional choice, raising a code error if there are
-     multiple choices. *)
-  let get_value_ensuring_at_most_one_choice t =
-    if List.length t > 1
-    then
-      Code_error.raise
-        "Expected at most one conditional choice"
-        [ ( "conditions"
-          , List.map t ~f:(fun { Conditional.condition; _ } -> condition)
-            |> Dyn.list Solver_env_disjunction.to_dyn )
-        ];
-    List.hd_opt t |> Option.map ~f:(fun { Conditional.value; _ } -> value)
   ;;
 end
 
@@ -271,12 +254,22 @@ module Conditional_choice_or_all_platforms = struct
 
   let to_conditional_choice ~solved_for_platforms = function
     | Choice choice -> choice
-    | All_platforms value -> [ { Conditional.value; condition = solved_for_platforms } ]
+    | All_platforms value ->
+      (* An empty platform list is how legacy lock dirs without
+         solved_for_platforms metadata are represented; the package is
+         enabled on all platforms. *)
+      let condition =
+        match solved_for_platforms with
+        | [] -> [ Solver_env.empty ]
+        | platforms -> platforms
+      in
+      [ { Conditional.value; condition } ]
   ;;
 
   let decode decode_value =
     let open Decoder in
     sum
+      ~force_parens:true
       [ ( "choice"
         , let+ choice = repeat (Conditional.decode decode_value) in
           Choice choice )
@@ -382,15 +375,7 @@ module Build_command = struct
     let build = "build"
   end
 
-  let encode_non_portable t =
-    let open Encoder in
-    match t with
-    | None -> field_o Fields.build Encoder.unit None
-    | Some Dune -> field_b Fields.dune true
-    | Some (Action a) -> field Fields.build Action.encode a
-  ;;
-
-  let encode_portable t =
+  let encode t =
     let open Encoder in
     Dune_lang.List
       (record_fields
@@ -400,7 +385,7 @@ module Build_command = struct
          ])
   ;;
 
-  let decode_portable =
+  let decode =
     let open Decoder in
     enter
     @@ fields
@@ -414,15 +399,15 @@ module Build_command = struct
          ]
   ;;
 
-  let decode_fields ~portable_lock_dir =
+  let decode_fields ~legacy =
     let open Decoder in
     let parse_action =
-      if portable_lock_dir
-      then Conditional_choice_or_all_platforms.decode decode_portable
-      else
+      if legacy
+      then
         let+ action = Action.decode_pkg in
         Conditional_choice_or_all_platforms.Choice
           (Conditional_choice.singleton_all_platforms (Action action))
+      else Conditional_choice_or_all_platforms.decode decode
     in
     fields_mutually_exclusive
       ~default:None
@@ -725,30 +710,30 @@ module Pkg = struct
     let enabled_on_platforms = "enabled_on_platforms"
   end
 
-  let decode ~portable_lock_dir =
+  let decode ~legacy =
     let open Decoder in
     let parse_install_command =
-      if portable_lock_dir
-      then Conditional_choice_or_all_platforms.decode Action.decode_pkg
-      else
+      if legacy
+      then
         let+ action = Action.decode_pkg in
         Conditional_choice_or_all_platforms.Choice
           (Conditional_choice.singleton_all_platforms action)
+      else Conditional_choice_or_all_platforms.decode Action.decode_pkg
     in
     let parse_depends =
-      if portable_lock_dir
-      then Conditional_choice_or_all_platforms.decode (enter @@ repeat Dependency.decode)
-      else
+      if legacy
+      then
         let+ depends = repeat Dependency.decode in
         Conditional_choice_or_all_platforms.Choice
           (Conditional_choice.singleton_all_platforms depends)
+      else Conditional_choice_or_all_platforms.decode (enter @@ repeat Dependency.decode)
     in
     let parse_depexts =
-      if portable_lock_dir
-      then repeat Depexts.decode
-      else
+      if legacy
+      then
         let+ external_package_names = repeat string in
         [ { Depexts.external_package_names; enabled_if = `Always } ]
+      else repeat Depexts.decode
     in
     let empty_choice = Conditional_choice_or_all_platforms.Choice [] in
     enter
@@ -756,7 +741,7 @@ module Pkg = struct
     @@ let+ version = field Fields.version Package_version.decode
        and+ install_command =
          field ~default:empty_choice Fields.install parse_install_command
-       and+ build_command = Build_command.decode_fields ~portable_lock_dir
+       and+ build_command = Build_command.decode_fields ~legacy
        and+ depends = field ~default:empty_choice Fields.depends parse_depends
        and+ depexts = field ~default:[] Fields.depexts parse_depexts
        and+ source = field_o Fields.source Source.decode
@@ -827,7 +812,6 @@ module Pkg = struct
   ;;
 
   let encode
-        ~portable_lock_dir
         ~solved_for_platforms
         { build_command
         ; install_command
@@ -840,59 +824,32 @@ module Pkg = struct
     =
     let open Encoder in
     let install_command, build_command, depends, depexts, enabled_on_platforms =
-      if portable_lock_dir
-      then (
-        let encode_field n v c =
-          Conditional_choice_or_all_platforms.encode_field ~solved_for_platforms n v c
-        in
-        ( encode_field Fields.install Action.encode install_command
-        , encode_field Fields.build Build_command.encode_portable build_command
-        , (let depends =
-             match depends with
-             | [ { Conditional.value = []; _ } ] ->
-               (* Omit the dependencies field to reduce noise in the case
+      let encode_field n v c =
+        Conditional_choice_or_all_platforms.encode_field ~solved_for_platforms n v c
+      in
+      ( encode_field Fields.install Action.encode install_command
+      , encode_field Fields.build Build_command.encode build_command
+      , (let depends =
+           match depends with
+           | [ { Conditional.value = []; _ } ] ->
+             (* Omit the dependencies field to reduce noise in the case
                   where there is explictly an empty list of dependencies. *)
-               []
-             | other -> other
-           in
-           encode_field Fields.depends Dependencies.encode depends)
-        , field_l Fields.depexts Depexts.encode depexts
-        , match
-            Enabled_on_platforms.of_solver_env_disjunction
-              ~solved_for_platforms
-              enabled_on_platforms
-          with
-          | All ->
-            (* Omit the field if it's enabled everywhere to reduce noise. The
+             []
+           | other -> other
+         in
+         encode_field Fields.depends Dependencies.encode depends)
+      , field_l Fields.depexts Depexts.encode depexts
+      , match
+          Enabled_on_platforms.of_solver_env_disjunction
+            ~solved_for_platforms
+            enabled_on_platforms
+        with
+        | All ->
+          (* Omit the field if it's enabled everywhere to reduce noise. The
                parser will assume [All] by default. *)
-            []
-          | other ->
-            [ field Fields.enabled_on_platforms Enabled_on_platforms.encode other ] ))
-      else
-        ( field_o
-            Fields.install
-            Action.encode
-            (Conditional_choice.get_value_ensuring_at_most_one_choice install_command)
-        , Build_command.encode_non_portable
-            (Conditional_choice.get_value_ensuring_at_most_one_choice build_command)
-        , field_l
-            Fields.depends
-            Package_name.encode
-            (Conditional_choice.get_value_ensuring_at_most_one_choice depends
-             |> Option.value ~default:[]
-             |> List.map ~f:(fun { Dependency.name; _ } -> name))
-        , field_l
-            Fields.depexts
-            string
-            (match depexts with
-             | [] -> []
-             | [ { Depexts.external_package_names; _ } ] -> external_package_names
-             | _ ->
-               Code_error.raise
-                 "When using non-portable lockdirs it's expected that at most a single \
-                  set of depexts will be stored in each lockfile."
-                 [ "depexts", Dyn.list Depexts.to_dyn depexts ])
-        , [] )
+          []
+        | other -> [ field Fields.enabled_on_platforms Enabled_on_platforms.encode other ]
+      )
     in
     record_fields
       ([ field Fields.version Package_version.encode version
@@ -911,8 +868,8 @@ module Pkg = struct
 
   (* More general version of [files_dir] which works on generic paths *)
   let files_dir package_name maybe_package_version ~lock_dir =
-    (* TODO(steve): Once portable lockdirs are enabled by default, make the
-       package version non-optional *)
+    (* The version is always present in newly written lockdirs; [None] is only
+       accepted for lockdirs written before versioned package files. *)
     let basename = package_basename package_name maybe_package_version in
     Path.relative lock_dir (basename ^ ".files")
   ;;
@@ -960,9 +917,8 @@ module Pkg = struct
   ;;
 
   let is_enabled_on_platform t ~platform =
-    (* XXX: currently treat empty lists of platforms as if the platform is
-       enabled on all platforms to simplify supporting both portable and
-       non-portable lockdirs with the same code. *)
+    (* An empty list of platforms means the package is enabled on all
+       platforms. *)
     List.is_empty t.enabled_on_platforms
     || Solver_env_disjunction.matches_platform t.enabled_on_platforms ~platform
   ;;
@@ -1119,6 +1075,7 @@ let remove_locs t =
   { t with
     packages = Packages.remove_locs t.packages
   ; ocaml = Option.map t.ocaml ~f:(fun (_, ocaml) -> Loc.none, ocaml)
+  ; solved_for_platforms = Loc.none, snd t.solved_for_platforms
   }
 ;;
 
@@ -1250,16 +1207,23 @@ let create_latest_version
       complete, Some used
   in
   let solved_for_platforms_platform_specific_only =
-    List.map solved_for_platforms ~f:Solver_env.remove_all_except_platform_specific
+    if portable_lock_dir
+    then (
+      match
+        List.map
+          solved_for_platforms
+          ~f:Solver_env.remove_all_except_platform_specific
+      with
+      | [] -> [ Solver_env.empty ]
+      | platforms -> platforms)
+    else []
   in
   let expanded_solver_variable_bindings =
-    match portable_lock_dir with
-    | false -> expanded_solver_variable_bindings
-    | true ->
-      (* To make a portable lockdir, only include solver variables which are
-         not platform-specific. *)
+    if portable_lock_dir
+    then
       Solver_stats.Expanded_variable_bindings.remove_platform_specific
         expanded_solver_variable_bindings
+    else expanded_solver_variable_bindings
   in
   { version
   ; dependency_hash
@@ -1279,7 +1243,6 @@ module Metadata = Dune_sexp.Versioned_file.Make (Unit)
 let () = Metadata.Lang.register Dune_lang.Pkg.syntax ()
 
 let encode_metadata
-      ~portable_lock_dir
       { version
       ; dependency_hash
       ; ocaml
@@ -1323,15 +1286,11 @@ let encode_metadata
                  expanded_solver_variable_bindings)
        ])
   @
-  if portable_lock_dir
-  then (
-    let _loc, solved_for_platforms = solved_for_platforms in
-    [ list
-        sexp
-        (string "solved_for_platforms"
-         :: List.map ~f:Solver_env.encode solved_for_platforms)
-    ])
-  else []
+  let _loc, solved_for_platforms = solved_for_platforms in
+  [ list
+      sexp
+      (string "solved_for_platforms" :: List.map ~f:Solver_env.encode solved_for_platforms)
+  ]
 ;;
 
 let decode_metadata =
@@ -1361,10 +1320,8 @@ module Package_filename = struct
   let file_extension_string = Filename.Extension.to_string file_extension
 
   let make package_name maybe_package_version =
-    (* TODO(steve): the [maybe_package_version] argument is an [_ option]
-       because if portable lockdirs is not enabled then we want to fall back to
-       the behaviour where version numbers are not included in lockfile names.
-       Make it non-optional when lockdirs become portable by default. *)
+    (* [maybe_package_version] is [None] for lockdirs written before versioned
+       package files. *)
     package_basename package_name maybe_package_version ^ file_extension_string
     |> Filename.of_string_exn
   ;;
@@ -1388,15 +1345,14 @@ module Package_filename = struct
   ;;
 end
 
-let file_contents_by_path ~portable_lock_dir t =
-  (Filename.to_string metadata_filename, encode_metadata ~portable_lock_dir t)
+let file_contents_by_path t =
+  (Filename.to_string metadata_filename, encode_metadata t)
   :: (Packages.to_pkg_list t.packages
       |> List.map ~f:(fun (pkg : Pkg.t) ->
         let _loc, solved_for_platforms = t.solved_for_platforms in
         let package_version = Option.some_if (uses_versioned_paths t) pkg.info.version in
         let package_filename = Package_filename.make pkg.info.name package_version in
-        ( Filename.to_string package_filename
-        , Pkg.encode ~portable_lock_dir ~solved_for_platforms pkg )))
+        Filename.to_string package_filename, Pkg.encode ~solved_for_platforms pkg))
 ;;
 
 module Write_disk = struct
@@ -1523,9 +1479,9 @@ module Write_disk = struct
   type t = unit -> unit
 
   let prepare
-        ~portable_lock_dir
         ~lock_dir_path:lock_dir_path_external
         ~(files : File_entry.t Package_version.Map.Multi.t Package_name.Map.t)
+        ~portable_lock_dir:_
         lock_dir
     =
     let lock_dir_hidden =
@@ -1543,7 +1499,7 @@ module Write_disk = struct
     in
     let build lock_dir_path =
       let lock_dir_path = Result.ok_exn lock_dir_path in
-      file_contents_by_path ~portable_lock_dir lock_dir
+      file_contents_by_path lock_dir
       |> List.iter ~f:(fun (path_within_lock_dir, contents) ->
         let path = Path.relative lock_dir_path path_within_lock_dir in
         Option.iter (Path.parent path) ~f:Path.mkdir_p;
@@ -1660,7 +1616,7 @@ struct
   ;;
 
   let load_pkg
-        ~portable_lock_dir
+        ~legacy
         ~version
         ~lock_dir_path
         ~solved_for_platforms
@@ -1679,7 +1635,7 @@ struct
     let parser =
       let env = Pform.Env.pkg Dune_lang.Pkg.syntax version in
       let decode =
-        Syntax.set Dune_lang.Pkg.syntax (Active version) (Pkg.decode ~portable_lock_dir)
+        Syntax.set Dune_lang.Pkg.syntax (Active version) (Pkg.decode ~legacy)
         |> Syntax.set Dune_lang.Stanza.syntax (Active Dune_lang.Stanza.latest_version)
       in
       String_with_vars.set_decoding_env env decode
@@ -1740,10 +1696,10 @@ struct
       =
       load_metadata (Path.relative_fname lock_dir_path metadata_filename)
     in
-    let portable_lock_dir, solved_for_platforms =
+    let legacy, solved_for_platforms =
       match solved_for_platforms with
-      | Some x -> true, x
-      | None -> false, (Loc.none, [])
+      | Some solved_for_platforms -> false, solved_for_platforms
+      | None -> true, (Loc.none, [])
     in
     let* package_filenames =
       Io.readdir_with_kinds lock_dir_path
@@ -1756,7 +1712,7 @@ struct
     in
     let package_paths =
       let default =
-        if portable_lock_dir then Package_paths.Versioned else Package_paths.Unversioned
+        if legacy then Package_paths.Unversioned else Package_paths.Versioned
       in
       List.map package_filenames ~f:snd |> Package_paths.infer ~lock_dir_path ~default
     in
@@ -1765,7 +1721,7 @@ struct
         let _loc, solved_for_platforms = solved_for_platforms in
         let+ pkg =
           load_pkg
-            ~portable_lock_dir
+            ~legacy
             ~version
             ~lock_dir_path
             ~solved_for_platforms
@@ -1879,8 +1835,8 @@ let check_if_solved_for_platform { solved_for_platforms; _ } ~platform =
   let loc, solved_for_platforms = solved_for_platforms in
   if List.is_empty solved_for_platforms
   then
-    (* TODO(steve): this case is only necessary while supporting non-portable
-       lockdirs. Once portable lockdirs are always enabled then remove this case. *)
+    (* Lockdirs written before the solved_for_platforms metadata existed have
+       an empty list. *)
     ()
   else (
     match Solver_env_disjunction.matches_platform solved_for_platforms ~platform with

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -167,9 +167,9 @@ module Write_disk : sig
   type t
 
   val prepare
-    :  portable_lock_dir:bool
-    -> lock_dir_path:Path.t
+    :  lock_dir_path:Path.t
     -> files:File_entry.t Package_version.Map.Multi.t Package_name.Map.t
+    -> portable_lock_dir:bool
     -> lock_dir
     -> t
 

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -105,6 +105,17 @@ module Packages : sig
   val pkgs_by_platform : t -> Pkg.t list Solver_env.Map.t
 end
 
+module Package_paths : sig
+  type t =
+    | Versioned
+    | Unversioned
+
+  (** Choose the package path layout for a newly generated lock directory.
+      [DUNE_PKG_VERSIONED_LOCK_DIR_PATHS=enabled|disabled] overrides the
+      existing default selected by [portable_lock_dir]. *)
+  val for_writing : portable_lock_dir:bool -> t
+end
+
 type t = private
   { version : Syntax.Version.t
   ; dependency_hash : (Loc.t * Local_package.Dependency_hash.t) option
@@ -119,15 +130,16 @@ type t = private
       dependencies. Can be used to determine if a lockdir is compatible
       with a particular system. *)
   ; solved_for_platforms : Loc.t * Solver_env.t list
+  ; package_paths : Package_paths.t
   }
 
 val remove_locs : t -> t
 val equal : t -> t -> bool
 val to_dyn : t -> Dyn.t
 
-(** Returns whether this lock directory uses versioned paths for package
-    files directories. Portable lock directories use versioned paths to
-    handle multiple versions of the same package. *)
+(** Returns whether this lock directory uses versioned paths for package files
+    and package file directories. The layout is detected while reading and does
+    not depend on the writer's environment variable. *)
 val uses_versioned_paths : t -> bool
 
 (** [create_latest_version packages ~ocaml ~repos
@@ -142,6 +154,7 @@ val create_latest_version
   -> repos:Opam_repo.t list option
   -> expanded_solver_variable_bindings:Solver_stats.Expanded_variable_bindings.t
   -> solved_for_platforms:Solver_env.t list
+  -> package_paths:Package_paths.t
   -> portable_lock_dir:bool
   -> t
 

--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -607,7 +607,10 @@ let opam_package_to_lock_file_pkg_single
      platforms. [lockfile_field_choice value] creates a choice with a single
      possible value predicated by the platform this package is enabled on. *)
   let lockfile_field_choice value =
-    Lock_dir.Conditional_choice.singleton_multi [ solver_env ] value
+    let condition =
+      if portable_lock_dir then solver_env else Solver_env.empty
+    in
+    Lock_dir.Conditional_choice.singleton_multi [ condition ] value
   in
   let build_command =
     Option.map build_command ~f:lockfile_field_choice
@@ -621,7 +624,6 @@ let opam_package_to_lock_file_pkg_single
         opam_package
         (OpamFile.OPAM.depexts opam_file)
     else (
-      (* In the non-portable case, only include depexts for the current platform. *)
       let external_package_names =
         OpamFile.OPAM.depexts opam_file
         |> List.concat_map ~f:(fun (sys_pkgs, filter) ->

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -828,6 +828,10 @@ module Solver = struct
       | Selected of Input.dependency list
       | Unselected
 
+    type search_item =
+      | Visit_role of Input.Role.t
+      | Visit_dependencies of Input.dependency list
+
     type selection =
       { impl : Input.Impl.t (** The implementation chosen to fill the role *)
       ; var : Sat.lit
@@ -1193,33 +1197,56 @@ module Solver = struct
       in
       let+ impl_clauses = Fiber.Cache.to_table impl_clauses in
       (* Run the solve *)
+      let pending = ref [ Visit_role root_req ] in
+      let seen = Table.create (module Input.Role) 100 in
+      let previous_decision_level = ref 0 in
+      let reset_search () =
+        pending := [ Visit_role root_req ];
+        Table.clear seen
+      in
       let decider () =
-        (* Walk the current solution, depth-first, looking for the first
-           undecided interface. Then try the most preferred implementation of
-           it that hasn't been ruled out. *)
-        let seen = Table.create (module Input.Role) 100 in
-        let rec find_undecided req =
-          if Table.mem seen req
-          then None (* Break cycles *)
-          else (
-            Table.set seen req true;
-            match Table.find_exn impl_clauses req |> Candidates.state with
-            | Unselected -> None
-            | Undecided lit -> Some lit
-            | Selected deps ->
-              (* We've already selected a candidate for this component. Now
-                 check its dependencies. *)
-              List.find_map deps ~f:(fun (dep : Input.dependency) ->
-                match dep.importance with
-                | Ensure -> find_undecided dep.drole
-                | Prevent ->
-                  (* Restrictions don't express that we do or don't want the
-                     dependency, so skip them here. If someone else needs this,
-                     we'll handle it when we get to them.
-                     If noone wants it, it will be set to unselected at the end. *)
-                  None))
+        (* Resume the depth-first walk from the previous decision. Assignments
+           are monotonic until a backjump, so already visited roles cannot gain
+           a new undecided candidate. *)
+        let decision_level = Sat.get_decision_level sat in
+        if decision_level < !previous_decision_level then reset_search ();
+        previous_decision_level := decision_level;
+        let rec find_undecided () =
+          match !pending with
+          | [] -> None
+          | Visit_role req :: rest ->
+            if Table.mem seen req
+            then (
+              pending := rest;
+              find_undecided ())
+            else (
+              match Table.find_exn impl_clauses req |> Candidates.state with
+              | Unselected ->
+                Table.set seen req true;
+                pending := rest;
+                find_undecided ()
+              | Undecided lit -> Some lit
+              | Selected deps ->
+                (* We've already selected a candidate for this component. Now
+                   check its dependencies. *)
+                Table.set seen req true;
+                pending := Visit_dependencies deps :: rest;
+                find_undecided ())
+          | Visit_dependencies [] :: rest ->
+            pending := rest;
+            find_undecided ()
+          | Visit_dependencies (dep :: deps) :: rest ->
+            pending := Visit_dependencies deps :: rest;
+            (match dep.importance with
+             | Ensure -> pending := Visit_role dep.drole :: !pending
+             | Prevent ->
+               (* Restrictions don't express that we do or don't want the
+                  dependency. If another package needs it, it will be visited
+                  from that package. *)
+               ());
+            find_undecided ()
         in
-        find_undecided root_req
+        find_undecided ()
       in
       let start = Time.now () in
       let result = Sat.run_solver sat decider in

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -2291,6 +2291,7 @@ let solve_lock_dir
       ~constraints
       ~selected_depopts
       ~portable_lock_dir
+      ~package_paths
   =
   match platform_overlays with
   | [] -> Code_error.raise "solve_lock_dir called with empty platform_overlays" []
@@ -2548,6 +2549,7 @@ let solve_lock_dir
               ~repos:(Some repos)
               ~expanded_solver_variable_bindings
               ~solved_for_platforms:full_solver_envs
+              ~package_paths
               ~portable_lock_dir
           in
           let+ files =

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -38,6 +38,7 @@ val solve_lock_dir
            handling both portable and non-portable lockdirs with the same code.
            Once portable lockdirs are enabled unconditionally, remove this
            argument. *)
+  -> package_paths:Lock_dir.Package_paths.t
   -> ( Solver_result.t
        , [ `Solve_error of User_message.Style.t Pp.t | `Manifest_error of User_message.t ]
        )

--- a/src/dune_rules/compile_time.ml
+++ b/src/dune_rules/compile_time.ml
@@ -3,7 +3,3 @@ open Import
 let toolchains = Config.make_toggle ~name:"toolchains" ~default:Setup.toolchains
 let lock_dev_tools = Config.make_toggle ~name:"lock_dev_tool" ~default:Setup.lock_dev_tool
 let bin_dev_tools = Config.make_toggle ~name:"bin_dev_tools" ~default:Setup.bin_dev_tools
-
-let portable_lock_dir =
-  Config.make_toggle ~name:"portable_lock_dir" ~default:Setup.portable_lock_dir
-;;

--- a/src/dune_rules/compile_time.mli
+++ b/src/dune_rules/compile_time.mli
@@ -18,4 +18,3 @@ val toolchains : Toggle.t Config.t
 val lock_dev_tools : Toggle.t Config.t
 
 val bin_dev_tools : Toggle.t Config.t
-val portable_lock_dir : Toggle.t Config.t

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -136,11 +136,6 @@ module Spec = struct
     let open Fiber.O in
     let* () = Fiber.return () in
     let local_packages = Package.Name.Map.map packages ~f:Local_package.for_solver in
-    let portable_lock_dir =
-      match Config.get Compile_time.portable_lock_dir with
-      | `Enabled -> true
-      | `Disabled -> false
-    in
     let* solver_env =
       let open Fiber.O in
       let+ solver_env_from_current_system =
@@ -156,7 +151,7 @@ module Spec = struct
         Opam_solver.base_solver_env_and_platforms
           solver_env
           ~solve_for_platforms:Solver_env.popular_platform_envs
-          ~portable_lock_dir
+          ~portable_lock_dir:true
       in
       Opam_solver.solve_lock_dir
         base_solver_env
@@ -167,8 +162,9 @@ module Spec = struct
         ~local_packages
         ~constraints
         ~selected_depopts
-        ~package_paths:(Dune_pkg.Lock_dir.Package_paths.for_writing ~portable_lock_dir)
-        ~portable_lock_dir
+        ~package_paths:
+          (Dune_pkg.Lock_dir.Package_paths.for_writing ~portable_lock_dir:true)
+        ~portable_lock_dir:true
     in
     match solver_result with
     | Error (`Manifest_error diagnostic) -> raise (User_error.E diagnostic)
@@ -179,7 +175,7 @@ module Spec = struct
         Dune_pkg.Lock_dir.compute_missing_checksums ~pinned_packages lock_dir
       in
       Dune_pkg.Lock_dir.Write_disk.prepare
-        ~portable_lock_dir
+        ~portable_lock_dir:true
         ~lock_dir_path
         ~files
         lock_dir

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -167,6 +167,7 @@ module Spec = struct
         ~local_packages
         ~constraints
         ~selected_depopts
+        ~package_paths:(Dune_pkg.Lock_dir.Package_paths.for_writing ~portable_lock_dir)
         ~portable_lock_dir
     in
     match solver_result with

--- a/src/dune_rules/setup.defaults.ml
+++ b/src/dune_rules/setup.defaults.ml
@@ -15,4 +15,3 @@ let prefix : string option = None
 let toolchains = `Enabled
 let lock_dev_tool = `Disabled
 let bin_dev_tools = `Disabled
-let portable_lock_dir = `Enabled

--- a/src/dune_rules/setup.mli
+++ b/src/dune_rules/setup.mli
@@ -15,5 +15,4 @@ val roots : string option Install.Roots.t
 val toolchains : Toggle.t
 val lock_dev_tool : Toggle.t
 val bin_dev_tools : Toggle.t
-val portable_lock_dir : Toggle.t
 val prefix : string option

--- a/src/sat/sat.ml
+++ b/src/sat/sat.ml
@@ -126,6 +126,10 @@ module Make (User : USER) = struct
       (* The decision level at which we got a value (when not Undecided) *)
     ; mutable undo : undo list
       (* Functions to call if we become unbound (by backtracking) *)
+    ; (* Undecided variables form a linked list. Assigned variables retain their
+         neighbours so trail-ordered undo can restore them in constant time. *)
+      mutable previous_undecided : var option
+    ; mutable next_undecided : var option
     ; watch_queue : clause Queue.t (* Clauses to notify when var becomes True *)
     ; neg_watch_queue : clause Queue.t (* Clauses to notify when var becomes False *)
     ; obj : User.t (* The object this corresponds to (for our caller and for debugging) *)
@@ -137,6 +141,7 @@ module Make (User : USER) = struct
     { id_maker : VarID.mint
     ; (* Propagation *)
       mutable vars : var list
+    ; mutable first_undecided : var option
     ; propQ : lit Queue.t (* propagation queue *)
     ; (* Assignments *)
       mutable trail : lit list (* order of assignments, most recent first *)
@@ -195,6 +200,8 @@ module Make (User : USER) = struct
     ; reason = None
     ; level = -1
     ; undo = []
+    ; previous_undecided = None
+    ; next_undecided = None
     ; watch_queue = Queue.create ()
     ; neg_watch_queue = Queue.create ()
     ; obj
@@ -224,6 +231,7 @@ module Make (User : USER) = struct
     if debug then log_debug (Pp.text "--- new SAT problem ---");
     { id_maker = VarID.make_mint ()
     ; vars = []
+    ; first_undecided = None
     ; propQ = Queue.create ()
     ; trail = []
     ; trail_len = 0
@@ -292,13 +300,34 @@ module Make (User : USER) = struct
   let get_decision_level problem = problem.trail_lim_len
 
   let add_variable problem obj : lit =
+    if problem.trail_lim_len <> 0
+    then invalid_arg "Sat.add_variable: cannot add variables after decisions have begun";
     (* if debug then log_debug "add_variable('%s')" obj; *)
     let var =
       let i = VarID.issue problem.id_maker in
       make_var i obj
     in
+    var.next_undecided <- problem.first_undecided;
+    Option.iter problem.first_undecided ~f:(fun first ->
+      first.previous_undecided <- Some var);
+    problem.first_undecided <- Some var;
     problem.vars <- var :: problem.vars;
     Pos, var
+  ;;
+
+  let remove_undecided problem var =
+    (match var.previous_undecided with
+     | None -> problem.first_undecided <- var.next_undecided
+     | Some previous -> previous.next_undecided <- var.next_undecided);
+    Option.iter var.next_undecided ~f:(fun next ->
+      next.previous_undecided <- var.previous_undecided)
+  ;;
+
+  let restore_undecided problem var =
+    (match var.previous_undecided with
+     | None -> problem.first_undecided <- Some var
+     | Some previous -> previous.next_undecided <- Some var);
+    Option.iter var.next_undecided ~f:(fun next -> next.previous_undecided <- Some var)
   ;;
 
   (* [lit] is now [True].
@@ -318,6 +347,7 @@ module Make (User : USER) = struct
     | True -> true (* Already set (shouldn't happen) *)
     | Undecided ->
       let var_info = var_of_lit lit in
+      remove_undecided problem var_info;
       var_info.value <- (if fst lit == Neg then False else True);
       var_info.level <- get_decision_level problem;
       var_info.reason <- Some reason;
@@ -335,6 +365,7 @@ module Make (User : USER) = struct
       (* if debug then log_debug "(pop %s)" (name_lit lit); *)
       let var_info = var_of_lit lit in
       var_info.value <- Undecided;
+      restore_undecided problem var_info;
       var_info.reason <- None;
       var_info.level <- -1;
       problem.trail <- rest;
@@ -897,8 +928,8 @@ module Make (User : USER) = struct
                If it leads to a conflict, we'll backtrack and
                try it the other way. *)
             let undecided =
-              match List.find problem.vars ~f:(fun info -> info.value = Undecided) with
-              | Some s -> s
+              match problem.first_undecided with
+              | Some undecided -> undecided
               | None -> raise_notrace (SolveDone true)
             in
             let lit =

--- a/src/sat/sat.mli
+++ b/src/sat/sat.mli
@@ -22,6 +22,9 @@ module Make (User : USER) : sig
   type lit
 
   val neg : lit -> lit
+
+  (** [add_variable problem user_data] adds a variable while constructing [problem].
+      @raise Invalid_argument if a decision level is active. *)
   val add_variable : t -> User.t -> lit
 
   (** A clause is a boolean expression made up of literals. e.g. [A and B and not(C)] *)

--- a/src/sat/sat.mli
+++ b/src/sat/sat.mli
@@ -65,6 +65,11 @@ module Make (User : USER) : sig
       Use this to tidy up at the end, when you no longer care about the order. *)
   val run_solver : t -> (unit -> lit option) -> bool
 
+  (** Return the current decision level. A decrease between calls to the decider
+      indicates that the solver backtracked, allowing incremental deciders to
+      invalidate cached state. *)
+  val get_decision_level : t -> int
+
   (** Return the first literal in the list whose value is [Undecided], or [None] if they're all decided.
       The decider function may find this useful. *)
   val get_best_undecided : at_most_one_clause -> lit option

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -524,13 +524,9 @@ dune_pkg_lock_normalized() {
   out="$(mktemp)"
   if dune pkg lock "$@" 2>> "${out}"; then
     processed="$(mktemp)"
-    if [ "${DUNE_CONFIG__PORTABLE_LOCK_DIR:-}" = "disabled" ]; then
-      cp "${out}" "${processed}"
-    else
-        awk '/Solution/{printf"%s:\n",$0;f=0};f{print};/Dependencies.*:/{f=1}' "${out}" \
-        | dune_cmd subst '\(none\)' '(no dependencies to lock)' \
-        > "${processed}"
-    fi
+    awk '/Solution/{printf"%s:\n",$0;f=0};f{print};/Dependencies.*:/{f=1}' "${out}" \
+      | dune_cmd subst '\(none\)' '(no dependencies to lock)' \
+      > "${processed}"
     cat "${processed}"
   else
     processed="$(mktemp)"

--- a/test/blackbox-tests/test-cases/pkg/legacy-lockdir-atom-depends.t
+++ b/test/blackbox-tests/test-cases/pkg/legacy-lockdir-atom-depends.t
@@ -1,0 +1,13 @@
+Legacy lock dirs written before the conditional package-field format store
+dependencies as bare atoms. They must still decode as unconditional.
+
+  $ make_lockdir
+  $ make_lockpkg a <<EOF
+  > (version 0.0.1)
+  > (depends b)
+  > EOF
+  $ make_lockpkg b <<EOF
+  > (version 0.0.1)
+  > EOF
+
+  $ build_pkg a

--- a/test/blackbox-tests/test-cases/pkg/legacy-lockdir-depexts.t
+++ b/test/blackbox-tests/test-cases/pkg/legacy-lockdir-depexts.t
@@ -1,0 +1,12 @@
+Legacy lock dirs written before the conditional package-field format store
+external dependencies as bare strings. They must decode as unconditional.
+
+  $ make_lockdir
+  $ make_lockpkg foo <<EOF
+  > (version 0.0.1)
+  > (depexts unzip gnupg)
+  > EOF
+
+  $ dune show depexts
+  gnupg
+  unzip

--- a/test/blackbox-tests/test-cases/pkg/legacy-lockdir-install-command.t
+++ b/test/blackbox-tests/test-cases/pkg/legacy-lockdir-install-command.t
@@ -1,0 +1,16 @@
+Legacy lock dirs written before the conditional lock file format store the
+install command as a bare action. It must still run: the command is executed
+and its output is visible.
+
+  $ make_lockdir
+  $ make_lockpkg test <<EOF
+  > (version 0.0.1)
+  > (build
+  >  (run echo BUILDING))
+  > (install
+  >  (run echo INSTALLING))
+  > EOF
+
+  $ build_pkg test
+  BUILDING
+  INSTALLING

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-selection.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-selection.t
@@ -1,11 +1,7 @@
 Test that dune can dynamically select a lockdir with a cond statement 
 
-Disable portable lockdirs, as there's no need to generate platform-specific
-lockdirs if each lockdir is portable across different platforms. The feature
-for generating platform-specific lockdirs should be removed in favour of making
-all lockdirs portable.
-  $ export DUNE_CONFIG__PORTABLE_LOCK_DIR=disabled
-
+Each lockdir is solved for its explicit [solve_for_platforms] set, so the
+selection is dynamic.
   $ mkrepo
 
   $ mkpkg arm64-only <<EOF
@@ -25,21 +21,21 @@ all lockdirs portable.
   > (lock_dir
   >  (path dune.macos.arm64.lock)
   >  (repositories mock)
-  >  (solver_env
-  >   (arch arm64)
-  >   (os macos)))
+  >  (solve_for_platforms
+  >   ((arch arm64)
+  >    (os macos))))
   > (lock_dir
   >  (path dune.macos.lock)
   >  (repositories mock)
-  >  (solver_env
-  >   (arch amd64)
-  >   (os macos)))
+  >  (solve_for_platforms
+  >   ((arch amd64)
+  >    (os macos))))
   > (lock_dir
   >  (path dune.linux.lock)
   >  (repositories mock)
-  >  (solver_env
-  >   (arch amd64)
-  >   (os linux)))
+  >  (solve_for_platforms
+  >   ((arch amd64)
+  >    (os linux))))
   > (lock_dir
   >  (repositories mock))
   > (repository
@@ -67,18 +63,24 @@ all lockdirs portable.
 
 Generate all lockdirs:
   $ dune pkg lock dune.macos.arm64.lock
-  Solution for dune.macos.arm64.lock:
+  Solution for dune.macos.arm64.lock
+  
+  Dependencies common to all supported platforms:
   - arm64-only.0.0.1
   - macos-only.0.0.1
   $ dune pkg lock dune.macos.lock
-  Solution for dune.macos.lock:
+  Solution for dune.macos.lock
+  
+  Dependencies common to all supported platforms:
   - macos-only.0.0.1
   $ DUNE_TRACE=+sat dune pkg lock dune.linux.lock
-  Solution for dune.linux.lock:
+  Solution for dune.linux.lock
+  
+  Dependencies common to all supported platforms:
   - linux-only.0.0.1
 
 The trace file is reset per dune invocation, so the assertion below
-covers only the last pkg lock above (one SAT engine run, non-portable).
+covers only the last pkg lock above (one SAT engine run).
 
   $ dune trace cat \
   > | jq -s 'include "dune"; [ .[] | satSolveEvents ] | length'
@@ -130,9 +132,9 @@ Test that cond statements can have a default value:
   $ cat >dune-workspace <<EOF
   > (lang dune 3.13)
   > (lock_dir
-  >  (solver_env
-  >   (arch amd64)
-  >   (os linux))
+  >  (solve_for_platforms
+  >   ((arch amd64)
+  >    (os linux)))
   >  (repositories mock))
   > (repository
   >  (name mock)
@@ -146,8 +148,10 @@ Test that cond statements can have a default value:
   > EOF
 
   $ dune pkg lock dune.lock
-  Solution for dune.lock:
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
   - linux-only.0.0.1
   $ dune clean
-  $ build_pkg linux-only
+  $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=amd64 build_pkg linux-only
   linux-only

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-versioned-package-paths.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-versioned-package-paths.t
@@ -1,0 +1,66 @@
+Package version numbers in lock-directory paths are a writer-only choice. Both
+layouts must load and produce the same build plan.
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ cat > data.txt <<'EOF'
+  > layout invariant
+  > EOF
+  $ data_checksum=$(md5sum data.txt | cut -d' ' -f1)
+
+  $ mkpkg layout 1.2 <<EOF
+  > build: [
+  >  ["sh" "-c" "mkdir -p %{share}% && cp data.txt %{share}%/result"]
+  > ]
+  > extra-files: ["data.txt" "md5=$data_checksum"]
+  > EOF
+  $ mkdir -p "$mock_packages/layout/layout.1.2/files"
+  $ cp data.txt "$mock_packages/layout/layout.1.2/files/data.txt"
+
+  $ cat > dune-project <<'EOF'
+  > (lang dune 3.22)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends layout))
+  > EOF
+
+Invalid values are rejected by the writer.
+
+  $ DUNE_PKG_VERSIONED_LOCK_DIR_PATHS=other dune pkg lock
+  Error: Invalid value "other" for DUNE_PKG_VERSIONED_LOCK_DIR_PATHS.
+  Hint: Expected "enabled" or "disabled".
+  [1]
+
+Generate the same solution with each package path layout.
+
+  $ DUNE_PKG_VERSIONED_LOCK_DIR_PATHS=enabled dune_pkg_lock_normalized >/dev/null
+  $ mv dune.lock versioned.lock
+  $ test -f versioned.lock/layout.1.2.pkg
+  $ test -f versioned.lock/layout.1.2.files/data.txt
+
+  $ DUNE_PKG_VERSIONED_LOCK_DIR_PATHS=disabled dune_pkg_lock_normalized >/dev/null
+  $ mv dune.lock unversioned.lock
+  $ test -f unversioned.lock/layout.pkg
+  $ test -f unversioned.lock/layout.files/data.txt
+
+The reader must detect the layout from the lock directory rather than consulting
+the writer flag. Build each lock directory with the opposite flag value.
+
+  $ cp -R versioned.lock dune.lock
+  $ versioned_digest=$(DUNE_PKG_VERSIONED_LOCK_DIR_PATHS=disabled dune pkg print-digest layout)
+  $ DUNE_PKG_VERSIONED_LOCK_DIR_PATHS=disabled build_pkg layout
+  $ cp "$(get_build_pkg_dir layout)/target/share/result" versioned-result
+
+  $ rm -rf dune.lock
+  $ cp -R unversioned.lock dune.lock
+  $ dune clean
+  $ unversioned_digest=$(DUNE_PKG_VERSIONED_LOCK_DIR_PATHS=enabled dune pkg print-digest layout)
+  $ DUNE_PKG_VERSIONED_LOCK_DIR_PATHS=enabled build_pkg layout
+  $ cp "$(get_build_pkg_dir layout)/target/share/result" unversioned-result
+
+  $ test "$versioned_digest" = "$unversioned_digest" && echo 'package digests match'
+  package digests match
+  $ cmp versioned-result unversioned-result && cat versioned-result
+  layout invariant

--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-basic.t
@@ -13,7 +13,9 @@ a lockdir containing an "ocaml" lockfile.
   $ dune build
 
   $ dune tools exec ocamlmerlin
-  Solution for _build/.dev-tools.locks/merlin:
+  Solution for _build/.dev-tools.locks/merlin
+  
+  Dependencies common to all supported platforms:
   - merlin.0.0.1
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0

--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-env.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-env.t
@@ -13,7 +13,9 @@ executable in PATH is the one installed by dune as a dev tool.
 
 First install the tool:
   $ dune tools exec ocamlmerlin
-  Solution for _build/.dev-tools.locks/merlin:
+  Solution for _build/.dev-tools.locks/merlin
+  
+  Dependencies common to all supported platforms:
   - merlin.0.0.1
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0

--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-package-change.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-package-change.t
@@ -46,7 +46,9 @@ lock directory from the updated recipe.
   lockdir has changed to 5.2.0 (formerly the compiler version was 5.2.0). The
   dev-tool "merlin" will be re-locked and rebuilt with this version of the
   compiler.
-  Solution for _build/.dev-tools.locks/merlin:
+  Solution for _build/.dev-tools.locks/merlin
+  
+  Dependencies common to all supported platforms:
   - merlin.0.0.1
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0

--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-version-change.t
@@ -18,7 +18,9 @@ same version of the ocaml compiler as the code that it's analyzing.
 Initially merlin will depend on ocaml-base-compiler.5.2.0 to match the project.
 
   $ dune tools exec ocamlmerlin
-  Solution for _build/.dev-tools.locks/merlin:
+  Solution for _build/.dev-tools.locks/merlin
+  
+  Dependencies common to all supported platforms:
   - merlin.0.0.1
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
@@ -33,7 +35,9 @@ We can re-run "dune tools exec ocamlmerlin" without relocking or rebuilding.
   lockdir has changed to 5.2.0 (formerly the compiler version was 5.2.0). The
   dev-tool "merlin" will be re-locked and rebuilt with this version of the
   compiler.
-  Solution for _build/.dev-tools.locks/merlin:
+  Solution for _build/.dev-tools.locks/merlin
+  
+  Dependencies common to all supported platforms:
   - merlin.0.0.1
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
@@ -53,7 +57,9 @@ before running. Merlin now depends on ocaml.5.1.0.
   lockdir has changed to 5.1.0 (formerly the compiler version was 5.2.0). The
   dev-tool "merlin" will be re-locked and rebuilt with this version of the
   compiler.
-  Solution for _build/.dev-tools.locks/merlin:
+  Solution for _build/.dev-tools.locks/merlin
+  
+  Dependencies common to all supported platforms:
   - merlin.0.0.1
   - ocaml-base-compiler.5.1.0
   - ocaml-compiler.5.1.0

--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-version-change.t
@@ -24,7 +24,7 @@ Initially merlin will depend on ocaml-base-compiler.5.2.0 to match the project.
   - ocaml-compiler.5.2.0
        Running 'ocamlmerlin'
   hello from fake ocamlmerlin
-  $ grep "version" "${dev_tool_lock_dir}"/ocaml-base-compiler.pkg
+  $ grep '^(version ' "${dev_tool_lock_dir}"/ocaml-base-compiler.pkg
   (version 5.2.0)
 
 We can re-run "dune tools exec ocamlmerlin" without relocking or rebuilding.
@@ -59,5 +59,5 @@ before running. Merlin now depends on ocaml.5.1.0.
   - ocaml-compiler.5.1.0
        Running 'ocamlmerlin'
   hello from fake ocamlmerlin
-  $ grep "version" "${dev_tool_lock_dir}"/ocaml-base-compiler.pkg
+  $ grep '^(version ' "${dev_tool_lock_dir}"/ocaml-base-compiler.pkg
   (version 5.1.0)

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/fmt-lockdir-behavior-gh11037.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/fmt-lockdir-behavior-gh11037.t
@@ -39,7 +39,9 @@ attempt to build the package "foo".
   $ cat foo.ml
   let () = print_endline "Hello, world"
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.0.1
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-conflict-with-project.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-conflict-with-project.t
@@ -28,7 +28,9 @@ Add a fake executable in the PATH
 
 Build the OCamlFormat binary dev-tool
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
   File "dune", line 1, characters 0-0:
   --- dune

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-taking-from-project-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-taking-from-project-deps.t
@@ -44,7 +44,9 @@ Format using the dev-tools feature, it does not invoke the OCamlFormat binary fr
 the project dependencies (0.26.2) but instead builds and runs the OCamlFormat binary as a
 dev-tool (0.26.3).
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.3
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-custom-build-dir.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-custom-build-dir.t
@@ -33,7 +33,9 @@ Make sure we don't have a lock dir
 Install our fake ocamlformat, making sure to override the build directory.
 
   $ dune tools install ocamlformat --build-dir="${custom_build_dir}"
-  Solution for _other_build/.dev-tools.locks/ocamlformat:
+  Solution for _other_build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
 
 This should've worked and picked up our ocamlformat using the lock dir

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-deps-conflict-project-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-deps-conflict-project-deps.t
@@ -90,7 +90,9 @@ It shows that the project uses printer.2.0
 Format foo.ml, "dune fmt" uses printer.1.0 instead. There is no conflict with different
 versions of the same dependency.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
   - printer.1.0
   File "foo.ml", line 1, characters 0-0:

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-fails-to-build.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-fails-to-build.t
@@ -12,11 +12,13 @@ Make dune-project that uses the mocked dev-tool opam-reposiotry.
 
 It fails during the build because of missing OCamlFormat module.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.4
-  File "_build/.dev-tools.locks/ocamlformat/ocamlformat.pkg", line 4, characters 6-10:
-  4 |  (run dune build -p %{pkg-self:name} @install))
-            ^^^^
+  File "_build/.dev-tools.locks/ocamlformat/ocamlformat.0.26.4.pkg", line 4, characters 30-34:
+  4 |  (all_platforms ((action (run dune build -p %{pkg-self:name} @install)))))
+                                    ^^^^
   Error: Logs for package ocamlformat
   File "dune", line 2, characters 14-25:
   2 |  (public_name ocamlformat))

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dune-tools-install.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dune-tools-install.t
@@ -43,7 +43,9 @@ We have no lock dir for ocamlformat, it should use the one from path
 Installing ocamlformat via `dune tools install` should work:
 
   $ dune tools install ocamlformat
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
 
 Formatting should use the locked ocamlformat with the feature flag enabled:

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-e2e.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-e2e.t
@@ -24,7 +24,9 @@ Make dune-project that uses the mocked dev-tool opam-reposiotry.
 Without a ".ocamlformat" file, "dune fmt" takes the latest version of
 OCamlFormat.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.3
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml
@@ -46,7 +48,9 @@ An important cleaning here, "dune fmt" will relock and build the new version(0.2
 With a ".ocamlformat" file, "dune fmt" takes the version mentioned inside ".ocamlformat"
 file.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml
@@ -70,7 +74,9 @@ When the lock dir is removed, the solving/lock is renewed:
 
   $ rm -r "${dev_tool_lock_dir}"
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-ignore.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-ignore.t
@@ -28,7 +28,9 @@ Create ".ocamlformat-ignore"
 
 Check with the feature when ".ocamlformat-ignore" file exists.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-install.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-install.t
@@ -8,7 +8,9 @@ Test `dune tools which ocamlformat`:
 
 Install ocamlformat as a dev tool:
   $ dune tools install ocamlformat
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
 
 Verify that ocamlformat is installed:

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-patch-extra-files.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-patch-extra-files.t
@@ -59,7 +59,9 @@ Make a project that uses the fake ocamlformat:
 
 First run of 'dune fmt' is supposed to format the fail.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
@@ -28,7 +28,9 @@ Initial file:
 This should choose the 0.24+foo version:
   $ echo "version=0.24" > .ocamlformat
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.24+foo
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml
@@ -46,7 +48,9 @@ This should choose the 0.24+bar version:
   $ echo "version=0.25" > .ocamlformat
   $ rm -r "${dev_tool_lock_dir}"
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.25+bar
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relock-on-corrupt-lockdir.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relock-on-corrupt-lockdir.t
@@ -11,7 +11,9 @@ Make a fake ocamlformat package
 
 Install ocamlformat once to generate the lockdir.
   $ dune tools install ocamlformat
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.0
 
 Delete ocamlformat's lockfile.
@@ -23,5 +25,7 @@ Reinstall ocamlformat.
   contain a lockfile for the package "ocamlformat". This may indicate that the
   lock directory has been tampered with. Please avoid making manual changes to
   tool lock directories. The tool will now be relocked.
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.0

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-rerun-on-source-change-gh10991.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-rerun-on-source-change-gh10991.t
@@ -18,7 +18,9 @@ Initial file:
   let () = print_endline "Hello, world"
 
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.0.1
   File "foo.ml", line 1, characters 0-0:
   --- foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-version-change.t
@@ -21,7 +21,9 @@ Create .ocamlformat file
 
 Install ocamlformat. 0.26.0 should be installed because that's the version in .ocamlformat.
   $ dune tools install ocamlformat
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.0
 
 Change the version in .ocamlformat.
@@ -34,5 +36,7 @@ Install ocamlformat again. Dune should detect that the version has changed and r
   The lock directory for the tool "ocamlformat" exists but contains a solution
   for 0.26.0 of the tool, whereas version 0.27.0 now needs to be installed. The
   tool will now be re-locked.
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.27.0

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-which.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-which.t
@@ -21,7 +21,9 @@ The command will fail because the dev tool is not installed:
 
 Install the dev tool:
   $ dune tools exec ocamlformat
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
        Running 'ocamlformat'
   formatted with version 0.26.2

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-wrapper.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-wrapper.t
@@ -7,7 +7,9 @@ Exercise running the ocamlformat wrapper command.
   $ make_project_with_dev_tool_lockdir
 
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamlformat
-  Solution for _build/.dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat
+  
+  Dependencies common to all supported platforms:
   - ocamlformat.0.26.2
        Running 'ocamlformat'
   formatted with version 0.26.2

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
@@ -12,7 +12,9 @@ a lockdir containing an "ocaml" lockfile.
   $ dune build
 
   $ dune tools exec ocamllsp
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
   - ocaml-lsp-server.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-configure.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-configure.t
@@ -37,7 +37,9 @@ Add ocamlbuild 0.0.2 as a constraint to make sure the constraint field makes the
 Installing ocamllsp picks the right version of ocamlbuild
 
   $ dune tools install ocamllsp
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
   - ocaml-lsp-server.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
@@ -20,7 +20,9 @@ Make a fake ocamllsp package that prints out the PATH variable:
 
 Confirm that each dev tool's bin directory is now in PATH:
   $ dune tools exec ocamllsp | tr : '\n' | grep '_build/_private/default/.dev-tool'
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
   - ocaml-lsp-server.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-pinned-compiler.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-pinned-compiler.t
@@ -51,7 +51,9 @@ The key indicator is that we see "ocaml-base-compiler.dev" in the solution (from
 rather than "ocaml-base-compiler.5.2.0" from opam-repository.
 
   $ dune tools install ocamllsp 2>&1 | head -10
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.dev
   - ocaml-lsp-server.0.0.1
 
@@ -60,7 +62,9 @@ rather than "ocaml-base-compiler.5.2.0" from opam-repository.
   lockdir has changed to dev (formerly the compiler version was dev). The
   dev-tool "ocaml-lsp-server" will be re-locked and rebuilt with this version
   of the compiler.
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.dev
   - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
@@ -17,7 +17,9 @@ same version of the ocaml compiler as the code that it's analyzing.
 
 Initially ocamllsp will depend on ocaml-base-compiler.5.2.0 to match the project.
   $ dune tools exec ocamllsp
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
   - ocaml-lsp-server.0.0.1
@@ -33,7 +35,9 @@ We can re-run "dune tools exec ocamllsp" without relocking or rebuilding.
   lockdir has changed to 5.2.0 (formerly the compiler version was 5.2.0). The
   dev-tool "ocaml-lsp-server" will be re-locked and rebuilt with this version
   of the compiler.
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
   - ocaml-lsp-server.0.0.1
@@ -53,7 +57,9 @@ before running. Ocamllsp now depends on ocaml.5.1.0.
   lockdir has changed to 5.1.0 (formerly the compiler version was 5.2.0). The
   dev-tool "ocaml-lsp-server" will be re-locked and rebuilt with this version
   of the compiler.
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.1.0
   - ocaml-compiler.5.1.0
   - ocaml-lsp-server.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
@@ -23,7 +23,7 @@ Initially ocamllsp will depend on ocaml-base-compiler.5.2.0 to match the project
   - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'
   hello from fake ocamllsp
-  $ grep "version" "${dev_tool_lock_dir}"/ocaml-base-compiler.pkg
+  $ grep '^(version ' "${dev_tool_lock_dir}"/ocaml-base-compiler.pkg
   (version 5.2.0)
 
 
@@ -59,5 +59,5 @@ before running. Ocamllsp now depends on ocaml.5.1.0.
   - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'
   hello from fake ocamllsp
-  $ grep "version" "${dev_tool_lock_dir}"/ocaml-base-compiler.pkg
+  $ grep '^(version ' "${dev_tool_lock_dir}"/ocaml-base-compiler.pkg
   (version 5.1.0)

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-special-compiler-version.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-special-compiler-version.t
@@ -16,7 +16,9 @@ Test the special compiler version is picked up by ocamllsp.
 
 Here `ocamllsp` will pickup the compiler dependency on 5.2.0+ox
   $ dune tools exec ocamllsp
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server
+  
+  Dependencies common to all supported platforms:
   - ocaml-lsp-server.0.0.1
   - ocaml-variants.5.2.0+ox
        Running 'ocamllsp'

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-basic.t
@@ -12,7 +12,9 @@ a lockdir containing an "ocaml" lockfile.
   $ dune build
 
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune ocaml doc
-  Solution for _build/.dev-tools.locks/odoc:
+  Solution for _build/.dev-tools.locks/odoc
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
   - odoc.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-dune-tools-install.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-dune-tools-install.t
@@ -52,7 +52,9 @@ Install odoc via `dune tools install`, populating the dev-tool lockdir at
 _build/.dev-tools.locks/odoc:
 
   $ dune tools install odoc
-  Solution for _build/.dev-tools.locks/odoc:
+  Solution for _build/.dev-tools.locks/odoc
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
   - odoc.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
@@ -17,7 +17,9 @@ same version of the ocaml compiler as the code that it's analyzing.
 
 Initially odoc will depend on ocaml-base-compiler.5.2.0 to match the project.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune ocaml doc
-  Solution for _build/.dev-tools.locks/odoc:
+  Solution for _build/.dev-tools.locks/odoc
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
   - odoc.0.0.1
@@ -38,7 +40,9 @@ We can re-run "dune ocaml doc" without relocking or rebuilding.
   lockdir has changed to 5.2.0 (formerly the compiler version was 5.2.0). The
   dev-tool "odoc" will be re-locked and rebuilt with this version of the
   compiler.
-  Solution for _build/.dev-tools.locks/odoc:
+  Solution for _build/.dev-tools.locks/odoc
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
   - odoc.0.0.1
@@ -63,7 +67,9 @@ before running. Odoc now depends on ocaml.5.1.0.
   lockdir has changed to 5.1.0 (formerly the compiler version was 5.2.0). The
   dev-tool "odoc" will be re-locked and rebuilt with this version of the
   compiler.
-  Solution for _build/.dev-tools.locks/odoc:
+  Solution for _build/.dev-tools.locks/odoc
+  
+  Dependencies common to all supported platforms:
   - ocaml-base-compiler.5.1.0
   - ocaml-compiler.5.1.0
   - odoc.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
@@ -29,7 +29,7 @@ Initially odoc will depend on ocaml-base-compiler.5.2.0 to match the project.
   Error: Rule failed to generate the following targets:
   - _doc/_odoc/pkg/foo/page-index.odoc
   [1]
-  $ grep "version" "${dev_tool_lock_dir}"/ocaml-base-compiler.pkg
+  $ grep '^(version ' "${dev_tool_lock_dir}"/ocaml-base-compiler.pkg
   (version 5.2.0)
 
 We can re-run "dune ocaml doc" without relocking or rebuilding.
@@ -75,5 +75,5 @@ before running. Odoc now depends on ocaml.5.1.0.
   Error: Rule failed to generate the following targets:
   - _doc/_odoc/pkg/foo/page-index.odoc
   [1]
-  $ grep "version" "${dev_tool_lock_dir}"/ocaml-base-compiler.pkg
+  $ grep '^(version ' "${dev_tool_lock_dir}"/ocaml-base-compiler.pkg
   (version 5.1.0)

--- a/test/blackbox-tests/test-cases/pkg/pkg-validate-on-build.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-validate-on-build.t
@@ -1,12 +1,9 @@
 Test that we validate lockdirs before using them to build a package.
 
-Disable portable lockdirs. This test exercise dune's ability to detect when
-dune is asked to execute a build plan on a different platform than the platform
-it was generated for. A similar case is possible with portable lockdirs where
-the current platform isn't one of the platforms for which a solution exists in
-the lockdir, and this is tested in "portable-lockdirs-custom-platforms".
-  $ export DUNE_CONFIG__PORTABLE_LOCK_DIR=disabled
-
+This test exercises Dune's ability to detect when it is asked to execute a
+build plan on a platform for which the lock directory has no solution. The
+analogous case for an explicitly configured platform set is tested in
+"portable-lockdirs-custom-platforms".
   $ mkrepo
 
   $ mkpkg a <<EOF
@@ -18,7 +15,7 @@ the lockdir, and this is tested in "portable-lockdirs-custom-platforms".
   $ mkpkg bar <<EOF
   > depends: [
   >   "a" { ? custom }
-  >   "b" { os = "macos" }
+  >   "b" { flavor = "macos" }
   > ]
   > EOF
 
@@ -44,7 +41,7 @@ Helper function that creates a workspace file with a given solver env.
 
   $ generate_workspace > dune-workspace <<EOF
   > (solver_env
-  >  (os macos))
+  >  (flavor macos))
   > EOF
 
   $ solve_project <<EOF
@@ -60,19 +57,19 @@ Helper function that creates a workspace file with a given solver env.
 When the workspace and lockdir is consistent we can build packages in the lockdir.
   $ build_pkg bar
 
-Now change the workspace so that the "os" solver variable is changed, but don't
-regenerate the lockdir, leaving the project in an inconsistent state.
+Now change the "flavor" solver variable, but don't regenerate the lockdir,
+leaving the project in an inconsistent state.
   $ generate_workspace > dune-workspace <<EOF
   > (solver_env
-  >  (os linux))
+  >  (flavor linux))
   > EOF
 
 Print an error when attempting to build when the lockdir and workspace disagree
 about the value of a variable.
   $ build_pkg bar
   Error: The dependency solution relies on the assignment of the solver
-  variable "os" to "macos" but the solver environment in the workspace would
-  assign it the value "linux".
+  variable "flavor" to "macos" but the solver environment in the workspace
+  would assign it the value "linux".
   Hint: This can happen if the "solver_env" for the lockdir in the
   dune-workspace file has changed since generating the lockdir. Regenerate the
   lockdir by running:
@@ -83,7 +80,7 @@ Also detect the case where a variable that was unassigned at solve time and
 used during solving is later given a value in the workspace file:
   $ generate_workspace > dune-workspace <<EOF
   > (solver_env
-  >  (os macos)
+  >  (flavor macos)
   >  (custom foo))
   > EOF
 
@@ -97,12 +94,18 @@ used during solving is later given a value in the workspace file:
   Hint: 'dune pkg lock'
   [1]
 
-If we don't set a variable in the workspace but that variable appears in
-lockdir metadata it's not an error because it might have got there by polling
-the current system. Note that to prevent the "os" variable from being taken
-from the current system it must be added to the unset variables in the
-workspace.
+The default platform set is independent from [unset_solver_vars]. A variable
+listed there remains in explicit or default platform overlays.
 
   $ generate_workspace > dune-workspace <<EOF
   > (unset_solver_vars os)
   > EOF
+
+Regenerating with [os] unset still records it in the default platform set:
+  $ dune pkg lock >/dev/null
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
+  - bar.0.0.1
+  $ grep -q '(os linux)' dune.lock/lock.dune
+  $ grep -q '(os macos)' dune.lock/lock.dune

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-build-context-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-build-context-solver-env.t
@@ -32,7 +32,7 @@ Create a package whose build result records the selected operating system.
 
 The lock stanza selects macOS, but the build context still selects Linux.
 
-  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock >/dev/null 2>&1
+  $ dune pkg lock >/dev/null 2>&1
   $ dune build
   $ cat $pkg_root/$(dune pkg print-digest foo)/target/share/kernel
   Linux

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-common-version-extra-files.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-common-version-extra-files.t
@@ -28,7 +28,7 @@ package version and omits files belonging only to rejected versions.
   >  (depends (foo (= 1))))
   > EOF
 
-  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  $ dune pkg lock
   Solution for dune.lock
   
   Dependencies common to all supported platforms:

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-conflict-class-platform.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-conflict-class-platform.t
@@ -44,7 +44,7 @@ class.
 The transitive macOS dependency and the Linux package must coexist even though
 they belong to the same conflict class on different platforms.
 
-  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  $ dune pkg lock
   Solution for dune.lock
   
   Dependencies common to all supported platforms:
@@ -75,7 +75,7 @@ restriction rather than attributing the failure to the conflict class.
   >   "needs-impossible" {os = "macos"}
   > ]
   > EOF
-  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  $ dune pkg lock
   Error:
   Unable to solve dependencies while generating lock directory: dune.lock
   

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-dedup-manifest-errors.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-dedup-manifest-errors.t
@@ -77,7 +77,7 @@ Update dune-package to pin the dune package:
   >  (name x)
   >  (depends foo))
   > EOF
-  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  $ dune pkg lock
   File "dune-project", line 4, characters 1-22:
   4 |  (package (name dune)))
        ^^^^^^^^^^^^^^^^^^^^^

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-malformed-conditional-field.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-malformed-conditional-field.t
@@ -1,0 +1,23 @@
+Malformed conditional fields in a new-format lock directory must report the
+conditional grammar error. They must not be retried as legacy bare fields.
+
+  $ mkdir -p "${source_lock_dir}"
+  $ cat >"${source_lock_dir}/lock.dune" <<'EOF'
+  > (lang package 0.1)
+  > (repositories (complete true))
+  > (solved_for_platforms
+  >  ((arch x86_64)
+  >   (os linux)))
+  > EOF
+  $ make_lockpkg foo.0.0.1 <<'EOF'
+  > (version 0.0.1)
+  > (depends
+  >  (choice not-a-conditional))
+  > EOF
+
+  $ build_pkg foo
+  File "_build/_private/default/.lock/dune.lock/foo.0.0.1.pkg", line 3, characters 9-26:
+  3 |  (choice not-a-conditional))
+               ^^^^^^^^^^^^^^^^^
+  Error: List expected
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-print-avoid-version.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-print-avoid-version.t
@@ -11,7 +11,7 @@ avoid-version, include a message to that extent in the output.
 
   $ write_portable_lockdirs_project
 
-  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  $ dune pkg lock
   Solution for dune.lock
   
   Dependencies common to all supported platforms:

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-solver-env-platform-precedence.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-solver-env-platform-precedence.t
@@ -35,7 +35,7 @@ variables in the lock stanza's solver_env.
   > (pkg enabled)
   > EOF
 
-  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  $ dune pkg lock
   Solution for dune.lock
   
   Dependencies common to all supported platforms:

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-with-doc.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-with-doc.t
@@ -15,7 +15,7 @@ dune-workspace.
 
   $ mkpkg foo
 
-  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  $ dune pkg lock
   Solution for dune.lock
   
   Dependencies common to all supported platforms:

--- a/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
+++ b/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
@@ -2,13 +2,10 @@ Test that dune records platform information used by the solver in the lockdir.
 This information allows dune to later check that a build plan is compatible
 with the machine it is being built on.
 
-This is only relevant when not using portable lockdirs, since platform
-information is stored in the lockdir in a different way when using portable
-lockdirs. The analogous cases for portable lockdirs is tested in
-"portable-lockdirs-custom-solver-env" (setting non-platform variables in dune-workspace)
-and "portable-lockdirs-custom-platforms" (setting platform variables in dune-workspace).
-  $ export DUNE_CONFIG__PORTABLE_LOCK_DIR=disabled
-
+This test covers solver variables configured directly on a lock directory.
+The analogous cases for explicit platform sets are tested in
+"portable-lockdirs-custom-solver-env" (non-platform variables) and
+"portable-lockdirs-custom-platforms" (platform variables).
   $ mkrepo
 
   $ mkpkg no-deps-a 1.0 <<EOF
@@ -67,7 +64,12 @@ Make a workspace file which sets some of the variables.
   >   (os linux)
   >   (os-family dunefamily)
   >   (os-version 15)
-  >   (arch arm)))
+  >   (arch arm))
+  >  (solve_for_platforms
+  >   ((os linux)
+  >    (os-family dunefamily)
+  >    (os-version 15)
+  >    (arch arm))))
   > (context
   >  (default
   >   (name default)))
@@ -90,7 +92,11 @@ Solve the packages again, this time with the variables set.
    (complete false)
    (used))
   
-  (solved_for_platforms)
+  (solved_for_platforms
+   ((arch arm)
+    (os linux)
+    (os-family dunefamily)
+    (os-version 15)))
   Solution for dune.lock:
   - dynamic-deps.1.0
   - no-deps-a.1.0
@@ -103,12 +109,11 @@ Solve the packages again, this time with the variables set.
    (complete false)
    (used))
   
-  (expanded_solver_variable_bindings
-   (variable_values
+  (solved_for_platforms
+   ((arch arm)
     (os linux)
-    (arch arm)))
-  
-  (solved_for_platforms)
+    (os-family dunefamily)
+    (os-version 15)))
   Solution for dune.lock:
   - dynamic-deps-lazy.1.0
   - no-deps-a.1.0
@@ -121,14 +126,11 @@ Solve the packages again, this time with the variables set.
    (complete false)
    (used))
   
-  (expanded_solver_variable_bindings
-   (variable_values
-    (os-version 15)
-    (os-family dunefamily)
+  (solved_for_platforms
+   ((arch arm)
     (os linux)
-    (arch arm)))
-  
-  (solved_for_platforms)
+    (os-family dunefamily)
+    (os-version 15)))
 
 Test that variables referred to in filters on build and install commands are
 stored in the lockdir metadata:
@@ -152,17 +154,15 @@ stored in the lockdir metadata:
   Solution for dune.lock:
   - filtered-commands.0.0.1
 
-  $ cat ${default_lock_dir}/filtered-commands.pkg
+  $ cat ${default_lock_dir}/filtered-commands.0.0.1.pkg
   (version 0.0.1)
   
   (install
-   (choice
-    ((())
-     (run echo qux))))
+   (all_platforms
+    (run echo qux)))
   
   (build
-   (choice
-    ((()) ((action (progn (run echo foo) (run echo baz)))))))
+   (all_platforms ((action (progn (run echo foo) (run echo baz))))))
   $ cat ${default_lock_dir}/lock.dune
   (lang package 0.1)
   
@@ -173,9 +173,10 @@ stored in the lockdir metadata:
    (used))
   
   (expanded_solver_variable_bindings
-   (variable_values
-    (os linux)
-    (arch arm))
    (unset_variables x))
   
-  (solved_for_platforms)
+  (solved_for_platforms
+   ((arch arm)
+    (os linux)
+    (os-family dunefamily)
+    (os-version 15)))

--- a/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
+++ b/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
@@ -89,6 +89,8 @@ Solve the packages again, this time with the variables set.
   (repositories
    (complete false)
    (used))
+  
+  (solved_for_platforms)
   Solution for dune.lock:
   - dynamic-deps.1.0
   - no-deps-a.1.0
@@ -105,6 +107,8 @@ Solve the packages again, this time with the variables set.
    (variable_values
     (os linux)
     (arch arm)))
+  
+  (solved_for_platforms)
   Solution for dune.lock:
   - dynamic-deps-lazy.1.0
   - no-deps-a.1.0
@@ -123,6 +127,8 @@ Solve the packages again, this time with the variables set.
     (os-family dunefamily)
     (os linux)
     (arch arm)))
+  
+  (solved_for_platforms)
 
 Test that variables referred to in filters on build and install commands are
 stored in the lockdir metadata:
@@ -150,12 +156,13 @@ stored in the lockdir metadata:
   (version 0.0.1)
   
   (install
-   (run echo qux))
+   (choice
+    ((())
+     (run echo qux))))
   
   (build
-   (progn
-    (run echo foo)
-    (run echo baz)))
+   (choice
+    ((()) ((action (progn (run echo foo) (run echo baz)))))))
   $ cat ${default_lock_dir}/lock.dune
   (lang package 0.1)
   
@@ -170,3 +177,5 @@ stored in the lockdir metadata:
     (os linux)
     (arch arm))
    (unset_variables x))
+  
+  (solved_for_platforms)

--- a/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
@@ -3,25 +3,25 @@ solver.
 
   $ mkrepo
 
-This test is specialized to non-portable lockdirs. For an analogous test of
-portable-lockdirs where different packages or packgae versions are available on
-different platforms, see the tests "portable-lockdirs-partial-solve" and
+This test uses separate lock directories configured for Linux and macOS.
+For analogous multi-platform cases where packages or package versions are
+available on different platforms, see
 "portable-lockdirs-platform-dependant-version".
-  $ export DUNE_CONFIG__PORTABLE_LOCK_DIR=disabled
-
 Set up two build contexts: a default one for linux and another for macos.
   $ cat >dune-workspace <<EOF
   > (lang dune 3.8)
   > (lock_dir
   >  (path dune.lock)
   >  (repositories mock)
-  >  (solver_env
-  >   (os linux)))
+  >  (solve_for_platforms
+  >   ((arch x86_64) (os linux))
+  >   ((arch arm64) (os linux))))
   > (lock_dir
   >  (path dune.macos.lock)
   >  (repositories mock)
-  >  (solver_env
-  >   (os macos)))
+  >  (solve_for_platforms
+  >   ((arch x86_64) (os macos))
+  >   ((arch arm64) (os macos))))
   > (context
   >  (default))
   > (context
@@ -89,10 +89,17 @@ A package whose oldest and newest version is only available if with-test is fals
 No solution will be available on macos as all versions of this package are only
 available on linux.
   $ solve linux-only
-  Solution for dune.lock:
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
   - linux-only.0.0.2
-  Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.macos.lock:
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.macos.lock
+  
+  The dependency solver failed to find a solution for the requested platforms:
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
+  ...with this error:
   Couldn't solve the package dependency formula.
   Selected candidates: x.dev
   - linux-only -> (problem)
@@ -104,19 +111,29 @@ available on linux.
 The latest version of the package will be chosen on linux but the middle
 version will be chosen on macos as that's the only version available on macos.
   $ solve macos-sometimes
-  Solution for dune.lock:
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
   - macos-sometimes.0.0.3
-  Solution for dune.macos.lock:
+  Solution for dune.macos.lock
+  
+  Dependencies common to all supported platforms:
   - macos-sometimes.0.0.2
 
-An undefined variable makes undefined-var.0.0.1 unavailable.
-undefined-var.0.0.2 has a valid `available` filter but is only available on
-linux.
+The undefined variable in undefined-var.0.0.1's availability filter makes that
+version unavailable. Version 0.0.2 is only available on Linux.
   $ solve undefined-var
-  Solution for dune.lock:
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
   - undefined-var.0.0.2
-  Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.macos.lock:
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.macos.lock
+  
+  The dependency solver failed to find a solution for the requested platforms:
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
+  ...with this error:
   Couldn't solve the package dependency formula.
   Selected candidates: x.dev
   - undefined-var -> (problem)
@@ -128,16 +145,26 @@ linux.
 Non-boolean availability filters make their package versions unavailable, so
 no solution will be found.
   $ solve availability-string
-  Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.lock
+  
+  The dependency solver failed to find a solution for the requested platforms:
+  - arch = x86_64; os = linux
+  - arch = arm64; os = linux
+  ...with this error:
   Couldn't solve the package dependency formula.
   Selected candidates: x.dev
   - availability-string -> (problem)
       No usable implementations:
         availability-string.0.0.2: Availability condition not satisfied
         availability-string.0.0.1: Availability condition not satisfied
-  Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.macos.lock:
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.macos.lock
+  
+  The dependency solver failed to find a solution for the requested platforms:
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
+  ...with this error:
   Couldn't solve the package dependency formula.
   Selected candidates: x.dev
   - availability-string -> (problem)
@@ -150,7 +177,11 @@ The middle version will be picked as this is the only one available if
 with-test is set. This exercises that we can handle flags in the available
 filter.
   $ solve with-test-check
-  Solution for dune.lock:
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
   - with-test-check.0.0.2
-  Solution for dune.macos.lock:
+  Solution for dune.macos.lock
+  
+  Dependencies common to all supported platforms:
   - with-test-check.0.0.2

--- a/test/expect-tests/dune_pkg/encode_decode_tests.ml
+++ b/test/expect-tests/dune_pkg/encode_decode_tests.ml
@@ -64,7 +64,11 @@ end
 let lock_dir_encode_decode_round_trip_test ?commit ~lock_dir_path ~lock_dir () =
   let lock_dir_path = Path.of_string lock_dir_path in
   Lock_dir.Write_disk.(
-    prepare ~portable_lock_dir:false ~lock_dir_path ~files:Package_name.Map.empty lock_dir
+    prepare
+      ~lock_dir_path
+      ~files:Package_name.Map.empty
+      ~portable_lock_dir:true
+      lock_dir
     |> commit);
   let lock_dir_round_tripped =
     try Lock_dir.read_disk_exn lock_dir_path with
@@ -101,21 +105,22 @@ let run thunk =
 ;;
 
 let%expect_test "encode/decode round trip test for lockdir with no deps" =
-  lock_dir_encode_decode_round_trip_test
-    ~lock_dir_path:"empty_lock_dir"
-    ~lock_dir:
-      (Lock_dir.create_latest_version
-         Package_name.Map.empty
-         ~local_packages:[]
-         ~ocaml:None
-         ~repos:None
-         ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
-         ~solved_for_platforms:[]
-         ~package_paths:Lock_dir.Package_paths.Unversioned
-         ~portable_lock_dir:false)
-    ();
+  let lock_dir =
+    Lock_dir.create_latest_version
+      Package_name.Map.empty
+      ~local_packages:[]
+      ~ocaml:None
+      ~repos:None
+      ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
+      ~solved_for_platforms:[]
+      ~package_paths:Lock_dir.Package_paths.Versioned
+      ~portable_lock_dir:true
+  in
+  printfn "uses versioned paths: %b" (Lock_dir.uses_versioned_paths lock_dir);
+  lock_dir_encode_decode_round_trip_test ~lock_dir_path:"empty_lock_dir" ~lock_dir ();
   [%expect
     {|
+    uses versioned paths: true
     lockdir matches after roundtrip:
     { version = (0, 1)
     ; dependency_hash = None
@@ -124,8 +129,8 @@ let%expect_test "encode/decode round trip test for lockdir with no deps" =
     ; repos = { complete = true; used = None }
     ; expanded_solver_variable_bindings =
         { variable_values = []; unset_variables = [] }
-    ; solved_for_platforms = ("<none>:1", [])
-    ; package_paths = Unversioned
+    ; solved_for_platforms = ("empty_lock_dir/lock.dune:6", [ map {} ])
+    ; package_paths = Versioned
     }
     |}]
 ;;
@@ -166,8 +171,8 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
            ; unset_variables = [ Package_variable_name.os_family ]
            }
          ~solved_for_platforms:[]
-         ~package_paths:Lock_dir.Package_paths.Unversioned
-         ~portable_lock_dir:false
+         ~package_paths:Lock_dir.Package_paths.Versioned
+         ~portable_lock_dir:true
          (Package_name.Map.of_list_exn
             [ mk_pkg_basic ~name:"foo" ~version:(Package_version.of_string "0.1.0")
             ; mk_pkg_basic ~name:"bar" ~version:(Package_version.of_string "0.2.0")
@@ -222,11 +227,9 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
     ; ocaml = Some ("simple_lock_dir/lock.dune:3", "ocaml")
     ; repos = { complete = true; used = None }
     ; expanded_solver_variable_bindings =
-        { variable_values = [ ("os", "linux") ]
-        ; unset_variables = [ "os-family" ]
-        }
-    ; solved_for_platforms = ("<none>:1", [])
-    ; package_paths = Unversioned
+        { variable_values = []; unset_variables = [] }
+    ; solved_for_platforms = ("simple_lock_dir/lock.dune:8", [ map {} ])
+    ; package_paths = Versioned
     }
     |}]
 ;;
@@ -330,8 +333,8 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
       ~repos:(Some [ opam_repo ])
       ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
       ~solved_for_platforms:[]
-      ~package_paths:Lock_dir.Package_paths.Unversioned
-      ~portable_lock_dir:false
+      ~package_paths:Lock_dir.Package_paths.Versioned
+      ~portable_lock_dir:true
       (Package_name.Map.of_list_exn [ pkg_a; pkg_b; pkg_c ])
   in
   lock_dir_encode_decode_round_trip_test ~lock_dir_path:"complex_lock_dir" ~lock_dir ();
@@ -382,7 +385,9 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                     ; depends =
                         [ { condition = [ map {} ]
                           ; value =
-                              [ { loc = "complex_lock_dir/b.pkg:3"; name = "a" }
+                              [ { loc = "complex_lock_dir/b.dev.pkg:4"
+                                ; name = "a"
+                                }
                               ]
                           }
                         ]
@@ -413,8 +418,12 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                     ; depends =
                         [ { condition = [ map {} ]
                           ; value =
-                              [ { loc = "complex_lock_dir/c.pkg:3"; name = "a" }
-                              ; { loc = "complex_lock_dir/c.pkg:3"; name = "b" }
+                              [ { loc = "complex_lock_dir/c.0.2.pkg:5"
+                                ; name = "a"
+                                }
+                              ; { loc = "complex_lock_dir/c.0.2.pkg:5"
+                                ; name = "b"
+                                }
                               ]
                           }
                         ]
@@ -443,8 +452,8 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
         }
     ; expanded_solver_variable_bindings =
         { variable_values = []; unset_variables = [] }
-    ; solved_for_platforms = ("<none>:1", [])
-    ; package_paths = Unversioned
+    ; solved_for_platforms = ("complex_lock_dir/lock.dune:9", [ map {} ])
+    ; package_paths = Versioned
     }
     |}]
 ;;
@@ -480,8 +489,8 @@ let%expect_test "encode/decode round trip test with locked repo revision" =
         ~repos:(Some [ opam_repo ])
         ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
         ~solved_for_platforms:[]
-        ~package_paths:Lock_dir.Package_paths.Unversioned
-        ~portable_lock_dir:false
+        ~package_paths:Lock_dir.Package_paths.Versioned
+        ~portable_lock_dir:true
         (Package_name.Map.of_list_exn [ pkg_a; pkg_b; pkg_c ])
     in
     lock_dir_encode_decode_round_trip_test
@@ -565,8 +574,8 @@ let%expect_test "encode/decode round trip test with locked repo revision" =
         }
     ; expanded_solver_variable_bindings =
         { variable_values = []; unset_variables = [] }
-    ; solved_for_platforms = ("<none>:1", [])
-    ; package_paths = Unversioned
+    ; solved_for_platforms = ("complex_lock_dir/lock.dune:11", [ map {} ])
+    ; package_paths = Versioned
     }
     |}]
 ;;

--- a/test/expect-tests/dune_pkg/encode_decode_tests.ml
+++ b/test/expect-tests/dune_pkg/encode_decode_tests.ml
@@ -111,6 +111,7 @@ let%expect_test "encode/decode round trip test for lockdir with no deps" =
          ~repos:None
          ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
          ~solved_for_platforms:[]
+         ~package_paths:Lock_dir.Package_paths.Unversioned
          ~portable_lock_dir:false)
     ();
   [%expect
@@ -124,6 +125,7 @@ let%expect_test "encode/decode round trip test for lockdir with no deps" =
     ; expanded_solver_variable_bindings =
         { variable_values = []; unset_variables = [] }
     ; solved_for_platforms = ("<none>:1", [])
+    ; package_paths = Unversioned
     }
     |}]
 ;;
@@ -164,6 +166,7 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
            ; unset_variables = [ Package_variable_name.os_family ]
            }
          ~solved_for_platforms:[]
+         ~package_paths:Lock_dir.Package_paths.Unversioned
          ~portable_lock_dir:false
          (Package_name.Map.of_list_exn
             [ mk_pkg_basic ~name:"foo" ~version:(Package_version.of_string "0.1.0")
@@ -223,6 +226,7 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
         ; unset_variables = [ "os-family" ]
         }
     ; solved_for_platforms = ("<none>:1", [])
+    ; package_paths = Unversioned
     }
     |}]
 ;;
@@ -326,6 +330,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
       ~repos:(Some [ opam_repo ])
       ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
       ~solved_for_platforms:[]
+      ~package_paths:Lock_dir.Package_paths.Unversioned
       ~portable_lock_dir:false
       (Package_name.Map.of_list_exn [ pkg_a; pkg_b; pkg_c ])
   in
@@ -439,6 +444,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
     ; expanded_solver_variable_bindings =
         { variable_values = []; unset_variables = [] }
     ; solved_for_platforms = ("<none>:1", [])
+    ; package_paths = Unversioned
     }
     |}]
 ;;
@@ -474,6 +480,7 @@ let%expect_test "encode/decode round trip test with locked repo revision" =
         ~repos:(Some [ opam_repo ])
         ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
         ~solved_for_platforms:[]
+        ~package_paths:Lock_dir.Package_paths.Unversioned
         ~portable_lock_dir:false
         (Package_name.Map.of_list_exn [ pkg_a; pkg_b; pkg_c ])
     in
@@ -559,6 +566,7 @@ let%expect_test "encode/decode round trip test with locked repo revision" =
     ; expanded_solver_variable_bindings =
         { variable_values = []; unset_variables = [] }
     ; solved_for_platforms = ("<none>:1", [])
+    ; package_paths = Unversioned
     }
     |}]
 ;;

--- a/test/expect-tests/sat/sat_tests.ml
+++ b/test/expect-tests/sat/sat_tests.ml
@@ -101,6 +101,45 @@ let%expect_test "run_solver records decisions, and counters are cumulative" =
   |}]
 ;;
 
+let%expect_test "incremental deciders can detect non-chronological backtracking" =
+  let open Sat in
+  let p = create () in
+  let a = add_variable p 1 in
+  let c = add_variable p 2 in
+  let d = add_variable p 3 in
+  let x = add_variable p 4 in
+  (* Selecting [a] and [d] implies both [x] and [not x]. The unrelated
+     decision [c] makes conflict analysis backjump from level 3 to level 1. *)
+  at_least_one p [ neg a; neg d; x ];
+  at_least_one p [ neg a; neg d; neg x ];
+  let choices = ref [ a; c; d ] in
+  let previous_level = ref 0 in
+  let decide () =
+    let level = get_decision_level p in
+    if level < !previous_level
+    then Format.printf "backtracked from level %d to %d@." !previous_level level;
+    previous_level := level;
+    Format.printf "decide at level %d@." level;
+    match !choices with
+    | [] -> None
+    | choice :: rest ->
+      choices := rest;
+      Some choice
+  in
+  print_endline (string_of_bool (run_solver p decide));
+  print_stats p;
+  [%expect
+    {|
+    decide at level 0
+    decide at level 1
+    decide at level 2
+    backtracked from level 2 to 1
+    decide at level 1
+    true
+    num_variables=4 num_clauses=2 num_decisions=5 num_conflicts=1
+  |}]
+;;
+
 let%expect_test "impossible problems are rejected before solving" =
   let open Sat in
   let p = create () in

--- a/test/expect-tests/sat/sat_tests.ml
+++ b/test/expect-tests/sat/sat_tests.ml
@@ -101,6 +101,31 @@ let%expect_test "run_solver records decisions, and counters are cumulative" =
   |}]
 ;;
 
+let%expect_test "variables cannot be added at an active decision level" =
+  let open Sat in
+  let p = create () in
+  let a = add_variable p 1 in
+  let _b = add_variable p 2 in
+  let first_decision = ref true in
+  let decide () =
+    if !first_decision
+    then (
+      first_decision := false;
+      Some a)
+    else (
+      (match add_variable p 3 with
+       | exception Invalid_argument message -> print_endline message
+       | _ -> print_endline "unexpectedly added a variable");
+      None)
+  in
+  print_endline (string_of_bool (run_solver p decide));
+  [%expect
+    {|
+    Sat.add_variable: cannot add variables after decisions have begun
+    true
+  |}]
+;;
+
 let%expect_test "incremental deciders can detect non-chronological backtracking" =
   let open Sat in
   let p = create () in


### PR DESCRIPTION
> Depends on #16218. This remains a draft while the remaining lock-directory differences are consolidated incrementally.

## Summary

The current stack separates three mechanical cleanups:

1. **Normalize conditional package fields** — write the conditional package-field representation while preserving legacy atom, bare-action, and bare-depext decoding.
2. **Normalize solution summaries** — use one platform-aware success renderer, with a fallback for lock directories without a platform map.
3. **Remove the feature toggle** — delete the configure/runtime toggle and migrate tests that relied on it to explicit `solve_for_platforms` entries.

Package path numbering is handled independently by #16218. This stack will be revised further as the semantic differences between the formats are isolated.

## Checks

- `dune build @check @fmt`
- Focused legacy decoder, lock selection, metadata, unavailable-package, SAT, and dev-tool crams