### PR TITLE
test(meta): snapshot malformed source template acceptance

### DIFF
--- a/test/blackbox-tests/test-cases/meta-file/source-template.t
+++ b/test/blackbox-tests/test-cases/meta-file/source-template.t
@@ -1,0 +1,20 @@
+Malformed source META file templates are currently installed without a
+diagnostic. Snapshot that behavior before adding validation.
+
+  $ make_dune_project_with_package 2.7 foobarlib
+
+  $ cat >foobarlib.ml <<EOF
+  > let foo () = ()
+  > EOF
+
+  $ cat >dune <<EOF
+  > (library
+  >  (public_name foobarlib))
+  > EOF
+
+  $ cat >META.foobarlib.template <<EOF
+  > package "broken" (
+  > # DUNE_GEN
+  > EOF
+
+  $ dune build @install


### PR DESCRIPTION
Records that `@install` currently accepts a malformed source META file template. The follow-up invariant is that source syntax gates installation and diagnostics point to the source file.

Test: `dune runtest test/blackbox-tests/test-cases/meta-file/source-template.t`