### PR TITLE
fix(nix): use bootstrapped Dune for MinGW cross build

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -36,8 +36,10 @@ jobs:
           - os: ubuntu-26.04
             name: x86_64-unknown-linux-musl
             installable: .#dune-static
-          # Building x86_64-pc-windows-gnu does not work when Dune itself uses
-          # an unreleased version of Dune.
+          - os: ubuntu-26.04
+            name: x86_64-pc-windows-gnu
+            installable: .#windows-static
+            binary: dune.exe
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,9 @@
                     # construction and `fixOCamlPackage` can pair the cross
                     # derivation with this native template via
                     # `findNativePackage`.
-                    dune_target = oself.callPackage ./nix/dune-target.nix { };
+                    dune_target = oself.callPackage ./nix/dune-target.nix {
+                      duneForBuild = oself.dune_3;
+                    };
                   }
                 );
                 # Keep `ocaml-ng.ocamlPackages_5_5` in sync with the override

--- a/nix/dune-package.nix
+++ b/nix/dune-package.nix
@@ -74,7 +74,7 @@ let
   # avoids the `NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1` escape hatch at the call
   # site.
   duneFor =
-    crossPkgs:
+    duneForBuild: crossPkgs:
     let
       withDuneTarget = crossPkgs.appendOverlays [
         (self: super: {
@@ -107,7 +107,12 @@ let
         })
       ];
     in
-    withDuneTarget.ocamlPackages.dune_target.overrideAttrs { src = dune-source; };
+    (withDuneTarget.ocamlPackages.dune_target.override {
+      inherit duneForBuild;
+    }).overrideAttrs
+      {
+        src = dune-source;
+      };
 
   overrideOcaml =
     ocamlOverride: crossPkgs:
@@ -121,7 +126,7 @@ let
       })
     ];
 in
-{
+rec {
   default =
     with pkgs;
     stdenv.mkDerivation {
@@ -148,8 +153,10 @@ in
 
   musl-static = pkgs-static.pkgsCross.musl64.ocamlPackages.dune;
 
-  # `framePointerSupport` is forced off because mingw can't build OCaml
-  windows-static = duneFor (
+  # `framePointerSupport` is forced off because mingw can't build OCaml.
+  # Use the bootstrapped Dune from this source tree so unreleased language
+  # versions can be cross-compiled.
+  windows-static = duneFor default (
     overrideOcaml { framePointerSupport = false; } pkgs.pkgsCross.mingwW64Static
   );
 }

--- a/nix/dune-target.nix
+++ b/nix/dune-target.nix
@@ -9,6 +9,7 @@
   buildDunePackage,
   ocaml,
   dune_3,
+  duneForBuild,
   csexp,
   pp,
   ppx_expect,
@@ -46,10 +47,14 @@ else
     dontAddPrefix = true;
     dontFixup = true;
     depsBuildBuild = [ buildPackages.stdenv.cc ];
-    nativeBuildInputs = lib.remove buildPackages.stdenv.cc (o.nativeBuildInputs or [ ]);
+    nativeBuildInputs = [
+      duneForBuild
+    ]
+    ++ lib.remove dune_3 (lib.remove buildPackages.stdenv.cc (o.nativeBuildInputs or [ ]));
     buildPhase = ''
       runHook preBuild
-      dune build -x ${crossName} ''${enableParallelBuilding:+-j $NIX_BUILD_CORES} bin/main.exe
+      ${duneForBuild}/bin/dune build -x ${crossName} \
+        ''${enableParallelBuilding:+-j $NIX_BUILD_CORES} bin/main.exe
       runHook postBuild
     '';
     installPhase = ''


### PR DESCRIPTION
## Description

Use the Dune bootstrapped from the current source tree to drive the MinGW cross-build instead of the released Dune supplied by `nix-overlays`. Restore the `x86_64-pc-windows-gnu` binary job in the same change.

The ordinary `dune_target` template continues to use the packaged `dune_3`; only `windows-static` substitutes the source-built Dune.

## Motivation

After #15919 moved the repository to `(lang dune 3.25)`, the released Dune 3.24.2 could no longer parse the source tree, so the Windows job originally added in #15285 had to be disabled. Bootstrapping the native build driver from the checkout allows unreleased language versions to be cross-compiled.

## Testing

- `./dune.exe build @check @fmt`
- `nixfmt --check flake.nix nix/dune-package.nix nix/dune-target.nix`
- `nix build path:.#windows-static`
- `file result/bin/dune.exe`

  ```text
  result/bin/dune.exe: PE32+ executable for MS Windows 5.02 (console), x86-64, 21 sections
  ```
