### PR TITLE
fix(meta): reject malformed META file templates

### DIFF
--- a/doc/changes/fixed/15994.md
+++ b/doc/changes/fixed/15994.md
@@ -1,0 +1,2 @@
+- Reject malformed META file templates at their source or generated location,
+  and preserve backslashes in generated values. (#15994, @Alizter)

--- a/src/dune_findlib/meta.ml
+++ b/src/dune_findlib/meta.ml
@@ -320,16 +320,16 @@ let pp_predicate p =
      | Neg p -> "-" ^ p)
 ;;
 
+let escape_quoted_string s = String.escape_only '"' (String.escape_only '\\' s)
+
 let pp_print_text s =
   let open Pp.O in
-  Pp.verbatim "\"" ++ Pp.hvbox (Pp.text (String.escape_only '"' s)) ++ Pp.verbatim "\""
+  Pp.verbatim "\"" ++ Pp.hvbox (Pp.text (escape_quoted_string s)) ++ Pp.verbatim "\""
 ;;
 
 let pp_print_string s =
   let open Pp.O in
-  Pp.verbatim "\""
-  ++ Pp.hvbox (Pp.verbatim (String.escape_only '"' s))
-  ++ Pp.verbatim "\""
+  Pp.verbatim "\"" ++ Pp.hvbox (Pp.verbatim (escape_quoted_string s)) ++ Pp.verbatim "\""
 ;;
 
 let pp_quoted_value var =

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -1001,54 +1001,174 @@ end = struct
       Super_context.add_rule sctx ~dir:ctx.build_dir action
   ;;
 
+  let meta_entries_for_main_package entries =
+    Scope.DB.Lib_entry.Set.partition_map entries ~f:(function
+      | Scope.DB.Lib_entry.Deprecated_library_name
+          { old_name = public, Deprecated { deprecated_package }; _ } as entry ->
+        (match Public_lib.sub_dir public with
+         | None -> Left (deprecated_package, entry)
+         | Some _ -> Right entry)
+      | entry -> Right entry)
+    |> snd
+  ;;
+
+  type meta_template_line =
+    { text : string
+    ; generation_marker_loc : Loc.t option
+    }
+
+  type meta_template =
+    { lines : meta_template_line list
+    ; path : Path.t
+    }
+
+  let invalid_meta_template (package : Package.t) ~loc (message : User_message.t) =
+    User_error.raise
+      ~loc
+      ~hints:message.hints
+      ~compound:message.compound
+      ~has_embedded_location:message.has_embedded_location
+      ~needs_stack_trace:message.needs_stack_trace
+      ?promotion:message.promotion
+      [ Pp.textf
+          "Invalid META template for package %s."
+          (Package.Name.to_string (Package.name package))
+      ; Pp.text (User_message.to_string message)
+      ]
+  ;;
+
+  let is_meta_generation_line line =
+    if String.starts_with ~prefix:"#" line
+    then (
+      match String.extract_blank_separated_words (String.drop line 1) with
+      | [ ("JBUILDER_GEN" | "DUNE_GEN") ] -> true
+      | _ -> false)
+    else false
+  ;;
+
+  let meta_template ctx (pkg : Package.t) entries =
+    let meta_template_path = Package_paths.meta_template ctx pkg in
+    let meta_template = Path.build meta_template_path in
+    let source_template =
+      Path.Build.drop_build_context_exn meta_template_path |> Path.source
+    in
+    let validate path contents =
+      let fname = Path.to_string path in
+      let lexbuf = Lexbuf.from_string contents ~fname in
+      match Meta.of_lex lexbuf ~name:(Some (Package.name pkg)) with
+      | (_ : Meta.Simplified.t) ->
+        let rec add_locations line_number acc = function
+          | [] -> List.rev acc
+          | text :: lines ->
+            let generation_marker_loc =
+              if is_meta_generation_line text
+              then (
+                let start : Lexing.position =
+                  { pos_fname = fname; pos_lnum = line_number; pos_cnum = 0; pos_bol = 0 }
+                in
+                Some
+                  (Loc.create ~start ~stop:{ start with pos_cnum = String.length text }))
+              else None
+            in
+            add_locations (line_number + 1) ({ text; generation_marker_loc } :: acc) lines
+        in
+        { lines = add_locations 1 [] (String.split_lines contents); path }
+      | exception User_error.E message ->
+        let loc = Option.value message.loc ~default:(Loc.in_file path) in
+        invalid_meta_template pkg ~loc message
+    in
+    let meta_template_or_fail =
+      let open Action_builder.O in
+      let* { Scope.DB.Lib_entry.Set.libraries; _ } = Action_builder.of_memo entries in
+      match
+        List.find_map libraries ~f:(fun lib ->
+          match Lib_info.kind (Lib.Local.info lib) with
+          | Parameter | Virtual -> Some lib
+          | Dune_file _ -> None)
+      with
+      | Some vlib ->
+        Action_builder.fail
+          { fail =
+              (fun () ->
+                let name = Lib.name (Lib.Local.to_lib vlib) in
+                User_error.raise
+                  ~loc:(Loc.in_file meta_template)
+                  [ Pp.textf
+                      "Package %s defines virtual library %s and has a META template. \
+                       This is not allowed."
+                      (Package.Name.to_string (Package.name pkg))
+                      (Lib_name.to_string name)
+                  ])
+          }
+      | None ->
+        let* contents = Action_builder.contents meta_template
+        and* source_contents =
+          Action_builder.if_file_exists
+            source_template
+            ~then_:
+              (let+ contents = Action_builder.contents source_template in
+               Some contents)
+            ~else_:(Action_builder.return None)
+        in
+        let path =
+          match source_contents with
+          | Some source_contents when String.equal contents source_contents ->
+            source_template
+          | None | Some _ -> meta_template
+        in
+        Action_builder.return (Some (validate path contents))
+    in
+    Action_builder.if_file_exists
+      meta_template
+      ~then_:meta_template_or_fail
+      ~else_:(Action_builder.return None)
+  ;;
+
+  let render_meta_template ~(package : Package.t) template (meta : Meta.t) =
+    let generated_line_count =
+      let generated = Format.asprintf "%a" Pp.to_fmt (Meta.pp meta.entries) in
+      match String.split_lines generated with
+      | [] -> 1
+      | lines -> List.length lines
+    in
+    let contents =
+      Pp.concat_map template.lines ~sep:Pp.newline ~f:(fun { text; _ } ->
+        if is_meta_generation_line text then Meta.pp meta.entries else Pp.verbatim text)
+      |> Pp.vbox
+      |> Format.asprintf "%a" Pp.to_fmt
+    in
+    match Meta.of_string contents ~name:(Some (Package.name package)) with
+    | (_ : Meta.Simplified.t) -> contents
+    | exception User_error.E message ->
+      let marker_locations =
+        let _, locations =
+          List.fold_left
+            template.lines
+            ~init:(1, [])
+            ~f:(fun (line_number, acc) -> function
+            | { generation_marker_loc = None; _ } -> line_number + 1, acc
+            | { generation_marker_loc = Some loc; _ } ->
+              line_number + generated_line_count, (line_number, loc) :: acc)
+        in
+        List.rev locations
+      in
+      let loc =
+        match message.loc with
+        | None -> Loc.in_file template.path
+        | Some rendered_loc ->
+          let rendered_line = (Loc.start rendered_loc).pos_lnum in
+          List.fold_left marker_locations ~init:None ~f:(fun loc (line_number, marker) ->
+            if line_number <= rendered_line then Some marker else loc)
+          |> Option.value ~default:(Loc.in_file template.path)
+      in
+      invalid_meta_template package ~loc message
+  ;;
+
   let gen_meta_file sctx (pkg : Package.t) entries =
     let ctx = Super_context.context sctx |> Context.build_context in
     let* () =
-      let template =
-        let meta_template = Path.build (Package_paths.meta_template ctx pkg) in
-        let meta_template_lines_or_fail =
-          let open Action_builder.O in
-          let* () = Action_builder.return () in
-          let* { Scope.DB.Lib_entry.Set.libraries; _ } = Action_builder.of_memo entries in
-          match
-            List.find_map libraries ~f:(fun lib ->
-              match Lib_info.kind (Lib.Local.info lib) with
-              | Parameter | Virtual -> Some lib
-              | Dune_file _ -> None)
-          with
-          | None -> Action_builder.lines_of meta_template
-          | Some vlib ->
-            Action_builder.fail
-              { fail =
-                  (fun () ->
-                    let name = Lib.name (Lib.Local.to_lib vlib) in
-                    let pkg_name = Package.name pkg in
-                    User_error.raise
-                      ~loc:(Loc.in_file meta_template)
-                      [ Pp.textf
-                          "Package %s defines virtual library %s and has a META \
-                           template. This is not allowed."
-                          (Package.Name.to_string pkg_name)
-                          (Lib_name.to_string name)
-                      ])
-              }
-        in
-        Action_builder.if_file_exists
-          meta_template
-          ~then_:meta_template_lines_or_fail
-          ~else_:(Action_builder.return [ "# DUNE_GEN" ])
-      in
-      let meta_entries =
-        entries
-        >>| Scope.DB.Lib_entry.Set.partition_map ~f:(function
-          | Scope.DB.Lib_entry.Deprecated_library_name
-              { old_name = public, Deprecated { deprecated_package }; _ } as entry ->
-            (match Public_lib.sub_dir public with
-             | None -> Left (deprecated_package, entry)
-             | Some _ -> Right entry)
-          | entry -> Right entry)
-        >>| snd
-      in
+      let template = meta_template ctx pkg entries in
+      let meta_entries = entries >>| meta_entries_for_main_package in
       Super_context.add_rule
         sctx
         ~dir:ctx.build_dir
@@ -1058,17 +1178,9 @@ end = struct
             Action_builder.of_memo meta_entries
             >>= Gen_meta.gen ~package:pkg ~add_directory_entry:true
           in
-          let pp =
-            Pp.concat_map template ~sep:Pp.newline ~f:(fun s ->
-              if String.starts_with ~prefix:"#" s
-              then (
-                match String.extract_blank_separated_words (String.drop s 1) with
-                | [ ("JBUILDER_GEN" | "DUNE_GEN") ] -> Meta.pp meta.entries
-                | _ -> Pp.verbatim s)
-              else Pp.verbatim s)
-            |> Pp.vbox
-          in
-          Format.asprintf "%a" Pp.to_fmt pp)
+          match template with
+          | None -> Format.asprintf "%a" Pp.to_fmt (Pp.vbox (Meta.pp meta.entries))
+          | Some template -> render_meta_template ~package:pkg template meta)
          |> Action_builder.write_file_dyn (Package_paths.meta_file ctx pkg))
     in
     let deprecated_packages =

--- a/test/blackbox-tests/test-cases/meta-file/backslash-roundtrip.t
+++ b/test/blackbox-tests/test-cases/meta-file/backslash-roundtrip.t
@@ -1,5 +1,5 @@
-Generated META values currently leave backslashes unescaped. Snapshot both the
-output and its failure to round-trip through findlib.
+Generated META values escape backslashes so the output round-trips through
+findlib without changing the decoded value.
 
   $ make_dune_project_with_package 2.7 slashlib
 
@@ -15,10 +15,9 @@ output and its failure to round-trip through findlib.
 
   $ dune build @install
   $ grep '^description' _build/default/META.slashlib
-  description = "ends in \"
+  description = "ends in \\"
 
   $ export OCAMLPATH="$PWD/_build/install/default/lib"
   $ export OCAMLFIND_LDCONF=ignore
   $ ocamlfind query -format '%D' slashlib
-  ocamlfind: While parsing '$TESTCASE_ROOT/_build/install/default/lib/slashlib/META': Expected 'name = value' clause at line 1 position 38
-  [2]
+  ends in \

--- a/test/blackbox-tests/test-cases/meta-file/generated-template.t
+++ b/test/blackbox-tests/test-cases/meta-file/generated-template.t
@@ -1,5 +1,5 @@
-Rule-generated META file templates are currently accepted when malformed. The
-rule omits a final newline so the diagnostic must use the exact contents.
+Rule-generated META file templates are validated using their exact contents and
+are diagnosed at their build path.
 
   $ make_dune_project_with_package 2.7 generated
 
@@ -18,10 +18,9 @@ rule omits a final newline so the diagnostic must use the exact contents.
   > EOF
 
   $ dune build @install
-
-The generated template has the exact unterminated contents, including no final
-newline, and those contents reach the generated META file.
-
-  $ printf 'package "broken" (' | cmp - _build/default/META.generated.template
-  $ grep '^package "broken" (' _build/default/META.generated
-  package "broken" (
+  File "_build/default/META.generated.template", line 1, characters 18-18:
+  1 | package "broken" (
+                        
+  Error: Invalid META template for package generated.
+  1 closing parentheses missing
+  [1]

--- a/test/blackbox-tests/test-cases/meta-file/promoted-template.t
+++ b/test/blackbox-tests/test-cases/meta-file/promoted-template.t
@@ -1,5 +1,5 @@
-A promoted META file template may have a source counterpart that differs from
-the rule output. The generated contents are currently accepted.
+Promoted META file templates are validated against the generated contents even
+when a stale source counterpart exists.
 
   $ make_dune_project_with_package 2.7 promoted
 
@@ -23,10 +23,9 @@ the rule output. The generated contents are currently accepted.
   > EOF
 
   $ dune build @install --disable-promotion
-
-The source remains valid, while the generated template and final META contain
-the malformed rule output.
-
-  $ printf '# DUNE_GEN\n' | cmp - META.promoted.template
-  $ printf 'package "broken" @' | cmp - _build/default/META.promoted.template
-  $ printf 'package "broken" @' | cmp - _build/default/META.promoted
+  File "_build/default/META.promoted.template", line 1, characters 17-18:
+  1 | package "broken" @
+                       ^
+  Error: Invalid META template for package promoted.
+  invalid character
+  [1]

--- a/test/blackbox-tests/test-cases/meta-file/promoted-template.t
+++ b/test/blackbox-tests/test-cases/meta-file/promoted-template.t
@@ -1,0 +1,32 @@
+A promoted META file template may have a source counterpart that differs from
+the rule output. The generated contents are currently accepted.
+
+  $ make_dune_project_with_package 2.7 promoted
+
+  $ cat >promoted.ml <<EOF
+  > let foo () = ()
+  > EOF
+
+  $ cat >META.promoted.template <<EOF
+  > # DUNE_GEN
+  > EOF
+
+  $ cat >dune <<'EOF'
+  > (library
+  >  (public_name promoted))
+  > 
+  > (rule
+  >  (target META.promoted.template)
+  >  (mode promote)
+  >  (action
+  >   (write-file %{target} "package \"broken\" @")))
+  > EOF
+
+  $ dune build @install --disable-promotion
+
+The source remains valid, while the generated template and final META contain
+the malformed rule output.
+
+  $ printf '# DUNE_GEN\n' | cmp - META.promoted.template
+  $ printf 'package "broken" @' | cmp - _build/default/META.promoted.template
+  $ printf 'package "broken" @' | cmp - _build/default/META.promoted

--- a/test/blackbox-tests/test-cases/meta-file/rendered-template.t
+++ b/test/blackbox-tests/test-cases/meta-file/rendered-template.t
@@ -1,0 +1,30 @@
+META file templates are validated after expansion. Failures introduced by
+generated entries are attributed to the responsible generation marker.
+
+  $ make_dune_project_with_package 2.7 rendered
+
+  $ cat >rendered.ml <<EOF
+  > let foo () = ()
+  > EOF
+
+  $ cat >dune <<EOF
+  > (library
+  >  (public_name rendered)
+  >  (synopsis "generated marker"))
+  > EOF
+
+  $ cat >META.rendered.template <<'EOF'
+  > # DUNE_GEN
+  > package "broken"
+  > # DUNE_GEN
+  > (
+  > )
+  > EOF
+
+  $ dune build @install
+  File "META.rendered.template", line 3, characters 0-10:
+  3 | # DUNE_GEN
+      ^^^^^^^^^^
+  Error: Invalid META template for package rendered.
+  '(' expected
+  [1]

--- a/test/blackbox-tests/test-cases/meta-file/rendered-template.t
+++ b/test/blackbox-tests/test-cases/meta-file/rendered-template.t
@@ -1,0 +1,34 @@
+A META file template may parse before expansion but become invalid when generated
+entries replace a later marker. This is currently accepted.
+
+  $ make_dune_project_with_package 2.7 rendered
+
+  $ cat >rendered.ml <<EOF
+  > let foo () = ()
+  > EOF
+
+  $ cat >dune <<EOF
+  > (library
+  >  (public_name rendered)
+  >  (synopsis "generated marker"))
+  > EOF
+
+  $ cat >META.rendered.template <<'EOF'
+  > # DUNE_GEN
+  > package "broken"
+  > # DUNE_GEN
+  > (
+  > )
+  > EOF
+
+  $ dune build @install
+
+Both markers were expanded, and the malformed literal was installed between
+them.
+
+  $ grep -c '^description = "generated marker"$' _build/default/META.rendered
+  2
+  $ grep '^package "broken"$' _build/default/META.rendered
+  package "broken"
+  $ awk '/^package "broken"$/ { getline; print; exit }' _build/default/META.rendered
+  description = "generated marker"

--- a/test/blackbox-tests/test-cases/meta-file/source-template.t
+++ b/test/blackbox-tests/test-cases/meta-file/source-template.t
@@ -1,5 +1,5 @@
-Malformed source META file templates are currently installed without a
-diagnostic. Snapshot that behavior before adding validation.
+Malformed source META file templates are rejected at their source location
+instead of being installed.
 
   $ make_dune_project_with_package 2.7 foobarlib
 
@@ -18,3 +18,7 @@ diagnostic. Snapshot that behavior before adding validation.
   > EOF
 
   $ dune build @install
+  File "META.foobarlib.template", line 3, characters 0-0:
+  Error: Invalid META template for package foobarlib.
+  1 closing parentheses missing
+  [1]


### PR DESCRIPTION
Depends on #16004 and #16006. Main already contains the generated-template, backslash, and virtual-library ordering regressions from #16005, #16007, and #16008.

Validate exact META file template contents before and after rendering. Preserve source/build origins and structured diagnostics, attribute rendered failures to the responsible marker, keep virtual-library checks ahead of template actions, and escape generated backslashes.

Test: `dune runtest test/blackbox-tests/test-cases/meta-file`