### PR TITLE
test(pkg): preserve platform filters in local constraints

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-local-platform-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-local-platform-constraints.t
@@ -1,0 +1,38 @@
+A local package's dependency filters are evaluated in each requested platform's
+environment.
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ mkpkg foo 1
+  $ mkpkg foo 2
+
+The conflict excludes foo.2 everywhere except Linux. The Linux solve must retain
+the platform filter instead of evaluating it in a platform-less environment.
+
+  $ cat >dune-project <<'EOF'
+  > (lang dune 3.18)
+  > EOF
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.20)
+  > (repository
+  >  (name mock)
+  >  (url "file://$(pwd)/mock-opam-repository"))
+  > (lock_dir
+  >  (repositories mock)
+  >  (solve_for_platforms
+  >   ((arch x86_64)
+  >    (os linux))))
+  > (pkg enabled)
+  > EOF
+  $ cat >x.opam <<'EOF'
+  > opam-version: "2.0"
+  > depends: [ "foo" {>= "2"} ]
+  > conflicts: [ "foo" {>= "2" & os != "linux"} ]
+  > EOF
+
+  $ dune pkg lock
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
+  - foo.2


### PR DESCRIPTION
## Summary

- Add a portable lock-directory regression for a local package whose dependency and conflict formulas contain platform filters.
- Request Linux explicitly and assert that `foo.2` remains selectable there.
- Guard against evaluating local-package formulas in a platform-less environment before multi-platform solving.

This is an independent test-only baseline for the joint-solver work in #15982.

## Tests

- `nix develop -c dune runtest test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-local-platform-constraints.t`
- `CI=true nix develop -c dune build @fmt @check`