### PR TITLE
test(pkg): document legacy per-platform version selection

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-language-version-compatibility.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-language-version-compatibility.t
@@ -1,0 +1,38 @@
+Existing language versions permit a portable lock directory to select different
+versions on different platforms.
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ mkpkg foo 1 <<'EOF'
+  > available: os = "linux"
+  > EOF
+  $ mkpkg foo 2 <<'EOF'
+  > available: os = "macos"
+  > EOF
+  $ cat >dune-project <<'EOF'
+  > (lang dune 3.18)
+  > (package
+  >  (name x)
+  >  (depends foo))
+  > EOF
+
+  $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=x86_64 dune pkg lock
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
+  (none)
+  
+  Additionally, some packages will only be built on specific platforms.
+  
+  arch = arm64; os = linux:
+  - foo.1
+  
+  arch = arm64; os = macos:
+  - foo.2
+  
+  arch = x86_64; os = linux:
+  - foo.1
+  
+  arch = x86_64; os = macos:
+  - foo.2


### PR DESCRIPTION
## Summary

- Add a regression documenting that existing language versions currently allow a portable lock directory to choose different versions of one package on different platforms.
- Use mutually exclusive Linux and macOS availability filters to make that behavior explicit.
- Establish the compatibility baseline changed by the joint solver.

This test intentionally documents legacy behavior; #15982 updates its expectation to the intended all-platform failure when no common version exists.

## Tests

- `nix develop -c dune runtest test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-language-version-compatibility.t`
- `CI=true nix develop -c dune build @fmt @check`