### PR TITLE
test(pkg): cover common-version extra files

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-common-version-extra-files.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-common-version-extra-files.t
@@ -1,0 +1,39 @@
+Successful portable locking preserves the extra files of the selected common
+package version and omits files belonging only to rejected versions.
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ VERSION1_FILE=mock-opam-repository/packages/foo/foo.1/files/version.txt
+  $ VERSION2_FILE=mock-opam-repository/packages/foo/foo.2/files/version.txt
+  $ mkdir -p $(dirname $VERSION1_FILE) $(dirname $VERSION2_FILE)
+  $ echo version_1 >$VERSION1_FILE
+  $ echo version_2 >$VERSION2_FILE
+
+  $ mkpkg foo 1 <<EOF
+  > extra-files: [
+  >   ["version.txt" "md5=$(md5sum $VERSION1_FILE | cut -f1 -d' ')" ]
+  > ]
+  > EOF
+  $ mkpkg foo 2 <<EOF
+  > extra-files: [
+  >   ["version.txt" "md5=$(md5sum $VERSION2_FILE | cut -f1 -d' ')" ]
+  > ]
+  > EOF
+
+  $ cat >dune-project <<'EOF'
+  > (lang dune 3.18)
+  > (package
+  >  (name x)
+  >  (depends (foo (= 1))))
+  > EOF
+
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
+  - foo.1
+
+  $ cat ${default_lock_dir}/foo.1.files/version.txt
+  version_1
+  $ test ! -e ${default_lock_dir}/foo.2.files


### PR DESCRIPTION
## Summary

- Add a portable lock-directory regression with distinct extra files attached to two versions of one package.
- Constrain the solve to the common selected version and assert that its file is copied into the lock directory.
- Assert that files belonging only to the rejected version are omitted.

This is an independent test-only baseline for per-platform lock extraction in #15982.

## Tests

- `nix develop -c dune runtest test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-common-version-extra-files.t`
- `CI=true nix develop -c dune build @fmt @check`