### PR TITLE
test(pkg): preserve single-platform SAT problem size

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-single-platform-sat-size.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-single-platform-sat-size.t
@@ -1,0 +1,34 @@
+A lock directory with one requested platform does not need cross-platform
+version-consistency variables or clauses.
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+  $ mkpkg foo
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.20)
+  > (repository
+  >  (name mock)
+  >  (url "file://$(pwd)/mock-opam-repository"))
+  > (lock_dir
+  >  (repositories mock)
+  >  (solve_for_platforms
+  >   ((arch x86_64)
+  >    (os linux))))
+  > (pkg enabled)
+  > EOF
+  $ write_portable_lockdirs_project
+
+The input is fixed, so the exact SAT problem size detects redundant encoding.
+
+  $ DUNE_TRACE=+sat dune pkg lock >/dev/null 2>&1
+  $ dune trace cat | jq -s 'include "dune";
+  > [ .[] | satSolveEvents
+  >   | .args | { num_variables, num_clauses }
+  > ]'
+  [
+    {
+      "num_variables": 2,
+      "num_clauses": 2
+    }
+  ]


### PR DESCRIPTION
## Summary

- Add a trace-based regression for a lock directory with exactly one requested platform.
- Assert the exact SAT problem size for a fixed one-package input: two variables and two clauses.
- Guard against adding cross-platform consistency encoding to the single-platform path.

This is an independent test-only performance baseline for the joint-solver work in #15982.

## Tests

- `nix develop -c dune runtest test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-single-platform-sat-size.t`
- `CI=true nix develop -c dune build @fmt @check`