### PR TITLE
test(meta): snapshot malformed promoted template acceptance

### DIFF
--- a/test/blackbox-tests/test-cases/meta-file/promoted-template.t
+++ b/test/blackbox-tests/test-cases/meta-file/promoted-template.t
@@ -1,0 +1,32 @@
+A promoted META file template may have a source counterpart that differs from
+the rule output. The generated contents are currently accepted.
+
+  $ make_dune_project_with_package 2.7 promoted
+
+  $ cat >promoted.ml <<EOF
+  > let foo () = ()
+  > EOF
+
+  $ cat >META.promoted.template <<EOF
+  > # DUNE_GEN
+  > EOF
+
+  $ cat >dune <<'EOF'
+  > (library
+  >  (public_name promoted))
+  > 
+  > (rule
+  >  (target META.promoted.template)
+  >  (mode promote)
+  >  (action
+  >   (write-file %{target} "package \"broken\" @")))
+  > EOF
+
+  $ dune build @install --disable-promotion
+
+The source remains valid, while the generated template and final META contain
+the malformed rule output.
+
+  $ printf '# DUNE_GEN\n' | cmp - META.promoted.template
+  $ printf 'package "broken" @' | cmp - _build/default/META.promoted.template
+  $ printf 'package "broken" @' | cmp - _build/default/META.promoted


### PR DESCRIPTION
Records promoted output that is malformed while its source counterpart is valid. This covers attributing validation to the generated contents rather than stale source.

Test: `dune runtest test/blackbox-tests/test-cases/meta-file/promoted-template.t`