### PR TITLE
test(meta): snapshot non-round-trippable generated META

### DIFF
--- a/test/blackbox-tests/test-cases/meta-file/backslash-roundtrip.t
+++ b/test/blackbox-tests/test-cases/meta-file/backslash-roundtrip.t
@@ -1,0 +1,24 @@
+Generated META values currently leave backslashes unescaped. Snapshot both the
+output and its failure to round-trip through findlib.
+
+  $ make_dune_project_with_package 2.7 slashlib
+
+  $ cat >slashlib.ml <<EOF
+  > let foo () = ()
+  > EOF
+
+  $ cat >dune <<'EOF'
+  > (library
+  >  (public_name slashlib)
+  >  (synopsis "ends in \\"))
+  > EOF
+
+  $ dune build @install
+  $ grep '^description' _build/default/META.slashlib
+  description = "ends in \"
+
+  $ export OCAMLPATH="$PWD/_build/install/default/lib"
+  $ export OCAMLFIND_LDCONF=ignore
+  $ ocamlfind query -format '%D' slashlib
+  ocamlfind: While parsing '$TESTCASE_ROOT/_build/install/default/lib/slashlib/META': Expected 'name = value' clause at line 1 position 38
+  [2]


### PR DESCRIPTION
Records generated META output that leaves backslashes unescaped and cannot be parsed by findlib. This covers parser round-tripping without changing the decoded value.

Test: `dune runtest test/blackbox-tests/test-cases/meta-file/backslash-roundtrip.t`