### PR TITLE
test(meta): preserve virtual template rejection ordering

### DIFF
--- a/test/blackbox-tests/test-cases/meta-file/virtual-library-template.t
+++ b/test/blackbox-tests/test-cases/meta-file/virtual-library-template.t
@@ -1,0 +1,24 @@
+Virtual-library incompatibility is diagnosed before running a generated META
+file template action.
+
+  $ make_dune_project_with_package 2.7 vlib
+
+  $ cat >vlib.mli <<EOF
+  > val foo : unit -> unit
+  > EOF
+
+  $ cat >dune <<'EOF'
+  > (library
+  >  (public_name vlib)
+  >  (virtual_modules vlib))
+  > 
+  > (rule
+  >  (target META.vlib.template)
+  >  (action (run false)))
+  > EOF
+
+  $ dune build @install
+  File "_build/default/META.vlib.template", line 1, characters 0-0:
+  Error: Package vlib defines virtual library vlib and has a META template.
+  This is not allowed.
+  [1]


### PR DESCRIPTION
Preserves the existing invariant that virtual-library incompatibility is diagnosed before a generated META file template action runs.

Test: `dune runtest test/blackbox-tests/test-cases/meta-file/virtual-library-template.t`