### PR TITLE
test(pkg): preserve legacy dependencies named like constructors

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/legacy-lockdir-constructor-name-depends.t
+++ b/test/blackbox-tests/test-cases/pkg/legacy-lockdir-constructor-name-depends.t
@@ -1,0 +1,17 @@
+Legacy lock dirs store dependencies as bare atoms. Package names that match
+conditional-field constructors must remain unconditional dependencies rather
+than being parsed as constructors.
+
+  $ make_lockdir
+  $ make_lockpkg root <<EOF
+  > (version 0.0.1)
+  > (depends choice all_platforms)
+  > EOF
+  $ make_lockpkg choice <<EOF
+  > (version 0.0.1)
+  > EOF
+  $ make_lockpkg all_platforms <<EOF
+  > (version 0.0.1)
+  > EOF
+
+  $ build_pkg root


### PR DESCRIPTION
## Summary

- Add a regression test for legacy lock directories whose bare dependency name is `choice` or `all_platforms`.
- Assert that these names remain unconditional dependencies instead of being parsed as conditional-field constructors.

## Tests

- `nix develop -c dune runtest test/blackbox-tests/test-cases/pkg/legacy-lockdir-constructor-name-depends.t`
- `CI=true nix develop -c dune build @fmt @check`