### PR TITLE
refactor(melange): share JS output components

### DIFF
--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -90,26 +90,23 @@ let output_of_lib =
       public_lib ~info ~target_dir (Lib_info.name info)
 ;;
 
-let make_js_name ~js_ext ~output m =
-  let dst_dir =
-    let src_dir =
-      Module.source m ~ml_kind:Impl
-      |> Option.value_exn
-      |> Module.File.original_path
-      |> Path.parent_exn
-    in
-    Output_kind.output_path output src_dir
-  in
-  let basename =
-    Filename.to_string (Module_compilation.melange_js_basename m)
-    ^ Filename.Extension.to_string js_ext
-  in
-  Path.Build.relative dst_dir basename
-;;
-
 let js_outputs_of_module ~module_systems ~output m =
-  List.map module_systems ~f:(fun (module_system, js_ext) ->
-    module_system, make_js_name ~js_ext ~output m)
+  match module_systems with
+  | [] -> []
+  | _ :: _ ->
+    let dst_dir =
+      let src_dir =
+        Module.source m ~ml_kind:Impl
+        |> Option.value_exn
+        |> Module.File.original_path
+        |> Path.parent_exn
+      in
+      Output_kind.output_path output src_dir
+    in
+    let basename = Module_compilation.melange_js_basename m in
+    List.map module_systems ~f:(fun (module_system, js_ext) ->
+      let basename = Filename.add_extension basename js_ext in
+      module_system, Path.Build.relative_fname dst_dir basename)
 ;;
 
 let modules_in_obj_dir ~sctx ~scope ~preprocess modules =


### PR DESCRIPTION
Compute each module’s JavaScript output directory and basename once across all configured module systems.