### PR TITLE
Refresh build status line periodically

### DIFF
--- a/doc/changes/fixed/16015.md
+++ b/doc/changes/fixed/16015.md
@@ -1,0 +1,2 @@
+- Refresh the build duration in the status line five times per second, even
+  when no other scheduler events occur. (#16015, @Alizter)

--- a/src/dune_scheduler/async_io.ml
+++ b/src/dune_scheduler/async_io.ml
@@ -309,8 +309,17 @@ let shutdown t =
     t.destroyed <- true)
 ;;
 
+let status_line_refresh_interval = Time.Span.of_secs 0.2
+
 let start ~name t =
   Thread0.spawn ~name (fun () ->
+    let status_line_refresh =
+      Lev.Timer.create
+        ~after:status_line_refresh_interval
+        ~repeat:status_line_refresh_interval
+        (fun _watcher -> Event.Queue.send_status_line_refresh t.scheduler_queue)
+    in
+    Lev.Timer.start status_line_refresh t.loop;
     let rec loop () =
       ignore
         (Lev.Loop.run t.loop Lev.Loop.Once : [ `No_more_active_watchers | `Otherwise ]);
@@ -329,6 +338,9 @@ let start ~name t =
       if not shutting_down then loop ()
     in
     Exn.protect ~f:loop ~finally:(fun () ->
+      if Lev.Timer.is_active status_line_refresh
+      then Lev.Timer.stop status_line_refresh t.loop;
+      Lev.Timer.destroy status_line_refresh;
       destroy_loop_resources t;
       Lev.Loop.destroy t.loop;
       t.destroyed <- true))
@@ -388,6 +400,7 @@ let create scheduler_queue =
     }
   in
   Lev.Async.start wakeup loop;
+  Mutex.protect t.mutex (fun () -> ensure_running_locked t);
   t
 ;;
 

--- a/src/dune_scheduler/event.ml
+++ b/src/dune_scheduler/event.ml
@@ -41,6 +41,7 @@ type t =
   | Shutdown of Shutdown.Reason.t
   | Fiber_fill_ivar of Fiber.fill
   | Job_complete_ready
+  | Status_line_refresh
 
 module Queue = struct
   type event = t
@@ -51,6 +52,7 @@ module Queue = struct
     ; mutex : Mutex.t
     ; cond : Condition.t
     ; mutable job_complete_ready : bool
+    ; mutable status_line_refresh_pending : bool
     ; worker_tasks_completed : Fiber.fill Queue.t
     ; mutable got_event : bool
     ; mutable yield : unit Fiber.Ivar.t option
@@ -72,6 +74,7 @@ module Queue = struct
     ; got_event = false
     ; yield = None
     ; job_complete_ready = false
+    ; status_line_refresh_pending = false
     }
   ;;
 
@@ -119,6 +122,10 @@ module Queue = struct
         Some Job_complete_ready
     ;;
 
+    let status_line_refresh : t =
+      fun q -> if q.status_line_refresh_pending then Some Status_line_refresh else None
+    ;;
+
     let jobs_completed q =
       Option.map (Queue.pop q.jobs_completed) ~f:(fun (job, proc_info) ->
         Fiber_fill_ivar (Fill (job.ivar, proc_info)))
@@ -143,13 +150,15 @@ module Queue = struct
        highest priority to maximize responsiveness to Ctrl+C.
        [worker_tasks_completed] is used for reacting to user input, so its
        latency is also important. [jobs_completed] and [yield] are where the
-       bulk of the work is done, so they are the lowest priority to avoid
-       starving other things. *)
+       bulk of the work is done, so they are low priority to avoid starving
+       other things. Status line refreshes are lowest because they are
+       redundant whenever another event wakes the scheduler. *)
     Event_source.
       [ shutdown
       ; worker_tasks_completed
       ; (if Sys.win32 then jobs_completed else job_complete_ready)
       ; yield
+      ; status_line_refresh
       ]
   ;;
 
@@ -170,6 +179,9 @@ module Queue = struct
       loop ()
     in
     let ev = loop () in
+    (* The scheduler refreshes the status line before requesting each event, so
+       whichever event was selected subsumes a pending dedicated refresh. *)
+    q.status_line_refresh_pending <- false;
     Mutex.unlock q.mutex;
     ev
   ;;
@@ -186,6 +198,10 @@ module Queue = struct
   ;;
 
   let send_job_completed_ready q = add_event q (fun q -> q.job_complete_ready <- true)
+
+  let send_status_line_refresh q =
+    add_event q (fun q -> q.status_line_refresh_pending <- true)
+  ;;
 
   let send_shutdown q signal =
     add_event q (fun q ->

--- a/src/dune_scheduler/event.mli
+++ b/src/dune_scheduler/event.mli
@@ -28,6 +28,7 @@ type t =
   | Shutdown of Shutdown.Reason.t
   | Fiber_fill_ivar of Fiber.fill
   | Job_complete_ready
+  | Status_line_refresh
 
 module Queue : sig
   type event := t
@@ -43,5 +44,6 @@ module Queue : sig
   val send_job_completed : t -> job -> Proc.Process_info.t -> unit
   val send_job_completed_ready : t -> unit
   val send_shutdown : t -> Shutdown.Reason.t -> unit
+  val send_status_line_refresh : t -> unit
   val yield_if_there_are_pending_events : t -> unit Fiber.t
 end

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -347,6 +347,7 @@ let rec cleanup_iter t saw_shutdown =
      | [] -> cleanup_iter t saw_shutdown
      | fills -> fills)
   | Fiber_fill_ivar fill -> [ fill ]
+  | Status_line_refresh -> cleanup_iter t saw_shutdown
   | Shutdown reason ->
     got_shutdown reason;
     saw_shutdown := Got_shutdown;
@@ -392,7 +393,7 @@ let kill_and_wait_for_all_processes t =
       let rec next () =
         match Event.Queue.next t.events with
         | Fiber_fill_ivar fill -> [ fill ]
-        | Job_complete_ready | Shutdown _ -> next ()
+        | Job_complete_ready | Status_line_refresh | Shutdown _ -> next ()
       in
       next ());
   (* This silliness is needed because we have tests that run the scheduler
@@ -474,6 +475,7 @@ module Run_once = struct
        | [] -> iter t
        | fills -> fills)
     | Fiber_fill_ivar fill -> [ fill ]
+    | Status_line_refresh -> []
     | Shutdown reason ->
       got_shutdown reason;
       raise @@ Abort (Shutdown_requested reason)

--- a/test/blackbox-tests/test-cases/status-line-refresh.t
+++ b/test/blackbox-tests/test-cases/status-line-refresh.t
@@ -30,7 +30,7 @@ the action is blocked.
   > | (grep -a -E -o "\[[0-9]+\.[0-9]s\]" || true) \
   > | sort -u \
   > | awk 'END { print NR >= 2 ? "build duration refreshed repeatedly" : "build duration did not refresh repeatedly" }'
-  build duration did not refresh repeatedly
+  build duration refreshed repeatedly
 
   $ touch "$RELEASE"
   $ wait_for_pid_to_exit_with_timeout "$BUILD_PID" 200 || (cat build-output; false)

--- a/test/blackbox-tests/test-cases/status-line-refresh.t
+++ b/test/blackbox-tests/test-cases/status-line-refresh.t
@@ -1,0 +1,37 @@
+The action remains silent and blocked while the status output is sampled.
+Recording the output offset after it starts excludes earlier scheduler updates;
+requiring two distinct later durations excludes a single unrelated wakeup.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+  $ STARTED="$PWD/started"
+  $ RELEASE="$PWD/release"
+  $ cat > dune <<EOF
+  > (rule
+  >  (target slow-target)
+  >  (action
+  >   (progn
+  >    (system "touch '$STARTED'; while test ! -f '$RELEASE'; do sleep 0.1; done")
+  >    (write-file %{target} done))))
+  > EOF
+
+Force the progress display even though stderr is redirected, then wait until
+the action is blocked.
+
+  $ INSIDE_EMACS=1 DUNE_CONFIG__THREADED_CONSOLE=disabled \
+  >   dune build --display progress slow-target > build-output 2>&1 &
+  $ BUILD_PID=$!
+  $ with_timeout dune_cmd wait-for-file-to-appear "$STARTED"
+  $ OUTPUT_SIZE=$(wc -c < build-output)
+  $ sleep 1
+  $ tail -c +$((OUTPUT_SIZE + 1)) build-output \
+  > | (grep -a -E -o "\[[0-9]+\.[0-9]s\]" || true) \
+  > | sort -u \
+  > | awk 'END { print NR >= 2 ? "build duration refreshed repeatedly" : "build duration did not refresh repeatedly" }'
+  build duration did not refresh repeatedly
+
+  $ touch "$RELEASE"
+  $ wait_for_pid_to_exit_with_timeout "$BUILD_PID" 200 || (cat build-output; false)
+  $ wait "$BUILD_PID"

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_lib.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_lib.ml
@@ -51,7 +51,7 @@ let create_watcher ?fsevents_debounce ~watch_exclusions () =
     let iter () =
       match Dune_scheduler.Event.Queue.next event_queue with
       | Fiber_fill_ivar fill -> [ fill ]
-      | Shutdown _ | Job_complete_ready -> assert false
+      | Shutdown _ | Job_complete_ready | Status_line_refresh -> assert false
     in
     Thread.create (fun () -> Fiber.run (read_events ()) ~iter) ()
   in

--- a/test/expect-tests/thread_safe_channel_tests.ml
+++ b/test/expect-tests/thread_safe_channel_tests.ml
@@ -9,7 +9,7 @@ let () = init ()
 let next_fills event_queue =
   match Event.Queue.next event_queue with
   | Fiber_fill_ivar fill -> [ fill ]
-  | Shutdown _ | Job_complete_ready -> assert false
+  | Shutdown _ | Job_complete_ready | Status_line_refresh -> assert false
 ;;
 
 let create_channel () =


### PR DESCRIPTION
The build duration in the status line currently advances only when another
scheduler event redraws the line. During long-running rules it can therefore
appear frozen.

This change installs a scheduler-owned 200 ms periodic timer in the async I/O
loop. Each tick sends a coalesced, lowest-priority status-line refresh event.
The event wakes an idle scheduler, while ordinary scheduler events subsume a
pending refresh. Rendering continues to run on the scheduler thread through
the existing status-line refresh hook.

The timer's lifetime is tied to the async I/O loop and it is stopped and
destroyed during scheduler shutdown. No console backend or progress renderer
changes are needed.

Tests:

- `./_boot/dune.exe runtest test/blackbox-tests/test-cases/status-line-refresh.t --force`
- `dune build bin/main.exe`
- `dune runtest test/blackbox-tests/test-cases/watching/rpc-build-status-line.t`
- manual PTY smoke test with a blocked long-running rule