### PR TITLE
test(meta): verify malformed source template installation

### DIFF
--- a/test/blackbox-tests/test-cases/meta-file/source-template.t
+++ b/test/blackbox-tests/test-cases/meta-file/source-template.t
@@ -18,3 +18,10 @@ diagnostic. Snapshot that behavior before adding validation.
   > EOF
 
   $ dune build @install
+
+The malformed source template reaches both generated and installed output.
+
+  $ grep '^package "broken" (' _build/default/META.foobarlib
+  package "broken" (
+  $ grep '^package "broken" (' _build/install/default/lib/foobarlib/META
+  package "broken" (


### PR DESCRIPTION
## Description

Strengthen the source-template regression to prove malformed template bytes reach both generated and installed META files before validation.

Related to #15994.