### PR TITLE
test(package-deps): snapshot nested namespace filtering

### DIFF
--- a/test/blackbox-tests/test-cases/package-materialization/dune
+++ b/test/blackbox-tests/test-cases/package-materialization/dune
@@ -1,6 +1,7 @@
 (cram
  (applies_to
   installed-package
+  nested-namespace
   no-transitive-through-targets
   ocamlfind
   virtual-without-default)

--- a/test/blackbox-tests/test-cases/package-materialization/nested-namespace.t
+++ b/test/blackbox-tests/test-cases/package-materialization/nested-namespace.t
@@ -1,0 +1,60 @@
+A package dependency currently omits a required library in a nested namespace.
+Once the library is materialized, metadata from structural namespace nodes must
+not leak into the filtered META file.
+
+  $ make_dune_project 3.24
+  $ cat >>dune-project <<EOF
+  > (package (name ns-root))
+  > (package (name ns-support))
+  > EOF
+
+  $ mkdir root support
+  $ cat >root/dune <<'EOF'
+  > (library
+  >  (name root)
+  >  (public_name ns-root)
+  >  (libraries ns-support.middle.selected))
+  > EOF
+  $ echo 'let value = ()' >root/root.ml
+
+  $ cat >support/dune <<'EOF'
+  > (library
+  >  (name selected)
+  >  (public_name ns-support.middle.selected))
+  > EOF
+  $ echo 'let value = ()' >support/selected.ml
+
+  $ cat >META.ns-support.template <<'EOF'
+  > package "middle" (
+  >  directory = "middle"
+  >  intermediate_marker = "drop"
+  >  package "selected" (
+  >   directory = "selected"
+  >   selected_marker = "keep"
+  >  )
+  > )
+  > EOF
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (target marker)
+  >  (deps (package ns-root))
+  >  (action
+  >   (with-stdout-to %{target}
+  >    (run %{bin:ocamlfind} query
+  >     -format "%(intermediate_marker)|%(selected_marker)|%d/selected.cmi"
+  >     ns-support.middle.selected))))
+  > EOF
+
+  $ dune build marker
+  File "dune", lines 1-8, characters 0-223:
+  1 | (rule
+  2 |  (target marker)
+  3 |  (deps (package ns-root))
+  4 |  (action
+  5 |   (with-stdout-to %{target}
+  6 |    (run %{bin:ocamlfind} query
+  7 |     -format "%(intermediate_marker)|%(selected_marker)|%d/selected.cmi"
+  8 |     ns-support.middle.selected))))
+  ocamlfind: Package `ns-support.middle.selected' not found
+  [1]


### PR DESCRIPTION
## Description

Snapshot a missing transitive library below a nested findlib namespace. The regression also requires structural namespace metadata to avoid leaking into the filtered META.

Related to #15511.