### PR TITLE
test(install): preserve duplicate library diagnostics

### DIFF
--- a/test/blackbox-tests/test-cases/lib-collision/lib-collision-public-same-public-name.t
+++ b/test/blackbox-tests/test-cases/lib-collision/lib-collision-public-same-public-name.t
@@ -20,6 +20,26 @@ different folders.
   >  (public_name bar.foo))
   > EOF
 
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (target package-layout)
+  >  (deps (package bar))
+  >  (action (write-file %{target} "ok")))
+  > EOF
+
+The scoped install-layout consumer preserves the usual diagnostic without
+relying on another target to force scope validation first.
+
+  $ dune build package-layout
+  File "b/dune", lines 1-3, characters 0-44:
+  1 | (library
+  2 |  (name bar)
+  3 |  (public_name bar.foo))
+  Error: Public library bar.foo is defined twice:
+  - a/dune:1
+  - b/dune:1
+  [1]
+
 Without any consumers of the libraries
 
   $ dune build


### PR DESCRIPTION
## Description

Pin the source-located duplicate-public-library diagnostic when a scoped package layout indexes install entries by library.

Related to #15511.