### PR TITLE
test: verify periodic status-line refresh

### DIFF
--- a/test/blackbox-tests/test-cases/status-line-refresh.t
+++ b/test/blackbox-tests/test-cases/status-line-refresh.t
@@ -1,0 +1,37 @@
+The action remains silent and blocked while the status output is sampled.
+Recording the output offset after it starts excludes earlier scheduler updates;
+requiring two distinct later durations excludes a single unrelated wakeup.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+  $ STARTED="$PWD/started"
+  $ RELEASE="$PWD/release"
+  $ cat > dune <<EOF
+  > (rule
+  >  (target slow-target)
+  >  (action
+  >   (progn
+  >    (system "touch '$STARTED'; while test ! -f '$RELEASE'; do sleep 0.1; done")
+  >    (write-file %{target} done))))
+  > EOF
+
+Force the progress display even though stderr is redirected, then wait until
+the action is blocked.
+
+  $ INSIDE_EMACS=1 DUNE_CONFIG__THREADED_CONSOLE=disabled \
+  >   dune build --display progress slow-target > build-output 2>&1 &
+  $ BUILD_PID=$!
+  $ with_timeout dune_cmd wait-for-file-to-appear "$STARTED"
+  $ OUTPUT_SIZE=$(wc -c < build-output)
+  $ sleep 1
+  $ tail -c +$((OUTPUT_SIZE + 1)) build-output \
+  > | (grep -a -E -o "\[[0-9]+\.[0-9]s\]" || true) \
+  > | sort -u \
+  > | awk 'END { print NR >= 2 ? "build duration refreshed repeatedly" : "build duration did not refresh repeatedly" }'
+  build duration did not refresh repeatedly
+
+  $ touch "$RELEASE"
+  $ wait_for_pid_to_exit_with_timeout "$BUILD_PID" 200 || (cat build-output; false)
+  $ wait "$BUILD_PID"


### PR DESCRIPTION
This is the regression-test commit for #16015, split out so the pre-fix behavior is visible independently while the test suite remains green.

The test starts a normal batch build whose action is blocked and silent. After the action starts, it records the current output offset, waits one second, and inspects only status output appended during that idle period. It requires two distinct duration values, excluding setup redraws and a single unrelated scheduler wakeup.

On `main`, the expected output records `build duration did not refresh repeatedly`; the cram test therefore passes while demonstrating the existing behavior. The implementation commit in #16015 changes that expected output to `build duration refreshed repeatedly`.

Verification:

- Test-only commit: `./_boot/dune.exe runtest test/blackbox-tests/test-cases/status-line-refresh.t --force` passes with the pre-fix output.
- With #16015 applied: the same command passes with the fixed output.