### PR TITLE
test(pkg): cover a solvable portable platform set

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-all-or-nothing.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-all-or-nothing.t
@@ -42,3 +42,24 @@ failure is reported once for the requested platform set:
 No partial lock directory is written:
 
   $ test ! -e dune.lock
+
+When the platform set only contains platforms where the package is available,
+locking succeeds:
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.11)
+  > (repository
+  >  (name mock)
+  >  (url "file://$(pwd)/mock-opam-repository"))
+  > (lock_dir
+  >  (repositories mock)
+  >  (solve_for_platforms
+  >   ((arch arm64)
+  >    (os macos))))
+  > EOF
+
+  $ dune pkg lock
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
+  - foo.0.0.1


### PR DESCRIPTION
Independent pre-feature regression branch used by #15982.

## Summary

- Extend the existing all-or-nothing portable-lock test with a solvable platform set.
- Verify locking succeeds when every requested platform can install the dependency.

## Checks

- `dune runtest test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-all-or-nothing.t`
- `CI=true dune build @fmt @check`
