### PR TITLE
refactor(melange): centralize compiler CLI flags

### DIFF
--- a/src/dune_rules/melange/melange.ml
+++ b/src/dune_rules/melange/melange.ml
@@ -13,6 +13,44 @@ module Module_system = struct
   ;;
 end
 
+module Cli = struct
+  type t =
+    { package_name : string
+    ; package_output : string
+    ; module_name : string
+    ; module_type : string
+    ; stop_after_cmj : string
+    }
+
+  let of_project project =
+    let version =
+      Dune_project.find_extension_version project Dune_lang.Melange.syntax
+      |> Option.value_exn
+    in
+    if version >= (1, 0)
+    then
+      { package_name = "--mel-package-name"
+      ; package_output = "--mel-package-output"
+      ; module_name = "--mel-module-name"
+      ; module_type = "--mel-module-type"
+      ; stop_after_cmj = "--mel-stop-after-cmj"
+      }
+    else
+      { package_name = "--bs-package-name"
+      ; package_output = "--bs-package-output"
+      ; module_name = "--bs-module-name"
+      ; module_type = "--bs-module-type"
+      ; stop_after_cmj = "--bs-stop-after-cmj"
+      }
+  ;;
+
+  let promotes_in_source project =
+    match Dune_project.find_extension_version project Dune_lang.Melange.syntax with
+    | Some version -> version >= (1, 0)
+    | None -> false
+  ;;
+end
+
 module Cm_kind = Dune_lang.Melange.Cm_kind
 
 module Source = struct

--- a/src/dune_rules/melange/melange.mli
+++ b/src/dune_rules/melange/melange.mli
@@ -9,6 +9,19 @@ module Module_system : sig
   val to_string : t -> string
 end
 
+module Cli : sig
+  type t =
+    { package_name : string
+    ; package_output : string
+    ; module_name : string
+    ; module_type : string
+    ; stop_after_cmj : string
+    }
+
+  val of_project : Dune_project.t -> t
+  val promotes_in_source : Dune_project.t -> bool
+end
+
 module Cm_kind : module type of Dune_lang.Melange.Cm_kind
 
 module Source : sig

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -423,10 +423,7 @@ let build_js
       m
   =
   let project = Scope.project scope in
-  let melange_extension_version =
-    Dune_project.find_extension_version project Dune_lang.Melange.syntax
-    |> Option.value_exn
-  in
+  let melange_cli = Melange.Cli.of_project project in
   let* compiler = Melange_binary.melc sctx ~loc:(Some loc) ~dir in
   Memo.parallel_iter module_systems ~f:(fun (module_system, js_ext) ->
     let js_output = make_js_name ~output ~js_ext m in
@@ -447,19 +444,13 @@ let build_js
         let obj_dir = [ Command.Args.A "-I"; Path (Obj_dir.melange_dir obj_dir) ] in
         let melange_package_args =
           let pkg_name_args =
-            match pkg_name, melange_extension_version with
-            | None, _ -> []
-            | Some pkg_name, (0, 1) ->
-              [ "--bs-package-name"; Package.Name.to_string pkg_name ]
-            | Some pkg_name, _ ->
-              [ "--mel-package-name"; Package.Name.to_string pkg_name ]
+            match pkg_name with
+            | None -> []
+            | Some pkg_name ->
+              [ melange_cli.package_name; Package.Name.to_string pkg_name ]
           in
           let js_modules_str = Melange.Module_system.to_string module_system in
-          (if melange_extension_version >= (1, 0)
-           then "--mel-module-type"
-           else "--bs-module-type")
-          :: js_modules_str
-          :: pkg_name_args
+          melange_cli.module_type :: js_modules_str :: pkg_name_args
         in
         Command.run
           ~dir:(Super_context.context sctx |> Context.build_dir |> Path.build)
@@ -764,12 +755,7 @@ let modules_for_js_and_obj_dir ~sctx ~dir_contents ~scope (mel : Melange_stanzas
   modules, modules_for_js, obj_dir
 ;;
 
-let should_promote_in_source scope =
-  let project = Scope.project scope in
-  match Dune_project.find_extension_version project Dune_lang.Melange.syntax with
-  | Some v -> v >= (1, 0)
-  | None -> false
-;;
+let should_promote_in_source scope = Melange.Cli.promotes_in_source (Scope.project scope)
 
 let setup_entries_js
       ~sctx

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -134,11 +134,10 @@ let melange_args (cctx : Compilation_context.t) (cm_kind : Lib_mode.Cm_kind.t) m
   match cm_kind with
   | Ocaml (Cmi | Cmo | Cmx) | Melange Cmi -> []
   | Melange Cmj ->
-    let melange_extension_version =
+    let melange_cli =
       let scope = Compilation_context.scope cctx in
       let dune_project = Scope.project scope in
-      Dune_project.find_extension_version dune_project Dune_lang.Melange.syntax
-      |> Option.value_exn
+      Melange.Cli.of_project dune_project
     in
     let mel_package_name, mel_package_output =
       let package_output =
@@ -163,29 +162,15 @@ let melange_args (cctx : Compilation_context.t) (cm_kind : Lib_mode.Cm_kind.t) m
           |> Path.Local.to_string
           |> Path.Build.relative build_dir
         in
-        ( [ Command.Args.A
-              (if melange_extension_version >= (1, 0)
-               then "--mel-package-name"
-               else "--bs-package-name")
-          ; A (Lib_name.to_string lib_name)
-          ]
+        ( [ Command.Args.A melange_cli.package_name; A (Lib_name.to_string lib_name) ]
         , Path.build dir )
     in
-    if melange_extension_version >= (1, 0)
-    then
-      Command.Args.A "--mel-stop-after-cmj"
-      :: A "--mel-package-output"
-      :: Command.Args.Path mel_package_output
-      :: A "--mel-module-name"
-      :: A (melange_js_basename module_ |> Filename.to_string)
-      :: mel_package_name
-    else
-      Command.Args.A "--bs-stop-after-cmj"
-      :: A "--bs-package-output"
-      :: Command.Args.Path mel_package_output
-      :: A "--bs-module-name"
-      :: A (melange_js_basename module_ |> Filename.to_string)
-      :: mel_package_name
+    Command.Args.A melange_cli.stop_after_cmj
+    :: A melange_cli.package_output
+    :: Command.Args.Path mel_package_output
+    :: A melange_cli.module_name
+    :: A (melange_js_basename module_ |> Filename.to_string)
+    :: mel_package_name
 ;;
 
 let build_cm


### PR DESCRIPTION
Centralize syntax-version-dependent Melange compiler flags used by CMJ compilation and JavaScript emission.