### PR TITLE
fix(pkg): repect lock_dir stanza

### DIFF
--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -153,8 +153,9 @@ module Lock_dirs_arg = struct
                ~docv:"LOCKDIRS"
                ~doc:
                  (Some
-                    "Lock directories to check for outdated packages. Defaults to \
-                     dune.lock."))
+                    "Lock directories to check for outdated packages. Defaults to the \
+                     lock directory declared by (lock_dir) in the workspace, or \
+                     dune.lock if there is none."))
        in
        Selected (List.map arg ~f:Path.Source.of_string))
       (let+ _all =
@@ -170,6 +171,13 @@ module Lock_dirs_arg = struct
        All)
   ;;
 
+  let default_lock_dir_path_of_workspace (workspace : Workspace.t) =
+    let default_path = Dune_rules.Lock_dir.default_source_path in
+    match workspace.lock_dirs with
+    | [ { Workspace.Lock_dir.path; _ } ] -> path
+    | _ -> default_path
+  ;;
+
   let lock_dirs_of_workspace t (workspace : Workspace.t) =
     let module Set = Path.Source.Set in
     let default_path = Dune_rules.Lock_dir.default_source_path in
@@ -182,7 +190,7 @@ module Lock_dirs_arg = struct
     in
     match t with
     | All -> workspace_lock_dirs
-    | Selected [] -> [ default_path ]
+    | Selected [] -> [ default_lock_dir_path_of_workspace workspace ]
     | Selected chosen_lock_dirs ->
       let workspace_lock_dirs_set = Set.of_list workspace_lock_dirs in
       let chosen_lock_dirs_set = Set.of_list chosen_lock_dirs in

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -73,9 +73,9 @@ module Lock_dirs_arg : sig
       The [workspace] argument is used to determine the list of all lock lock
       directories.
 
-      If no lock directories were selected ([t = Selected []]), the default
-      lock directory of the workspace is used: the one declared by a single
-      [lock_dir] stanza, or [dune.lock] when there is none.
+      If no lock directories were selected, the default lock directory of the
+      workspace is used: either the one declared by a single [lock_dir] stanza,
+      or [dune.lock] if there is none.
 
       A user error is raised if the list of positional arguments used when
       creating [t] is not a subset of the lock directories of the workspace. *)

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -73,6 +73,10 @@ module Lock_dirs_arg : sig
       The [workspace] argument is used to determine the list of all lock lock
       directories.
 
+      If no lock directories were selected ([t = Selected []]), the default
+      lock directory of the workspace is used: the one declared by a single
+      [lock_dir] stanza, or [dune.lock] when there is none.
+
       A user error is raised if the list of positional arguments used when
       creating [t] is not a subset of the lock directories of the workspace. *)
   val lock_dirs_of_workspace : t -> Workspace.t -> Path.Source.t list

--- a/doc/changes/fixed/16049.md
+++ b/doc/changes/fixed/16049.md
@@ -1,0 +1,4 @@
+- `dune pkg lock` (along with other `dune pkg` commands) now use the lock dir
+  declared by the `(lock_dir (path ...))` stanza in `dune-workspace` as the
+  default target instead of always defaulting to `dune.lock`.
+  (#16049, fixes #13841, @shunueda)

--- a/test/blackbox-tests/test-cases/pkg/lock-dir-path-no-args.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-dir-path-no-args.t
@@ -1,0 +1,56 @@
+Test that `dune pkg lock` (with no arguments) respects the `(lock_dir (path ...))`
+stanza in dune-workspace, rather than always defaulting to dune.lock.
+
+See https://github.com/ocaml/dune/issues/13841
+
+$ export DUNE_CONFIG__PORTABLE_LOCK_DIR=disabled
+
+  $ mkrepo
+  $ mkpkg foo
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.21)
+  > (package
+  >  (name test)
+  >  (depends foo))
+  > EOF
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.21)
+  > 
+  > (lock_dir
+  >  (path foo.lock)
+  >  (repositories mock))
+  > 
+  > (repository
+  >  (name mock)
+  >  (url "file://$(pwd)/mock-opam-repository"))
+  > EOF
+
+Running `dune pkg lock` with no arguments uses the path from the `lock_dir`
+stanza:
+
+  $ dune pkg lock
+  Solution for foo.lock
+  
+  Dependencies common to all supported platforms:
+  - foo.0.0.1
+
+Here foo.lock is created, not dune.lock
+
+  $ find . -maxdepth 1 -name "*.lock"
+  ./foo.lock
+
+Running with an explicit argument matching the configured path:
+
+  $ rm -rf foo.lock
+  $ dune pkg lock foo.lock
+  Solution for foo.lock
+  
+  Dependencies common to all supported platforms:
+  - foo.0.0.1
+
+Now foo.lock is created
+
+  $ find . -maxdepth 1 -name "*.lock"
+  ./foo.lock

--- a/test/blackbox-tests/test-cases/pkg/lock-dir-path-no-args.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-dir-path-no-args.t
@@ -3,8 +3,6 @@ stanza in dune-workspace, rather than always defaulting to dune.lock.
 
 See https://github.com/ocaml/dune/issues/13841
 
-$ export DUNE_CONFIG__PORTABLE_LOCK_DIR=disabled
-
   $ mkrepo
   $ mkpkg foo
 
@@ -54,3 +52,13 @@ Now foo.lock is created
 
   $ find . -maxdepth 1 -name "*.lock"
   ./foo.lock
+
+Passing an undeclared lock directory gives an error:
+
+  $ dune pkg lock bar.lock
+  Error: The following directories are not lock directories in this workspace:
+  - bar.lock
+  This workspace contains the following lock directories:
+  - dune.lock
+  - foo.lock
+  [1]


### PR DESCRIPTION
<!-- Thank you for contributing to dune!

 For general guidelines on contributing to dune, see
 https://github.com/ocaml/dune/blob/main/CONTRIBUTING.md#developing-dune -->

## Description

`dune pkg lock` should respect `lock_dir` stanza.

Partially cherry-picked from https://github.com/ocaml/dune/pull/13861.

## Related Issue and Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it closes an open issue, link to the issue here. -->
<!-- Non-trivial contributions are expected to be preceded by an issue, as
     per CONTRIBUTING.md. -->

Fixes #13841

## Checklist

- [ ] Tests added, if applicable.
- [x] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [ ] Documentation added for any user-facing changes.
