### PR TITLE
test(rocq): expose missing native plugin layout entries

### DIFF
--- a/test/blackbox-tests/test-cases/rocq/plugin-meta.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/plugin-meta.t/run.t
@@ -1,4 +1,5 @@
-The META file for plugins is built before calling coqdep
+The package layout for plugins is materialized before calling rocqdep. The
+native plugin is missing from it:
   $ cat > dune << EOF
   > (library
   >  (public_name bar.foo)
@@ -10,6 +11,7 @@ The META file for plugins is built before calling coqdep
   > EOF
 
   $ dune build .bar.theory.d
-  $ find _build/install/default/.packages -name META | censor
+  $ find _build/install/default/.packages \( -name META -o -name '*.cmxs' \) \
+  >   | sort | censor
   _build/install/default/.packages/$DIGEST/lib/bar/META
 


### PR DESCRIPTION
## Description

Extend the Rocq plugin META cram test to inspect native plugin entries in the package-scoped layout created before `rocqdep`.

The current expectation deliberately snapshots the bug: the META file is present while the `.cmxs` is absent, keeping the regression commit green. A follow-up fix will update the prose and expected output.

## Related Issue and Motivation

Part of #16048. Rocq can discover a plugin META file in the scoped layout while the corresponding native plugin has not been materialized.