### PR TITLE
fix(rocq): materialize native plugins in package layouts

### DIFF
--- a/doc/dev/install-layouts.md
+++ b/doc/dev/install-layouts.md
@@ -199,17 +199,22 @@ a `Code_error`.
 ### `For_rocq_only` escape hatch
 
 `Install_layout.For_rocq_only.lib_root` exposes just the layout's `lib` root,
-filtered to `Section.Lib` entries only. It exists because rocq puts the
-layout's `lib` dir on `OCAMLPATH`, where findlib walks eagerly; for a
-race-free, deterministic walk, every entry findlib could see must be a declared
-dep. The bulk `env` function isn't suitable here because it also pulls in
-`Section.Lib_root` entries. For rocq those include the theory's own `.vo`
-output under `lib/coq/user-contrib/...`, creating a build cycle in the
-same-package theory-plus-plugin case (the theory rule would depend on its own
-output via the layout symlink). Filtering to `Section.Lib` excludes the theory
-output while keeping METAs, `.cmxs`, `.cmi` etc., all of which are upstream of
-theory compilation. See the comment on the module in `install_layout.ml` for
-details.
+filtered to `Section.Lib` and `Section.Libexec` entries. Package-set layouts
+follow opam's layout, where both sections install under `lib/<package>` and
+`Libexec` additionally preserves the executable bit. Dune records native OCaml
+plugins (`.cmxs`) in `Libexec`.
+
+The special handling exists because rocq puts the layout's `lib` dir on
+`OCAMLPATH`, where findlib walks eagerly; for a race-free, deterministic walk,
+every entry findlib could see must be a declared dep. The bulk `env` function
+isn't suitable here because it also pulls in root-section entries. For rocq
+those include the theory's own `.vo` output
+under `lib/coq/user-contrib/...`, creating a build cycle in the same-package
+theory-plus-plugin case (the theory rule would depend on its own output via the
+layout symlink). Filtering to `Section.Lib` and `Section.Libexec` excludes the
+theory output while keeping METAs, `.cmi`, `.cmxs` etc., all of which are
+upstream of theory compilation. See the comment on the module in
+`install_layout.ml` for details.
 
 ## Future work
 

--- a/src/dune_rules/install_layout.ml
+++ b/src/dune_rules/install_layout.ml
@@ -185,13 +185,16 @@ let gen_rules context_name ~dir rest =
 module For_rocq_only = struct
   (* Rocq puts the layout's [lib] dir on [OCAMLPATH], where findlib walks
      eagerly. For a race-free, deterministic walk, every entry findlib could
-     see must be a declared dep. Bulk {!env} doesn't work: it also pulls in
-     {!Section.Lib_root} entries, which include Rocq theory [.vo] files under
+     see must be a declared dep. In the opam layout, both {!Section.Lib} and
+     {!Section.Libexec} are under [lib/<package>]; Dune uses Libexec for native
+     OCaml plugins so that their executable bit is preserved. Bulk {!env}
+     doesn't work: it also pulls in {!Section.Lib_root} entries, which include
+     Rocq theory [.vo] files under
      [lib/coq/user-contrib/...]; in the same-package theory-plus-plugin case,
      that creates a build cycle (the theory rule depending on its own output
-     via the layout symlink). Filtering to {!Section.Lib} excludes Lib_root
-     content (theory output) while keeping METAs, .cmxs, .cmi etc. — all
-     upstream of theory compilation. *)
+     via the layout symlink). Filtering to {!Section.Lib} and
+     {!Section.Libexec} excludes root-section content (theory output) while
+     keeping METAs, .cmi, .cmxs etc. — all upstream of theory compilation. *)
   let lib_root context_name packages =
     let open Action_builder.O in
     let* lib_paths =
@@ -200,7 +203,7 @@ module For_rocq_only = struct
             ~init:[]
             ~f:(fun dst (entry : Path.t Install.Entry.Expanded.t) acc ->
               match (entry.section : Section.t) with
-              | Lib -> Path.build dst :: acc
+              | Lib | Libexec -> Path.build dst :: acc
               | _ -> acc)
     in
     let+ () = Action_builder.paths lib_paths in

--- a/src/dune_rules/install_layout.mli
+++ b/src/dune_rules/install_layout.mli
@@ -30,6 +30,7 @@ module For_rocq_only : sig
 
       Returns the layout's [lib] root (suitable for prepending to
       [OCAMLPATH]) and registers the action's dependency on every
-      {!Section.Lib} entry the layout produces for the set. *)
+      {!Section.Lib} and {!Section.Libexec} entry the layout produces for the
+      set. *)
   val lib_root : Context_name.t -> Package.Name.Set.t -> Path.Build.t Action_builder.t
 end

--- a/test/blackbox-tests/test-cases/rocq/plugin-meta.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/plugin-meta.t/run.t
@@ -1,5 +1,5 @@
-The package layout for plugins is materialized before calling rocqdep. The
-native plugin is missing from it:
+The package layout for plugins is materialized before calling rocqdep. Both
+the META file and native plugin are present:
   $ cat > dune << EOF
   > (library
   >  (public_name bar.foo)
@@ -14,4 +14,5 @@ native plugin is missing from it:
   $ find _build/install/default/.packages \( -name META -o -name '*.cmxs' \) \
   >   | sort | censor
   _build/install/default/.packages/$DIGEST/lib/bar/META
+  _build/install/default/.packages/$DIGEST/lib/bar/foo/foo.cmxs
 


### PR DESCRIPTION
## Description

Materialize `Section.Libexec` entries in the package-scoped library layout used while compiling Rocq theories. Dune classifies native OCaml plugins as `Libexec`, while the opam-style layout places both `Lib` and `Libexec` under `lib/<package>`.

Root sections remain excluded so Rocq theory outputs do not introduce same-package build cycles. This updates the green regression snapshot from #16051 to include the native plugin.

## Validation

In addition to the targeted Rocq cram test, I reproduced #16048 with Rocq itself checked out in the same workspace. With this patch, Dune built the workspace Rocq and the consuming theory successfully, with the `rocq-runtime` native plugin links present in the scoped package layout.

## Related Issue and Motivation

Fixes #16048.