### PR TITLE
test(pkg): make `dune pkg outdated` fail early with a useful error message if pkg is not enabled

### DIFF
--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -504,7 +504,7 @@ let term =
   let common, config = Common.init builder in
   Scheduler_setup.go_with_rpc_server ~common ~config (fun () ->
     let open Fiber.O in
-    Pkg_common.check_pkg_management_enabled ()
+    Pkg_common.error_if_pkg_management_disabled ()
     >>>
     let portable_lock_dir =
       match Config.get Dune_rules.Compile_time.portable_lock_dir with

--- a/bin/pkg/outdated.ml
+++ b/bin/pkg/outdated.ml
@@ -78,7 +78,7 @@ let term =
   let common, config = Common.init builder in
   Scheduler_setup.go_with_rpc_server ~common ~config (fun () ->
     let open Fiber.O in
-    Pkg_common.error_if_pkg_management_disabled ()
+    Pkg_common.error_if_pkg_management_not_enabled ()
     >>> find_outdated_packages ~transitive ~lock_dirs_arg ())
 ;;
 

--- a/bin/pkg/outdated.ml
+++ b/bin/pkg/outdated.ml
@@ -78,7 +78,7 @@ let term =
   let common, config = Common.init builder in
   Scheduler_setup.go_with_rpc_server ~common ~config (fun () ->
     let open Fiber.O in
-    Pkg_common.check_pkg_management_enabled ()
+    Pkg_common.error_if_pkg_management_disabled ()
     >>> find_outdated_packages ~transitive ~lock_dirs_arg ())
 ;;
 

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -228,3 +228,21 @@ let error_if_pkg_management_disabled () =
              from your dune-workspace file."
         ]
 ;;
+
+let error_if_pkg_management_not_enabled () =
+  let open Fiber.O in
+  let* () = error_if_pkg_management_disabled () in
+  let+ workspace = Memo.run (Workspace.workspace ()) in
+  if not (Workspace.pkg_enabled workspace)
+  then
+    User_error.raise
+      [ Pp.text "Package management is not enabled in this project." ]
+      ~hints:
+        [ Pp.concat
+            ~sep:Pp.space
+            [ Pp.text "Create a lock directory with"
+            ; User_message.command "dune pkg lock"
+            ; Pp.text "or add (pkg enabled) to your dune-workspace file."
+            ]
+        ]
+;;

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -203,7 +203,7 @@ module Lock_dirs_arg = struct
   ;;
 end
 
-let check_pkg_management_enabled () =
+let error_if_pkg_management_disabled () =
   Memo.run
   @@
   let open Memo.O in

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -82,6 +82,17 @@ end
     [lock_dir]. *)
 val pp_packages : Dune_pkg.Lock_dir.Pkg.t list -> User_message.Style.t Pp.t
 
-(** [check_pkg_management_enabled ()] checks if package management is enabled in the
-    workspace configuration. Raises a user error if it is explicitly disabled. *)
-val check_pkg_management_enabled : unit -> unit Fiber.t
+(** [error_if_pkg_management_disabled ()] raises a user error if package
+    management is explicitly disabled. This is used to guard against invalid use
+    of functionality when package management should not be permitted. E.g.,
+    [dune pkg lock] should not be used when package management is explicitly disabled,
+    otherwise, it may create a lock directory, enabling package management. *)
+val error_if_pkg_management_disabled : unit -> unit Fiber.t
+
+(** [error_if_pkg_management_not_enabled ()] raises a user error when package
+    management is not enabled (even if it *could* be enabled). Commands that
+    assume package management is already enabled need this stronger check, so
+    that they fail cleanly and early instead of working towards an obscure
+    failure when they encounter some missing resources. E.g., [dune pkg
+    outdated] can only be used if package management is already enabled. *)
+val error_if_pkg_management_not_enabled : unit -> unit Fiber.t

--- a/bin/pkg/search.ml
+++ b/bin/pkg/search.ml
@@ -113,7 +113,7 @@ let term =
   let common, config = Common.init builder in
   Scheduler_setup.go_with_rpc_server ~common ~config (fun () ->
     let open Fiber.O in
-    Pkg_common.check_pkg_management_enabled () >>> search_packages ~query ())
+    Pkg_common.error_if_pkg_management_disabled () >>> search_packages ~query ())
 ;;
 
 let info =

--- a/bin/pkg/validate_lock_dir.ml
+++ b/bin/pkg/validate_lock_dir.ml
@@ -83,7 +83,7 @@ let term =
   let common, config = Common.init builder in
   Scheduler_setup.go_with_rpc_server ~common ~config (fun () ->
     let open Fiber.O in
-    Pkg_common.check_pkg_management_enabled () >>> validate_lock_dirs ~lock_dirs ())
+    Pkg_common.error_if_pkg_management_disabled () >>> validate_lock_dirs ~lock_dirs ())
 ;;
 
 let command = Cmd.v info term

--- a/doc/changes/fixed/16065.md
+++ b/doc/changes/fixed/16065.md
@@ -1,0 +1,3 @@
+- Fix `dune pkg outdated` so it fails early with a clear user message if it is
+  run when package management is not enabled. (#16065, @shonfeder)
+

--- a/test/blackbox-tests/test-cases/pkg/outdated-should-fail-early.t
+++ b/test/blackbox-tests/test-cases/pkg/outdated-should-fail-early.t
@@ -1,0 +1,9 @@
+Running `dune pkg outdated` assumes package management is already enabled for a
+project. If a user tries to run the subcommand without package management
+enabled, they should get an informative user error.
+
+  $ dune pkg outdated
+  Error: Package management is not enabled in this project.
+  Hint: Create a lock directory with 'dune pkg lock' or add (pkg enabled) to
+  your dune-workspace file.
+  [1]


### PR DESCRIPTION
## Description

Fix `dune pkg outdated` so that it will fail early with a user error if it is run in a context where package management is not enabled.

Without a check of this sort, the operation tries to fetch repos before discovering that the lock directory isn't present. An alternative approach here would be to first check for the presence of the lock directory and fail earlier on the resulting error if it is not found, but that leads to a less helpful error message and won't work with a lockless `pkg enabled`. The fix proposed here gives a clear and actionable user error as early as possible, accounting first for the possibility that package management may be disabled, and then for the possibility that it has not been properly enabled.

This PR includes a preparatory commit [7e90efb](https://github.com/ocaml/dune/pull/16056/commits/7e90efbc2b1133f2f4ab1008b873ecb395c3e61c) that fixes the naming of the existing check to clearly communicate its actual behavior. 

## Related Issue and Motivation

Discovered while working on #12135 

## Checklist

- [x] Tests added, if applicable.
- [x] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [x] Documentation added for any user-facing changes.
