### PR TITLE
fix(stdune): tolerate macOS process group EPERM

### DIFF
--- a/doc/changes/fixed/16059.md
+++ b/doc/changes/fixed/16059.md
@@ -1,0 +1,2 @@
+- Prevent build cancellation from crashing Dune when macOS reports `EPERM`
+  while signaling a process group (#16059, fixes #16053, @rgrinberg)

--- a/otherlibs/stdune/src/pid.ml
+++ b/otherlibs/stdune/src/pid.ml
@@ -43,9 +43,16 @@ let kill pid where (signal' : Signal.t) =
   | `Delivered -> `Delivered
   | `Dead -> `Dead
   | `Not_allowed ->
-    Code_error.raise
-      "Not allowed to signal"
-      [ "signal", Signal.to_dyn signal'; "pid", to_dyn pid ]
+    (match where, Platform.OS.value with
+     | `Group, Darwin ->
+       (* On macOS, this error can be expected when signaling a process group:
+          [kill(2)] returns [EPERM] if any group member could not be
+          signaled. *)
+       `Delivered
+     | _ ->
+       Code_error.raise
+         "Not allowed to signal"
+         [ "signal", Signal.to_dyn signal'; "pid", to_dyn pid ])
 ;;
 
 let kill_exn pid where signal =


### PR DESCRIPTION
On macOS, `kill(2)` may return `EPERM` when any member of a process group cannot be signaled. Treat that result as delivered for group signals so canceling a build does not crash the Dune server.

Fixes #16053