### PR TITLE
test(watch): reproduce staleness after queue overflow

### DIFF
--- a/bin/rpc/group.ml
+++ b/bin/rpc/group.ml
@@ -14,7 +14,12 @@ let info =
 let group =
   Cmd.group
     info
-    [ Rpc_status.cmd; Rpc_build.cmd; Rpc_ping.cmd; Rpc_flush_file_watcher.cmd ]
+    [ Rpc_status.cmd
+    ; Rpc_build.cmd
+    ; Rpc_ping.cmd
+    ; Rpc_flush_file_watcher.cmd
+    ; Rpc_simulate_file_watcher_queue_overflow.cmd
+    ]
 ;;
 
 module Build = Rpc_build

--- a/bin/rpc/rpc_simulate_file_watcher_queue_overflow.ml
+++ b/bin/rpc/rpc_simulate_file_watcher_queue_overflow.ml
@@ -1,0 +1,33 @@
+open Import
+
+let info =
+  let doc = "Simulate a file-watcher queue overflow." in
+  Cmd.info "simulate-file-watcher-queue-overflow" ~doc
+;;
+
+let term =
+  let+ (builder : Common.Builder.t) = Common.Builder.term
+  and+ wait = Rpc_common.wait_term in
+  Rpc_common.client_term builder
+  @@ fun () ->
+  let open Fiber.O in
+  let+ response =
+    Rpc_common.fire_request
+      ~name:"simulate_file_watcher_queue_overflow_cmd"
+      ~wait
+      builder
+      Dune_rpc_impl.Decl.simulate_file_watcher_queue_overflow
+      ()
+  in
+  let open Dune_rpc_impl.Decl.Queue_overflow in
+  match response with
+  | Ok -> ()
+  | Not_in_watch_mode ->
+    User_error.raise
+      [ Pp.text "queue overflow simulation is only available in watch mode" ]
+  | Build_failed ->
+    User_error.raise
+      [ Pp.text "the build triggered by the simulated queue overflow failed" ]
+;;
+
+let cmd = Cmd.v info term

--- a/bin/rpc/rpc_simulate_file_watcher_queue_overflow.mli
+++ b/bin/rpc/rpc_simulate_file_watcher_queue_overflow.mli
@@ -1,0 +1,3 @@
+(** [dune rpc simulate-file-watcher-queue-overflow] injects a queue overflow
+    into a running watch server. *)
+val cmd : unit Cmdliner.Cmd.t

--- a/src/dune_engine/build_loop.ml
+++ b/src/dune_engine/build_loop.ml
@@ -183,6 +183,13 @@ let request_restart t invalidation =
     trigger_wakeup t)
 ;;
 
+let simulate_file_watcher_queue_overflow t =
+  ignore (Debouncer.push t.file_event_debouncer : _);
+  request_restart
+    t
+    (invalidation_of_file_events [ Event.File_watcher_event.Queue_overflow ])
+;;
+
 let file_event_debounce_interval =
   Config.make
     ~name:"file_event_debounce"

--- a/src/dune_engine/build_loop.mli
+++ b/src/dune_engine/build_loop.mli
@@ -30,6 +30,10 @@ val cancel_all_rpc_requests : t -> unit Fiber.t
     period. *)
 val flush_file_watcher : t -> unit Fiber.t
 
+(** Simulate a file-watcher queue overflow. This is exposed for testing through
+    Dune's private RPC protocol. *)
+val simulate_file_watcher_queue_overflow : t -> unit Fiber.t
+
 (** [poll t ~action_runner ~sticky_goal] runs the watch loop managed by [t].
     [action_runner] is used for each build started by the loop. [sticky_goal] is
     rebuilt after file changes and is also included in builds started for

--- a/src/dune_rpc_impl/client.ml
+++ b/src/dune_rpc_impl/client.ml
@@ -3,7 +3,12 @@ open Import
 let client ?handler connection init ~f =
   Client.client
     ?handler
-    ~private_menu:[ Request Decl.build; Request Decl.status; Request Decl.pkg_enabled ]
+    ~private_menu:
+      [ Request Decl.build
+      ; Request Decl.status
+      ; Request Decl.pkg_enabled
+      ; Request Decl.simulate_file_watcher_queue_overflow
+      ]
     connection
     init
     ~f

--- a/src/dune_rpc_impl/decl.ml
+++ b/src/dune_rpc_impl/decl.ml
@@ -67,6 +67,32 @@ module Pkg_enabled = struct
   ;;
 end
 
+module Queue_overflow = struct
+  type response =
+    | Ok
+    | Not_in_watch_mode
+    | Build_failed
+
+  let v1 =
+    Decl.Request.make_current_gen
+      ~req:Conv.unit
+      ~resp:
+        (Conv.enum
+           [ "ok", Ok
+           ; "not-in-watch-mode", Not_in_watch_mode
+           ; "build-failed", Build_failed
+           ])
+      ~version:1
+  ;;
+
+  let decl =
+    Decl.Request.make
+      ~method_:(Method.Name.of_string "simulate-file-watcher-queue-overflow")
+      ~generations:[ v1 ]
+  ;;
+end
+
 let build = Build.decl
 let status = Status.decl
 let pkg_enabled = Pkg_enabled.decl
+let simulate_file_watcher_queue_overflow = Queue_overflow.decl

--- a/src/dune_rpc_impl/decl.mli
+++ b/src/dune_rpc_impl/decl.mli
@@ -17,6 +17,14 @@ module Status : sig
   val sexp : (t, Conv.values) Conv.t
 end
 
+module Queue_overflow : sig
+  type response =
+    | Ok
+    | Not_in_watch_mode
+    | Build_failed
+end
+
 val build : (string list, Build_outcome_with_diagnostics.t) Decl.Request.t
 val status : (unit, Status.t) Decl.Request.t
 val pkg_enabled : (unit, bool) Decl.Request.t
+val simulate_file_watcher_queue_overflow : (unit, Queue_overflow.response) Decl.Request.t

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -314,6 +314,21 @@ let handler (t : t Fdecl.t) : unit Handler.t =
     Handler.implement_request rpc Procedures.Public.flush_file_watcher f
   in
   let () =
+    let f session request_id () =
+      let t = Fdecl.get t in
+      let open Decl.Queue_overflow in
+      match t.server.watch_mode, t.build with
+      | No, _ | Yes _, Disabled -> Fiber.return Not_in_watch_mode
+      | Yes _, Enabled { build_loop; _ } ->
+        let* () = Build_loop.simulate_file_watcher_queue_overflow build_loop in
+        let+ outcome = submit_build_request t session request_id (Build []) in
+        (match outcome with
+         | Success -> Ok
+         | Failure -> Build_failed)
+    in
+    Handler.implement_request_with_id rpc Decl.simulate_file_watcher_queue_overflow f
+  in
+  let () =
     let shutdown _ () =
       let t = Fdecl.get t in
       let terminate_sessions () =

--- a/test/blackbox-tests/test-cases/watching/queue-overflow.t
+++ b/test/blackbox-tests/test-cases/watching/queue-overflow.t
@@ -1,0 +1,47 @@
+Regression test for https://github.com/ocaml/dune/issues/16052.
+
+A file-watcher queue overflow drops every Memo table. Nodes retained through
+dependencies must remain connected to entries subsequently looked up in those
+tables. Simulate the overflow through a private RPC rather than relying on an
+operating system to exhaust its event queue.
+
+  $ setup_xdg_runtime_dir
+  $ cat > dune-project <<'EOF'
+  > (lang dune 3.0)
+  > EOF
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (alias default)
+  >  (deps
+  >   (glob_files *.in))
+  >  (target all.out)
+  >  (action
+  >   (with-stdout-to
+  >    all.out
+  >    (echo "%{deps}"))))
+  > EOF
+
+  $ : > first.in
+  $ start_dune
+  $ build .
+  Success
+  $ cat _build/default/all.out
+  ./first.in
+
+The RPC returns after the build triggered by the simulated overflow finishes.
+
+  $ with_timeout dune rpc simulate-file-watcher-queue-overflow --wait
+
+A later event invalidates a new node created in the cleared table. The source
+tree still depends on the old detached node, so even a forwarded build returns
+the stale result.
+
+  $ : > second.in
+  $ with_timeout dune rpc flush-file-watcher --wait
+  $ build .
+  Success
+  $ cat _build/default/all.out
+  ./first.in
+  $ test -f second.in
+
+  $ stop_dune_quiet


### PR DESCRIPTION
Add a private RPC command that injects the file-watcher queue-overflow path and waits for the resulting rebuild. A blackbox test uses it to reproduce the stale glob behavior without requiring macOS or exhausting the operating system's event queue.

This intentionally captures the current broken behavior; a follow-up change will update the expectation alongside the fix.

Related to #16052.
