### PR TITLE
test(melange): cover imported virtual libraries without CMTs

### DIFF
--- a/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps-no-cmt.t
+++ b/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps-no-cmt.t
@@ -1,0 +1,108 @@
+An implementation of an installed Melange virtual library must conservatively
+stage copied objects when binary annotations are unavailable.
+
+  $ mkdir -p producer/vlib consumer/impl
+
+  $ cat > producer/dune-project <<'EOF'
+  > (lang dune 3.24)
+  > (using melange 1.0)
+  > (package (name repro))
+  > EOF
+  $ cat > producer/vlib/dune <<'EOF'
+  > (library
+  >  (name vlib)
+  >  (public_name repro.vlib)
+  >  (modes melange)
+  >  (private_modules helper unused)
+  >  (virtual_modules virt reverse))
+  > (env
+  >  (_
+  >   (bin_annot false)))
+  > EOF
+  $ cat > producer/vlib/virt.mli <<'EOF'
+  > val run : unit -> unit
+  > EOF
+  $ cat > producer/vlib/reverse.mli <<'EOF'
+  > val answer : int
+  > EOF
+  $ cat > producer/vlib/shared.ml <<'EOF'
+  > let answer = Helper.answer
+  > EOF
+  $ cat > producer/vlib/helper.ml <<'EOF'
+  > type t = int
+  > let answer = 42
+  > EOF
+  $ cat > producer/vlib/helper.mli <<'EOF'
+  > type t
+  > val answer : t
+  > EOF
+  $ cat > producer/vlib/unused.ml <<'EOF'
+  > let ignored = 0
+  > EOF
+
+  $ dune build --root producer @install
+  $ dune install --root producer --prefix "$PWD/prefix"
+  $ test ! -e "$PWD/prefix/lib/repro/vlib/melange/vlib__Shared.cmt"
+  $ test -e "$PWD/prefix/lib/repro/vlib/melange/.private/vlib__Helper.cmi"
+  $ test ! -e "$PWD/prefix/lib/repro/vlib/melange/.private/vlib__Helper.cmt"
+
+  $ cat > consumer/dune-project <<'EOF'
+  > (lang dune 3.24)
+  > (using melange 1.0)
+  > (package (name consumer))
+  > EOF
+  $ cat > consumer/impl/dune <<'EOF'
+  > (library
+  >  (name impl)
+  >  (public_name consumer.impl)
+  >  (modes melange)
+  >  (implements repro.vlib))
+  > EOF
+  $ cat > consumer/impl/virt.ml <<'EOF'
+  > let run () = ignore Shared.answer
+  > EOF
+
+Reverse depends on Virt in the opposite direction. Conservative staging must
+not turn copied artifacts into a Virt-to-Reverse module dependency cycle.
+
+  $ cat > consumer/impl/reverse.ml <<'EOF'
+  > let answer = Virt.run (); 0
+  > EOF
+  $ cat > consumer/dune <<'EOF'
+  > (melange.emit
+  >  (target output)
+  >  (emit_stdlib false)
+  >  (compile_flags :standard --mel-cross-module-opt)
+  >  (libraries impl))
+  > EOF
+
+  $ OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
+  > dune build --root consumer --sandbox=symlink @melange
+  Entering directory 'consumer'
+  File "impl/.impl.objs/melange/_unknown_", line 1, characters 0-0:
+  Error: No rule found for impl/.impl.objs/native/vlib__Shared.cmx
+  Leaving directory 'consumer'
+  [1]
+
+  $ OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
+  > dune rules --root consumer --recursive --format=json --deps --display=quiet \
+  > impl/.impl.objs/melange/vlib__Virt.cmj > deps.json
+  Entering directory 'consumer'
+  Error: No rule found for impl/.impl.objs/native/vlib__Shared.cmx
+  -> required by transitive deps of vlib__Shared.impl in _build/default/impl
+  -> required by transitive deps of vlib__Virt.impl in _build/default/impl
+  Leaving directory 'consumer'
+  [1]
+  $ jq_dune -r '
+  >   [.[] | depsFilePaths
+  >    | select(endswith("vlib__Helper.cmi")
+  >             or endswith("vlib__Helper.cmj")
+  >             or endswith("vlib__Reverse.cmi")
+  >             or endswith("vlib__Reverse.cmj")
+  >             or endswith("vlib__Unused.cmi")
+  >             or endswith("vlib__Unused.cmj")
+  >             or endswith("vlib__Virt.cmi")
+  >             or endswith("vlib__Virt.cmj"))
+  >    | select(startswith("_build/default/impl/.impl.objs/melange/"))]
+  >   | unique[]
+  > ' deps.json


### PR DESCRIPTION
Add a separate cram test for installed Melange virtual libraries built without binary annotations, including private modules and a reverse virtual-module dependency.

Companion to #16066.