### PR TITLE
fix(memo): invalidate nodes before clearing caches

### DIFF
--- a/doc/changes/fixed/16068.md
+++ b/doc/changes/fixed/16068.md
@@ -1,0 +1,2 @@
+- Fix watch mode builds remaining stale after the file watcher event queue
+  overflows (#16068, fixes #16052, @rgrinberg)

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -116,8 +116,8 @@ let create_with_cache
       f
   in
   Caches.register ~clear:(fun () ->
-    Store.clear cache;
-    Invalidation.invalidate_store cache);
+    Invalidation.invalidate_store cache;
+    Store.clear cache);
   { cache; spec }
 ;;
 

--- a/test/blackbox-tests/test-cases/watching/queue-overflow.t
+++ b/test/blackbox-tests/test-cases/watching/queue-overflow.t
@@ -32,16 +32,14 @@ The RPC returns after the build triggered by the simulated overflow finishes.
 
   $ with_timeout dune rpc simulate-file-watcher-queue-overflow --wait
 
-A later event invalidates a new node created in the cleared table. The source
-tree still depends on the old detached node, so even a forwarded build returns
-the stale result.
+A later event must invalidate the node retained by the source tree so that a
+forwarded build observes the new input.
 
   $ : > second.in
   $ with_timeout dune rpc flush-file-watcher --wait
   $ build .
   Success
   $ cat _build/default/all.out
-  ./first.in
-  $ test -f second.in
+  ./first.in ./second.in
 
   $ stop_dune_quiet


### PR DESCRIPTION
Memo table cache clearing removed entries before invalidating their nodes. Existing dependencies consequently retained detached nodes, while later filesystem events invalidated newly-created entries that could no longer propagate changes through the active graph.

Invalidate every table entry while it remains reachable, then clear the table. The queue-overflow reproducer added in #16060 now expects the subsequent build to observe the new file.

Fixes #16052.
