### PR TITLE
perf(targets): preserve unchanged target sets

### DIFF
--- a/src/dune_targets/dune_targets.ml
+++ b/src/dune_targets/dune_targets.ml
@@ -38,7 +38,9 @@ let is_empty { files; dirs } =
 ;;
 
 let combine x y =
-  if Stdlib.(x == empty)
+  if Stdlib.(x == y)
+  then x
+  else if Stdlib.(x == empty)
   then y
   else if Stdlib.(y == empty)
   then x
@@ -46,16 +48,16 @@ let combine x y =
   then y
   else if is_empty y
   then x
-  else
-    { files = Path.Build.Array.Set.union x.files y.files
-    ; dirs = Path.Build.Array.Set.union x.dirs y.dirs
-    }
-;;
-
-let diff t { files; dirs } =
-  { files = Path.Build.Array.Set.diff t.files files
-  ; dirs = Path.Build.Array.Set.diff t.dirs dirs
-  }
+  else (
+    let { files = x_files; dirs = x_dirs } = x in
+    let { files = y_files; dirs = y_dirs } = y in
+    let files = Path.Build.Array.Set.union x_files y_files in
+    let dirs = Path.Build.Array.Set.union x_dirs y_dirs in
+    if Stdlib.(files == x_files && dirs == x_dirs)
+    then x
+    else if Stdlib.(files == y_files && dirs == y_dirs)
+    then y
+    else { files; dirs })
 ;;
 
 let head { files; dirs } =

--- a/src/dune_targets/dune_targets.mli
+++ b/src/dune_targets/dune_targets.mli
@@ -13,7 +13,6 @@ val is_empty : t -> bool
 (** Combine the sets of file and directory targets. *)
 val combine : t -> t -> t
 
-val diff : t -> t -> t
 val iter : t -> file:(Path.Build.t -> unit) -> dir:(Path.Build.t -> unit) -> unit
 
 module File : sig


### PR DESCRIPTION
`Targets.combine` is used while accumulating action targets. When both set unions reuse the fields from an input, return that existing `Targets.t` instead of allocating an equivalent record.

Also remove the unused `Targets.diff` operation. This is an implementation-only change, so it does not need a changelog entry.