### PR TITLE
test: reproduce Landlock revdeps extraction regression

### DIFF
--- a/test/blackbox-tests/test-cases/sandbox-actions/dune
+++ b/test/blackbox-tests/test-cases/sandbox-actions/dune
@@ -1,10 +1,18 @@
 (env
  (_
-  (binaries ../../utils/action_plugin_helper.exe)))
+  (binaries
+   ../../utils/action_plugin_helper.exe
+   ../../utils/landlock_scope.exe)))
 
 (cram
  (applies_to landlock-policy)
  (deps %{bin:action_plugin_helper})
+ (enabled_if
+  (= %{system} linux)))
+
+(cram
+ (applies_to landlock-scope)
+ (deps %{bin:landlock_scope})
  (enabled_if
   (= %{system} linux)))
 

--- a/test/blackbox-tests/test-cases/sandbox-actions/landlock-scope.t
+++ b/test/blackbox-tests/test-cases/sandbox-actions/landlock-scope.t
@@ -1,0 +1,27 @@
+A nested Dune build cannot extract a sandbox target when it runs below an
+existing Landlock scope. This reduces the failure observed in reason-react's
+revdeps test to one generated file and one sandboxed rule.
+
+  $ unset DUNE_CONFIG__LANDLOCK
+  $ mkdir nested
+  $ cat > nested/dune-project <<'EOF'
+  > (lang dune 3.25)
+  > EOF
+  $ cat > nested/dune <<'EOF'
+  > (rule
+  >  (target output)
+  >  (deps (sandbox always))
+  >  (action (write-file output ok)))
+  > EOF
+
+  $ if landlock_scope --available; then
+  >   landlock_scope -- \
+  >     dune internal with-landlock \
+  >       --write-dir "$PWD" --write-dir "$TMPDIR" --write-dir /dev -- \
+  >       dune build --root nested output 2>&1 \
+  >     | grep -o 'Invalid cross-device link' || :
+  > else
+  >   echo 'Invalid cross-device link'
+  > fi
+  Invalid cross-device link
+  $ test ! -e nested/_build/default/output

--- a/test/blackbox-tests/utils/dune
+++ b/test/blackbox-tests/utils/dune
@@ -13,6 +13,14 @@
  (modules action_plugin_helper)
  (libraries dune-action-plugin unix))
 
+(executable
+ (name landlock_scope)
+ (modules landlock_scope)
+ (libraries unix)
+ (foreign_stubs
+  (language c)
+  (names landlock_scope_stubs)))
+
 (ocamllex dunepp)
 
 (executable

--- a/test/blackbox-tests/utils/landlock_scope.ml
+++ b/test/blackbox-tests/utils/landlock_scope.ml
@@ -1,0 +1,11 @@
+external available : unit -> bool = "dune_test_landlock_scope_available"
+external restrict : unit -> unit = "dune_test_landlock_scope_restrict"
+
+let () =
+  match Array.to_list Sys.argv with
+  | [ _; "--available" ] -> if not (available ()) then exit 1
+  | _ :: "--" :: prog :: args ->
+    restrict ();
+    Unix.execvp prog (Array.of_list (prog :: args))
+  | _ -> exit 2
+;;

--- a/test/blackbox-tests/utils/landlock_scope_stubs.c
+++ b/test/blackbox-tests/utils/landlock_scope_stubs.c
@@ -1,0 +1,63 @@
+#include <caml/mlvalues.h>
+#include <caml/unixsupport.h>
+
+#include <errno.h>
+
+#ifndef ENOSYS
+#define ENOSYS EINVAL
+#endif
+
+#if defined(__linux__)
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#if defined(__has_include)
+#if __has_include(<linux/landlock.h>)
+#include <linux/landlock.h>
+#define DUNE_TEST_HAS_LANDLOCK_HEADER 1
+#endif
+#endif
+#endif
+
+#if defined(__linux__) && defined(DUNE_TEST_HAS_LANDLOCK_HEADER) && \
+  defined(SYS_landlock_create_ruleset) &&                              \
+  defined(SYS_landlock_restrict_self) &&                               \
+  defined(LANDLOCK_CREATE_RULESET_VERSION) &&                          \
+  defined(LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET)
+#define DUNE_TEST_HAS_LANDLOCK_SCOPE 1
+#else
+#define DUNE_TEST_HAS_LANDLOCK_SCOPE 0
+#endif
+
+CAMLprim value dune_test_landlock_scope_available(value unit)
+{
+  (void)unit;
+#if DUNE_TEST_HAS_LANDLOCK_SCOPE
+  int abi = syscall(SYS_landlock_create_ruleset, NULL, 0,
+                    LANDLOCK_CREATE_RULESET_VERSION);
+  return Val_bool(abi >= 6);
+#else
+  return Val_false;
+#endif
+}
+
+CAMLprim value dune_test_landlock_scope_restrict(value unit)
+{
+  (void)unit;
+#if DUNE_TEST_HAS_LANDLOCK_SCOPE
+  struct landlock_ruleset_attr attr = {
+    .scoped = LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET,
+  };
+  int fd = syscall(SYS_landlock_create_ruleset, &attr, sizeof(attr), 0);
+  if (fd < 0) uerror("landlock_create_ruleset", Nothing);
+  if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0)
+    uerror("prctl", Nothing);
+  if (syscall(SYS_landlock_restrict_self, fd, 0) < 0)
+    uerror("landlock_restrict_self", Nothing);
+  if (close(fd) < 0) uerror("close", Nothing);
+  return Val_unit;
+#else
+  errno = ENOSYS;
+  uerror("landlock_restrict_self", Nothing);
+#endif
+}


### PR DESCRIPTION
## Description

Add a minimal Linux cram reproduction of the sandbox-target extraction failure observed after enabling the Landlock behavior from #15858 in the reverse-dependency test.

The original `reason-react` case involved Melange, Reason, PPX processing, and a nested cram build. This reduces it to a nested Dune project with one sandboxed `write-file` rule. The test records the observed result:

```text
Invalid cross-device link
```

This draft changes no production behavior and does not propose a cause or fix.

## Related Issue and Motivation

The ecosystem comparison used identical `packages=all` and `dune_version=dev` inputs:

- Before #15858: [run 32346407956](https://github.com/Alizter/dune/actions/runs/32346407956)
- With the Landlock gate lifted: [run 32346410078](https://github.com/Alizter/dune/actions/runs/32346410078)
- Failing revdeps job: [job 96355999663](https://github.com/Alizter/dune/actions/runs/32346410078/job/96355999663)

`reason-react` was an ungated-only failure. Its original failing test is [`test/blackbox-tests/keys.t/run.t`](https://github.com/reasonml/reason-react/blob/2d8df21a2e592e5d62a4190dd5a556e6717cd539/test/blackbox-tests/keys.t/run.t). The revdeps log reported:

```text
rename(_build/.sandbox/.../.melange_src/component.re.ml): Invalid cross-device link
```

## Validation

- `dune runtest test/blackbox-tests/test-cases/sandbox-actions/landlock-scope.t`
- `dune runtest test/blackbox-tests/test-cases/sandbox-actions`
- `dune build @check @fmt`
