### PR TITLE
fix(memo): preserve table nodes across global invalidation

### DIFF
--- a/src/dune_engine/build_loop.ml
+++ b/src/dune_engine/build_loop.ml
@@ -113,7 +113,8 @@ let invalidation_of_file_events events =
       acc
       (match (event : Event.File_watcher_event.t) with
        | Fs_memo_event event -> Fs_memo.handle_fs_event event
-       | Queue_overflow -> Memo.Invalidation.clear_caches ~reason:Event_queue_overflow))
+       | Queue_overflow ->
+         Memo.Invalidation.invalidate_caches ~reason:Event_queue_overflow))
 ;;
 
 let next_watch_run_id t =

--- a/src/memo/caches.ml
+++ b/src/memo/caches.ml
@@ -2,6 +2,6 @@ open! Import
 
 (* We can get rid of this once we use the memoization system more pervasively
    and all the dependencies are properly specified *)
-let cleaners = ref []
-let register ~clear = cleaners := clear :: !cleaners
-let clear () = List.iter !cleaners ~f:(fun f -> f ())
+let invalidators = ref []
+let register ~invalidate = invalidators := invalidate :: !invalidators
+let invalidate () = List.iter !invalidators ~f:(fun f -> f ())

--- a/src/memo/invalidation.ml
+++ b/src/memo/invalidation.ml
@@ -43,7 +43,7 @@ module Leaf = struct
   type kind =
     | Invalidate_node : _ Node.Dep_node.t -> kind
     | Clear_cache : ('input, ('input, 'output) Node.Dep_node.t) Store.t -> kind
-    | Clear_caches
+    | Invalidate_caches
     | Custom of (unit -> unit)
 
   type t =
@@ -79,7 +79,7 @@ let execute_leaf { Leaf.kind; _ } =
   match kind with
   | Invalidate_node dep_node -> Node.invalidate dep_node
   | Clear_cache store -> invalidate_store store
-  | Clear_caches -> Caches.clear ()
+  | Invalidate_caches -> Caches.invalidate ()
   | Custom f -> f ()
 ;;
 
@@ -155,7 +155,7 @@ let is_empty = function
   | _ -> false
 ;;
 
-let clear_caches ~reason = Leaf { kind = Clear_caches; reason }
+let invalidate_caches ~reason = Leaf { kind = Invalidate_caches; reason }
 
 let invalidate_table ~reason ({ cache; _ } : _ Table0.t) =
   Leaf { kind = Clear_cache cache; reason }

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -115,9 +115,7 @@ let create_with_cache
       ?on_event
       f
   in
-  Caches.register ~clear:(fun () ->
-    Invalidation.invalidate_store cache;
-    Store.clear cache);
+  Caches.register ~invalidate:(fun () -> Invalidation.invalidate_store cache);
   { cache; spec }
 ;;
 
@@ -423,7 +421,7 @@ module For_tests = struct
            deps)
   ;;
 
-  let clear_memoization_caches () = Caches.clear ()
+  let invalidate_memoization_caches () = Caches.invalidate ()
 end
 
 module Store = Store_intf

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -246,9 +246,8 @@ module Invalidation : sig
 
   val is_empty : t -> bool
 
-  (** Clear all memoization tables. We use it if the incremental mode is not
-      enabled. *)
-  val clear_caches : reason:Reason.t -> t
+  (** Invalidate all computations stored in all memoization tables. *)
+  val invalidate_caches : reason:Reason.t -> t
 
   (** Invalidate all computations stored in a given [memo] table. *)
   val invalidate_table : reason:Reason.t -> _ Table.t -> t
@@ -597,7 +596,7 @@ module For_tests : sig
 
   (** Forget all memoized values, forcing them to be recomputed on the next
       build run. *)
-  val clear_memoization_caches : unit -> unit
+  val invalidate_memoization_caches : unit -> unit
 end
 
 (** A check point. This fiber should be used to:

--- a/src/upgrader/dune_upgrader.ml
+++ b/src/upgrader/dune_upgrader.ml
@@ -417,7 +417,7 @@ let upgrade () =
          additional upgrade should be needed *)
       (* We reset memoization tables as a simple way to refresh the
          Source_tree *)
-      Memo.reset (Memo.Invalidation.clear_caches ~reason:Upgrade);
+      Memo.reset (Memo.Invalidation.invalidate_caches ~reason:Upgrade);
       aux true)
     else if !v2_updates
     then (

--- a/test/expect-tests/memo/create_with_store.ml
+++ b/test/expect-tests/memo/create_with_store.ml
@@ -65,8 +65,8 @@ let%expect_test "create_with_store routes memoization through a custom store" =
     computing 2
     f 2 = 20 (calls = 2)
     |}];
-  (* clear_caches empties the custom store (Store.clear), forcing a recompute. *)
-  Memo.reset (Memo.Invalidation.clear_caches ~reason:Reason.Test);
+  (* [invalidate_caches] invalidates the node in the custom store. *)
+  Memo.reset (Memo.Invalidation.invalidate_caches ~reason:Reason.Test);
   show 1;
   [%expect
     {|

--- a/test/expect-tests/memo/invalidation_api.ml
+++ b/test/expect-tests/memo/invalidation_api.ml
@@ -2,10 +2,10 @@ open! Stdune
 open Test_helpers.Make ()
 module Reason = Memo.Invalidation.Reason
 
-(* [clear_caches] and [changed_paths] are public-only Invalidation features, so they are
-   exercised only here. *)
+(* [invalidate_caches] and [changed_paths] are public-only [Invalidation]
+   features, so they are exercised only here. *)
 
-let%expect_test "clear_caches forces every memoized table to recompute" =
+let%expect_test "invalidate_caches forces every memoized table to recompute" =
   let fa =
     Memo.create
       "a"
@@ -42,8 +42,8 @@ let%expect_test "clear_caches forces every memoized table to recompute" =
     a 1 = 2
     b 2 = 4
     |}];
-  (* clear_caches empties every registered table, forcing both to recompute. *)
-  Memo.reset (Memo.Invalidation.clear_caches ~reason:Reason.Test);
+  (* [invalidate_caches] forces both tables to recompute. *)
+  Memo.reset (Memo.Invalidation.invalidate_caches ~reason:Reason.Test);
   run_both ();
   [%expect
     {|
@@ -54,7 +54,7 @@ let%expect_test "clear_caches forces every memoized table to recompute" =
     |}]
 ;;
 
-let%expect_test "clear_caches detaches nodes retained by a lazy node" =
+let%expect_test "invalidate_caches preserves retained nodes" =
   let source = ref 0 in
   let table =
     Memo.create
@@ -64,21 +64,22 @@ let%expect_test "clear_caches detaches nodes retained by a lazy node" =
       (fun () -> Memo.return !source)
   in
   let retained =
-    Memo.lazy_node ~name:"retained" ~cutoff:Int.equal (fun () -> Memo.exec table ())
+    let compute () = Memo.exec table () in
+    Memo.lazy_node ~name:"retained" ~cutoff:Int.equal compute
   in
   let show () =
     printfn "source = %d, retained = %d" !source (run (Memo.Node.read retained))
   in
   show ();
   [%expect {| source = 0, retained = 0 |}];
-  Memo.reset (Memo.Invalidation.clear_caches ~reason:Reason.Test);
-  (* Recompute the old table node, which is now retained only by the lazy node. *)
+  Memo.reset (Memo.Invalidation.invalidate_caches ~reason:Reason.Test);
+  (* Recompute the node while both the table and lazy node retain it. *)
   ignore (run (Memo.Node.read retained) : int);
   source := 1;
-  (* The table lookup creates and invalidates a new, disconnected node. *)
+  (* The table lookup returns and invalidates the same node. *)
   Memo.reset (Memo.Node.invalidate ~reason:Reason.Test (Memo.node table ()));
   show ();
-  [%expect {| source = 1, retained = 0 |}]
+  [%expect {| source = 1, retained = 1 |}]
 ;;
 
 let%expect_test "changed_paths returns the deduplicated Path_changed reasons only" =

--- a/test/expect-tests/memo/invalidation_api.ml
+++ b/test/expect-tests/memo/invalidation_api.ml
@@ -54,6 +54,33 @@ let%expect_test "clear_caches forces every memoized table to recompute" =
     |}]
 ;;
 
+let%expect_test "clear_caches detaches nodes retained by a lazy node" =
+  let source = ref 0 in
+  let table =
+    Memo.create
+      "table"
+      ~input:(module Unit)
+      ~cutoff:Int.equal
+      (fun () -> Memo.return !source)
+  in
+  let retained =
+    Memo.lazy_node ~name:"retained" ~cutoff:Int.equal (fun () -> Memo.exec table ())
+  in
+  let show () =
+    printfn "source = %d, retained = %d" !source (run (Memo.Node.read retained))
+  in
+  show ();
+  [%expect {| source = 0, retained = 0 |}];
+  Memo.reset (Memo.Invalidation.clear_caches ~reason:Reason.Test);
+  (* Recompute the old table node, which is now retained only by the lazy node. *)
+  ignore (run (Memo.Node.read retained) : int);
+  source := 1;
+  (* The table lookup creates and invalidates a new, disconnected node. *)
+  Memo.reset (Memo.Node.invalidate ~reason:Reason.Test (Memo.node table ()));
+  show ();
+  [%expect {| source = 1, retained = 0 |}]
+;;
+
 let%expect_test "changed_paths returns the deduplicated Path_changed reasons only" =
   let inv reason = Memo.Invalidation.custom ~reason ~f:(fun () -> ()) in
   let combined =

--- a/test/expect-tests/vcs/vcs_tests_common.ml
+++ b/test/expect-tests/vcs/vcs_tests_common.ml
@@ -87,7 +87,7 @@ let run_action (vcs : Vcs.t) action =
       (match vcs.kind with
        | Git -> "git"
        | Hg -> "hg");
-    Memo.reset (Memo.Invalidation.clear_caches ~reason:Test);
+    Memo.reset (Memo.Invalidation.invalidate_caches ~reason:Test);
     let vcs =
       match vcs.kind with
       | Hg when not has_hg -> { vcs with kind = Git }


### PR DESCRIPTION
Follow up on #16068 by removing the table eviction that originally made global Memo invalidation unsafe. Eviction breaks the canonical input-to-node mapping: lazy nodes can retain and recompute an evicted node, while later table lookups create and invalidate a disconnected replacement.

Keep table entries in place and invalidate their nodes instead. This preserves node identity while still forcing every cached computation to recompute. Rename the operation from `clear_caches` to `invalidate_caches` to reflect its semantics.

Related to #16052.
