### PR TITLE
fix(stdune): reject Windows path separators in filenames

### DIFF
--- a/doc/changes/fixed/16076.md
+++ b/doc/changes/fixed/16076.md
@@ -1,0 +1,2 @@
+- Reject Windows path separators in validated filename components (#16076,
+  @rgrinberg)

--- a/otherlibs/stdune/src/filename.ml
+++ b/otherlibs/stdune/src/filename.ml
@@ -6,6 +6,16 @@ let rec contains_slash s i =
   i >= 0 && (Char.equal (String.unsafe_get s i) '/' || contains_slash s (i - 1))
 ;;
 
+let rec contains_dir_sep s i =
+  if i < 0
+  then false
+  else (
+    match String.unsafe_get s i with
+    | '/' -> true
+    | ('\\' | ':') when Sys.win32 || Sys.cygwin -> true
+    | _ -> contains_dir_sep s (i - 1))
+;;
+
 let is_valid s =
   let len = String.length s in
   len > 0
@@ -14,7 +24,7 @@ let is_valid s =
       || not
            (Char.equal (String.unsafe_get s 0) '.'
             && Char.equal (String.unsafe_get s 1) '.'))
-  && not (contains_slash s (len - 1))
+  && not (contains_dir_sep s (len - 1))
 ;;
 
 let of_string s = Option.some_if (is_valid s) s
@@ -84,7 +94,9 @@ module Extension = struct
 
   let is_valid s =
     let len = String.length s in
-    len > 0 && Char.equal (String.unsafe_get s 0) '.' && not (contains_slash s (len - 1))
+    len > 0
+    && Char.equal (String.unsafe_get s 0) '.'
+    && not (contains_dir_sep s (len - 1))
   ;;
 
   let of_string s = Option.some_if (is_valid s) s

--- a/otherlibs/stdune/src/filename.mli
+++ b/otherlibs/stdune/src/filename.mli
@@ -1,7 +1,7 @@
 (** Represent a non-empty path component.
 
-    A path component is just a non-empty string without a '/' character. It
-    cannot be ["."] or [".."]. *)
+    A path component is just a non-empty string without a directory separator.
+    It cannot be ["."] or [".."]. *)
 
 val current_dir_name : string
 val parent_dir_name : string

--- a/otherlibs/stdune/test/filename_tests.ml
+++ b/otherlibs/stdune/test/filename_tests.ml
@@ -3,6 +3,33 @@ open Dune_tests_common
 
 let () = init ()
 
+let%expect_test "filenames reject platform directory separators" =
+  let windows = Sys.win32 || Sys.cygwin in
+  let check_filename s ~expected =
+    let actual = Option.is_some (Filename.of_string s) in
+    Printf.printf "filename %S: %b\n" s (Bool.equal actual expected)
+  in
+  let check_extension s ~expected =
+    let actual = Option.is_some (Filename.Extension.of_string s) in
+    Printf.printf "extension %S: %b\n" s (Bool.equal actual expected)
+  in
+  check_filename "a/b" ~expected:false;
+  check_filename "a\\b" ~expected:(not windows);
+  check_filename "a:b" ~expected:(not windows);
+  check_extension ".a/b" ~expected:false;
+  check_extension ".a\\b" ~expected:(not windows);
+  check_extension ".a:b" ~expected:(not windows);
+  [%expect
+    {|
+    filename "a/b": true
+    filename "a\\b": true
+    filename "a:b": true
+    extension ".a/b": true
+    extension ".a\\b": true
+    extension ".a:b": true
+    |}]
+;;
+
 let extension s =
   let ext =
     Filename.of_string s


### PR DESCRIPTION
Ensure `Filename.t` and `Filename.Extension.t` reject backslashes and colons on Windows and Cygwin, matching their path-component invariant. This prevents strings interpreted as multiple path components from passing filename validation.
