### PR TITLE
perf(stdune): append validated path components directly

### DIFF
--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -29,7 +29,7 @@ module Local = struct
     |> inside_workspace_exn ?loc:error_loc ~path ~from:(to_string t)
   ;;
 
-  let relative_fname ?error_loc t fn = relative ?error_loc t (Filename.to_string fn)
+  let relative_fname t fn = Path0.Local.relative_fname t fn
 
   let parse_string_exn ~loc s =
     parse_string_result s |> inside_workspace_exn ~loc ~path:s ~from:(to_string root)
@@ -76,7 +76,7 @@ module Source0 = struct
     |> inside_workspace_exn ?loc:error_loc ~path ~from:(to_string t)
   ;;
 
-  let relative_fname ?error_loc t fn = relative ?error_loc t (Filename.to_string fn)
+  let relative_fname t fn = Path0.Source.relative_fname t fn
 
   let parse_string_exn ~loc s =
     parse_string_result s |> inside_workspace_exn ~loc ~path:s ~from:(to_string root)
@@ -147,7 +147,11 @@ module Outside_build_dir = struct
     | External t -> External (External.relative t s)
   ;;
 
-  let relative_fname t fn = relative t (Filename.to_string fn)
+  let relative_fname t fn =
+    match t with
+    | In_source_dir t -> In_source_dir (Source0.relative_fname t fn)
+    | External t -> External (External.relative_fname t fn)
+  ;;
 
   let extend_basename t ~suffix =
     match t with
@@ -220,7 +224,7 @@ module Build = struct
     |> inside_workspace_exn ?loc:error_loc ~path ~from:(to_string t)
   ;;
 
-  let relative_fname ?error_loc t fn = relative ?error_loc t (Filename.to_string fn)
+  let relative_fname t fn = Path0.Build.relative_fname t fn
 
   let parse_string_exn ~loc s =
     parse_string_result s |> inside_workspace_exn ~loc ~path:s ~from:(to_string root)
@@ -464,7 +468,12 @@ let relative ?error_loc t fn =
      | External s -> external_ (External.relative s fn))
 ;;
 
-let relative_fname ?error_loc t fn = relative ?error_loc t (Filename.to_string fn)
+let relative_fname t fn =
+  match t with
+  | In_source_tree p -> Source0.relative_fname p fn |> Source0.to_local |> make_local_path
+  | In_build_dir p -> in_build_dir (Build.relative_fname p fn)
+  | External p -> external_ (External.relative_fname p fn)
+;;
 
 let parse_string_exn ~loc s =
   match s with

--- a/otherlibs/stdune/src/path0.ml
+++ b/otherlibs/stdune/src/path0.ml
@@ -118,7 +118,10 @@ module Local_gen = struct
         [ "t", to_dyn t; "path", String path ]
   ;;
 
-  let relative_fname t fn = relative t (Filename.to_string fn)
+  let relative_fname t fn =
+    let fn = Filename.to_string fn in
+    if is_root t then fn else String.append_with_char t ~sep:'/' fn
+  ;;
 
   (* Check whether a path is in canonical form: no '.' or '..' components, no
      repeated '/' components, no backslashes '\\' (on Windows only), and not

--- a/otherlibs/stdune/src/path_external.mli
+++ b/otherlibs/stdune/src/path_external.mli
@@ -7,7 +7,6 @@ val root : t
 include Path_intf.With_loc with type t := t
 
 val relative : t -> string -> t
-val relative_fname : t -> Filename.t -> t
 val initial_cwd : t
 val cwd : unit -> t
 val as_local : t -> string

--- a/otherlibs/stdune/src/path_intf.ml
+++ b/otherlibs/stdune/src/path_intf.ml
@@ -49,7 +49,7 @@ module type With_loc = sig
   type t
 
   val relative : ?error_loc:Loc0.t -> t -> string -> t
-  val relative_fname : ?error_loc:Loc0.t -> t -> Filename.t -> t
+  val relative_fname : t -> Filename.t -> t
   val parse_string_exn : loc:Loc0.t -> string -> t
 end
 


### PR DESCRIPTION
`Filename.t` now guarantees a valid path component on every platform, so the `Path.relative_fname` family can append it directly instead of converting and reparsing it. This also removes the unused `error_loc` optional argument from these functions.
