### PR TITLE
test(install): preserve fail-fast error behavior

### DIFF
--- a/test/blackbox-tests/test-cases/install/concurrent-install.t
+++ b/test/blackbox-tests/test-cases/install/concurrent-install.t
@@ -176,6 +176,22 @@ fast entry to be installed, so a sequential install would time out.
   Installing prefix/lib/foo/slow
   [1]
 
+Installation stops at the first copy error. Using a directory as the first
+source makes copying fail after destination validation; the later independent
+entry must not be installed.
+
+  $ rm -rf prefix source-dir
+  $ mkdir source-dir
+  $ printf 'second\n' >second
+  $ cat >_build/default/foo.install <<EOF
+  > lib: [
+  >   "source-dir" {"first"}
+  >   "second"
+  > ]
+  > EOF
+  $ if dune install --prefix prefix --display short >/dev/null 2>&1; then false; fi
+  $ test ! -e prefix/lib/foo/second
+
 A warning is not lost when the fallback copy fails. The FIFO is unlinked after
 Dune opens it, so parsing can finish but the fallback cannot reopen the source.
 


### PR DESCRIPTION
Adds regression coverage for fail-fast installation errors discovered while reviewing concurrent installation in #13054.