### PR TITLE
refactor(stdune): return filenames from directory reads

### DIFF
--- a/otherlibs/stdune/src/fpath.ml
+++ b/otherlibs/stdune/src/fpath.ml
@@ -216,7 +216,7 @@ let rec clear_dir ?(chmod = false) dir =
 
 and clear_files ?(chmod = false) dir listing =
   List.iter listing ~f:(fun (fn, kind) ->
-    let fn = Filename.concat dir fn in
+    let fn = Filename.append dir fn in
     (* Note that by the time we reach this point, [fn] might have been
        deleted by a concurrent process. Both [rm_rf_dir] and [unlink_no_err]
        will tolerate such phantom paths and succeed. *)
@@ -246,7 +246,6 @@ let rm_rf ?(chmod = false) fn =
 ;;
 
 let default ~dir:_ _ acc = acc
-let filename = Filename.of_string_exn
 
 (* CR-someday rgrinberg: maybe we should make sure that we don't hit any
    symlink loops here? *)
@@ -276,17 +275,16 @@ let traverse
           ]
   in
   let handle_kind ~dir fname kind stack acc =
-    let filename = filename fname in
     match (kind : Unix.file_kind) with
     | S_DIR ->
-      (match enter_dir ~dir filename with
+      (match enter_dir ~dir fname with
        | false -> stack, acc
        | true ->
-         let acc = on_dir ~dir filename acc in
-         let stack = Filename.concat dir fname :: stack in
+         let acc = on_dir ~dir fname acc in
+         let stack = Filename.append dir fname :: stack in
          stack, acc)
-    | S_REG -> stack, on_file ~dir filename acc
-    | kind -> stack, on_other ~dir filename kind acc
+    | S_REG -> stack, on_file ~dir fname acc
+    | kind -> stack, on_other ~dir fname kind acc
   in
   let on_error =
     match on_error with
@@ -309,7 +307,7 @@ let traverse
            then
              List.sort
                ~compare:(fun (name1, _kind1) (name2, _kind2) ->
-                 String.compare name2 name1)
+                 Filename.compare name2 name1)
                entries
            else entries
          in
@@ -322,16 +320,16 @@ let traverse
                   User_error.raise
                     [ Pp.textf
                         "Symlink %s is not allowed here"
-                        (Filename.concat dir fname)
+                        (Filename.append dir fname)
                     ]
                 | `Ignore -> stack, acc
                 | `Resolve ->
-                  (match Unix.stat (Filename.concat dir_path fname) with
+                  (match Unix.stat (Filename.append dir_path fname) with
                    | exception Unix.Unix_error (x, y, z) ->
                      stack, on_error ~dir (x, y, z) acc
                    | stat -> handle_kind ~dir fname stat.st_kind stack acc)
                 | `Call f ->
-                  let acc, kind = f ~dir (filename fname) acc in
+                  let acc, kind = f ~dir fname acc in
                   (match kind with
                    | None -> stack, acc
                    | Some kind -> handle_kind ~dir fname kind stack acc))

--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -773,19 +773,8 @@ let relative_to_source_in_build_or_external ?error_loc ~dir s =
      | In_build_dir _ | External _ -> path)
 ;;
 
-let readdir_unsorted t =
-  Result.map
-    (Readdir.read_directory (to_string t))
-    ~f:(List.map ~f:Filename.of_string_exn)
-;;
-
-let readdir_unsorted_with_kinds t =
-  Result.map
-    (Readdir.read_directory_with_kinds (to_string t))
-    ~f:(fun entries ->
-      List.map entries ~f:(fun (name, kind) -> Filename.of_string_exn name, kind))
-;;
-
+let readdir_unsorted t = Readdir.read_directory (to_string t)
+let readdir_unsorted_with_kinds t = Readdir.read_directory_with_kinds (to_string t)
 let build_dir_exists () = Fpath.is_directory (to_string build_dir)
 
 let ensure_build_dir_exists () =

--- a/otherlibs/stdune/src/proc.ml
+++ b/otherlibs/stdune/src/proc.ml
@@ -149,7 +149,9 @@ module Linux = struct
       | Error _ as error -> error
       | Ok tasks ->
         Result.List.fold_left tasks ~init:Pid.Set.empty ~f:(fun acc tid ->
-          let path = Printf.sprintf "/proc/%d/task/%s/children" pid tid in
+          let path =
+            Printf.sprintf "/proc/%d/task/%s/children" pid (Filename.to_string tid)
+          in
           match lines_of_file path with
           | Error (Unix.ENOENT, _, _) -> Ok acc
           | Error error -> Error (Cannot_read_file { path; error })

--- a/otherlibs/stdune/src/readdir.c
+++ b/otherlibs/stdune/src/readdir.c
@@ -15,6 +15,12 @@
 #include <dirent.h>
 typedef struct dirent directory_entry;
 
+static int is_dot_or_dot_dot(const char *name)
+{
+  return name[0] == '.'
+    && (name[1] == '\0' || (name[1] == '.' && name[2] == '\0'));
+}
+
 value val_file_type(int typ) {
   switch(typ)
     {
@@ -50,16 +56,19 @@ CAMLprim value caml__dune_filesystem_stubs__readdir(value vd)
   directory_entry * e;
   d = DIR_Val(vd);
   if (d == (DIR *) NULL) unix_error(EBADF, "readdir", Nothing);
-  caml_enter_blocking_section();
-  errno = 0;
-  e = readdir((DIR *) d);
-  caml_leave_blocking_section();
-  if (e == (directory_entry *) NULL) {
-    if(errno == 0) {
-      CAMLreturn(Val_int(0));
-    } else {
-      uerror("readdir", Nothing);
+  while (1) {
+    caml_enter_blocking_section();
+    errno = 0;
+    e = readdir((DIR *) d);
+    caml_leave_blocking_section();
+    if (e == (directory_entry *) NULL) {
+      if(errno == 0) {
+        CAMLreturn(Val_int(0));
+      } else {
+        uerror("readdir", Nothing);
+      }
     }
+    if (!is_dot_or_dot_dot(e->d_name)) break;
   }
   v_filename = caml_copy_string(e->d_name);
   v_tuple = caml_alloc_small(2, 0);

--- a/otherlibs/stdune/src/readdir.ml
+++ b/otherlibs/stdune/src/readdir.ml
@@ -35,7 +35,7 @@ module Readdir_result = struct
   (* The values are constructed on the C-side *)
   type t =
     | End_of_directory
-    | Entry of string * File_kind.Option.t
+    | Entry of Filename.t * File_kind.Option.t
 end
 
 external readdir_with_kind_if_available_unix
@@ -43,14 +43,15 @@ external readdir_with_kind_if_available_unix
   -> Readdir_result.t
   = "caml__dune_filesystem_stubs__readdir"
 
-let readdir_with_kind_if_available_win32 : Unix.dir_handle -> Readdir_result.t =
+let rec readdir_with_kind_if_available_win32 : Unix.dir_handle -> Readdir_result.t =
   fun dir ->
   (* Windows also gives us the information about file kind and it's discarded by
      [readdir]. We could do better here, but the Windows code is more
      complicated. (there's an additional OCaml abstraction layer) *)
   match Unix.readdir dir with
   | exception End_of_file -> Readdir_result.End_of_directory
-  | entry -> Entry (entry, File_kind.Option.UNKNOWN)
+  | "." | ".." -> readdir_with_kind_if_available_win32 dir
+  | entry -> Entry (Filename.of_string_exn entry, File_kind.Option.UNKNOWN)
 ;;
 
 let readdir_with_kind_if_available =
@@ -80,7 +81,6 @@ let read_directory_with_kinds_exn dir_path =
   with_directory dir_path ~f:(fun dir ->
     let rec loop acc =
       match readdir_with_kind_if_available dir with
-      | Entry (("." | ".."), _) -> loop acc
       | End_of_directory -> acc
       | Entry (base, kind) ->
         let k kind = loop ((base, kind) :: acc) in
@@ -88,7 +88,7 @@ let read_directory_with_kinds_exn dir_path =
         File_kind.Option.elim
           kind
           ~none:(fun () ->
-            match Unix.lstat (Filename.concat dir_path base) with
+            match Unix.lstat (Filename.append dir_path base) with
             | exception Unix.Unix_error _ ->
               (* File disappeared between readdir & lstat system calls. Handle
                    as if readdir never told us about it *)
@@ -107,7 +107,6 @@ let read_directory_exn dir_path =
   with_directory dir_path ~f:(fun dir ->
     let rec loop acc =
       match readdir_with_kind_if_available dir with
-      | Entry (("." | ".."), _) -> loop acc
       | End_of_directory -> acc
       | Entry (base, _) -> loop (base :: acc)
     in

--- a/otherlibs/stdune/src/readdir.mli
+++ b/otherlibs/stdune/src/readdir.mli
@@ -4,8 +4,8 @@
     returning kinds of the filesystem entries. *)
 val read_directory_with_kinds
   :  string
-  -> ((string * File_kind.t) list, Unix_error.Detailed.t) Result.t
+  -> ((Filename.t * File_kind.t) list, Unix_error.Detailed.t) Result.t
 
 (** [read_directory_with_kinds d] returns all the filesystem entries in [d]
     except for "." and "..", similar to [Sys.readdir]. *)
-val read_directory : string -> (string list, Unix_error.Detailed.t) Result.t
+val read_directory : string -> (Filename.t list, Unix_error.Detailed.t) Result.t

--- a/otherlibs/stdune/test/io_metrics_tests.ml
+++ b/otherlibs/stdune/test/io_metrics_tests.ml
@@ -61,10 +61,10 @@ let%expect_test "directory metrics count directory scans" =
   Path.mkdir_p second;
   let count_before = Counter.read Metrics.Directory_read.count in
   let time_before = Counter.Timer.read Metrics.Directory_read.time in
-  ignore (Readdir.read_directory (Path.to_string first) |> ok_exn : string list);
+  ignore (Readdir.read_directory (Path.to_string first) |> ok_exn : Filename.t list);
   ignore
     (Readdir.read_directory_with_kinds (Path.to_string second) |> ok_exn
-     : (string * Unix.file_kind) list);
+     : (Filename.t * Unix.file_kind) list);
   Dune_tests_common.print_dyn
     (Dyn.record
        [ "count", Dyn.int (Counter.read Metrics.Directory_read.count - count_before)

--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -317,8 +317,8 @@ let resolve_symlinks_in root =
           | Error e -> Unix_error.Detailed.raise e
           | Ok children ->
             List.iter children ~f:(fun (child_name, child_kind) ->
-              let src = Path.relative resolved child_name in
-              let dst = Path.relative relative child_name in
+              let src = Path.relative_fname resolved child_name in
+              let dst = Path.relative_fname relative child_name in
               match (child_kind : Unix.file_kind) with
               | S_REG -> Io.portable_hardlink ~src ~dst
               (* To avoid recursing here, we create symlinks will get resolved

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -109,12 +109,7 @@ module Load = Make_load (struct
       | Error _ ->
         (* CR-someday rgrinberg: add some proper message here *)
         User_error.raise [ Pp.text "" ]
-      | Ok content ->
-        let content =
-          Stdune.List.map content ~f:(fun (name, kind) ->
-            Filename.of_string_exn name, kind)
-        in
-        return content
+      | Ok content -> return content
     ;;
 
     let with_lexbuf_from_file path ~f =

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -2229,7 +2229,7 @@ let rec scan_contents p =
     dir_contents
     ~init:(P.Set.empty, P.Set.empty)
     ~f:(fun (files, empty_directories) (file_name, file_kind) ->
-      let p = P.relative p file_name in
+      let p = P.relative_fname p file_name in
       match (file_kind : Unix.file_kind) with
       | S_REG -> P.Set.add files p, empty_directories
       | S_DIR ->

--- a/src/rpc/poll_active.ml
+++ b/src/rpc/poll_active.ml
@@ -7,7 +7,7 @@ include
       let scandir dir =
         Fiber.return
           (match Stdune.Readdir.read_directory dir with
-           | Ok s -> Ok s
+           | Ok s -> Ok (Filename.L.to_string s)
            | Error (e, _, _) -> Error (Failure (dir ^ ": " ^ Unix.error_message e)))
       ;;
 


### PR DESCRIPTION
Return directory entries as `Filename.t` from `Readdir` so callers can consume them without revalidating path components. Filter `.` and `..` in the low-level Unix and Windows readers, and propagate the typed entries through existing callers.