### PR TITLE
perf(install): inspect build paths without generic wrappers

### DIFF
--- a/src/install/context.ml
+++ b/src/install/context.ml
@@ -18,8 +18,8 @@ let lib_dir ~context ~package =
 ;;
 
 let of_path path =
-  match Dune_engine.Dpath.analyse_dir (Path.build path) with
-  | Build (Regular (With_context (name, src))) ->
+  match Dune_engine.Dpath.Target_dir.of_target path with
+  | Regular (With_context (name, src)) ->
     Some
       (if Context_name.equal name install_context.name
        then (
@@ -27,8 +27,8 @@ let of_path path =
          | Some (ctx, _) -> Context_name.of_string (Filename.to_string ctx)
          | None -> name)
        else name)
-  | Build (Anonymous_action (With_context (name, _))) -> Some name
-  | _ -> None
+  | Anonymous_action (With_context (name, _)) -> Some name
+  | Regular Root | Anonymous_action Root | Invalid _ -> None
 ;;
 
 type analyze_path =


### PR DESCRIPTION
`Install.Context.of_path` already receives a `Path.Build.t`. Classify it directly with `Dpath.Target_dir.of_target` instead of wrapping it as a generic `Path.t` and immediately unwrapping the result. This makes impossible source and external cases unrepresentable and avoids intermediate variants while preserving the existing classification.
