### PR TITLE
test(install): cover staging path symlink aliases

### DIFF
--- a/test/blackbox-tests/test-cases/install/concurrent-install.t
+++ b/test/blackbox-tests/test-cases/install/concurrent-install.t
@@ -76,6 +76,25 @@ waits for that destination to be installed, so a sequential install times out.
   >   prefix/lib/foo/.#target.dune-temp
   Installing prefix/lib/foo/target
 
+Staging paths can themselves be symlinks. Here `.#target.dune-temp` points at
+the second entry's destination. Starting both entries would make them overwrite
+the same file, so they must remain sequential.
+
+  $ rm -rf prefix
+  $ rm -f aliased-staging-source
+  $ mkdir -p prefix/lib/foo
+  $ ln -s temp-target prefix/lib/foo/.#target.dune-temp
+  $ printf 'second\n' >second
+  $ cat >_build/default/foo.install <<EOF
+  > lib: [
+  >   "aliased-staging-source" {"target"}
+  >   "second" {"temp-target"}
+  > ]
+  > EOF
+  $ second_entry_must_not_start aliased-staging-source \
+  >   prefix/lib/foo/temp-target
+  Installing prefix/lib/foo/target
+
 Destinations that resolve through symlinks can also refer to the same file.
 The writer waits for the second alias, so preserving sequential behavior makes
 the install time out before it can start the second entry.


### PR DESCRIPTION
Adds regression coverage for artifact-substitution staging paths that alias install destinations through symlinks, discovered while reviewing #13054.