### PR TITLE
test(pkg): preserve per-platform post-dependency reachability

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-post-dependency-reachability.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-post-dependency-reachability.t
@@ -1,0 +1,44 @@
+A package retained in a portable lock directory must not keep a dependency that
+was pruned as unreachable on its platform.
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+On Linux, p is reachable only through a post dependency, so its dependency q
+should be pruned. On macOS, p is a regular dependency but q is inactive.
+
+  $ mkpkg p 1 <<'EOF'
+  > depends: [ "q" {os = "linux"} ]
+  > EOF
+  $ mkpkg q 1 <<'EOF'
+  > EOF
+
+  $ cat >xlinux.opam <<'EOF'
+  > opam-version: "2.0"
+  > depends: [ "p" {os = "linux" & post} ]
+  > EOF
+  $ cat >xmac.opam <<'EOF'
+  > opam-version: "2.0"
+  > depends: [ "p" {os = "macos"} ]
+  > EOF
+
+  $ cat >dune-project <<'EOF'
+  > (lang dune 3.20)
+  > EOF
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.20)
+  > (repository
+  >  (name mock)
+  >  (url "file://$(pwd)/mock-opam-repository"))
+  > (lock_dir
+  >  (repositories mock)
+  >  (solve_for_platforms
+  >   ((arch x86_64) (os linux))
+  >   ((arch x86_64) (os macos))))
+  > EOF
+
+Locking succeeds, p is retained, and q is not retained.
+
+  $ dune pkg lock >/dev/null 2>&1
+  $ test -e dune.lock/p.1.pkg
+  $ test ! -e dune.lock/q.1.pkg


### PR DESCRIPTION
## Summary

- Reproduce a portable-lock-directory case where a package is reachable through a post dependency on Linux and a regular dependency on macOS.
- Verify locking succeeds while the dependency pruned from the Linux graph is not retained.
- Provide the pre-feature regression test for #15982.

## Checks

- `dune runtest test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-post-dependency-reachability.t`
- `CI=true dune build @fmt @check`