### PR TITLE
fix(engine): reject colons in context names

### DIFF
--- a/doc/changes/changed/16085.md
+++ b/doc/changes/changed/16085.md
@@ -1,0 +1,2 @@
+- **BREAKING CHANGE:** Reject `:` in context names so they remain portable path
+  components (#16085, @rgrinberg)

--- a/src/dune_engine/context_name.ml
+++ b/src/dune_engine/context_name.ml
@@ -20,7 +20,7 @@ include (
       then false
       else (
         match String.unsafe_get name i with
-        | '/' | '\\' -> true
+        | '/' | '\\' | ':' -> true
         | _ -> contains_dir_sep name (i - 1))
     ;;
 

--- a/test/blackbox-tests/test-cases/workspaces/custom-context-names.t
+++ b/test/blackbox-tests/test-cases/workspaces/custom-context-names.t
@@ -16,6 +16,23 @@ Validates custom workspace context names.
   Error: "log" is an invalid context name.
   [1]
 
+Context names must be portable path components.
+
+  $ cat > dune-workspace << EOF
+  > (lang dune 3.13)
+  > (context default)
+  > (context
+  >  (default
+  >   (name foo:bar)))
+  > EOF
+
+  $ dune build
+  File "dune-workspace", line 5, characters 8-15:
+  5 |   (name foo:bar)))
+              ^^^^^^^
+  Error: "foo:bar" is an invalid context name.
+  [1]
+
   $ cat > dune-workspace << EOF
   > (lang dune 3.13)
   > (context default)


### PR DESCRIPTION
Context names become build-directory components and must remain portable. Reject `:` alongside `/` and `\`, since Dune path parsing treats colons as separators on Windows and Cygwin. This deliberately rejects existing context names containing colons rather than interpreting them differently across platforms.
