### PR TITLE
perf(engine): extract target contexts directly

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -553,10 +553,10 @@ module Internal = struct
   and execute_rule_impl ~rule_kind rule =
     let { Rule.id = _; targets; mode; action; info } = rule in
     let* execution_parameters =
-      match Dpath.Target_dir.of_target targets.root with
-      | Regular (With_context (context, _)) | Anonymous_action (With_context (context, _))
-        -> (Build_config.get ()).execution_parameters context ~dir:targets.root
-      | Anonymous_action Root | Regular Root | Invalid _ ->
+      match Dpath.Target_dir.context targets.root with
+      | Some context ->
+        (Build_config.get ()).execution_parameters context ~dir:targets.root
+      | None ->
         Code_error.raise
           "invalid dir for rule execution"
           [ "dir", Path.Build.to_dyn targets.root ]

--- a/src/dune_engine/dpath.ml
+++ b/src/dune_engine/dpath.ml
@@ -31,6 +31,18 @@ module Target_dir = struct
     | Regular of context_related
     | Invalid of Path.Build.t
 
+  let context fn =
+    match Path.Build.extract_first_component fn with
+    | None -> None
+    | Some (name, sub) ->
+      if Filename.equal name Build.anonymous_actions_dir_basename
+      then (
+        match Path.Local.split_first_component sub with
+        | None -> None
+        | Some (name, _) -> Some (Context_name.of_string (Filename.to_string name)))
+      else Context_name.of_string_opt (Filename.to_string name)
+  ;;
+
   (* _build/foo or _build/install/foo where foo is invalid *)
 
   let of_target fn =

--- a/src/dune_engine/dpath.mli
+++ b/src/dune_engine/dpath.mli
@@ -12,6 +12,7 @@ module Target_dir : sig
     | Regular of context_related
     | Invalid of Path.Build.t
 
+  val context : Path.Build.t -> Context_name.t option
   val of_target : Path.Build.t -> t
 end
 


### PR DESCRIPTION
Rule execution only needs the build context from `targets.root`, but `Target_dir.of_target` constructs a complete target classification, including the source remainder. Add `Target_dir.context` to extract only the context and use it when selecting execution parameters, preserving the existing root and invalid-path handling while avoiding intermediate variants.
