### PR TITLE
refactor(menhir): clarify context reuse

### DIFF
--- a/src/dune_rules/menhir/menhir_rules.ml
+++ b/src/dune_rules/menhir/menhir_rules.ml
@@ -196,7 +196,6 @@ module Run (P : PARAMS) = struct
     Memo.lazy_ ~name:"menhir-stanzas" (fun () ->
       let open Memo.O in
       let+ { Ml_sources.Parser_generators.deps; targets = _ } =
-        let sctx = Compilation_context.super_context cctx in
         Dir_contents.get sctx ~dir
         >>= Dir_contents.ml ~for_
         >>| Ml_sources.Parser_generators.modules ~for_:(Menhir stanza.loc)
@@ -298,19 +297,23 @@ module Run (P : PARAMS) = struct
         mock_module
         ~lint:false
     in
-    let cctx =
+    let inference_cctx =
       Compilation_context.set_sandbox cctx Sandbox_config.needs_sandboxing
       |> Compilation_context.without_bin_annot
     in
     let* deps =
-      let obj_dir = Compilation_context.obj_dir cctx in
-      let modules = Compilation_context.modules cctx in
-      let impl = Compilation_context.implements cctx in
+      let obj_dir = Compilation_context.obj_dir inference_cctx in
+      let modules = Compilation_context.modules inference_cctx in
+      let impl = Compilation_context.implements inference_cctx in
       let dir = Obj_dir.dir obj_dir in
       Dep_rules.for_module ~obj_dir ~modules ~sandbox ~impl ~dir ~sctx mock_module ~for_
     in
     let* () =
-      Module_compilation.ocamlc_i ~deps cctx mock_module ~output:(inferred_mli base)
+      Module_compilation.ocamlc_i
+        ~deps
+        inference_cctx
+        mock_module
+        ~output:(inferred_mli base)
     in
     let* explain_flags = explain_flags base stanza
     and* mode = expand_rule_mode stanza.mode in


### PR DESCRIPTION
Reuse the Menhir functor super context and distinguish its inference compilation context. Follow-up to #16092.