### PR TITLE
perf(cram): share stanza dependency evaluation

### DIFF
--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -175,14 +175,62 @@ let test_rule
     |> Action.Full.make
 ;;
 
+type prepared_stanza =
+  { expander : Expander.t
+  ; deps : (Sandbox_config.t Action_builder.t * Env.t Action_builder.t) option
+  }
+
+type stanza =
+  { dir : Path.Build.t
+  ; stanza : Cram_stanza.t
+  ; prepared : prepared_stanza Memo.Lazy.t
+  }
+
+(* Whole-subtree stanzas can apply to tests in many directories. Keep their
+   prepared dependency builders in this memoized result so that all the tests
+   share them. Prepare lazily to avoid doing this work for unmatched stanzas. *)
+let stanzas_in_dir =
+  Memo.create
+    "cram-stanzas-in-dir"
+    ~input:(module Path.Build)
+    (fun dir ->
+       Dune_load.stanzas_in_dir dir
+       >>= function
+       | None -> Memo.return []
+       | Some (d : Dune_file.t) ->
+         let+ stanzas = Dune_file.find_stanzas d Cram_stanza.key in
+         List.map stanzas ~f:(fun (stanza : Cram_stanza.t) ->
+           let prepared =
+             Memo.Lazy.create ~name:"prepare-cram-stanza" (fun () ->
+               let+ expander =
+                 let* sctx =
+                   let context =
+                     let context, _ = Path.Build.extract_build_context_exn dir in
+                     Context_name.of_string (Filename.to_string context)
+                   in
+                   Super_context.find_exn context
+                 in
+                 Super_context.expander sctx ~dir
+               in
+               let deps =
+                 Option.map stanza.deps ~f:(fun deps ->
+                   let env, _, sandbox =
+                     Dep_conf_eval.named
+                       ~expander
+                       Sandbox_config.no_special_requirements
+                       deps
+                   in
+                   sandbox, env)
+               in
+               { expander; deps })
+           in
+           { dir; stanza; prepared }))
+  |> Memo.exec
+;;
+
 let collect_stanzas =
   let stanzas dir ~f =
-    Dune_load.stanzas_in_dir dir
-    >>= function
-    | None -> Memo.return []
-    | Some (d : Dune_file.t) ->
-      Dune_file.find_stanzas d Cram_stanza.key
-      >>| List.filter_map ~f:(fun c -> Option.some_if (f c) (dir, c))
+    stanzas_in_dir dir >>| List.filter ~f:(fun { stanza; _ } -> f stanza)
   in
   let rec collect_whole_subtree acc dir =
     let* acc =
@@ -251,7 +299,7 @@ let rules ~sctx ~dir tests project =
         Memo.List.fold_left
           stanzas
           ~init
-          ~f:(fun (runtest_alias, (acc : Spec.t)) (dir, (stanza : Cram_stanza.t)) ->
+          ~f:(fun (runtest_alias, (acc : Spec.t)) { dir; stanza; prepared } ->
             match
               match stanza.applies_to with
               | Whole_subtree -> true
@@ -260,17 +308,11 @@ let rules ~sctx ~dir tests project =
             with
             | false -> Memo.return (runtest_alias, acc)
             | true ->
-              let+ expander = Super_context.expander sctx ~dir in
+              let+ { expander; deps } = Memo.Lazy.force prepared in
               let deps, sandbox, env =
-                match stanza.deps with
+                match deps with
                 | None -> acc.deps, acc.sandbox, acc.env
-                | Some deps ->
-                  let env, _, sandbox =
-                    Dep_conf_eval.named
-                      ~expander
-                      Sandbox_config.no_special_requirements
-                      deps
-                  in
+                | Some (sandbox, env) ->
                   let sandbox =
                     let open Action_builder.O in
                     let+ acc = acc.sandbox

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -9,6 +9,7 @@ type t =
   ; root_expander : Expander.t
   ; artifacts : Artifacts.t Memo.t
   ; get_node : Path.Build.t -> Env_node.t Memo.t
+  ; get_expander : Path.Build.t -> Expander.t Memo.t
   }
 
 let hash t = Context.hash t.context
@@ -51,11 +52,7 @@ let expander_for_artifacts t ~dir =
   |> Expander.set_scope ~dir ~project ~scope ~scope_host
 ;;
 
-let expander t ~dir =
-  let+ expander_for_artifacts = expander_for_artifacts t ~dir in
-  let artifacts_host = artifacts_host t ~dir in
-  Expander.set_artifacts expander_for_artifacts ~artifacts_host
-;;
+let expander t ~dir = t.get_expander dir
 
 let get_env_stanza ~dir =
   Dune_load.stanzas_in_dir dir
@@ -100,22 +97,24 @@ let get_impl t dir =
     ~default_artifacts:t.artifacts
 ;;
 
-(* Here we jump through some hoops to construct [t] as well as create a
-   memoization table that has access to [t] and is used in [t.get_node].
+(* Here we jump through some hoops to construct [t] as well as memoized
+   functions that have access to [t] and are used in [t.get_node] and
+   [t.get_expander].
 
    Morally, the code below is just:
 
-   let rec env_tree = ... and memo = ... in env_tree
+   let rec env_tree = ... and get_node = ... and get_expander = ... in env_tree
 
-   However, the right-hand side of [memo] is not allowed in a recursive let
-   binding. To work around this limitation, we place the functions into a
-   recursive module [Rec]. Since recursive let-modules are not allowed either,
-   we need to also wrap [Rec] inside a non-recursive module [Non_rec]. *)
+   However, these right-hand sides are not allowed in a recursive let binding.
+   To work around this limitation, we place the functions into a recursive
+   module [Rec]. Since recursive let-modules are not allowed either, we need to
+   also wrap [Rec] inside a non-recursive module [Non_rec]. *)
 let create ~context ~host_env_tree ~default_env ~root_expander ~artifacts ~context_env =
   let module Non_rec = struct
     module rec Rec : sig
       val env_tree : unit -> t
-      val memo : Path.Build.t -> Env_node.t Memo.t
+      val get_node : Path.Build.t -> Env_node.t Memo.t
+      val get_expander : Path.Build.t -> Expander.t Memo.t
     end = struct
       let env_tree =
         { context
@@ -124,16 +123,28 @@ let create ~context ~host_env_tree ~default_env ~root_expander ~artifacts ~conte
         ; host = host_env_tree
         ; root_expander
         ; artifacts
-        ; get_node = Rec.memo
+        ; get_node = Rec.get_node
+        ; get_expander = Rec.get_expander
         }
       ;;
 
-      let memo =
+      let get_node =
         Memo.exec
           (Memo.create
              "env-nodes-memo"
              ~input:(module Path.Build)
              (fun path -> get_impl env_tree path))
+      ;;
+
+      let get_expander =
+        Memo.exec
+          (Memo.create
+             "super-context-expanders"
+             ~input:(module Path.Build)
+             (fun dir ->
+                let+ expander_for_artifacts = expander_for_artifacts env_tree ~dir in
+                let artifacts_host = artifacts_host env_tree ~dir in
+                Expander.set_artifacts expander_for_artifacts ~artifacts_host))
       ;;
 
       let env_tree () = env_tree


### PR DESCRIPTION
Whole-subtree Cram stanzas can apply to tests in many directories. Memoize their expanders and dependency builders by the defining directory instead of recreating them for every matching test, while preparing them lazily so unmatched stanzas do no extra work. This reduces null-build time for the blackbox `test-cases` runtest alias by roughly 15–20%.
