### PR TITLE
perf(path): append known filenames without normalization

### DIFF
--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -193,7 +193,7 @@ module Dune_project = struct
     ; project : Dune_project.t
     }
 
-  let filename = Path.Source.of_string (Filename.to_string Dune_project.filename)
+  let filename = Path.Source.relative_fname Path.Source.root Dune_project.filename
 
   let load ~dir ~files ~infer_from_opam_files =
     let open Memo.O in

--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -248,7 +248,7 @@ module Build = struct
 
   let extract_build_context_dir t =
     Option.map (split_first_component t) ~f:(fun (before, after) ->
-      of_local (Local.of_string (Filename.to_string before)), Source0.of_local after)
+      of_local (Local.relative_fname Local.root before), Source0.of_local after)
   ;;
 
   let split_sandbox_root t_original =
@@ -767,9 +767,7 @@ let relative_to_source_in_build_or_external ?error_loc ~dir s =
     (match path with
      | In_source_tree s ->
        in_build_dir
-         (Build.relative
-            (Build.of_string (Filename.to_string bctxt))
-            (Source0.to_string s))
+         (Build.relative (Build.relative_fname Build.root bctxt) (Source0.to_string s))
      | In_build_dir _ | External _ -> path)
 ;;
 
@@ -858,9 +856,7 @@ module Map = O.Map
 module Set = struct
   include O.Set
 
-  let of_listing ~dir ~filenames =
-    of_list_map filenames ~f:(fun f -> relative dir (Filename.to_string f))
-  ;;
+  let of_listing ~dir ~filenames = of_list_map filenames ~f:(relative_fname dir)
 end
 
 let source s = in_source_tree s

--- a/otherlibs/stdune/src/path0.ml
+++ b/otherlibs/stdune/src/path0.ml
@@ -424,9 +424,7 @@ module Local_gen = struct
     module Set = struct
       include String.Set
 
-      let of_listing ~dir ~filenames =
-        of_list_map filenames ~f:(fun f -> relative dir (Filename.to_string f))
-      ;;
+      let of_listing ~dir ~filenames = of_list_map filenames ~f:(relative_fname dir)
     end
   end
 end

--- a/otherlibs/stdune/src/path_external.ml
+++ b/otherlibs/stdune/src/path_external.ml
@@ -24,6 +24,18 @@ let parse_string_exn ~loc t =
 
 let to_dyn t = Dyn.variant "External" [ Dyn.string t ]
 
+let append_component x y =
+  (* Strip a trailing directory separator from [x] so we don't produce double
+     slashes (e.g. "/root/" + "foo" -> "/root/foo"). We use [is_dir_sep] so
+     that on Windows a trailing '\' is also removed, normalising the join to
+     always use '/'. *)
+  let x =
+    let len = String.length x in
+    if len > 0 && is_dir_sep x.[len - 1] then String.take x (len - 1) else x
+  in
+  String.append_with_char x ~sep:'/' y
+;;
+
 let relative x y =
   match y with
   | "." -> x
@@ -35,19 +47,10 @@ let relative x y =
     in
     (match y with
      | "" | "." -> x
-     | _ ->
-       (* Strip a trailing directory separator from [x] so we don't produce
-          double slashes (e.g. "/root/" + "foo" -> "/root/foo"). We use
-          [is_dir_sep] so that on Windows a trailing '\' is also removed,
-          normalising the join to always use '/'. *)
-       let x =
-         let len = String.length x in
-         if len > 0 && is_dir_sep x.[len - 1] then String.take x (len - 1) else x
-       in
-       String.append_with_char x ~sep:'/' y)
+     | _ -> append_component x y)
 ;;
 
-let relative_fname t fn = relative t (Filename.to_string fn)
+let relative_fname t fn = append_component t (Filename.to_string fn)
 let append_local t local = relative t (Local.to_string local)
 let root = of_string "/"
 let is_root = equal root
@@ -132,7 +135,5 @@ module Map = String.Map
 module Set = struct
   include String.Set
 
-  let of_listing ~dir ~filenames =
-    of_list_map filenames ~f:(fun f -> relative dir (Filename.to_string f))
-  ;;
+  let of_listing ~dir ~filenames = of_list_map filenames ~f:(relative_fname dir)
 end

--- a/otherlibs/stdune/test/path_tests.ml
+++ b/otherlibs/stdune/test/path_tests.ml
@@ -17,6 +17,12 @@ let external_relative a b =
   |> print_endline
 ;;
 
+let external_relative_fname a b =
+  Path.External.relative_fname (Path.External.of_string a) (Filename.of_string_exn b)
+  |> Path.External.to_string
+  |> print_endline
+;;
+
 let external_append_local a b =
   Path.External.append_local (Path.External.of_string a) b
   |> Path.External.to_string
@@ -775,6 +781,16 @@ let%expect_test "path relative external dot-slash" =
 let%expect_test "path relative external plain" =
   relative (Path.of_string "/ext") "foo";
   [%expect {| External "/ext/foo" |}]
+;;
+
+let%expect_test "external relative filename" =
+  external_relative_fname "/root/" "foo";
+  external_relative_fname "/" "foo";
+  [%expect
+    {|
+    /root/foo
+    /foo
+    |}]
 ;;
 
 let%expect_test "external relative trailing slash" =

--- a/src/dune_cache/layout.ml
+++ b/src/dune_cache/layout.ml
@@ -13,21 +13,22 @@ let cache_path ~dir ~hex =
 let list_entries ~storage =
   let open Result.O in
   let entries dir =
-    let dir = Filename.to_string dir in
-    match String.length dir = 2 && String.for_all ~f:Char.is_lowercase_hex dir with
+    match
+      let dir_s = Filename.to_string dir in
+      String.length dir_s = 2 && String.for_all ~f:Char.is_lowercase_hex dir_s
+    with
     | false ->
       (* Ignore directories whose name isn't a two-character hex value. *)
       Ok []
     | true ->
-      let dir = storage / dir in
+      let dir = Path.relative_fname storage dir in
       Path.readdir_unsorted dir
       >>| List.filter_map ~f:(fun entry_name ->
-        let entry_name = Filename.to_string entry_name in
-        match Digest.from_hex entry_name with
+        match Digest.from_hex (Filename.to_string entry_name) with
         | None ->
           (* Ignore entries whose names are not hex values. *)
           None
-        | Some digest -> Some (dir / entry_name, digest))
+        | Some digest -> Some (Path.relative_fname dir entry_name, digest))
   in
   match Path.readdir_unsorted storage >>= Result.List.concat_map ~f:entries with
   | Ok res -> res

--- a/src/dune_digest/digest.ml
+++ b/src/dune_digest/digest.ml
@@ -502,7 +502,9 @@ exception E of Path_digest_error.t
 
 let directory_digest_with =
   let directory_digest_version = 4 in
-  let directory_digest_repr = Repr.(triple int (list (pair string digest_repr)) bool) in
+  let directory_digest_repr =
+    Repr.(triple int (list (pair Filename.repr digest_repr)) bool)
+  in
   fun repr_digest ~contents ~executable ->
     repr_digest directory_digest_repr (directory_digest_version, contents, executable)
 ;;
@@ -538,8 +540,7 @@ let path_with_stats_internal
        | Ok listing ->
          (match
             List.rev_map listing ~f:(fun name ->
-              let name = Filename.to_string name in
-              let path = Path.relative path name in
+              let path = Path.relative_fname path name in
               let stats =
                 match Path.lstat path with
                 | Error e -> raise_notrace (E (Unix_error e))
@@ -551,7 +552,7 @@ let path_with_stats_internal
                 | Error e -> raise_notrace (E e)
               in
               name, digest)
-            |> List.sort ~compare:(fun (x, _) (y, _) -> String.compare x y)
+            |> List.sort ~compare:(fun (x, _) (y, _) -> Filename.compare x y)
           with
           | exception E e -> Error e
           | contents -> Ok (directory_digest ~contents ~executable:stats.executable)))

--- a/src/dune_engine/action_trace.ml
+++ b/src/dune_engine/action_trace.ml
@@ -58,10 +58,10 @@ let collect { dir; digest } =
   let root = dir in
   let root_path = Path.build root in
   if Fpath.exists (Path.to_string root_path) then needs_cleanup := true;
-  let build_path_of ~dir fname = Path.Build.relative root (Filename.append dir fname) in
   let build_dir_of dir =
     if String.equal dir "" then root else Path.Build.relative root dir
   in
+  let build_path_of ~dir fname = Path.Build.relative_fname (build_dir_of dir) fname in
   let push_broken_symlink ~dir fname error =
     needs_cleanup := true;
     let path = build_path_of ~dir fname in

--- a/src/dune_engine/dpath.ml
+++ b/src/dune_engine/dpath.ml
@@ -6,7 +6,7 @@ module Build = struct
   let anonymous_actions_dir_basename = Filename.actions_dir_basename
 
   let anonymous_actions_dir =
-    Path.Build.(relative root) (Filename.to_string anonymous_actions_dir_basename)
+    Path.Build.relative_fname Path.Build.root anonymous_actions_dir_basename
   ;;
 end
 

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -215,10 +215,10 @@ let snapshot t =
       ~dir:(Path.to_string root)
       ~init:Path.Map.empty
       ~on_dir:(fun ~dir fname acc ->
-        let path = Path.relative root (Filename.append dir fname) in
+        let path = Path.relative_fname (Path.relative root dir) fname in
         Path.Map.add_exn acc path `Dir)
       ~on_file:(fun ~dir fname acc ->
-        let p = Path.relative root (Filename.append dir fname) in
+        let p = Path.relative_fname (Path.relative root dir) fname in
         let stats = Stat.stat (Path.to_string p) in
         Path.Map.add_exn acc p (`File stats))
       ~on_other:`Ignore
@@ -245,7 +245,7 @@ let find_corrected_files (t : real) ~deps =
         not (String.equal fname ".sandbox" || String.equal fname "_build"))
       ~on_file:(fun ~dir fname acc ->
         match
-          let path = Path.Build.relative t.dir (Filename.append dir fname) in
+          let path = Path.Build.relative_fname (Path.Build.relative t.dir dir) fname in
           if
             let extension = Filename.extension fname in
             Filename.Extension.Or_empty.check extension Filename.Extension.corrected

--- a/src/dune_engine/target_promotion.ml
+++ b/src/dune_engine/target_promotion.ml
@@ -218,10 +218,13 @@ let promote ~(targets : _ Targets.Produced.t) ~(promote : Rule.Promote.t) ~promo
       Fs_memo.Dir_contents.iter dir_contents ~f:(fun file_name kind ->
         match kind with
         | S_REG ->
-          let file_name_s = Filename.to_string file_name in
           if
-            not (Targets.Produced.mem targets (Path.Build.relative build_dir file_name_s))
-          then Fpath.unlink_no_err (Path.to_string (Path.relative dst_dir file_name_s))
+            not
+              (Targets.Produced.mem
+                 targets
+                 (Path.Build.relative_fname build_dir file_name))
+          then
+            Fpath.unlink_no_err (Path.to_string (Path.relative_fname dst_dir file_name))
         | S_DIR ->
           let src_dir = Path.Build.relative_fname build_dir file_name in
           if not (Targets.Produced.mem_dir targets src_dir)

--- a/src/dune_engine/tree_copy.ml
+++ b/src/dune_engine/tree_copy.ml
@@ -6,23 +6,22 @@ let copy ~src ~dst ~copy_file ~mkdir ~on_unsupported ?(on_symlink = `Raise) () =
     | S_REG -> copy_file ~src ~dst
     | S_DIR ->
       mkdir ~src ~dst;
+      let relative path ~dir fname = Path.relative_fname (Path.relative path dir) fname in
       Fpath.traverse
         ~dir:(Path.to_string src)
         ~init:()
         ~on_file:(fun ~dir fname () ->
-          let rel = Filename.append dir fname in
-          let src = Path.relative src rel in
-          let dst = Path.relative dst rel in
+          let src = relative src ~dir fname in
+          let dst = relative dst ~dir fname in
           copy_file ~src ~dst)
         ~on_dir:(fun ~dir fname () ->
-          let rel = Filename.append dir fname in
-          let src = Path.relative src rel in
-          let dst = Path.relative dst rel in
+          let src = relative src ~dir fname in
+          let dst = relative dst ~dir fname in
           mkdir ~src ~dst)
         ~on_other:
           (`Call
               (fun ~dir fname kind () ->
-                let src = Path.relative src (Filename.append dir fname) in
+                let src = relative src ~dir fname in
                 on_unsupported ~src kind))
         ~on_symlink:
           (match on_symlink with
@@ -31,7 +30,7 @@ let copy ~src ~dst ~copy_file ~mkdir ~on_unsupported ?(on_symlink = `Raise) () =
            | `Call f ->
              `Call
                (fun ~dir fname () ->
-                 let src = Path.relative src (Filename.append dir fname) in
+                 let src = relative src ~dir fname in
                  (), f ~src))
         ()
     | kind -> on_unsupported ~src kind

--- a/src/dune_findlib/config.ml
+++ b/src/dune_findlib/config.ml
@@ -45,9 +45,7 @@ module File = struct
              Memo.parallel_map
                (Fs_memo.Dir_contents.to_list dir_contents)
                ~f:(fun (p, _kind) ->
-                 let p =
-                   Path.Outside_build_dir.relative config_dir (Filename.to_string p)
-                 in
+                 let p = Path.Outside_build_dir.relative_fname config_dir p in
                  load p)
            in
            List.fold_left all_vars ~init:vars ~f:(fun acc vars ->

--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -265,8 +265,8 @@ let is_descendant t ~of_ =
    building packages, resolving them as hardlinks is good enough. *)
 let resolve_symlinks_in root =
   let on_symlink ~dir:raw_dir name () =
+    let relative = Path.relative_fname (Path.relative root raw_dir) name in
     let name = Filename.to_string name in
-    let relative = Path.relative (Path.relative root raw_dir) name in
     let full_name = Path.to_string relative in
     match Fpath.follow_symlink full_name with
     | Error Not_a_symlink ->
@@ -427,9 +427,8 @@ let%test_module "resolve symlink tests" =
        - other (pipes, sockets, etc.): "path [kind]" *)
     let dump_tree root =
       let str ~dir fname =
-        let fname = Filename.to_string fname in
         let dir = if String.is_empty dir then root else Path.relative root dir in
-        Path.to_string (Path.relative dir fname)
+        Path.to_string (Path.relative_fname dir fname)
       in
       let inodes = Table.create (module Int) 16 in
       Fpath.traverse

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -1456,12 +1456,12 @@ module Write_disk = struct
     | Error e -> raise_user_error_on_check_existance src e
     | Ok `Non_existant -> ()
     | Ok `Is_existing_lock_dir ->
-      let dst_of ~dir fname = Path.relative dst (Filename.append dir fname) in
+      let dst_of ~dir fname = Path.relative_fname (Path.relative dst dir) fname in
       Fpath.traverse
         ~dir:(Path.to_string src)
         ~init:()
         ~on_file:(fun ~dir fname () ->
-          let child_src = Path.relative src (Filename.append dir fname) in
+          let child_src = Path.relative_fname (Path.relative src dir) fname in
           let child_dst = dst_of ~dir fname in
           Path.mkdir_p (Path.relative dst dir);
           Io.copy_file ~src:child_src ~dst:child_dst ())

--- a/src/dune_rules/compile_commands.ml
+++ b/src/dune_rules/compile_commands.ml
@@ -42,8 +42,7 @@ let build_c_command
   let src_relative =
     Foreign.Source.path src
     |> Path.Build.basename
-    |> Filename.to_string
-    |> Path.Local.of_string
+    |> Path.Local.relative_fname Path.Local.root
   in
   { directory = Path.build dir
   ; file = src_relative

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -159,7 +159,7 @@ let rec dir_contents ~loc d =
   | Ok contents ->
     Fs_memo.Dir_contents.to_list contents
     |> Memo.parallel_map ~f:(fun (entry, kind) ->
-      let path = Path.Outside_build_dir.relative d (Filename.to_string entry) in
+      let path = Path.Outside_build_dir.relative_fname d entry in
       match kind with
       | Unix.S_REG -> Memo.return [ path ]
       | S_DIR -> dir_contents ~loc path

--- a/src/dune_rules/fetch_rules.ml
+++ b/src/dune_rules/fetch_rules.ml
@@ -314,11 +314,10 @@ module Copy = struct
         ~init:()
         ~dir:(Path.to_string src_dir)
         ~on_dir:(fun ~dir fname () ->
-          Path.L.relative dst_dir [ dir; Filename.to_string fname ] |> Path.mkdir_p)
+          Path.relative_fname (Path.relative dst_dir dir) fname |> Path.mkdir_p)
         ~on_file:(fun ~dir fname () ->
-          let fname = Filename.to_string fname in
-          let src = Path.L.relative src_dir [ dir; fname ] in
-          let dst = Path.L.relative dst_dir [ dir; fname ] in
+          let src = Path.relative_fname (Path.relative src_dir dir) fname in
+          let dst = Path.relative_fname (Path.relative dst_dir dir) fname in
           Io.copy_file ~src ~dst ())
         ()
     ;;

--- a/src/dune_rules/findlib.ml
+++ b/src/dune_rules/findlib.ml
@@ -76,10 +76,9 @@ module DB = struct
 end
 
 let resolve_link ~dir ~fname (kind : File_kind.t) =
-  let fname_s = Filename.to_string fname in
   match kind with
   | S_LNK ->
-    (match Path.Untracked.stat (Path.relative dir fname_s) with
+    (match Path.Untracked.stat (Path.relative_fname dir fname) with
      | Ok { Unix.st_kind; _ } -> Some st_kind
      | Error _ -> None)
   | _ -> Some kind
@@ -187,14 +186,14 @@ let to_dune_library (t : Findlib.Package.t) ~dir_contents ~ext_lib ~external_loc
            But it seems to be too invasive *)
         [], []
       | Ok dir_contents ->
-        List.rev_filter_partition_map dir_contents ~f:(fun f ->
-          let f = Filename.to_string f in
+        List.rev_filter_partition_map dir_contents ~f:(fun fname ->
+          let f = Filename.to_string fname in
           let ext =
             Stdlib.Filename.extension f |> Filename.Extension.Or_empty.of_string_exn
           in
           if Filename.Extension.Or_empty.check ext ext_lib
           then (
-            let file = Path.relative t.dir f in
+            let file = Path.relative_fname t.dir fname in
             if String.starts_with ~prefix:Foreign.Archive.Name.lib_file_prefix f
             then Left file
             else Right file)
@@ -505,16 +504,16 @@ module Loader = struct
           let+ sub_dirs =
             Filename.Set.to_list sub_dirs
             |> Memo.List.filter_map ~f:(fun name ->
-              let name = Filename.to_string name in
-              Path.L.relative dir [ name; Filename.to_string Findlib.Package.meta_fn ]
+              Path.relative_fname (Path.relative_fname dir name) Findlib.Package.meta_fn
               |> Fs.file_exists
               >>| function
-              | true -> Some (Package.Name.of_string name)
+              | true -> Some (Package.Name.of_string (Filename.to_string name))
               | false -> None)
           in
           let metas =
             Filename.Set.to_list_map metas ~f:(fun fn ->
-              String.drop_prefix ~prefix:Findlib_dir.file_prefix (Filename.to_string fn)
+              Filename.to_string fn
+              |> String.drop_prefix ~prefix:Findlib_dir.file_prefix
               |> Option.value_exn
               |> Package.Name.of_string)
           in

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -372,9 +372,8 @@ let header_files dir_contents =
   |> List.fold_left ~init:[] ~f:(fun acc dc ->
     Dir_contents.text_files dc
     |> Filename.Array.Set.fold ~init:acc ~f:(fun fn acc ->
-      let fn = Filename.to_string fn in
-      if String.ends_with fn ~suffix:header_ext
-      then Path.relative (Path.build (Dir_contents.dir dc)) fn :: acc
+      if String.ends_with (Filename.to_string fn) ~suffix:header_ext
+      then Path.relative_fname (Path.build (Dir_contents.dir dc)) fn :: acc
       else acc))
 ;;
 

--- a/src/dune_rules/foreign_sources.ml
+++ b/src/dune_rules/foreign_sources.ml
@@ -81,11 +81,10 @@ module Unresolved = struct
   let load ~dune_version ~dir ~files =
     let init = String.Map.empty in
     Filename.Array.Set.fold files ~init ~f:(fun fn acc ->
-      let fn_s = Filename.to_string fn in
-      match drop_source_extension fn_s ~dune_version with
+      match drop_source_extension (Filename.to_string fn) ~dune_version with
       | None -> acc
       | Some (obj, language) ->
-        let path = Path.Build.relative dir fn_s in
+        let path = Path.Build.relative_fname dir fn in
         String.Map.add_multi acc obj (language, path))
   ;;
 

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -1336,9 +1336,11 @@ struct
         ~dir:(Path.to_string entry.src)
         ~init:[]
         ~on_file:(fun ~dir fname acc ->
-          let file = Filename.append dir fname in
-          let path = Path.relative entry.src file in
-          let comps = Path.Local.of_string file |> Path.Local.explode in
+          let path = Path.relative_fname (Path.relative entry.src dir) fname in
+          let comps =
+            Path.Local.relative_fname (Path.Local.relative Path.Local.root dir) fname
+            |> Path.Local.explode
+          in
           (path, comps) :: acc)
         ()
       |> List.rev_map ~f:(fun (path, comps) -> make_entry entry path comps)

--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -978,13 +978,13 @@ let setup_separate_compilation_rules sctx components =
          Memo.parallel_iter archives ~f:(fun fn ->
            let build_context = Context.build_context ctx in
            let name = Path.basename fn in
-           let name_s = Filename.to_string name in
            let dir = in_build_dir build_context ~config [ lib_name ] in
            let src =
              let src_dir = Lib_info.src_dir info in
-             Path.relative src_dir name_s
+             Path.relative_fname src_dir name
            in
            let target =
+             let name_s = Filename.to_string name in
              in_build_dir build_context ~config [ lib_name; with_js_ext ~mode name_s ]
            in
            let shapes =

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -21,10 +21,7 @@ module Files = struct
   ;;
 
   let from_source_file ~mdx_dir src =
-    let dot_mdx_path =
-      let basename = Path.Build.basename src |> Filename.to_string in
-      Path.Build.relative mdx_dir basename
-    in
+    let dot_mdx_path = Path.Build.relative_fname mdx_dir (Path.Build.basename src) in
     let corrected = corrected_file dot_mdx_path in
     { src; corrected }
   ;;

--- a/src/dune_rules/merlin/merlin_ident.ml
+++ b/src/dune_rules/merlin/merlin_ident.ml
@@ -22,6 +22,7 @@ let to_string = function
 let merlin_folder_name = Filename.merlin_conf_dir_basename
 
 let merlin_file_path path ident =
-  Filename.concat (Filename.to_string merlin_folder_name) (to_string ident)
-  |> Path.Build.relative path
+  Path.Build.relative
+    (Path.Build.relative_fname path merlin_folder_name)
+    (to_string ident)
 ;;

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -244,26 +244,28 @@ let raise_duplicate_module ?loc ~dir name f1 f2 =
 let module_files ~root_dir ~dialects ~dir ~files ~for_ =
   let loc = Loc.in_dir (Path.build dir) in
   let impl_files, intf_files =
-    let make_module dialect name ~original_fn ~fn =
+    let make_module dialect name ~original_filename ~fn =
       let path_in_build_dir =
         match for_ with
-        | Compilation_mode.Ocaml -> Path.Build.relative dir fn
+        | Compilation_mode.Ocaml -> Path.Build.relative_fname dir fn
         | Melange ->
-          let dst = Path.Build.relative dir fn in
+          let dst = Path.Build.relative_fname dir fn in
           let descendant =
             Path.Local.descendant (Path.Build.local dst) ~of_:(Path.Build.local root_dir)
             |> Option.value_exn
           in
           source_in_dir ~dir:root_dir descendant ~for_
       in
-      let original_path = Path.Build.relative dir original_fn |> Path.build in
+      let original_path = Path.Build.relative_fname dir original_filename |> Path.build in
       name, Module.File.make dialect ~original_path (Path.build path_in_build_dir)
     in
-    List.filter_partition_map (Filename.Array.Set.to_list files) ~f:(fun fn ->
-      let fn = Filename.to_string fn in
-      (* We don't use [Filename.extension] because Melange-specific files have
-         two extensions, while other multi-extension filenames must be ignored. *)
-      match String.lsplit2 fn ~on:'.' with
+    List.filter_partition_map (Filename.Array.Set.to_list files) ~f:(fun filename ->
+      match
+        let fn = Filename.to_string filename in
+        (* We don't use [Filename.extension] because Melange-specific files have
+           two extensions, while other multi-extension filenames must be ignored. *)
+        String.lsplit2 fn ~on:'.'
+      with
       | None -> Skip
       | Some (s, ext) ->
         let melange_specific, ext =
@@ -283,8 +285,8 @@ let module_files ~root_dir ~dialects ~dir ~files ~for_ =
                   make_module
                     dialect
                     name
-                    ~original_fn:fn
-                    ~fn:(s ^ Filename.Extension.to_string ext)
+                    ~original_filename:filename
+                    ~fn:(Filename.of_string_exn (s ^ Filename.Extension.to_string ext))
                 in
                 name, (module_, melange_specific)
               in

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1808,7 +1808,7 @@ module Install_action = struct
 
     let collect_files ~root ~skip_dirs =
       List.iter skip_dirs ~f:(fun s -> assert (Path.equal root (Path.parent_exn s)));
-      let path_of ~dir fname = Path.relative root (Filename.append dir fname) in
+      let path_of ~dir fname = Path.relative_fname (Path.relative root dir) fname in
       Fpath.traverse
         ~dir:(Path.to_string root)
         ~init:[]

--- a/src/dune_rules/rocq/rocq_path.ml
+++ b/src/dune_rules/rocq/rocq_path.ml
@@ -51,12 +51,12 @@ let build_user_contrib ~vo ~path ~name = { name; path; vo; corelib = false }
 (* Scanning todos: blacklist? *)
 let scan_vo ~dir dir_contents =
   let f (d, kind) =
-    let d = Filename.to_string d in
+    let d_s = Filename.to_string d in
     match kind with
     (* Skip some files as Rocq does, for now files with '-' *)
-    | _ when String.contains d '-' -> None
-    | (File_kind.S_REG | S_LNK) when String.ends_with ~suffix:".vo" d ->
-      Some (Path.relative dir d)
+    | _ when String.contains d_s '-' -> None
+    | (File_kind.S_REG | S_LNK) when String.ends_with ~suffix:".vo" d_s ->
+      Some (Path.relative_fname dir d)
     | _ -> None
   in
   List.filter_map ~f dir_contents
@@ -85,20 +85,20 @@ let rec scan_path ~(f : ('prefix, 'res) Scan_action.t) ~acc ~prefix ~dir dir_con
   =
   let open Memo.O in
   let f (d, kind) =
-    let d = Filename.to_string d in
+    let d_s = Filename.to_string d in
     match kind with
     (* We skip directories starting by . , this is mainly to avoid
        .coq-native *)
-    | (File_kind.S_DIR | S_LNK) when d.[0] = '.' -> Memo.return []
+    | (File_kind.S_DIR | S_LNK) when d_s.[0] = '.' -> Memo.return []
     (* Need to check the link resolves to a directory! *)
     | File_kind.S_DIR | S_LNK ->
-      let dir = Path.relative dir d in
+      let dir = Path.relative_fname dir d in
       let* dir_contents = Fs_memo.dir_contents (Path.as_outside_build_dir_exn dir) in
       (match dir_contents with
        | Error _ -> Memo.return []
        | Ok dir_contents ->
          let dir_contents = Fs_memo.Dir_contents.to_list dir_contents in
-         let prefix = acc prefix d in
+         let prefix = acc prefix d_s in
          let* subresults = scan_path ~f ~acc ~prefix ~dir dir_contents in
          f ~dir ~prefix ~subresults dir_contents)
     | _ -> Memo.return []

--- a/src/dune_rules/simple_rules.ml
+++ b/src/dune_rules/simple_rules.ml
@@ -297,9 +297,8 @@ let copy_files sctx ~dir ~expander ~src_dir (def : Copy_files.t) =
     Filename_set.filenames files
     |> Filename.Array.Set.to_list
     |> Memo.parallel_iter ~f:(fun basename ->
-      let basename = Filename.to_string basename in
-      let file_src = Path.relative src_in_build basename in
-      let file_dst = Path.Build.relative dir basename in
+      let file_src = Path.relative_fname src_in_build basename in
+      let file_dst = Path.Build.relative_fname dir basename in
       let context = Super_context.context sctx in
       Super_context.add_rule
         sctx

--- a/src/dune_targets/dune_targets.ml
+++ b/src/dune_targets/dune_targets.ml
@@ -339,11 +339,15 @@ module Produced = struct
       with
       | None -> acc
       | Some payload ->
-        let key = Path.Local.of_string (Filename.append dir fname) in
+        let key =
+          Path.Local.relative_fname (Path.Local.relative Path.Local.root dir) fname
+        in
         Path.Local.Map.set acc key (Some payload)
     in
     let on_dir ~dir fname acc =
-      let key = Path.Local.of_string (Filename.append dir fname) in
+      let key =
+        Path.Local.relative_fname (Path.Local.relative Path.Local.root dir) fname
+      in
       Path.Local.Map.set acc key None
     in
     let on_error ~dir err _acc =
@@ -364,7 +368,9 @@ module Produced = struct
           ~on_other:
             (`Call
                 (fun ~dir fname kind _ ->
-                  let path = Path.Build.relative root (Filename.append dir fname) in
+                  let path =
+                    Path.Build.relative_fname (Path.Build.relative root dir) fname
+                  in
                   raise_notrace (Traverse_error (Unsupported_file (path, kind)))))
           ~on_symlink:(`Call (fun ~dir fname acc -> on_file ~dir fname acc, None))
           ~on_error:(`Call on_error)

--- a/src/source/workspace.ml
+++ b/src/source/workspace.ml
@@ -1322,7 +1322,11 @@ let workspace_step1 =
     let* workspace_file =
       match clflags.workspace_file with
       | None ->
-        let p = Path.Outside_build_dir.of_string (Filename.to_string filename) in
+        let p =
+          Path.Outside_build_dir.relative_fname
+            (Path.Outside_build_dir.In_source_dir Path.Source.root)
+            filename
+        in
         let+ exists = Fs_memo.file_exists p in
         Option.some_if exists p
       | Some p ->

--- a/src/upgrader/dune_upgrader.ml
+++ b/src/upgrader/dune_upgrader.ml
@@ -162,9 +162,7 @@ module Common = struct
     | Some _ -> ()
     | None ->
       let fn =
-        Path.Source.relative
-          (Dune_project.root project)
-          (Filename.to_string Dune_project.filename)
+        Path.Source.relative_fname (Dune_project.root project) Dune_project.filename
         |> Path.source
       in
       Console.print [ Pp.textf "Creating %s..." (Path.to_string_maybe_quoted fn) ];


### PR DESCRIPTION
Use `relative_fname` when appending values already known to be valid `Filename.t` path components, avoiding redundant conversion and normalization across directory traversal, cache, package, and rule paths. Append external filename components directly and cover root and trailing-separator behavior.