### PR TITLE
perf(blake3): compact digest representation

### DIFF
--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -351,7 +351,7 @@ module Facts = struct
   let union a b =
     Map.union a b ~f:(fun _ a b ->
       (* Conflicting facts for the same dependency are invalid. *)
-      assert (a = b);
+      assert (Fact.equal a b);
       Some a)
   ;;
 

--- a/src/dune_engine/workspace_cache.ml
+++ b/src/dune_engine/workspace_cache.ml
@@ -250,7 +250,7 @@ module P = Persistent.Make (struct
     type nonrec t = t
 
     let name = "WORKSPACE-CACHE"
-    let version = 4
+    let version = 5
     let sharing = true
     let repr = repr
   end)

--- a/src/ocaml-blake3-mini/blake3_mini.ml
+++ b/src/ocaml-blake3-mini/blake3_mini.ml
@@ -1,25 +1,32 @@
 module Digest = struct
-  type t = string
+  (* Float-only record fields are stored unboxed. The fields contain int64 bits
+     rather than floating-point values. *)
+  type t =
+    { first : float
+    ; second : float
+    }
 
-  let equal = String.equal
-  let compare = String.compare
-  let to_binary x = x
+  external equal : t -> t -> bool = "blake3_mini_digest_equal" [@@noalloc]
+  external compare : t -> t -> int = "blake3_mini_digest_compare" [@@noalloc]
 
-  include (
-  struct
-    let[@ocaml.warning "-32"] hash = Hashtbl.hash
+  let hash { first; _ } = Int64.to_int (Int64.bits_of_float first)
 
-    include String
-  end :
-  sig
-    val hash : t -> int
-  end)
+  let to_binary { first; second } =
+    let result = Bytes.create 16 in
+    Bytes.set_int64_ne result 0 (Int64.bits_of_float first);
+    Bytes.set_int64_ne result 8 (Int64.bits_of_float second);
+    Bytes.unsafe_to_string result
+  ;;
 
-  let to_hex = Digest.to_hex
+  let to_hex digest = Digest.to_hex (to_binary digest)
 
   let of_hex s =
     match Digest.from_hex s with
-    | s -> Some s
+    | s ->
+      Some
+        { first = Int64.float_of_bits (String.get_int64_ne s 0)
+        ; second = Int64.float_of_bits (String.get_int64_ne s 8)
+        }
     | exception Invalid_argument _ -> None
   ;;
 end
@@ -48,7 +55,7 @@ external feed_bigstring_release_lock
   -> unit
   = "blake3_mini_feed_bigstring_unlock"
 
-external fd : Unix.file_descr -> string = "blake3_mini_fd"
+external fd : Unix.file_descr -> Digest.t = "blake3_mini_fd"
 external file_with_size_unix : string -> Digest.t * int = "blake3_mini_file_with_size"
 
 let file_with_size_ocaml file =

--- a/src/ocaml-blake3-mini/blake3_stubs.c
+++ b/src/ocaml-blake3-mini/blake3_stubs.c
@@ -1,4 +1,6 @@
 #include <errno.h>
+#include <stdint.h>
+#include <string.h>
 #ifndef _WIN32
 #ifndef O_CLOEXEC
 #define O_CLOEXEC 0
@@ -22,10 +24,47 @@
 
 #define Blake3_val(v) (*(blake3_hasher **)Data_custom_val(v))
 
-static inline value alloc_hash(blake3_hasher *hasher, int len) {
-  value v_ret = caml_alloc_string(len);
-  const char *ret = String_val(v_ret);
-  blake3_hasher_finalize(hasher, (uint8_t *) ret, len);
+#define BLAKE3_MINI_DIGEST_SIZE 16
+
+static inline uint64_t digest_field(value digest, mlsize_t field) {
+  uint64_t result;
+  memcpy(&result, Op_val(digest) + (field * Double_wosize), sizeof(result));
+  return result;
+}
+
+static inline uint64_t digest_field_for_compare(value digest, mlsize_t field) {
+  uint64_t result = digest_field(digest, field);
+#ifndef ARCH_BIG_ENDIAN
+  result = ((result & UINT64_C(0x00ff00ff00ff00ff)) << 8) |
+           ((result & UINT64_C(0xff00ff00ff00ff00)) >> 8);
+  result = ((result & UINT64_C(0x0000ffff0000ffff)) << 16) |
+           ((result & UINT64_C(0xffff0000ffff0000)) >> 16);
+  result = (result << 32) | (result >> 32);
+#endif
+  return result;
+}
+
+CAMLprim value blake3_mini_digest_equal(value left, value right) {
+  return Val_bool(digest_field(left, 0) == digest_field(right, 0) &&
+                  digest_field(left, 1) == digest_field(right, 1));
+}
+
+CAMLprim value blake3_mini_digest_compare(value left, value right) {
+  uint64_t left_field = digest_field_for_compare(left, 0);
+  uint64_t right_field = digest_field_for_compare(right, 0);
+  if (left_field == right_field) {
+    left_field = digest_field_for_compare(left, 1);
+    right_field = digest_field_for_compare(right, 1);
+  }
+  return Val_int((left_field > right_field) - (left_field < right_field));
+}
+
+static inline value alloc_hash(blake3_hasher *hasher) {
+  /* Keep this allocation in sync with the float-only record in
+     [Blake3_mini.Digest]. */
+  value v_ret = caml_alloc(2 * Double_wosize, Double_array_tag);
+  blake3_hasher_finalize(hasher, (uint8_t *)Op_val(v_ret),
+                         BLAKE3_MINI_DIGEST_SIZE);
   return v_ret;
 }
 
@@ -60,7 +99,7 @@ CAMLprim value blake3_mini_fd(value v_fd) {
 
   caml_acquire_runtime_system();
   CAMLlocal1(v_ret);
-  v_ret = alloc_hash(&hasher, 16);
+  v_ret = alloc_hash(&hasher);
   CAMLreturn(v_ret);
 }
 
@@ -133,7 +172,7 @@ done:
     uerror(err_op, v_path);
   }
 
-  v_digest = alloc_hash(&hasher, 16);
+  v_digest = alloc_hash(&hasher);
   v_size = Val_long(size);
   v_result = caml_alloc_tuple(2);
   Store_field(v_result, 0, v_digest);
@@ -179,7 +218,7 @@ CAMLprim value blake3_mini_digest(value v_t) {
   CAMLlocal1(v_ret);
 
   blake3_hasher *hasher = Blake3_val(v_t);
-  v_ret = alloc_hash(hasher, 16);
+  v_ret = alloc_hash(hasher);
 
   CAMLreturn(v_ret);
 }

--- a/test/expect-tests/blake3/blake3_mini_tests.ml
+++ b/test/expect-tests/blake3/blake3_mini_tests.ml
@@ -44,8 +44,8 @@ let%expect_test "digest representation" =
   printf "unboxed fields: %b\n" (Obj.tag repr = Obj.double_array_tag);
   [%expect
     {|
-    payload bytes: 24
-    unboxed fields: false
+    payload bytes: 16
+    unboxed fields: true
     |}]
 ;;
 
@@ -92,7 +92,7 @@ let%expect_test "digest operations" =
     nan bits equal: true false
     compare: true true true true
     lexicographic compare: true
-    same-prefix hashes: false
+    same-prefix hashes: true
     |}]
 ;;
 


### PR DESCRIPTION
Represent each 128-bit BLAKE3 digest as a float-only record containing two
unboxed 64-bit fields. This reduces a digest from four words to three on 64-bit
platforms while allowing equality and comparison to inspect two machine words
directly.

Digest generation writes directly into the record payload. Equality and
comparison use allocation-free primitives, comparison retains the previous
lexicographic ordering, and hashing returns the first field. Since arbitrary
digest bits can encode NaNs, dependency facts now use semantic rather than
polymorphic equality.
