### PR TITLE
perf(targets): specialize singleton validation

### DIFF
--- a/otherlibs/stdune/src/array_intf.ml
+++ b/otherlibs/stdune/src/array_intf.ml
@@ -9,6 +9,7 @@ module type S = sig
     val iter : t -> f:(elt -> unit) -> unit
     val to_dyn : t -> Dyn.t
     val is_empty : t -> bool
+    val length : t -> int
     val mem : t -> elt -> bool
     val of_list : elt list -> t
     val of_sorted_list : elt list -> t

--- a/src/dune_targets/dune_targets.ml
+++ b/src/dune_targets/dune_targets.ml
@@ -136,37 +136,48 @@ module Validation_result = struct
 end
 
 let validate { files; dirs } =
-  let first =
-    match Path.Build.Array.Set.choose files with
-    | Some _ as first -> first
-    | None -> Path.Build.Array.Set.choose dirs
-  in
-  match first with
-  | None -> Validation_result.No_targets
-  | Some first ->
-    let root = Path.Build.parent_exn first in
-    let exception Invalid of Validation_result.t in
-    (try
-       let files =
-         Path.Build.Array.Set.fold files ~init:Filename.Set.empty ~f:(fun path names ->
-           if Path.Build.equal root (Path.Build.parent_exn path)
-           then Filename.Set.add names (Path.Build.basename path)
-           else raise_notrace (Invalid Inconsistent_parent_dir))
-       in
-       let dirs =
-         Path.Build.Array.Set.fold dirs ~init:Filename.Set.empty ~f:(fun path names ->
-           if Path.Build.equal root (Path.Build.parent_exn path)
-           then (
-             let name = Path.Build.basename path in
-             if Filename.Set.mem files name
-             then
-               raise_notrace (Invalid (File_and_directory_target_with_the_same_name path))
-             else Filename.Set.add names name)
-           else raise_notrace (Invalid Inconsistent_parent_dir))
-       in
-       Valid { Validated.root; files; dirs }
-     with
-     | Invalid result -> result)
+  let first = Path.Build.Array.Set.choose files in
+  if Path.Build.Array.Set.length files = 1 && Path.Build.Array.Set.is_empty dirs
+  then (
+    let first = Option.value_exn first in
+    Validation_result.Valid
+      { Validated.root = Path.Build.parent_exn first
+      ; files = Filename.Set.singleton (Path.Build.basename first)
+      ; dirs = Filename.Set.empty
+      })
+  else (
+    let first =
+      match first with
+      | Some _ as first -> first
+      | None -> Path.Build.Array.Set.choose dirs
+    in
+    match first with
+    | None -> Validation_result.No_targets
+    | Some first ->
+      let root = Path.Build.parent_exn first in
+      let exception Invalid of Validation_result.t in
+      (try
+         let files =
+           Path.Build.Array.Set.fold files ~init:Filename.Set.empty ~f:(fun path names ->
+             if Path.Build.equal root (Path.Build.parent_exn path)
+             then Filename.Set.add names (Path.Build.basename path)
+             else raise_notrace (Invalid Inconsistent_parent_dir))
+         in
+         let dirs =
+           Path.Build.Array.Set.fold dirs ~init:Filename.Set.empty ~f:(fun path names ->
+             if Path.Build.equal root (Path.Build.parent_exn path)
+             then (
+               let name = Path.Build.basename path in
+               if Filename.Set.mem files name
+               then
+                 raise_notrace
+                   (Invalid (File_and_directory_target_with_the_same_name path))
+               else Filename.Set.add names name)
+             else raise_notrace (Invalid Inconsistent_parent_dir))
+         in
+         Valid { Validated.root; files; dirs }
+       with
+       | Invalid result -> result))
 ;;
 
 module Produced = struct


### PR DESCRIPTION
Bypass the general target-validation path for the common case of a rule with a single file target. Expose `Array.Set.length` so the singleton fast path can be detected without converting the compact set representation.