### PR TITLE
refactor(rules): centralize project-root scope lookup

### DIFF
--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -898,14 +898,7 @@ let setup_shared_runtime_rule sctx s_config s_digest =
     let { Runtime_key.Decoded.mode; lib_names; project_root } =
       Runtime_key.decode digest
     in
-    let* scope =
-      let dir =
-        match project_root with
-        | None -> Context.build_dir ctx
-        | Some dir -> Path.Build.append_source build_context.build_dir dir
-      in
-      Scope.DB.find_by_dir dir
-    in
+    let* scope = Scope.DB.find_by_project_root ctx project_root in
     let* libs =
       let lib_db = Scope.libs scope in
       Memo.parallel_map lib_names ~f:(fun name ->

--- a/src/dune_rules/parameterised_rules.ml
+++ b/src/dune_rules/parameterised_rules.ml
@@ -430,15 +430,8 @@ let has_rules fn =
 
 let find_scope ~sctx encoded_scope =
   let project_root = Parameterised_name.Scope.decode encoded_scope in
-  let ctx = Super_context.context sctx in
-  let dir =
-    match project_root with
-    | None -> Context.build_dir ctx
-    | Some dir ->
-      let build_context = Context.build_context ctx in
-      Path.Build.append_source build_context.build_dir dir
-  in
-  Scope.DB.find_by_dir dir
+  let context = Super_context.context sctx in
+  Scope.DB.find_by_project_root context project_root
 ;;
 
 let gen_rules ~sctx ~dir rest =

--- a/src/dune_rules/pp_spec_rules.ml
+++ b/src/dune_rules/pp_spec_rules.ml
@@ -53,14 +53,7 @@ let get_rules sctx key =
         [ Pp.textf "invalid ppx key for %s" (Path.Build.to_string_maybe_quoted exe) ]
     | Some key ->
       let { Ppx_exe.Key.Decoded.pps; project_root } = Ppx_exe.Key.decode key in
-      let+ scope =
-        let dir =
-          match project_root with
-          | None -> Context.build_dir ctx
-          | Some dir -> Path.Build.append_source build_context.build_dir dir
-        in
-        Scope.DB.find_by_dir dir
-      in
+      let+ scope = Scope.DB.find_by_project_root ctx project_root in
       pps, scope
   in
   let* pps =

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -424,6 +424,17 @@ module DB = struct
     find_by_dir scopes dir
   ;;
 
+  let find_by_project_root context project_root =
+    let dir =
+      match project_root with
+      | None -> Context.build_dir context
+      | Some project_root ->
+        let build_context = Context.build_context context in
+        Path.Build.append_source build_context.build_dir project_root
+    in
+    find_by_dir dir
+  ;;
+
   let find_by_project context project =
     let+ scopes, _ = create_from_stanzas context in
     find_by_project scopes project

--- a/src/dune_rules/scope.mli
+++ b/src/dune_rules/scope.mli
@@ -18,6 +18,7 @@ val rocq_libs : t -> Rocq_lib.DB.t Memo.t
 (** Scope databases *)
 module DB : sig
   val find_by_dir : Path.Build.t -> t Memo.t
+  val find_by_project_root : Context.t -> Path.Source.t option -> t Memo.t
   val find_by_project : Context_name.t -> Dune_project.t -> t Memo.t
   val public_libs : Context_name.t -> Lib.DB.t Memo.t
 


### PR DESCRIPTION
Several rule generators independently translate an optional project root into a build directory before looking up its scope. Add `Scope.DB.find_by_project_root` to centralize this translation and use it for JavaScript, parameterised, and preprocessing rules.

This removes duplicated lookup logic without changing behavior.
