### PR TITLE
refactor(lang): type module artifact filenames

### DIFF
--- a/src/dune_lang/module_name.ml
+++ b/src/dune_lang/module_name.ml
@@ -167,7 +167,10 @@ module Unique = struct
   ;;
 
   let to_dyn = to_dyn
-  let artifact_filename (t : t) ~ext = t ^ Filename.Extension.to_string ext
+
+  let artifact_filename (t : t) ~ext =
+    Filename.of_string_exn (t ^ Filename.Extension.to_string ext)
+  ;;
 
   module Map = Map
   module Set = Set

--- a/src/dune_lang/module_name.mli
+++ b/src/dune_lang/module_name.mli
@@ -84,7 +84,7 @@ module Unique : sig
   val to_string : t -> string
   val compare : t -> t -> Ordering.t
   val equal : t -> t -> bool
-  val artifact_filename : t -> ext:Filename.Extension.t -> string
+  val artifact_filename : t -> ext:Filename.Extension.t -> Filename.t
 
   include Conv.S with type t := t
   include Comparable_intf.S with type key := t

--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -700,6 +700,7 @@ let cmo_js_of_module ~mode m =
   Module_name.Unique.artifact_filename
     (Module.obj_name m)
     ~ext:(Js_of_ocaml.Ext.cmo ~mode)
+  |> Filename.to_string
 ;;
 
 let link_rule

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -435,7 +435,7 @@ let setup_build_archives (lib : Library.t) ~top_sorted_modules ~cctx ~expander ~
                file explicitly *)
             Module.obj_name m
             |> Module_name.Unique.artifact_filename ~ext
-            |> Path.Build.relative (Obj_dir.dir obj_dir)
+            |> Path.Build.relative_fname (Obj_dir.dir obj_dir)
           in
           Action_builder.symlink ~src ~dst
         in

--- a/src/dune_rules/module.ml
+++ b/src/dune_rules/module.ml
@@ -452,7 +452,7 @@ let generated
         | Ocaml -> src_dir
         | Melange -> Path.Build.relative src_dir Melange.Source.dir
       in
-      Path.Build.relative src_dir basename |> Path.build |> File.make Dialect.ocaml
+      Path.Build.relative_fname src_dir basename |> Path.build |> File.make Dialect.ocaml
     in
     Source.make ~impl:(Some impl) ~intf:None path
   in

--- a/src/dune_rules/obj_dir.ml
+++ b/src/dune_rules/obj_dir.ml
@@ -494,9 +494,9 @@ let to_local (t : Path.t t) =
 module Module = struct
   let relative (type path) (t : path t) (dir : path) name : path =
     match t with
-    | Local _ -> Path.Build.relative dir name
-    | Local_as_path _ -> Path.relative dir name
-    | External _ -> Path.relative dir name
+    | Local _ -> Path.Build.relative_fname dir name
+    | Local_as_path _ -> Path.relative_fname dir name
+    | External _ -> Path.relative_fname dir name
   ;;
 
   let path_of_build (type path) (t : path t) (dir : path) : Path.t =


### PR DESCRIPTION
`Module_name.Unique.artifact_filename` always produces a single path component, but returned it as an unstructured string. Return `Filename.t` so this invariant is represented in the type and use filename-aware path construction at call sites.

This avoids sending known filenames through general path parsing and normalization without changing generated artifact paths.
