### PR TITLE
refactor(jsoo): type object directory names

### DIFF
--- a/src/dune_rules/jsoo/jsoo_archive_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_archive_rules.ml
@@ -86,13 +86,13 @@ end
 let parse_lib_archive_dir dir =
   let jsoo_dir_config =
     match Path.Build.basename dir with
-    | s when Obj_dir.is_jsoo_dirname (Filename.to_string s) -> Some (dir, None)
+    | basename when Obj_dir.is_jsoo_dirname basename -> Some (dir, None)
     | config ->
       (match Path.Build.parent dir with
        | Some parent
          when (not (Path.Build.is_root parent))
-              && Obj_dir.is_jsoo_dirname (Path.Build.basename parent |> Filename.to_string)
-         -> Some (parent, Some (Filename.to_string config))
+              && Obj_dir.is_jsoo_dirname (Path.Build.basename parent) ->
+         Some (parent, Some (Filename.to_string config))
        | _ -> None)
   in
   match jsoo_dir_config with

--- a/src/dune_rules/obj_dir.ml
+++ b/src/dune_rules/obj_dir.ml
@@ -7,8 +7,8 @@ module Paths = struct
 
   let library_native_dir ~obj_dir = Path.Build.relative obj_dir "native"
   let library_byte_dir ~obj_dir = Path.Build.relative obj_dir "byte"
-  let jsoo_dirname = "jsoo"
-  let library_jsoo_dir ~obj_dir = Path.Build.relative obj_dir jsoo_dirname
+  let jsoo_dirname = Filename.of_string_exn "jsoo"
+  let library_jsoo_dir ~obj_dir = Path.Build.relative_fname obj_dir jsoo_dirname
   let library_melange_dir ~obj_dir = Path.Build.relative obj_dir "melange"
   let library_public_cmi_ocaml_dir ~obj_dir = Path.Build.relative obj_dir "public_cmi"
 
@@ -401,7 +401,7 @@ let public_cmi_melange_dir =
 ;;
 
 let byte_dir = get_path ~l:Local.byte_dir ~e:External.byte_dir
-let is_jsoo_dirname s = String.equal s Paths.jsoo_dirname
+let is_jsoo_dirname = Filename.equal Paths.jsoo_dirname
 let jsoo_dir = get_path ~l:Local.jsoo_dir ~e:External.jsoo_dir
 let native_dir = get_path ~l:Local.native_dir ~e:External.native_dir
 let melange_dir = get_path ~l:Local.melange_dir ~e:External.melange_dir

--- a/src/dune_rules/obj_dir.mli
+++ b/src/dune_rules/obj_dir.mli
@@ -44,7 +44,7 @@ val native_dir : 'path t -> 'path
 (** The private compiled byte file directories, and all cmi *)
 val byte_dir : 'path t -> 'path
 
-val is_jsoo_dirname : string -> bool
+val is_jsoo_dirname : Filename.t -> bool
 val jsoo_dir : 'path t -> 'path
 
 (** The private compiled melange file directories, and all cmi *)

--- a/src/dune_rules/parameterised_rules.ml
+++ b/src/dune_rules/parameterised_rules.ml
@@ -455,7 +455,7 @@ let gen_rules ~sctx ~dir rest =
     let* lib = resolve_instantiation scope instance_name in
     instantiate ~sctx lib
   | [ scope; _lib_name; instance_name; ".instance.objs"; jsoo; s_config ]
-    when Obj_dir.is_jsoo_dirname jsoo ->
+    when Obj_dir.is_jsoo_dirname (Filename.of_string_exn jsoo) ->
     let* scope = find_scope ~sctx scope in
     has_rules
     @@ fun () ->


### PR DESCRIPTION
The fixed js_of_ocaml object-directory name is a single path component, but it was stored and compared as an unstructured string. Represent it as `Filename.t`, construct its path with `relative_fname`, and compare it directly with path basenames.
