### PR TITLE
refactor(rules): centralize executable targets

### DIFF
--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -621,7 +621,6 @@ module Crawl = struct
     >>= function
     | false -> Memo.return None
     | true ->
-      let first_exe = snd (Nonempty_list.hd exes.names) in
       let* scope =
         Scope.DB.find_by_project (Super_context.context sctx |> Context.name) project
       in
@@ -632,7 +631,7 @@ module Crawl = struct
           Ml_sources.modules_and_obj_dir
             ml_sources
             ~libs:(Scope.libs scope)
-            ~for_:(Exe { first_exe })
+            ~for_:(Exe_target (Executables.exe_target exes))
         in
         Modules.With_vlib.modules modules_, obj_dir
       in

--- a/src/dune_rules/artifacts_db.ml
+++ b/src/dune_rules/artifacts_db.ml
@@ -21,7 +21,7 @@ let available_exes ~dir (exes : Executables.t) =
     in
     Lib.DB.resolve_user_written_deps
       libs
-      (`Exe exes.names)
+      (Executables.exe_target exes)
       exes.buildable.libraries
       ~allow_unused_libraries:exes.buildable.allow_unused_libraries
       ~pps

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -175,12 +175,12 @@ let gen_rules sctx t ~dir ~scope =
          ~sandbox
          [ A "-staged"; Target cinaps_ml; Deps (List.map cinapsed_files ~f:Path.build) ])
   and* expander = Super_context.expander sctx ~dir in
+  let exe_target = Exe_target.executables Nonempty_list.[ t.loc, name ] in
   let compile_info =
     let dune_version = Scope.project scope |> Dune_project.dune_version in
-    let names = Nonempty_list.[ t.loc, name ] in
     Lib.DB.resolve_user_written_deps
       (Scope.libs scope)
-      (`Exe names)
+      exe_target
       (Lib_dep.Direct (loc, Lib_name.of_string "cinaps.runtime") :: t.libraries)
       ~allow_unused_libraries:[]
       ~pps:(Preprocess.Per_module.pps t.preprocess)
@@ -207,7 +207,7 @@ let gen_rules sctx t ~dir ~scope =
       in
       let requires_compile = Lib.Compile.direct_requires compile_info ~for_ in
       let requires_link = Lib.Compile.requires_link compile_info ~for_ in
-      let obj_dir = Obj_dir.make_exe ~dir:cinaps_dir ~name in
+      let obj_dir = Obj_dir.make_for_exe_target ~dir:cinaps_dir exe_target in
       Compilation_context.create
         for_
         ~super_context:sctx

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -161,9 +161,10 @@ let executables_rules
   (* Use "eobjs" rather than "objs" to avoid a potential conflict with a library
      of the same name *)
   let* modules, obj_dir =
-    let first_exe = first_exe exes in
     Dir_contents.ml dir_contents ~for_
-    >>= Ml_sources.modules_and_obj_dir ~libs:(Scope.libs scope) ~for_:(Exe { first_exe })
+    >>= Ml_sources.modules_and_obj_dir
+          ~libs:(Scope.libs scope)
+          ~for_:(Exe_target (Executables.exe_target exes))
   in
   let* () = Check_rules.add_obj_dir sctx ~obj_dir for_ in
   let ctx = Super_context.context sctx in
@@ -348,7 +349,7 @@ let executables_rules
       ~preprocess:
         (Preprocess.Per_module.without_instrumentation exes.buildable.preprocess.config)
       ~dialects:(Dune_project.dialects (Scope.project scope))
-      ~ident:(Merlin_ident.for_exes ~names:(Nonempty_list.map ~f:snd exes.names))
+      ~ident:(Merlin_ident.for_exe_target (Executables.exe_target exes))
       ~for_
       ~parameters:(Resolve.return [])
   in
@@ -367,7 +368,7 @@ let compile_info ~scope (exes : Executables.t) =
   in
   Lib.DB.resolve_user_written_deps
     (Scope.libs scope)
-    (`Exe exes.names)
+    (Executables.exe_target exes)
     exes.buildable.libraries
     ~allow_unused_libraries:exes.buildable.allow_unused_libraries
     ~pps
@@ -392,6 +393,6 @@ let rules ~sctx ~dir_contents ~scope ~expander (exes : Executables.t) =
   in
   let* () = Buildable_rules.gen_select_rules sctx compile_info ~dir ~for_
   and* () = Bootstrap_info.gen_rules sctx exes ~dir compile_info dir_contents in
-  let merlin_ident = Merlin_ident.for_exes ~names:(Nonempty_list.map ~f:snd exes.names) in
+  let merlin_ident = Merlin_ident.for_exe_target (Executables.exe_target exes) in
   Buildable_rules.with_lib_deps (Super_context.context sctx) merlin_ident ~dir ~f
 ;;

--- a/src/dune_rules/exe_target.ml
+++ b/src/dune_rules/exe_target.ml
@@ -1,0 +1,48 @@
+open Import
+
+type t =
+  | Executables of (Loc.t * string) Nonempty_list.t
+  | Melange_emit of string
+
+let executables names = Executables names
+let melange_emit name = Melange_emit name
+
+let compilation_mode = function
+  | Executables _ -> Compilation_mode.Ocaml
+  | Melange_emit _ -> Melange
+;;
+
+let names = function
+  | Executables names -> Nonempty_list.map names ~f:snd
+  | Melange_emit name -> Nonempty_list.[ name ]
+;;
+
+let first_name = function
+  | Executables ((_, name) :: _) | Melange_emit name -> name
+;;
+
+let description = function
+  | Melange_emit name -> Pp.textf "melange target %s" name
+  | Executables Nonempty_list.[ (loc, name) ] ->
+    Pp.textf "executable %s in %s" name (Loc.to_file_colon_line loc)
+  | Executables (Nonempty_list.((loc, _) :: _) as names) ->
+    Pp.textf
+      "executables %s in %s"
+      (String.enumerate_and (Nonempty_list.map ~f:snd names |> Nonempty_list.to_list))
+      (Loc.to_file_colon_line loc)
+;;
+
+let repr =
+  let executables =
+    Repr.view (Repr.list (Repr.pair Loc.repr Repr.string)) ~to_:Nonempty_list.to_list
+  in
+  Repr.variant
+    "exe-target"
+    [ Repr.case "Executables" executables ~proj:(function
+        | Executables names -> Some names
+        | Melange_emit _ -> None)
+    ; Repr.case "Melange_emit" Repr.string ~proj:(function
+        | Melange_emit name -> Some name
+        | Executables _ -> None)
+    ]
+;;

--- a/src/dune_rules/exe_target.mli
+++ b/src/dune_rules/exe_target.mli
@@ -1,0 +1,12 @@
+open Import
+
+(** An executable or [melange.emit] target. *)
+type t
+
+val executables : (Loc.t * string) Nonempty_list.t -> t
+val melange_emit : string -> t
+val compilation_mode : t -> Compilation_mode.t
+val names : t -> string Nonempty_list.t
+val first_name : t -> string
+val description : t -> 'a Pp.t
+val repr : t Repr.t

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -202,6 +202,7 @@ include Sub_system.Register_end_point (struct
       in
       let dune_version = Scope.project scope |> Dune_project.dune_version in
       let runner_name = Inline_tests_info.inline_test_runner in
+      let exe_target = Exe_target.executables Nonempty_list.[ loc, "t" ] in
       let main_module =
         let name = Module_name.of_checked_string "main" in
         Module.generated ~kind:Impl ~for_ ~src_dir:inline_test_dir [ name ]
@@ -271,7 +272,7 @@ include Sub_system.Register_end_point (struct
           in
           Ocaml_flags.append_common ocaml_flags [ "-w"; "-24"; "-g" ]
         in
-        let obj_dir = Obj_dir.make_exe ~dir:inline_test_dir ~name:"t" in
+        let obj_dir = Obj_dir.make_for_exe_target ~dir:inline_test_dir exe_target in
         let modules = Modules.With_vlib.singleton_exe main_module in
         let runner_libs =
           let lib_db = Scope.libs scope in

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -531,7 +531,7 @@ end = struct
                Lib.DB.resolve_user_written_deps
                  (Scope.libs scope)
                  ~forbidden_libraries:[]
-                 (`Exe exes.names)
+                 (Executables.exe_target exes)
                  exes.buildable.libraries
                  ~allow_unused_libraries:exes.buildable.allow_unused_libraries
                  ~pps

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -2505,11 +2505,7 @@ module DB = struct
         ~pps
         ~dune_version
     =
-    let for_ =
-      match targets with
-      | `Melange_emit _name -> Compilation_mode.Melange
-      | `Exe _ -> Ocaml
-    in
+    let for_ = Exe_target.compilation_mode targets in
     let resolved =
       Memo.lazy_ ~name:"resolved-library-dependencies" (fun () ->
         Resolve_names.resolve_deps_and_add_runtime_deps
@@ -2550,17 +2546,7 @@ module DB = struct
                  ~forbidden_libraries
                  ~for_
                  res)
-            ~human_readable_description:(fun () ->
-              match targets with
-              | `Melange_emit name -> Pp.textf "melange target %s" name
-              | `Exe Nonempty_list.[ (loc, name) ] ->
-                Pp.textf "executable %s in %s" name (Loc.to_file_colon_line loc)
-              | `Exe (Nonempty_list.((loc, _) :: _) as names) ->
-                Pp.textf
-                  "executables %s in %s"
-                  (String.enumerate_and
-                     (Nonempty_list.map ~f:snd names |> Nonempty_list.to_list))
-                  (Loc.to_file_colon_line loc)))
+            ~human_readable_description:(fun () -> Exe_target.description targets))
       in
       let init =
         Memo.lazy_ ~name:"empty-library-requires-link" (fun () -> Resolve.Memo.return [])

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -199,7 +199,7 @@ module DB : sig
       This function is for executables or melange.emit stanzas. *)
   val resolve_user_written_deps
     :  t
-    -> [ `Exe of (Loc.t * string) Nonempty_list.t | `Melange_emit of string ]
+    -> Exe_target.t
     -> allow_overlaps:bool
     -> forbidden_libraries:(Loc.t * Lib_name.t) list
     -> Lib_dep.t list

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -453,12 +453,13 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~mdx_prog =
      field *)
   let main_module_name = Module_name.of_checked_string name in
   let dune_version = Scope.project scope |> Dune_project.dune_version in
+  let exe_target = Exe_target.executables Nonempty_list.[ t.loc, name ] in
   let* cctx =
     let lib name = Lib_dep.Direct (loc, Lib_name.of_string name) in
     let compile_info =
       Lib.DB.resolve_user_written_deps
         (Scope.libs scope)
-        (`Exe Nonempty_list.[ t.loc, name ])
+        exe_target
         ~allow_overlaps:false
         ~forbidden_libraries:[]
         (lib "mdx.test" :: lib "mdx.top" :: lib "unix" :: t.libraries)
@@ -468,7 +469,7 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~mdx_prog =
     in
     let requires_compile = Lib.Compile.direct_requires compile_info ~for_
     and requires_link = Lib.Compile.requires_link compile_info ~for_ in
-    let obj_dir = Obj_dir.make_exe ~dir ~name in
+    let obj_dir = Obj_dir.make_for_exe_target ~dir exe_target in
     let modules =
       Module.generated ~kind:Impl ~src_dir:dir ~for_ [ main_module_name ]
       |> Modules.With_vlib.singleton_exe

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -133,7 +133,7 @@ let emit_modules_and_obj_dir ~dir_contents ~scope (mel : Melange_stanzas.Emit.t)
   Dir_contents.ml dir_contents ~for_:Compilation_mode.Melange
   >>= Ml_sources.modules_and_obj_dir
         ~libs:(Scope.libs scope)
-        ~for_:(Melange { target = mel.target })
+        ~for_:(Exe_target (Melange_stanzas.Emit.exe_target mel))
 ;;
 
 let add_rule sctx ?mode ?loc ~dir build =
@@ -322,7 +322,7 @@ let compile_info ~scope (mel : Melange_stanzas.Emit.t) =
   in
   Lib.DB.resolve_user_written_deps
     (Scope.libs scope)
-    (`Melange_emit mel.target)
+    (Melange_stanzas.Emit.exe_target mel)
     ~allow_overlaps:mel.allow_overlapping_dependencies
     ~forbidden_libraries:[]
     libraries
@@ -514,7 +514,7 @@ let setup_emit_cmj_rules
   =
   let* compile_info = compile_info ~scope mel in
   let ctx = Super_context.context sctx in
-  let merlin_ident = Merlin_ident.for_melange ~target:mel.target in
+  let merlin_ident = Merlin_ident.for_exe_target (Melange_stanzas.Emit.exe_target mel) in
   let dir = Dir_contents.dir dir_contents in
   let f () =
     let* source_modules, obj_dir = emit_modules_and_obj_dir ~dir_contents ~scope mel in

--- a/src/dune_rules/melange/melange_stanzas.ml
+++ b/src/dune_rules/melange/melange_stanzas.ml
@@ -157,6 +157,7 @@ module Emit = struct
        })
   ;;
 
+  let exe_target t = Exe_target.melange_emit t.target
   let target_dir (emit : t) ~dir = Path.Build.relative dir emit.target
 end
 

--- a/src/dune_rules/melange/melange_stanzas.mli
+++ b/src/dune_rules/melange/melange_stanzas.mli
@@ -24,5 +24,6 @@ module Emit : sig
 
   val implicit_alias : Alias.Name.t
   val decode : t Dune_lang.Decoder.t
+  val exe_target : t -> Exe_target.t
   val target_dir : t -> dir:Path.Build.t -> Path.Build.t
 end

--- a/src/dune_rules/merlin/merlin_ident.ml
+++ b/src/dune_rules/merlin/merlin_ident.ml
@@ -2,21 +2,26 @@ open Import
 
 type t =
   | Lib of Lib_name.t
-  | Exes of string Nonempty_list.t
-  | Melange_entries of string
+  | Exe_target of Exe_target.t
 
 let for_lib l = Lib l
-let for_exes ~names = Exes names
-let for_melange ~target = Melange_entries target
+let for_exe_target target = Exe_target target
 
 (* For debug purposes we use the name of one library or executable and the hash
    of the others if there are multiple executables to name the merlin file *)
 let to_string = function
   | Lib name -> sprintf "lib-%s" (Lib_name.to_string name)
-  | Exes [ name ] -> sprintf "exe-%s" name
-  | Exes (name :: names) ->
-    sprintf "exe-%s-%s" name Digest.(repr (Repr.list String.repr) names |> to_string)
-  | Melange_entries name -> sprintf "melange-%s" name
+  | Exe_target target ->
+    (match Exe_target.compilation_mode target with
+     | Melange -> sprintf "melange-%s" (Exe_target.first_name target)
+     | Ocaml ->
+       (match Exe_target.names target with
+        | [ name ] -> sprintf "exe-%s" name
+        | name :: names ->
+          sprintf
+            "exe-%s-%s"
+            name
+            Digest.(repr (Repr.list String.repr) names |> to_string)))
 ;;
 
 let merlin_folder_name = Filename.merlin_conf_dir_basename

--- a/src/dune_rules/merlin/merlin_ident.mli
+++ b/src/dune_rules/merlin/merlin_ident.mli
@@ -5,8 +5,7 @@ open Import
 type t
 
 val for_lib : Lib_name.t -> t
-val for_exes : names:string Nonempty_list.t -> t
-val for_melange : target:string -> t
+val for_exe_target : Exe_target.t -> t
 
 (** Merlin config folder name *)
 val merlin_folder_name : Filename.t

--- a/src/dune_rules/merlin/ocaml_index.ml
+++ b/src/dune_rules/merlin/ocaml_index.ml
@@ -162,8 +162,11 @@ let context_indexes =
                | Executables.T exes | Tests.T { exes; _ } ->
                  Some (Executables.obj_dir ~dir exes)
                | Library.T lib -> Some (Library.obj_dir ~dir lib)
-               | Melange_stanzas.Emit.T { target; _ } ->
-                 Some (Obj_dir.make_melange_emit ~dir ~name:target)
+               | Melange_stanzas.Emit.T melange_emit ->
+                 Some
+                   (Obj_dir.make_for_exe_target
+                      ~dir
+                      (Melange_stanzas.Emit.exe_target melange_emit))
                | _ -> None
              in
              match obj with

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -336,15 +336,13 @@ let modules_of_files ~root_dir ~path ~dialects ~dir ~files ~for_ =
 
 type for_ =
   | Library of Lib_id.Local.t
-  | Exe of { first_exe : string }
-  | Melange of { target : string }
+  | Exe_target of Exe_target.t
 
 let dyn_of_for_ =
   let open Dyn in
   function
   | Library n -> variant "Library" [ Lib_id.Local.to_dyn n ]
-  | Exe { first_exe } -> variant "Exe" [ record [ "first_exe", string first_exe ] ]
-  | Melange { target } -> variant "Melange" [ record [ "target", string target ] ]
+  | Exe_target target -> variant "Exe_target" [ Repr.to_dyn Exe_target.repr target ]
 ;;
 
 let raise_module_conflict_error ~module_path origins =
@@ -425,8 +423,11 @@ let modules_and_obj_dir t ~libs ~for_ =
   match
     match for_ with
     | Library lib_id -> Lib_id.Local.Map.find t.modules.libraries lib_id
-    | Exe { first_exe } -> String.Map.find t.modules.executables first_exe
-    | Melange { target } -> String.Map.find t.modules.melange_emits target
+    | Exe_target target ->
+      let name = Exe_target.first_name target in
+      (match Exe_target.compilation_mode target with
+       | Ocaml -> String.Map.find t.modules.executables name
+       | Melange -> String.Map.find t.modules.melange_emits name)
   with
   | Some (Library _, modules, obj_dir) ->
     let* () =
@@ -464,8 +465,10 @@ let modules_and_obj_dir t ~libs ~for_ =
       match for_ with
       | Library _ ->
         Lib_id.Local.Map.keys t.modules.libraries |> Dyn.list Lib_id.Local.to_dyn
-      | Exe _ -> String.Map.keys t.modules.executables |> Dyn.(list string)
-      | Melange _ -> String.Map.keys t.modules.melange_emits |> Dyn.(list string)
+      | Exe_target target ->
+        (match Exe_target.compilation_mode target with
+         | Ocaml -> String.Map.keys t.modules.executables |> Dyn.(list string)
+         | Melange -> String.Map.keys t.modules.melange_emits |> Dyn.(list string))
     in
     Code_error.raise
       "modules_and_obj_dir: failed lookup"
@@ -1201,7 +1204,9 @@ let modules_of_stanzas =
                in
                make_tests ~dir ~expander ~modules ~project tests
              | Melange_stanzas.Emit.T mel ->
-               let obj_dir = Obj_dir.make_melange_emit ~dir ~name:mel.target in
+               let obj_dir =
+                 Obj_dir.make_for_exe_target ~dir (Melange_stanzas.Emit.exe_target mel)
+               in
                let+ sources, modules =
                  let modules =
                    Generated_modules.with_lib_select_deps

--- a/src/dune_rules/ml_sources.mli
+++ b/src/dune_rules/ml_sources.mli
@@ -22,10 +22,7 @@ val artifacts : t -> Artifacts_obj.t Memo.t
 
 type for_ =
   | Library of Lib_id.Local.t
-  | Exe of
-      { first_exe : string (** Name of first executable appearing in executables stanza *)
-      }
-  | Melange of { target : string }
+  | Exe_target of Exe_target.t
 
 val modules_and_obj_dir
   :  t

--- a/src/dune_rules/obj_dir.ml
+++ b/src/dune_rules/obj_dir.ml
@@ -16,16 +16,19 @@ module Paths = struct
     Path.Build.relative obj_dir "public_cmi_melange"
   ;;
 
-  (* Use "eobjs" rather than "objs" to avoid a potential conflict with a library
-     of the same name *)
-  let executable_object_directory ~dir name =
-    Path.Build.relative dir ("." ^ name ^ ".eobjs")
-  ;;
-
-  let melange_object_directory ~dir name =
-    (* Use "mobjs" rather than "objs" to avoid a potential conflict with a
-       library / executable of the same name *)
-    Path.Build.relative dir ("." ^ name ^ ".mobjs")
+  let exe_target_object_directory ~dir target =
+    let suffix =
+      match Exe_target.compilation_mode target with
+      | Ocaml ->
+        (* Use "eobjs" rather than "objs" to avoid a potential conflict with a
+           library of the same name. *)
+        ".eobjs"
+      | Melange ->
+        (* Use "mobjs" rather than "objs" to avoid a potential conflict with a
+           library or executable of the same name. *)
+        ".mobjs"
+    in
+    Path.Build.relative dir ("." ^ Exe_target.first_name target ^ suffix)
   ;;
 end
 
@@ -310,13 +313,8 @@ module Local = struct
       ~private_lib:false
   ;;
 
-  let make_exe ~dir ~name =
-    let obj_dir = Paths.executable_object_directory ~dir name in
-    make_non_library ~dir ~obj_dir
-  ;;
-
-  let make_melange_emit ~dir ~name =
-    let obj_dir = Paths.melange_object_directory ~dir name in
+  let make_for_exe_target ~dir target =
+    let obj_dir = Paths.exe_target_object_directory ~dir target in
     make_non_library ~dir ~obj_dir
   ;;
 
@@ -467,8 +465,7 @@ let as_local_exn (t : Path.t t) =
     Code_error.raise "Obj_dir.as_local_exn: external dir" [ "t", External.to_dyn e ]
 ;;
 
-let make_exe ~dir ~name = Local (Local.make_exe ~dir ~name)
-let make_melange_emit ~dir ~name = Local (Local.make_melange_emit ~dir ~name)
+let make_for_exe_target ~dir target = Local (Local.make_for_exe_target ~dir target)
 
 let for_pp ~dir =
   Local

--- a/src/dune_rules/obj_dir.mli
+++ b/src/dune_rules/obj_dir.mli
@@ -84,8 +84,7 @@ val convert_to_external
 
 val cm_dir : 'path t -> Lib_mode.Cm_kind.t -> Visibility.t -> 'path
 val to_dyn : _ t -> Dyn.t
-val make_exe : dir:Path.Build.t -> name:string -> Path.Build.t t
-val make_melange_emit : dir:Path.Build.t -> name:string -> Path.Build.t t
+val make_for_exe_target : dir:Path.Build.t -> Exe_target.t -> Path.Build.t t
 val for_pp : dir:Path.Build.t -> Path.Build.t t
 val as_local_exn : Path.t t -> Path.Build.t t
 

--- a/src/dune_rules/stanzas/executables.ml
+++ b/src/dune_rules/stanzas/executables.ml
@@ -583,8 +583,5 @@ let single, multi =
 
 let has_foreign t = Buildable.has_foreign t.buildable
 let has_foreign_cxx t = Buildable.has_foreign_cxx t.buildable
-
-let obj_dir t ~dir =
-  let name = snd (Nonempty_list.hd t.names) in
-  Obj_dir.make_exe ~dir ~name
-;;
+let exe_target t = Exe_target.executables t.names
+let obj_dir t ~dir = Obj_dir.make_for_exe_target ~dir (exe_target t)

--- a/src/dune_rules/stanzas/executables.mli
+++ b/src/dune_rules/stanzas/executables.mli
@@ -63,6 +63,7 @@ val has_foreign : t -> bool
 (** Check if the executables have any c++ foreign stubs. *)
 val has_foreign_cxx : t -> bool
 
+val exe_target : t -> Exe_target.t
 val obj_dir : t -> dir:Path.Build.t -> Path.Build.t Obj_dir.t
 val single : t Dune_lang.Decoder.t
 val multi : t Dune_lang.Decoder.t

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -26,7 +26,8 @@ module Source = struct
     |> Path.as_in_build_dir_exn
   ;;
 
-  let obj_dir { dir; name; _ } = Obj_dir.make_exe ~dir ~name
+  let exe_target t = Exe_target.executables Nonempty_list.[ t.loc, t.name ]
+  let obj_dir t = Obj_dir.make_for_exe_target ~dir:t.dir (exe_target t)
 
   let modules t pp =
     main_module t |> Pp_spec.pp_module pp >>| Modules.With_vlib.singleton_exe
@@ -211,7 +212,6 @@ module Stanza = struct
           let compiler_libs =
             Lib_name.parse_string_exn (source.loc, "compiler-libs.toplevel")
           in
-          let names = Nonempty_list.[ source.loc, source.name ] in
           let pps =
             match toplevel.pps with
             | Preprocess.Pps pps -> pps.pps
@@ -220,7 +220,7 @@ module Stanza = struct
           in
           Lib.DB.resolve_user_written_deps
             (Scope.libs scope)
-            (`Exe names)
+            (Source.exe_target source)
             ~forbidden_libraries:[]
             (Lib_dep.Direct (source.loc, compiler_libs)
              :: List.map toplevel.libraries ~f:(fun d -> Lib_dep.Direct d))

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -89,7 +89,7 @@ let add_stanza db ~dir (acc, pps) stanza =
         in
         Lib.DB.resolve_user_written_deps
           db
-          (`Exe exes.names)
+          (Executables.exe_target exes)
           exes.buildable.libraries
           ~allow_unused_libraries:exes.buildable.allow_unused_libraries
           ~pps


### PR DESCRIPTION
Executable and `melange.emit` targets were represented independently as raw strings and ad hoc variants across object-directory layout, dependency resolution, source lookup, and Merlin identifiers.

Introduce an abstract `Exe_target.t` and use it consistently across these paths. This also replaces the separate `Obj_dir.make_exe` and `make_melange_emit` entry points with one target-aware constructor while preserving existing names, paths, and diagnostics.
