### PR TITLE
fix(cache): normalize absolute workspace build directory

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1248,8 +1248,36 @@ let init_with_root_and_rpc ~(root : Workspace_root.t) ~rpc_build (builder : Buil
   let c = build root builder in
   No_build.set c.builder.no_build;
   if c.root.dir <> Filename.current_dir_name then Sys.chdir c.root.dir;
-  Path.set_root (normalize_path (Path.External.cwd ()));
-  Path.Build.set_build_dir (Path.Outside_build_dir.of_string c.builder.build_dir);
+  let source_root = normalize_path (Path.External.cwd ()) in
+  Path.set_root source_root;
+  let build_dir =
+    match Path.Outside_build_dir.of_string c.builder.build_dir with
+    | In_source_dir _ as build_dir -> build_dir
+    | External external_build_dir as build_dir ->
+      let external_build_dir = Path.External.to_string external_build_dir in
+      (match Filename.of_string (Filename.basename external_build_dir) with
+       | None -> build_dir
+       | Some basename ->
+         let parent =
+           Filename.dirname external_build_dir
+           |> Path.External.of_string
+           |> normalize_path
+         in
+         let parent_is_source_root =
+           Path.External.equal parent source_root
+           ||
+           match Unix.realpath (Path.External.to_string parent) with
+           | parent ->
+             Path.External.equal
+               (normalize_path (Path.External.of_string parent))
+               source_root
+           | exception Unix.Unix_error _ -> false
+         in
+         if parent_is_source_root
+         then In_source_dir (Path.Source.relative_fname Path.Source.root basename)
+         else build_dir)
+  in
+  Path.Build.set_build_dir build_dir;
   let () =
     match builder.trace_file with
     | None -> Log.init No_log_file

--- a/doc/changes/fixed/16108.md
+++ b/doc/changes/fixed/16108.md
@@ -1,0 +1,3 @@
+- Canonicalize absolute spellings of a build directory directly beneath the
+  workspace, so they use workspace-relative paths and share cache entries with
+  relative spellings (#16108, fixes #16072, @Alizter).

--- a/test/blackbox-tests/test-cases/cram/custom-build-dir.t
+++ b/test/blackbox-tests/test-cases/cram/custom-build-dir.t
@@ -32,9 +32,7 @@ path
   +     $ echo bar
   +  +  bar
   +  [1]
-  Promoting
-    $TESTCASE_ROOT/tmp/default/foo.t.corrected
-    to foo.t.
+  Promoting tmp/default/foo.t.corrected to foo.t.
   [1]
   $ cat foo.t
     $ echo "  $ echo bar" >bar.t

--- a/test/blackbox-tests/test-cases/dune-cache/absolute-build-dir.t
+++ b/test/blackbox-tests/test-cases/dune-cache/absolute-build-dir.t
@@ -16,8 +16,8 @@ Populate the shared cache with the relative build directory.
   $ dune build target
   $ rm -rf _build
 
-Rebuilding with the same directory spelled as an absolute path currently misses
-the shared cache. Inspecting cache events tests the lookup directly, without
+Rebuilding with the same directory spelled as an absolute path hits the shared
+cache. Inspecting cache events tests the lookup directly, without
 relying on action output or undeclared targets.
 
   $ DUNE_BUILD_DIR=$PWD/_build dune build target
@@ -30,5 +30,10 @@ relying on action output or undeclared targets.
   >   ]'
   [
     "workspace_local_miss",
-    "miss"
+    "hit"
   ]
+
+Absolute build directories outside the workspace remain external.
+
+  $ DUNE_BUILD_DIR=$PWD/../absolute-build-dir-external dune build target
+  $ test -f ../absolute-build-dir-external/default/target


### PR DESCRIPTION
## Description

Treat an absolute build directory directly beneath the workspace root as the corresponding workspace-relative build directory. This makes relative and absolute spellings use the same rendered paths and shared-cache keys.

Dune first compares the parent directly, then resolves that existing parent as a best effort for logical workspace paths such as `/tmp` on macOS. If resolution fails or the build directory is elsewhere, it remains external.

The regression test was added separately in #16106. This PR flips it from a cache miss to a hit, preserves an outside-workspace case, and updates the existing cram path-rendering expectation.

## Related Issue and Motivation

Fixes #16072.