### PR TITLE
feat(ocaml): infer module interfaces for promotion

### DIFF
--- a/bin/ocaml/inferred_mli.ml
+++ b/bin/ocaml/inferred_mli.ml
@@ -1,0 +1,76 @@
+open Import
+
+let doc = "Generate an inferred interface for an OCaml module."
+
+let man =
+  [ `S Cmdliner.Manpage.s_description
+  ; `P
+      {|Run the OCaml compiler to infer the interface of MODULE using its build
+        configuration. The generated .mli is registered for promotion; run
+        $(b,dune promote) to copy it into the source tree.|}
+  ; `Blocks Common.help_secs
+  ]
+;;
+
+let info = Cmd.info "inferred-mli" ~doc ~man
+
+let source_path common module_path =
+  if Filename.is_relative module_path
+  then
+    Common.prefix_target common module_path
+    |> Path.Local.of_string
+    |> Path.Source.of_local
+  else (
+    let root =
+      (Common.root common).dir
+      |> Path.of_string
+      |> Path.to_absolute_filename
+      |> Path.of_string
+    in
+    match Path.drop_prefix ~prefix:root (Path.of_string module_path) with
+    | Some module_path -> Path.Source.of_local module_path
+    | None ->
+      User_error.raise
+        [ Pp.text "Module path is not a descendant of the workspace root." ])
+;;
+
+let term =
+  let+ builder = Common.Builder.term
+  and+ module_path =
+    Arg.(
+      required
+      & pos 0 (some string) None
+      & info [] ~docv:"MODULE" ~doc:(Some "Path to an OCaml implementation."))
+  and+ context_name = Common.context_arg ~doc:(Some "Build context to use.") in
+  let common, config = Common.init builder in
+  let source = source_path common module_path in
+  if
+    not
+      (Filename.Extension.Or_empty.check
+         (Path.Source.extension source)
+         Filename.Extension.ml)
+  then User_error.raise [ Pp.text "Module path must have a .ml extension." ];
+  Scheduler_setup.go_with_rpc_server ~common ~config (fun () ->
+    Build.build_memo_exn (fun () ->
+      let open Memo.O in
+      let* sctx =
+        let+ setup = Util.setup () in
+        Dune_rules.Main.find_scontext_exn setup ~name:context_name
+      in
+      Dune_rules.Top_module.find_module sctx source
+      >>= function
+      | None ->
+        let source = Path.Source.to_string_maybe_quoted source in
+        User_error.raise [ Pp.textf "No module found for %s." source ]
+      | Some (_, _, _, Melange _) ->
+        User_error.raise
+          [ Pp.text "Modules belonging to `melange.emit' are not supported." ]
+      | Some (module_, cctx, _, _) ->
+        if not (Dune_rules.Module.has module_ ~ml_kind:Impl)
+        then (
+          let name = Dune_rules.Module.name module_ |> Dune_lang.Module_name.to_string in
+          User_error.raise [ Pp.textf "Module %s has no implementation." name ]);
+        Dune_rules.Module_compilation.infer_interface cctx module_))
+;;
+
+let command = Cmd.v info term

--- a/bin/ocaml/inferred_mli.mli
+++ b/bin/ocaml/inferred_mli.mli
@@ -1,0 +1,3 @@
+open Import
+
+val command : unit Cmd.t

--- a/bin/ocaml/ocaml.ml
+++ b/bin/ocaml/ocaml.ml
@@ -1,4 +1,5 @@
 module Doc = Doc
+module Inferred_mli = Inferred_mli
 module Ocaml_cmd = Ocaml_cmd
 module Ocaml_merlin = Ocaml_merlin
 module Top = Top

--- a/bin/ocaml/ocaml_cmd.ml
+++ b/bin/ocaml/ocaml_cmd.ml
@@ -6,6 +6,7 @@ let group =
   Cmdliner.Cmd.group
     info
     [ Utop.command
+    ; Inferred_mli.command
     ; Ocaml_merlin.command
     ; Ocaml_merlin.Dump_dot_merlin.command
     ; Top.command

--- a/doc/changes/added/16111.md
+++ b/doc/changes/added/16111.md
@@ -1,0 +1,3 @@
+- Add `dune ocaml inferred-mli` to infer an interface with a module's build
+  configuration and register it for promotion. (#16111, fixes #12727,
+  @rgrinberg)

--- a/src/dune_rules/dune_rules.ml
+++ b/src/dune_rules/dune_rules.ml
@@ -13,6 +13,7 @@ module Foreign_rules = Foreign_rules
 module Jsoo_rules = Jsoo_rules
 module Super_context = Super_context
 module Compilation_context = Compilation_context
+module Module_compilation = Module_compilation
 module Colors = Colors
 module Dune_package = Dune_package
 module Alias_rec = Alias_rec

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -30,6 +30,28 @@ let opens modules m =
   Command.Args.As (Modules.With_vlib.local_open modules m |> Ocaml_flags.open_flags)
 ;;
 
+let as_parameter_arg m =
+  Command.Args.As (if Module.kind m = Parameter then [ "-as-parameter" ] else [])
+;;
+
+let as_argument_for cctx m =
+  Command.Args.dyn
+    (let open Action_builder.O in
+     let impl = Compilation_context.implements cctx in
+     Virtual_rules.implements_parameter impl m
+     |> Resolve.Memo.read
+     >>| function
+     | None -> []
+     | Some parameter -> [ "-as-argument-for"; Module_name.to_string parameter ])
+;;
+
+let parameters cctx =
+  Command.Args.dyn
+    (let open Action_builder.O in
+     Resolve.Memo.read (Compilation_context.parameters cctx)
+     >>| List.concat_map ~f:(fun m -> [ "-parameter"; Module_name.to_string m ]))
+;;
+
 let add_rule ?mode ?loc ~can_go_in_shared_cache sctx ~dir build =
   let build =
     if can_go_in_shared_cache
@@ -323,22 +345,6 @@ let build_cm
      then A "-opaque"
      else Command.Args.empty
    in
-   let as_parameter_arg = if Module.kind m = Parameter then [ "-as-parameter" ] else [] in
-   let as_argument_for =
-     Command.Args.dyn
-       (let open Action_builder.O in
-        let impl = Compilation_context.implements cctx in
-        let+ argument = Resolve.Memo.read @@ Virtual_rules.implements_parameter impl m in
-        match argument with
-        | None -> []
-        | Some parameter -> [ "-as-argument-for"; Module_name.to_string parameter ])
-   in
-   let parameters =
-     Command.Args.dyn
-       (let open Action_builder.O in
-        Resolve.Memo.read (Compilation_context.parameters cctx)
-        >>| List.concat_map ~f:(fun m -> [ "-parameter"; Module_name.to_string m ]))
-   in
    let flags = Command.Args.dyn (Ocaml_flags.get (Compilation_context.flags cctx) mode) in
    let pp_flags, sandbox =
      match Module.pp_flags m with
@@ -394,9 +400,9 @@ let build_cm
             ; Command.Args.as_any
                 (Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) cm_kind)
             ; extra_args
-            ; As as_parameter_arg
-            ; as_argument_for
-            ; parameters
+            ; as_parameter_arg m
+            ; as_argument_for cctx m
+            ; parameters cctx
             ; S (melange_args cctx cm_kind m)
             ; A "-no-alias-deps"
             ; opaque_arg
@@ -493,49 +499,102 @@ let build_module ?(force_write_cmi = false) ?(precompiled_cmi = false) cctx m =
     Rules.Produce.Alias.add_deps (Alias.make Alias0.all ~dir) deps
 ;;
 
-let ocamlc_i ~deps cctx (m : Module.t) ~output =
-  let sctx = Compilation_context.super_context cctx in
+let ocamlc_i_action ~deps cctx (m : Module.t) =
   let obj_dir = Compilation_context.obj_dir cctx in
-  let dir = Compilation_context.dir cctx in
-  let ctx = Super_context.context sctx in
+  let ctx = Compilation_context.super_context cctx |> Super_context.context in
   let src = Option.value_exn (Module.file m ~ml_kind:Impl) in
-  let sandbox = Compilation_context.sandbox cctx in
+  let original = Module.source_without_pp m ~ml_kind:Impl in
+  let sandbox =
+    match Module.kind m with
+    | Root -> Sandbox_config.needs_sandboxing
+    | _ -> Compilation_context.sandbox cctx
+  in
+  let pp_flags, sandbox =
+    match Module.pp_flags m with
+    | None -> Command.Args.empty, sandbox
+    | Some (pp_flags, pp_sandbox) ->
+      Command.Args.dyn pp_flags, Sandbox_config.inter sandbox pp_sandbox
+  in
   let cm_deps =
     Action_builder.dyn_paths_unit
       (let open Action_builder.O in
-       let+ deps = Ml_kind.Dict.get deps Impl in
-       List.concat_map deps ~f:(fun m ->
+       Ml_kind.Dict.get deps Impl
+       >>| List.concat_map ~f:(fun m ->
          [ Path.build (Obj_dir.Module.cm_file_exn obj_dir m ~kind:(Ocaml Cmi)) ]))
   in
   let ocaml_flags = Ocaml_flags.get (Compilation_context.flags cctx) (Ocaml Byte) in
   let modules = Compilation_context.modules cctx in
   let ocaml = Compilation_context.ocaml cctx in
-  Super_context.add_rule
+  let open Action_builder.O in
+  cm_deps
+  >>> Command.run'
+        (Ok ocaml.ocamlc)
+        ~dir:(Path.build (Context.build_dir ctx))
+        ~sandbox
+        ~forbid_action_runner:true
+        [ Command.Args.dyn ocaml_flags
+        ; pp_flags
+        ; A "-I"
+        ; Path (Path.build (Obj_dir.byte_dir obj_dir))
+        ; Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) (Ocaml Cmo)
+        ; as_parameter_arg m
+        ; as_argument_for cctx m
+        ; parameters cctx
+        ; opens modules m
+        ; A "-short-paths"
+        ; A "-i"
+        ; Command.Ml_kind.flag Impl
+        ; Dep src
+        ; Hidden_deps (Dep.Set.of_files (Option.to_list original))
+        ]
+;;
+
+let ocamlc_i ~deps cctx m ~output =
+  let sctx = Compilation_context.super_context cctx in
+  let dir = Compilation_context.dir cctx in
+  ocamlc_i_action ~deps cctx m
+  |> Action_builder.with_stdout_to output
+  |> Super_context.add_rule sctx ~dir
+;;
+
+let infer_interface cctx m =
+  let sctx = Compilation_context.super_context cctx in
+  let dir = Compilation_context.dir cctx in
+  let action =
+    let source_file =
+      match Module.source_without_pp m ~ml_kind:Intf with
+      | Some source_file -> Path.as_in_build_dir_exn source_file
+      | None ->
+        Module.source_without_pp m ~ml_kind:Impl
+        |> Option.value_exn
+        |> Path.set_extension ~ext:Filename.Extension.mli
+        |> Path.as_in_build_dir_exn
+    in
+    let source_path = Path.build source_file in
+    let open Action_builder.O in
+    let+ action =
+      let deps =
+        let dep_graphs = Compilation_context.dep_graphs cctx in
+        Ml_kind.Dict.of_func (fun ~ml_kind ->
+          Dep_graph.deps_of (Ml_kind.Dict.get dep_graphs ml_kind) m)
+      in
+      ocamlc_i_action ~deps cctx m
+    and+ () = Action_builder.paths_existing [ source_path ] in
+    Action.Full.map action ~f:(fun action ->
+      let correction_file =
+        Path.Build.extend_basename source_file ~suffix:Filename.corrected
+      in
+      Action.progn
+        [ Action.with_stdout_to correction_file action
+        ; Action.diff ~optional:true source_path correction_file
+        ])
+  in
+  Super_context.execute_action_stdout
     sctx
+    ~loc:(Option.value (Compilation_context.loc cctx) ~default:Loc.none)
     ~dir
-    (Action_builder.With_targets.add
-       ~file_targets:[ output ]
-       (let open Action_builder.With_targets.O in
-        Action_builder.with_no_targets cm_deps
-        >>> Command.run
-              (Ok ocaml.ocamlc)
-              ~dir:(Path.build (Context.build_dir ctx))
-              ~stdout_to:output
-              ~sandbox
-              ~forbid_action_runner:true
-              [ Command.Args.dyn ocaml_flags
-              ; A "-I"
-              ; Path (Path.build (Obj_dir.byte_dir obj_dir))
-              ; Command.Args.as_any
-                  (Lib_mode.Cm_kind.Map.get
-                     (Compilation_context.includes cctx)
-                     (Ocaml Cmo))
-              ; opens modules m
-              ; A "-short-paths"
-              ; A "-i"
-              ; Command.Ml_kind.flag Impl
-              ; Dep src
-              ]))
+    action
+  >>| fun (_ : string) -> ()
 ;;
 
 module Alias_module = struct

--- a/src/dune_rules/module_compilation.mli
+++ b/src/dune_rules/module_compilation.mli
@@ -17,6 +17,9 @@ val ocamlc_i
   -> output:Path.Build.t
   -> unit Memo.t
 
+(** Infer the interface of a module and register it for promotion. *)
+val infer_interface : Compilation_context.t -> Module.t -> unit Memo.t
+
 val build_all : Compilation_context.t -> unit Memo.t
 
 val with_empty_intf

--- a/test/blackbox-tests/test-cases/top-module/inferred-mli.t
+++ b/test/blackbox-tests/test-cases/top-module/inferred-mli.t
@@ -1,0 +1,89 @@
+Generate an inferred interface for a module using the module's build
+configuration, and register it for promotion.
+
+  $ make_dune_project 3.25
+  $ echo '(lang dune 3.25)' >dune-workspace
+
+  $ mkdir dep ppx foo
+  $ cat >dep/dune <<'EOF'
+  > (library (name dep))
+  > EOF
+  $ cat >dep/dep.ml <<'EOF'
+  > let value = 20
+  > EOF
+
+  $ cat >ppx/dune <<'EOF'
+  > (library
+  >  (name ppx)
+  >  (kind ppx_rewriter)
+  >  (libraries ppxlib))
+  > EOF
+  $ cat >ppx/ppx.ml <<'EOF'
+  > open Ppxlib
+  > 
+  > let extension =
+  >   Extension.declare "inferred_mli" Expression Ast_pattern.__
+  >     (fun ~loc ~path:_ _ -> Ast_builder.Default.estring ~loc "generated")
+  > 
+  > let () =
+  >   Driver.register_transformation
+  >     "inferred_mli"
+  >     ~rules:[ Context_free.Rule.extension extension ]
+  > EOF
+
+  $ cat >foo/dune <<'EOF'
+  > (library
+  >  (name foo)
+  >  (libraries dep)
+  >  (preprocess (pps ppx)))
+  > EOF
+  $ cat >foo/helper.ml <<'EOF'
+  > let value = 22
+  > EOF
+  $ cat >foo/foo.ml <<'EOF'
+  > let answer = Dep.value + Helper.value
+  > let text = [%inferred_mli]
+  > EOF
+
+A module without an interface gets one as a correction registered for promotion.
+Run the command from the module's directory, with workspace root detection
+enabled.
+
+  $ (cd foo &&
+  >  unset INSIDE_DUNE &&
+  >  dune ocaml inferred-mli --diff-command=- foo.ml)
+  Entering directory '$TESTCASE_ROOT'
+  File "foo/foo.mli", line 1, characters 0-0:
+  Error: Files _build/default/foo/foo.mli and
+  _build/default/foo/foo.mli.corrected differ.
+  Leaving directory '$TESTCASE_ROOT'
+  [1]
+  $ test ! -e foo/foo.mli
+  $ test ! -e _build/default/foo/foo.mli
+  $ dune promotion list
+  foo/foo.mli
+
+  $ dune promote foo/foo.mli >/dev/null 2>&1
+  $ cat foo/foo.mli
+  val answer : int
+  val text : string
+
+A module with an up-to-date interface does not register a promotion.
+
+  $ dune ocaml inferred-mli foo/foo.ml
+  $ dune promotion list
+
+A module with an outdated interface gets an updated correction.
+
+  $ echo 'val answer : string' >foo/foo.mli
+  $ dune ocaml inferred-mli foo/foo.ml
+  File "foo/foo.mli", line 1, characters 0-0:
+  --- foo/foo.mli
+  +++ foo/foo.mli.corrected
+  @@ -1 +1,2 @@
+  -val answer : string
+  +val answer : int
+  +val text : string
+  [1]
+  $ dune promotion list
+  foo/foo.mli


### PR DESCRIPTION
Add `dune ocaml inferred-mli MODULE` to infer an OCaml interface using the
module's actual build configuration, including preprocessing, dependencies,
opens, and parameter flags.

Missing or stale interfaces are reported through Dune's correction workflow and
can be applied with `dune promote`; an up-to-date interface succeeds without
registering a promotion. This avoids having to reproduce the module's compiler
configuration manually when generating an interface.

Fixes #12727
