### PR TITLE
refactor(odoc): share support files rule

### DIFF
--- a/src/dune_rules/odoc/odoc.ml
+++ b/src/dune_rules/odoc/odoc.ml
@@ -639,22 +639,17 @@ let setup_generate_markdown sctx odoc_file =
   setup_generate sctx ~search_db:None odoc_file Markdown
 ;;
 
-let setup_css_rule sctx =
+let setup_support_files_rule sctx ~dir =
   let ctx = Super_context.context sctx in
-  let dir = Paths.odoc_support ctx in
-  let run_odoc =
-    let cmd =
-      run_odoc
-        sctx
-        ~dir:(Path.build (Context.build_dir ctx))
-        "support-files"
-        ~quiet:false
-        ~flags_for:None
-        [ A "-o"; Path (Path.build dir) ]
-    in
-    Action_builder.With_targets.add_directories ~directory_targets:[ dir ] cmd
-  in
-  add_rule sctx run_odoc
+  run_odoc
+    sctx
+    ~dir:(Path.build (Context.build_dir ctx))
+    "support-files"
+    ~quiet:false
+    ~flags_for:None
+    [ A "-o"; Path (Path.build dir) ]
+  |> Action_builder.With_targets.add_directories ~directory_targets:[ dir ]
+  |> add_rule sctx
 ;;
 
 let sp = Printf.sprintf
@@ -1275,7 +1270,7 @@ let gen_rules sctx ~dir rest =
     has_rules
       ~directory_targets
       (Sherlodoc.sherlodoc_dot_js sctx ~dir:(Paths.html_root ctx)
-       >>> setup_css_rule sctx
+       >>> setup_support_files_rule sctx ~dir:(Paths.odoc_support ctx)
        >>> setup_toplevel_index_rule sctx Html
        >>> setup_toplevel_index_rule sctx Json)
   | [ "_markdown" ] ->

--- a/src/dune_rules/odoc/odoc.mli
+++ b/src/dune_rules/odoc/odoc.mli
@@ -33,6 +33,7 @@ val run_odoc
   -> Command.Args.any Command.Args.t list
   -> Action.Full.t Action_builder.With_targets.t
 
+val setup_support_files_rule : Super_context.t -> dir:Path.Build.t -> unit Memo.t
 val setup_library_odoc_rules : Compilation_context.t -> Lib.Local.t -> unit Memo.t
 val gen_project_rules : Super_context.t -> Dune_project.t -> unit Memo.t
 

--- a/src/dune_rules/odoc/odoc_new.ml
+++ b/src/dune_rules/odoc/odoc_new.ml
@@ -1934,24 +1934,6 @@ let setup_odoc_rules sctx ~all =
   []
 ;;
 
-let setup_css_rule sctx ~all =
-  let run_odoc =
-    let ctx = Super_context.context sctx in
-    let dir = Paths.odoc_support ctx ~all in
-    let cmd =
-      Odoc.run_odoc
-        sctx
-        ~quiet:false
-        ~dir:(Path.build (Context.build_dir ctx))
-        "support-files"
-        ~flags_for:None
-        [ Command.Args.A "-o"; Path (Path.build dir) ]
-    in
-    Action_builder.With_targets.add_directories cmd ~directory_targets:[ dir ]
-  in
-  add_rule sctx run_odoc
-;;
-
 let static_html_rule ctx ~all =
   let open Paths in
   [ odoc_support ctx ~all ]
@@ -1998,7 +1980,7 @@ let setup_all_html_rules sctx ~all =
       (Dep.html_alias (Index.html_dir ctx ~all []))
       (Action_builder.deps deps)
   and+ dirs = hierarchical_html_rules sctx all tree ~search_db
-  and+ () = setup_css_rule sctx ~all
+  and+ () = Odoc.setup_support_files_rule sctx ~dir:(Paths.odoc_support ctx ~all)
   and+ () =
     let dir = Index.html_dir ctx ~all [] in
     Sherlodoc.sherlodoc_dot_js sctx ~dir


### PR DESCRIPTION
The legacy and new odoc pipelines duplicated construction of the `odoc support-files` rule. Expose the shared rule from `Odoc` and reuse it for both support directories.