### PR TITLE
refactor(describe): share build context setup

### DIFF
--- a/bin/build.ml
+++ b/bin/build.ml
@@ -207,3 +207,15 @@ let build =
 ;;
 
 let build_memo_exn f = Build_system.run_exn f
+
+let describe builder ~context_name f =
+  let common, config = Common.init builder in
+  Scheduler_setup.go_with_rpc_server ~common ~config
+  @@ fun () ->
+  build_memo_exn
+  @@ fun () ->
+  let open Memo.O in
+  let* setup = Util.setup () in
+  let sctx = Dune_rules.Main.find_scontext_exn setup ~name:context_name in
+  f common setup sctx
+;;

--- a/bin/build.mli
+++ b/bin/build.mli
@@ -15,3 +15,9 @@ val run_build_command
   -> unit
 
 val build_memo_exn : (unit -> 'a Memo.t) -> 'a Fiber.t
+
+val describe
+  :  Common.Builder.t
+  -> context_name:Dune_engine.Context_name.t
+  -> (Common.t -> Dune_rules.Main.build_system -> Super_context.t -> 'a Memo.t)
+  -> 'a

--- a/bin/describe/describe_external_lib_deps.ml
+++ b/bin/describe/describe_external_lib_deps.ml
@@ -272,22 +272,16 @@ let term =
   and+ include_empty = arg_include_empty
   and+ split_public_names = arg_split_public_names
   and+ format = Describe_format.arg in
-  let common, config = Common.init builder in
-  Scheduler_setup.go_with_rpc_server ~common ~config
-  @@ fun () ->
-  Build.build_memo_exn
-  @@ fun () ->
-  let open Memo.O in
-  let* setup = Util.setup () in
-  let super_context = Dune_rules.Main.find_scontext_exn setup ~name:context_name in
-  let context_name =
-    Super_context.context super_context
-    |> Context.name
-    |> Dune_engine.Context_name.to_string
-  in
-  external_resolved_libs ~include_empty (Super_context.context super_context)
-  >>| to_dyn ~split_public_names context_name
-  >>| Describe_format.print_dyn format
+  Build.describe builder ~context_name (fun _common _setup super_context ->
+    let open Memo.O in
+    let context_name =
+      Super_context.context super_context
+      |> Context.name
+      |> Dune_engine.Context_name.to_string
+    in
+    external_resolved_libs ~include_empty (Super_context.context super_context)
+    >>| to_dyn ~split_public_names context_name
+    >>| Describe_format.print_dyn format)
 ;;
 
 let command =

--- a/bin/describe/describe_pp.ml
+++ b/bin/describe/describe_pp.ml
@@ -169,18 +169,12 @@ let term =
     (* CR-someday Alizter: document this option *)
     Arg.(required & pos 0 (some string) None (Arg.info [] ~docv:"FILE" ~doc:None))
   in
-  let common, config = Common.init builder in
-  Scheduler_setup.go_with_rpc_server ~common ~config
-  @@ fun () ->
-  Build.build_memo_exn
-  @@ fun () ->
-  let open Memo.O in
-  let* setup = Util.setup () in
-  let sctx = Dune_rules.Main.find_scontext_exn setup ~name:context_name in
-  let* result = get_pped_file sctx file in
-  match result with
-  | Error file -> Io.cat file |> Memo.return
-  | Ok (pp_file, ml_kind) -> print_pped_file ~sctx file pp_file ~ml_kind
+  Build.describe builder ~context_name (fun _common _setup sctx ->
+    let open Memo.O in
+    let* result = get_pped_file sctx file in
+    match result with
+    | Error file -> Io.cat file |> Memo.return
+    | Ok (pp_file, ml_kind) -> print_pped_file ~sctx file pp_file ~ml_kind)
 ;;
 
 let command =

--- a/bin/describe/describe_tests.ml
+++ b/bin/describe/describe_tests.ml
@@ -141,21 +141,15 @@ let term : unit Term.t =
   let+ builder = Common.Builder.term
   and+ context_name = Common.context_arg ~doc:(Some "Build context to use.")
   and+ format = Describe_format.arg in
-  let common, config = Common.init builder in
-  Scheduler_setup.go_with_rpc_server ~common ~config
-  @@ fun () ->
-  Build.build_memo_exn
-  @@ fun () ->
-  let open Memo.O in
-  let* setup = Util.setup () in
-  let super_context = Dune_rules.Main.find_scontext_exn setup ~name:context_name in
-  let context = Super_context.context super_context in
-  let* tests_data = Crawl.tests setup context in
-  let dyn_data =
-    List.map tests_data ~f:Test_description.to_dyn |> fun list -> Dyn.List list
-  in
-  Describe_format.print_dyn format dyn_data;
-  Memo.return ()
+  Build.describe builder ~context_name (fun _common setup super_context ->
+    let open Memo.O in
+    let context = Super_context.context super_context in
+    let* tests_data = Crawl.tests setup context in
+    let dyn_data =
+      List.map tests_data ~f:Test_description.to_dyn |> fun list -> Dyn.List list
+    in
+    Describe_format.print_dyn format dyn_data;
+    Memo.return ())
 ;;
 
 let command =

--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -886,7 +886,6 @@ let term : unit Term.t =
   and+ format = Describe_format.arg
   and+ lang = Lang.arg
   and+ options = Options.arg in
-  let common, config = Common.init builder in
   let dirs =
     let args = "workspace" :: what in
     let parse =
@@ -911,23 +910,18 @@ let term : unit Term.t =
     in
     Dune_lang.Decoder.parse parse Univ_map.empty ast
   in
-  Scheduler_setup.go_with_rpc_server ~common ~config
-  @@ fun () ->
-  Build.build_memo_exn
-  @@ fun () ->
-  let open Memo.O in
-  let* setup = Util.setup () in
-  let super_context = Dune_rules.Main.find_scontext_exn setup ~name:context_name in
-  let context = Super_context.context super_context in
-  let* findlib_paths = Context.findlib_paths context in
-  (* prefix directories with the workspace root, so that the
-     command also works correctly when it is run from a
-     subdirectory *)
-  Memo.Option.map dirs ~f:(Memo.List.map ~f:(find_dir common))
-  >>= Crawl.workspace options setup context
-  >>| Sanitize_for_tests.Workspace.sanitize ~findlib_paths
-  >>| Descr.Workspace.to_dyn options
-  >>| Describe_format.print_dyn format
+  Build.describe builder ~context_name (fun common setup super_context ->
+    let open Memo.O in
+    let context = Super_context.context super_context in
+    let* findlib_paths = Context.findlib_paths context in
+    (* prefix directories with the workspace root, so that the
+       command also works correctly when it is run from a
+       subdirectory *)
+    Memo.Option.map dirs ~f:(Memo.List.map ~f:(find_dir common))
+    >>= Crawl.workspace options setup context
+    >>| Sanitize_for_tests.Workspace.sanitize ~findlib_paths
+    >>| Descr.Workspace.to_dyn options
+    >>| Describe_format.print_dyn format)
 ;;
 
 let command =

--- a/bin/describe/package_entries.ml
+++ b/bin/describe/package_entries.ml
@@ -4,17 +4,11 @@ let term =
   let+ builder = Common.Builder.term
   and+ context_name = Common.context_arg ~doc:(Some "Build context to use.")
   and+ format = Describe_format.arg in
-  let common, config = Common.init builder in
-  Scheduler_setup.go_with_rpc_server ~common ~config
-  @@ fun () ->
-  Build.build_memo_exn
-  @@ fun () ->
-  let open Memo.O in
-  let* setup = Util.setup () in
-  let super_context = Dune_rules.Main.find_scontext_exn setup ~name:context_name in
-  Dune_rules.Install_rules.stanzas_to_entries super_context
-  >>| Package.Name.Map.to_dyn (Dyn.list Install.Entry.Sourced.Unexpanded.to_dyn)
-  >>| Describe_format.print_dyn format
+  Build.describe builder ~context_name (fun _common _setup super_context ->
+    let open Memo.O in
+    Dune_rules.Install_rules.stanzas_to_entries super_context
+    >>| Package.Name.Map.to_dyn (Dyn.list Install.Entry.Sourced.Unexpanded.to_dyn)
+    >>| Describe_format.print_dyn format)
 ;;
 
 let command =


### PR DESCRIPTION
Several `dune describe` subcommands repeated scheduler startup, build-system initialization, and build-context lookup. Centralize that setup in `Build.describe` so each command only supplies its memoized describe operation.