### PR TITLE
fix(stdune): reject non-finite JSON numbers

### DIFF
--- a/otherlibs/stdune/src/json.ml
+++ b/otherlibs/stdune/src/json.ml
@@ -56,7 +56,12 @@ let rec to_buf t buf =
   match t with
   | `String s -> quote_string_to_buf s buf
   | `Int i -> Buffer.add_string buf (string_of_int i)
-  | `Float f -> Buffer.add_string buf (Printf.sprintf "%.17g" f)
+  | `Float f ->
+    (match classify_float f with
+     | FP_normal | FP_subnormal | FP_zero ->
+       Buffer.add_string buf (Printf.sprintf "%.17g" f)
+     | FP_infinite | FP_nan ->
+       Code_error.raise "Json.to_string: non-finite float" [ "float", Dyn.float f ])
   | `Bool b -> Buffer.add_string buf (string_of_bool b)
   | `List l ->
     Buffer.add_char buf '[';

--- a/otherlibs/stdune/test/json_tests.ml
+++ b/otherlibs/stdune/test/json_tests.ml
@@ -6,14 +6,16 @@ let print_json_string_bytes string =
   print_newline ()
 ;;
 
-let%expect_test "non-finite floats produce invalid JSON tokens" =
+let%expect_test "non-finite floats are rejected" =
   List.iter [ Stdlib.infinity; Stdlib.neg_infinity; Stdlib.nan ] ~f:(fun float ->
-    Json.to_string (`Float float) |> print_endline);
+    match Json.to_string (`Float float) with
+    | _ -> print_endline "accepted non-finite float"
+    | exception Code_error.E _ -> print_endline "rejected non-finite float");
   [%expect
     {|
-    inf
-    -inf
-    nan
+    rejected non-finite float
+    rejected non-finite float
+    rejected non-finite float
     |}]
 ;;
 


### PR DESCRIPTION
JSON does not permit NaN or infinite numeric values, but the encoder currently emits invalid `nan`, `inf`, and `-inf` tokens. Reject non-finite floats with a code error instead.