### PR TITLE
perf(stdune): use memchr to validate spawn arguments

### DIFF
--- a/otherlibs/stdune/src/spawn.ml
+++ b/otherlibs/stdune/src/spawn.ml
@@ -1,3 +1,5 @@
+external contains_null : string -> bool = "dune_spawn_contains_null" [@@noalloc]
+
 module Working_dir = struct
   type 'a gen =
     | Path of string
@@ -222,7 +224,7 @@ let spawn_windows
 ;;
 
 let no_null s =
-  if String.contains s '\000'
+  if contains_null s
   then
     Printf.ksprintf
       invalid_arg

--- a/otherlibs/stdune/src/spawn_stubs.c
+++ b/otherlibs/stdune/src/spawn_stubs.c
@@ -26,6 +26,7 @@
 
 #include <errno.h>
 #include <stdint.h>
+#include <string.h>
 
 #ifndef ENOSYS
 #define ENOSYS EINVAL
@@ -208,6 +209,11 @@ static int __pthread_fchdir(int fd) {
 
 #endif
 
+CAMLprim value dune_spawn_contains_null(value v_string)
+{
+  return Val_bool(memchr(String_val(v_string), '\0', caml_string_length(v_string)) != NULL);
+}
+
 #if !defined(_WIN32)
 
 # if defined(USE_POSIX_SPAWN)
@@ -220,7 +226,6 @@ static int __pthread_fchdir(int fd) {
 # endif
 
 #include <assert.h>
-#include <string.h>
 #if !defined(__CYGWIN__) && !defined(__HAIKU__)
 #include <sys/syscall.h>
 #endif


### PR DESCRIPTION
Every process invocation validates the working directory, executable, and argument strings for embedded NUL bytes. Replace the OCaml byte-by-byte scan with an allocation-free C stub using libc `memchr`, while preserving the existing validation errors.
