### PR TITLE
test(stdune): cover blank-separated words

### DIFF
--- a/otherlibs/stdune/test/string_tests.ml
+++ b/otherlibs/stdune/test/string_tests.ml
@@ -208,6 +208,18 @@ let%expect_test _ =
   [%expect {| [ ""; ""; ""; "" ] |}]
 ;;
 
+let%expect_test "extract blank separated words" =
+  List.iter [ ""; " \t "; "one"; " one\ttwo  three " ] ~f:(fun s ->
+    String.extract_blank_separated_words s |> list string |> print_dyn);
+  [%expect
+    {|
+    []
+    []
+    [ "one" ]
+    [ "one"; "two"; "three" ]
+    |}]
+;;
+
 let%expect_test "split_lines preserves carriage returns outside CRLF" =
   List.iter [ "\r"; "first\n\r"; "first\rsecond"; "first\r\nsecond" ] ~f:(fun s ->
     String.split_lines s |> list string |> print_dyn);


### PR DESCRIPTION
Add regression coverage for extracting words from empty and blank-only strings, as well as inputs containing tabs, repeated separators, and surrounding blanks. This establishes the behavior before specializing the scanner.
