### PR TITLE
perf(stdune): reuse validated canonical path components

### DIFF
--- a/otherlibs/stdune/src/filename.ml
+++ b/otherlibs/stdune/src/filename.ml
@@ -28,6 +28,7 @@ let is_valid s =
 ;;
 
 let of_string s = Option.some_if (is_valid s) s
+let of_string_unchecked s = s
 
 let of_string_exn s =
   if is_valid s

--- a/otherlibs/stdune/src/filename.mli
+++ b/otherlibs/stdune/src/filename.mli
@@ -17,6 +17,10 @@ val quote : string -> string
 type t
 
 val of_string : string -> t option
+
+(** Convert a string that is already known to be a valid path component. *)
+val of_string_unchecked : string -> t
+
 val of_string_exn : string -> t
 val to_string : t -> string
 

--- a/otherlibs/stdune/src/path0.ml
+++ b/otherlibs/stdune/src/path0.ml
@@ -67,7 +67,7 @@ module Local_gen = struct
         | None -> t
         | Some i -> String.sub t ~pos:(i + 1) ~len:(len - i - 1))
     in
-    Filename.of_string_exn basename
+    Filename.of_string_unchecked basename
   ;;
 
   let to_dyn t = Dyn.String t
@@ -391,12 +391,14 @@ module Local_gen = struct
     then None
     else (
       match String.lsplit2 t ~on:'/' with
-      | None -> Some (Filename.of_string_exn t, root)
-      | Some (before, after) -> Some (Filename.of_string_exn before, after |> of_string))
+      | None -> Some (Filename.of_string_unchecked t, root)
+      | Some (before, after) -> Some (Filename.of_string_unchecked before, after))
   ;;
 
   let explode p =
-    if is_root p then [] else String.split p ~on:'/' |> List.map ~f:Filename.of_string_exn
+    if is_root p
+    then []
+    else String.split p ~on:'/' |> List.map ~f:Filename.of_string_unchecked
   ;;
 
   let of_comps = function


### PR DESCRIPTION
`Path.Local.t` already guarantees that its slash-separated components are valid filenames. Avoid validating those components again in `basename`, `explode`, and `split_first_component`, and reuse the canonical suffix returned by the latter directly.

General filename construction continues to use the checked APIs; the unchecked conversion is limited to boundaries where the local-path invariant provides the validation.
