### PR TITLE
test: reproduce nested build directory rejection

### DIFF
--- a/test/blackbox-tests/test-cases/custom-build-dir.t/run.t
+++ b/test/blackbox-tests/test-cases/custom-build-dir.t/run.t
@@ -18,6 +18,14 @@
   of the workspace.
   [1]
 
+The same restriction applies when the build directory is set in the environment.
+
+  $ DUNE_BUILD_DIR=.temp/dune dune build foo
+  Error: Invalid build directory: .temp/dune
+  The build directory must be an absolute path or a sub-directory of the root
+  of the workspace.
+  [1]
+
   $ mkdir project
   $ cp dune dune-project project/
 


### PR DESCRIPTION
## Description

Extend the custom build directory regression coverage with the reproduction
from #16112. The test records that a nested relative `DUNE_BUILD_DIR` is
currently rejected even though the diagnostic describes it as a subdirectory
of the workspace root.

This is the test-only change; the behavior change will follow separately.

## Related Issue and Motivation

Refs #16112.
