### PR TITLE
refactor(rules): share executable pps resolution

### DIFF
--- a/src/dune_rules/artifacts_db.ml
+++ b/src/dune_rules/artifacts_db.ml
@@ -9,16 +9,10 @@ let available_exes ~dir (exes : Executables.t) =
       Dune_project.dune_version project
     in
     let libs = Scope.libs scope in
-    let+ pps =
-      (* Instead of making the binary unavailable, this will just
-         fail when loading artifacts. This is clearly bad but
-         "optional" executables shouldn't be used. *)
-      Instrumentation.with_instrumentation
-        exes.buildable.preprocess.config
-        ~instrumentation_backend:(Lib.DB.instrumentation_backend libs)
-      |> Resolve.Memo.read_memo
-      >>| Preprocess.Per_module.pps
-    in
+    (* Instead of making the binary unavailable, this will just fail when
+       loading artifacts. This is clearly bad but "optional" executables
+       shouldn't be used. *)
+    let+ pps = Lib.DB.pps_for_preprocessing libs exes.buildable.preprocess.config in
     Lib.DB.resolve_user_written_deps
       libs
       (Executables.exe_target exes)

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -358,16 +358,10 @@ let executables_rules
 
 let compile_info ~scope (exes : Executables.t) =
   let dune_version = Scope.project scope |> Dune_project.dune_version in
-  let+ pps =
-    (* TODO resolution should be delayed *)
-    Instrumentation.with_instrumentation
-      exes.buildable.preprocess.config
-      ~instrumentation_backend:(Lib.DB.instrumentation_backend (Scope.libs scope))
-    |> Resolve.Memo.read_memo
-    >>| Preprocess.Per_module.pps
-  in
+  let libs = Scope.libs scope in
+  let+ pps = Lib.DB.pps_for_preprocessing libs exes.buildable.preprocess.config in
   Lib.DB.resolve_user_written_deps
-    (Scope.libs scope)
+    libs
     (Executables.exe_target exes)
     exes.buildable.libraries
     ~allow_unused_libraries:exes.buildable.allow_unused_libraries

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -517,19 +517,14 @@ end = struct
            else
              let* compile_info =
                let dune_version = Scope.project scope |> Dune_project.dune_version in
+               let libs = Scope.libs scope in
+               (* This is wrong. If the preprocessors fail to resolve, we
+                  shouldn't install the binary rather than failing outright. *)
                let+ pps =
-                 (* This is wrong. If the preprocessors fail to resolve,
-                    we shouldn't install the binary rather than failing outright
-                 *)
-                 Instrumentation.with_instrumentation
-                   exes.buildable.preprocess.config
-                   ~instrumentation_backend:
-                     (Lib.DB.instrumentation_backend (Scope.libs scope))
-                 |> Resolve.Memo.read_memo
-                 >>| Preprocess.Per_module.pps
+                 Lib.DB.pps_for_preprocessing libs exes.buildable.preprocess.config
                in
                Lib.DB.resolve_user_written_deps
-                 (Scope.libs scope)
+                 libs
                  ~forbidden_libraries:[]
                  (Executables.exe_target exes)
                  exes.buildable.libraries

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -2637,6 +2637,15 @@ module DB = struct
   let instrumentation_backend t libname =
     instrumentation_backend t.instrument_with (resolve t) libname
   ;;
+
+  let pps_for_preprocessing t preprocess =
+    (* TODO Instrumentation backend resolution should be delayed. *)
+    Instrumentation.with_instrumentation
+      preprocess
+      ~instrumentation_backend:(instrumentation_backend t)
+    |> Resolve.Memo.read_memo
+    |> Memo.map ~f:Preprocess.Per_module.pps
+  ;;
 end
 
 let to_resolve_memo

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -218,6 +218,11 @@ module DB : sig
     :  t
     -> Loc.t * Lib_name.t
     -> Preprocess.Without_instrumentation.t option Resolve.Memo.t
+
+  val pps_for_preprocessing
+    :  t
+    -> Preprocess.With_instrumentation.t Preprocess.Per_module.t
+    -> (Loc.t * Lib_name.t) list Memo.t
 end
 
 (** {1 Transitive closure} *)

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -81,11 +81,7 @@ let add_stanza db ~dir (acc, pps) stanza =
           Dune_project.dune_version project
         in
         let+ pps =
-          Instrumentation.with_instrumentation
-            exes.buildable.preprocess.config
-            ~instrumentation_backend:(Lib.DB.instrumentation_backend (Scope.libs scope))
-          |> Resolve.Memo.read_memo
-          >>| Preprocess.Per_module.pps
+          Lib.DB.pps_for_preprocessing (Scope.libs scope) exes.buildable.preprocess.config
         in
         Lib.DB.resolve_user_written_deps
           db


### PR DESCRIPTION
Executable compilation, installation, artifact loading, and utop generation independently applied instrumentation and collected the resulting PPX dependencies before resolving libraries.

Centralize that logic in `Lib.DB`. The helper operates on preprocessing configuration and reuses the database's existing instrumentation resolver, avoiding a dependency from the library database onto executable stanzas.
