### PR TITLE
ci(copilot): move Nix activation into setup workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,38 +2,19 @@
 
 For full development guidance, see [AGENTS.md](../AGENTS.md).
 
-## Environment Setup
-
-This repository uses a [Nix](https://nixos.org/) dev shell to provide the
-OCaml toolchain (`ocaml`, `dune`, `opam`, `ocamlformat`, etc.).  The shell is
-**not** activated automatically, so every command must be prefixed with
-`nix develop -c`.
-
-### First-time setup
-
-On a fresh checkout (or after the `_boot/` directory has been removed), run
-bootstrap once before anything else:
-
-```bash
-nix develop -c make bootstrap
-```
-
-This builds `_boot/dune.exe`, the seed binary that Dune uses to build itself.
-It is slow but only needed once per environment.
-
 ## Common Commands
 
-All commands from [AGENTS.md](../AGENTS.md) must be wrapped with
-`nix develop -c`:
+The setup workflow prepares Copilot's development environment. Run repository
+commands directly:
 
 ```bash
-nix develop -c dune build @check          # Quick build (recommended)
-nix develop -c dune build @install        # Full build
-nix develop -c dune runtest dir/          # Run tests in a directory
-nix develop -c dune runtest dir/test.t    # Run a specific cram test
-nix develop -c dune fmt                   # Auto-format code (run before committing)
-nix develop -c dune promote               # Accept test output changes (ask user first)
-nix develop -c make dev                   # Full build (bootstraps if necessary)
+dune build @check          # Quick build (recommended)
+dune build @install        # Full build
+dune runtest dir/          # Run tests in a directory
+dune runtest dir/test.t    # Run a specific cram test
+dune fmt                   # Auto-format code (run before committing)
+dune promote               # Accept test output changes (ask user first)
+make dev                   # Full build (bootstraps if necessary)
 ```
 
 ## Reviewing PRs

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -36,5 +36,63 @@ jobs:
           gc-max-store-size-linux: 2G
           save: false
 
-      - name: Enter Nix dev shell
-        run: nix develop -c true
+      - name: Prepare Nix development environment
+        shell: bash
+        run: |
+          nix develop path:. -c make bootstrap
+
+          dev_env="$RUNNER_TEMP/dune-dev-env.json"
+          nix print-dev-env path:. --json > "$dev_env"
+          python3 - "$dev_env" "$GITHUB_ENV" <<'PY'
+          import json
+          import os
+          import secrets
+          import sys
+
+          with open(sys.argv[1]) as source:
+              variables = json.load(source)["variables"]
+
+          # print-dev-env contains derivation variables, not the ambient runner
+          # environment. Preserve runner controls and transient shell state.
+          excluded = {
+              "BASH_ENV",
+              "CI",
+              "NODE_OPTIONS",
+              "HOME",
+              "NIX_BUILD_TOP",
+              "NIX_LOG_FD",
+              "OLDPWD",
+              "TEMP",
+              "TEMPDIR",
+              "TMP",
+              "TMPDIR",
+              "shellHook",
+          }
+
+          with open(sys.argv[2], "a") as output:
+              for name, variable in variables.items():
+                  if variable["type"] != "exported" or name in excluded:
+                      continue
+                  if name.startswith(("ACTIONS_", "GITHUB_", "RUNNER_")):
+                      continue
+
+                  value = variable["value"]
+                  if name == "PATH":
+                      value = f"{value}{os.pathsep}{os.environ['PATH']}"
+                  elif name == "XDG_DATA_DIRS" and os.environ.get(name):
+                      value = f"{value}{os.pathsep}{os.environ[name]}"
+
+                  delimiter = f"__NIX_ENV_{secrets.token_hex(16)}__"
+                  output.write(f"{name}<<{delimiter}\n{value}\n{delimiter}\n")
+          PY
+          # The repository shell hook only sets this variable and Bash
+          # completion, which noninteractive agent commands do not need.
+          printf 'DUNE_SOURCE_ROOT=%s\n' "$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
+
+      - name: Verify unwrapped commands
+        shell: bash
+        run: |
+          test "$INSIDE_NIX" = true
+          command -v ocaml
+          command -v dune
+          dune --version


### PR DESCRIPTION
## Description

- Bootstrap Dune and export the Nix development-shell environment from the Copilot setup workflow.
- Persist exported variables through `GITHUB_ENV` so Copilot can run repository commands without per-command `nix develop` wrappers.
- Remove Copilot-specific Nix wrapping guidance from the shared instruction context.

## Related Issue and Motivation

The Nix wrapping guidance is consumed by non-Copilot agents even though those agents already run in the correct development environment. Moving environment provisioning into Copilot's setup job keeps it scoped to the Copilot runner.

## Testing

- Linted `.github/workflows/copilot-setup-steps.yml` with `actionlint`.
- Simulated the workflow setup and verification steps with a clean child environment; unwrapped `ocaml`, `dune`, and `dune --version` succeeded.

## Checklist

- [x] Tests added, if applicable.
- [x] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes. Not user-facing.
- [x] Documentation added for any user-facing changes. Not user-facing.