### PR TITLE
fix(ocaml): resolve module paths from the initial directory

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1147,6 +1147,17 @@ let normalize_path path =
   else path
 ;;
 
+let source_path t path =
+  if Filename.is_relative path
+  then Path.Source.of_string (prefix_target t path)
+  else (
+    let root = Path.External.cwd () |> normalize_path |> Path.external_ in
+    match Path.drop_prefix ~prefix:root (Path.of_string path) with
+    | Some path -> Path.Source.of_local path
+    | None ->
+      User_error.raise [ Pp.text "Path is not a descendant of the workspace root." ])
+;;
+
 let print_entering_message c =
   let cwd = Path.to_absolute_filename Path.root in
   if cwd <> Fpath.initial_cwd && not c.builder.no_print_directory

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -23,6 +23,11 @@ val sandbox_actions : t -> bool
 val action_runner : t -> Dune_engine.Action_runner.t option
 val action_runner_requested : t -> bool
 val prefix_target : t -> string -> string
+
+(** Resolve a command-line path relative to the directory where Dune was
+    started, and require it to be inside the workspace. *)
+val source_path : t -> string -> Stdune.Path.Source.t
+
 val find_default_trace_file : unit -> string
 
 (** [No_build] describes the most basic command-line flags that don't affect

--- a/bin/ocaml/inferred_mli.ml
+++ b/bin/ocaml/inferred_mli.ml
@@ -14,26 +14,6 @@ let man =
 
 let info = Cmd.info "inferred-mli" ~doc ~man
 
-let source_path common module_path =
-  if Filename.is_relative module_path
-  then
-    Common.prefix_target common module_path
-    |> Path.Local.of_string
-    |> Path.Source.of_local
-  else (
-    let root =
-      (Common.root common).dir
-      |> Path.of_string
-      |> Path.to_absolute_filename
-      |> Path.of_string
-    in
-    match Path.drop_prefix ~prefix:root (Path.of_string module_path) with
-    | Some module_path -> Path.Source.of_local module_path
-    | None ->
-      User_error.raise
-        [ Pp.text "Module path is not a descendant of the workspace root." ])
-;;
-
 let term =
   let+ builder = Common.Builder.term
   and+ module_path =
@@ -43,7 +23,7 @@ let term =
       & info [] ~docv:"MODULE" ~doc:(Some "Path to an OCaml implementation."))
   and+ context_name = Common.context_arg ~doc:(Some "Build context to use.") in
   let common, config = Common.init builder in
-  let source = source_path common module_path in
+  let source = Common.source_path common module_path in
   if
     not
       (Filename.Extension.Or_empty.check

--- a/bin/ocaml/top.ml
+++ b/bin/ocaml/top.ml
@@ -234,23 +234,7 @@ module Module = struct
           Dune_engine.Context_name.Map.find setup.scontexts ctx_name |> Option.value_exn
         in
         let+ directives =
-          let module_path =
-            if Filename.is_relative module_path
-            then Path.Local.of_string module_path
-            else (
-              let root =
-                (Common.root common).dir
-                |> Path.of_string
-                |> Path.to_absolute_filename
-                |> Path.of_string
-              in
-              match Path.drop_prefix ~prefix:root (Path.of_string module_path) with
-              | Some module_path -> module_path
-              | None ->
-                User_error.raise
-                  [ Pp.text "Module path not a descendent of workspace root." ])
-          in
-          module_directives sctx (Path.Source.of_local module_path)
+          module_directives sctx (Common.source_path common module_path)
         in
         Dune_rules.Toplevel.print_toplevel_init_file directives))
   ;;

--- a/doc/changes/fixed/16135.md
+++ b/doc/changes/fixed/16135.md
@@ -1,0 +1,3 @@
+- Resolve relative paths passed to `dune ocaml top-module` from the directory
+  where Dune was started, allowing use from workspace subdirectories. (#16135,
+  @rgrinberg)

--- a/test/blackbox-tests/test-cases/top-module/load-from-lib.t
+++ b/test/blackbox-tests/test-cases/top-module/load-from-lib.t
@@ -66,13 +66,16 @@ We try to load a module defined in a library with a dependency
   open Foo__
   ;;
 
-Relative module paths are currently resolved from the workspace root rather
-than the directory where Dune was started.
+Relative module paths are resolved from the directory where Dune was started.
 
   $ (cd foo &&
   >  unset INSIDE_DUNE &&
   >  dune ocaml top-module foo.ml)
-  Entering directory '$TESTCASE_ROOT'
-  Error: no module found
-  Leaving directory '$TESTCASE_ROOT'
-  [1]
+  #directory "$TESTCASE_ROOT/_build/default/.topmod/foo/foo.ml";;
+  #directory "$TESTCASE_ROOT/_build/default/mydummylib/.mydummylib.objs/byte";;
+  #load "$TESTCASE_ROOT/_build/default/mydummylib/mydummylib.cma";;
+  #load "$TESTCASE_ROOT/_build/default/foo/.foo.objs/byte/foo__.cmo";;
+  #load "$TESTCASE_ROOT/_build/default/foo/.foo.objs/byte/foo__Bar.cmo";;
+  #load "$TESTCASE_ROOT/_build/default/.topmod/foo/foo.ml/foo.cmo";;
+  open Foo__
+  ;;


### PR DESCRIPTION
Centralize command-line source path resolution in `Common.source_path` and use
it for both `dune ocaml top-module` and `dune ocaml inferred-mli`.

Relative paths are now resolved from the directory where Dune was started,
which fixes `top-module` when invoked from a workspace subdirectory. Absolute
paths continue to be accepted only when they are inside the workspace.

This follows #16111 and the test-only reproduction in #16134.
