### PR TITLE
refactor(utop): use shared source path handling

### DIFF
--- a/bin/ocaml/utop.ml
+++ b/bin/ocaml/utop.ml
@@ -28,16 +28,7 @@ let term =
   (* CR-someday Alizter: document this option *)
   and+ args = Arg.(value & pos_right 0 string [] (Arg.info [] ~docv:"ARGS" ~doc:None)) in
   let common, config = Common.init builder in
-  let dir =
-    match Path.of_string dir with
-    | External _ as ext ->
-      (* Absolute path: if it's an external path inside the workspace, localize it.
-        Otherwise leave it external so the existing error handling kicks in *)
-      Path.Expert.try_localize_external ext |> Path.to_string
-    | _ ->
-      (* Relative path: account for the cwd when run from a subdirectory. *)
-      Common.prefix_target common dir
-  in
+  let dir = Common.source_path common dir |> Path.Source.to_string in
   if not (Fpath.is_directory (Path.to_string (Path.of_string dir)))
   then User_error.raise [ Pp.textf "cannot find directory: %s" (String.maybe_quoted dir) ];
   let env, utop_path =

--- a/test/blackbox-tests/test-cases/absolute-paths/utop-absolute.t
+++ b/test/blackbox-tests/test-cases/absolute-paths/utop-absolute.t
@@ -29,6 +29,6 @@ relative form:
 An absolute path that is genuinely outside the workspace should produce a
 clean user error rather than a crash.
 
-  $ dune utop /tmp/does-not-exist 2>&1 | grep "cannot find"
-  Error: cannot find directory: /tmp/does-not-exist
+  $ dune utop /tmp/does-not-exist
+  Error: Path is not a descendant of the workspace root.
   [1]


### PR DESCRIPTION
Use `Common.source_path`, introduced in #16135, to resolve the directory passed
to `dune utop`.

This removes the command's separate relative/absolute localization logic while
preserving support for relative paths and absolute paths inside the workspace.
Paths outside the workspace now use the shared source-path error.
