### PR TITLE
test(ocaml): demonstrate top absolute directory failure

### DIFF
--- a/test/blackbox-tests/test-cases/toplevel/toplevel-integration.t
+++ b/test/blackbox-tests/test-cases/toplevel/toplevel-integration.t
@@ -18,6 +18,21 @@ Test toplevel-init-file on a tiny project
   #directory "$TESTCASE_ROOT/_build/default/.test.objs/byte";;
   #load "$TESTCASE_ROOT/_build/default/test.cma";;
 
+Absolute directory arguments are currently rejected.
+
+  $ dune ocaml top "$PWD" 2>&1 | awk '/Internal error!/,/Raised at/'
+  Internal error! Please report to https://github.com/ocaml/dune/issues,
+  providing the file _build/trace.csexp, if possible. This includes build
+  commands, message logs, and file paths.
+  Description:
+    ("Local.relative: received absolute path",
+     { t = "default"
+     ; path =
+         "$TESTCASE_ROOT"
+     })
+  Raised at Stdune__Code_error.raise in file
+  [1]
+
   $ ocaml -stdin <<EOF
   > #use_output "dune ocaml top";;
   > Test.Main.hello ();;


### PR DESCRIPTION
Add a regression test recording the current internal error when `dune ocaml
top` receives an absolute directory path inside the workspace.

This is test-only groundwork for resolving the command's directory through the
shared `Common.source_path` handling.
