### PR TITLE
test(rocq): demonstrate absolute top file failure

### DIFF
--- a/test/blackbox-tests/test-cases/rocq/coqtop/coqtop-workspace.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/coqtop/coqtop-workspace.t/run.t
@@ -14,6 +14,21 @@ Calling "dune rocq top" from the workspace root.
   $ coqtop_test project/coq_dir2/file5.v
   $ coqtop_test project/coq_dir2/dir2/file6.v
 
+Absolute file arguments are currently rejected.
+
+  $ true | dune rocq top "$PWD/file1.v" 2>&1 | awk '/Internal error!/,/Raised at/'
+  Internal error! Please report to https://github.com/ocaml/dune/issues,
+  providing the file _build/trace.csexp, if possible. This includes build
+  commands, message logs, and file paths.
+  Description:
+    ("Local.relative: received absolute path",
+     { t = "."
+     ; path =
+         "$TESTCASE_ROOT/file1.v"
+     })
+  Raised at Stdune__Code_error.raise in file
+  [1]
+
 Calling "dune rocq top" from the "coq_dir1" directory.
 
   $ cd coq_dir1


### PR DESCRIPTION
Add a regression test recording the current internal error when `dune rocq
top` receives an absolute source-file path inside the workspace.

This is test-only groundwork for resolving the command's file argument through
the shared `Common.source_path` handling.
