### PR TITLE
test(promotion): demonstrate absolute path failure

### DIFF
--- a/test/blackbox-tests/test-cases/promote/promotion-list.t
+++ b/test/blackbox-tests/test-cases/promote/promotion-list.t
@@ -28,6 +28,22 @@ Tests dune promotion list output.
   $ dune promotion list b.expected --diff-command 'diff -u'
   b.expected
 
+Absolute paths inside the workspace are currently rejected.
+
+  $ dune promotion list "$PWD/b.expected" --diff-command 'diff -u' 2>&1 \
+  > | awk '/Internal error!/,/Raised at/'
+  Internal error! Please report to https://github.com/ocaml/dune/issues,
+  providing the file _build/trace.csexp, if possible. This includes build
+  commands, message logs, and file paths.
+  Description:
+    ("Local.relative: received absolute path",
+     { t = "."
+     ; path =
+         "$TESTCASE_ROOT/b.expected"
+     })
+  Raised at Stdune__Code_error.raise in file
+  [1]
+
   $ dune promotion list a.expected nothing-to-promote.txt --diff-command 'diff -u'
   Warning: Nothing to promote for nothing-to-promote.txt.
   a.expected


### PR DESCRIPTION
Add a regression test recording the current internal error when a promotion
subcommand receives an absolute source path inside the workspace.

This is test-only groundwork for using the shared `Common.source_path` handling
for promotion file and directory arguments.
