### PR TITLE
test(describe): demonstrate absolute directory rejection

### DIFF
--- a/test/blackbox-tests/test-cases/describe/describe.t
+++ b/test/blackbox-tests/test-cases/describe/describe.t
@@ -1411,6 +1411,12 @@ not stable across different setups.
           (for_impl ()))))))
      (include_dirs (_build/default/virtual_impl2/.virtual_impl2.objs/byte)))))
 
+Absolute directory filters inside the workspace are currently rejected.
+
+  $ dune describe workspace --lang 0.1 "$PWD/virtual"
+  Error: relative file path expected
+  [1]
+
   $ dune describe workspace --lang 0.1 --sanitize-for-tests virtual | censor
   ((root /WORKSPACE_ROOT)
    (build_context _build/default)


### PR DESCRIPTION
Add a regression test recording that `dune describe workspace` rejects an
absolute directory filter inside the workspace.

This is test-only groundwork for resolving workspace directory filters through
the shared `Common.source_path` handling.
