### PR TITLE
fix(ocaml): accept absolute directories in top

### DIFF
--- a/bin/ocaml/top.ml
+++ b/bin/ocaml/top.ml
@@ -60,8 +60,9 @@ let term =
       let context = Super_context.context sctx in
       let* libs =
         let dir =
-          let build_dir = Context.build_dir context in
-          Path.Build.relative build_dir (Common.prefix_target common dir)
+          Path.Build.append_source
+            (Context.build_dir context)
+            (Common.source_path common dir)
         in
         let* db =
           let+ scope = Dune_rules.Scope.DB.find_by_dir dir in

--- a/doc/changes/fixed/16142.md
+++ b/doc/changes/fixed/16142.md
@@ -1,0 +1,2 @@
+- Allow `dune ocaml top` to accept absolute directory paths inside the
+  workspace. (#16142, @rgrinberg)

--- a/test/blackbox-tests/test-cases/toplevel/toplevel-integration.t
+++ b/test/blackbox-tests/test-cases/toplevel/toplevel-integration.t
@@ -18,20 +18,11 @@ Test toplevel-init-file on a tiny project
   #directory "$TESTCASE_ROOT/_build/default/.test.objs/byte";;
   #load "$TESTCASE_ROOT/_build/default/test.cma";;
 
-Absolute directory arguments are currently rejected.
+Absolute directory arguments identify the same source directory.
 
-  $ dune ocaml top "$PWD" 2>&1 | awk '/Internal error!/,/Raised at/'
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
-  providing the file _build/trace.csexp, if possible. This includes build
-  commands, message logs, and file paths.
-  Description:
-    ("Local.relative: received absolute path",
-     { t = "default"
-     ; path =
-         "$TESTCASE_ROOT"
-     })
-  Raised at Stdune__Code_error.raise in file
-  [1]
+  $ dune ocaml top "$PWD"
+  #directory "$TESTCASE_ROOT/_build/default/.test.objs/byte";;
+  #load "$TESTCASE_ROOT/_build/default/test.cma";;
 
   $ ocaml -stdin <<EOF
   > #use_output "dune ocaml top";;


### PR DESCRIPTION
Resolve the directory passed to `dune ocaml top` through
`Common.source_path`, then map the resulting source path into the selected
build context.

This accepts absolute directories inside the workspace instead of raising the
internal error recorded in #16137.
