### PR TITLE
fix(promotion): accept absolute source paths

### DIFF
--- a/bin/promotion.ml
+++ b/bin/promotion.ml
@@ -5,9 +5,7 @@ let files_to_promote ~common files : Dune_rpc.Files_to_promote.t =
   match files with
   | [] -> All
   | _ ->
-    let files =
-      List.map files ~f:(fun fn -> Path.Source.of_string (Common.prefix_target common fn))
-    in
+    let files = List.map files ~f:(Common.source_path common) in
     These files
 ;;
 

--- a/doc/changes/fixed/16143.md
+++ b/doc/changes/fixed/16143.md
@@ -1,0 +1,2 @@
+- Allow Dune promotion commands to accept absolute source paths inside the
+  workspace. (#16143, @rgrinberg)

--- a/test/blackbox-tests/test-cases/promote/promotion-list.t
+++ b/test/blackbox-tests/test-cases/promote/promotion-list.t
@@ -28,21 +28,10 @@ Tests dune promotion list output.
   $ dune promotion list b.expected --diff-command 'diff -u'
   b.expected
 
-Absolute paths inside the workspace are currently rejected.
+Absolute paths inside the workspace identify the same promotion.
 
-  $ dune promotion list "$PWD/b.expected" --diff-command 'diff -u' 2>&1 \
-  > | awk '/Internal error!/,/Raised at/'
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
-  providing the file _build/trace.csexp, if possible. This includes build
-  commands, message logs, and file paths.
-  Description:
-    ("Local.relative: received absolute path",
-     { t = "."
-     ; path =
-         "$TESTCASE_ROOT/b.expected"
-     })
-  Raised at Stdune__Code_error.raise in file
-  [1]
+  $ dune promotion list "$PWD/b.expected" --diff-command 'diff -u'
+  b.expected
 
   $ dune promotion list a.expected nothing-to-promote.txt --diff-command 'diff -u'
   Warning: Nothing to promote for nothing-to-promote.txt.


### PR DESCRIPTION
Resolve promotion file and directory arguments through `Common.source_path`.
Absolute paths inside the workspace now select the same pending promotions as
their relative forms.

This fixes the internal error recorded in #16139.
