### PR TITLE
fix(describe): accept absolute workspace directories

### DIFF
--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -857,7 +857,7 @@ module Crawl = struct
 end
 
 let find_dir common dir =
-  let p = Path.Source.(relative root) (Common.prefix_target common dir) in
+  let p = Common.source_path common dir in
   let s = Path.source p in
   if not @@ Fpath.exists (Path.to_string s)
   then User_error.raise [ Pp.textf "No such file or directory: %s" (Path.to_string s) ];
@@ -894,7 +894,7 @@ let term : unit Term.t =
       let open Dune_lang.Decoder in
       fields
       @@ field "workspace"
-      @@ let+ dirs = repeat relative_file in
+      @@ let+ dirs = repeat string in
          (* [None] means that all directories should be accepted,
             whereas [Some l] means that only the directories in the
             list [l] should be accepted. The checks on whether the

--- a/doc/changes/fixed/16144.md
+++ b/doc/changes/fixed/16144.md
@@ -1,0 +1,2 @@
+- Allow `dune describe workspace` to accept absolute directory filters inside
+  the workspace. (#16144, @rgrinberg)

--- a/test/blackbox-tests/test-cases/describe/describe.t
+++ b/test/blackbox-tests/test-cases/describe/describe.t
@@ -1411,11 +1411,11 @@ not stable across different setups.
           (for_impl ()))))))
      (include_dirs (_build/default/virtual_impl2/.virtual_impl2.objs/byte)))))
 
-Absolute directory filters inside the workspace are currently rejected.
+Absolute directory filters inside the workspace are accepted.
 
-  $ dune describe workspace --lang 0.1 "$PWD/virtual"
-  Error: relative file path expected
-  [1]
+  $ dune describe workspace --lang 0.1 --sanitize-for-tests "$PWD/virtual" \
+  > | grep -o '(name virtual)'
+  (name virtual)
 
   $ dune describe workspace --lang 0.1 --sanitize-for-tests virtual | censor
   ((root /WORKSPACE_ROOT)


### PR DESCRIPTION
Parse `dune describe workspace` directory filters as path strings and resolve
them through `Common.source_path`.

Absolute directory filters inside the workspace now select the same source
directory as relative filters, fixing the rejection recorded in #16140.
