### PR TITLE
refactor(memo): add Option.value

### DIFF
--- a/otherlibs/stdune/src/monad.ml
+++ b/otherlibs/stdune/src/monad.ml
@@ -124,6 +124,12 @@ module Option (M : S) = struct
     | None -> M.return None
     | Some a -> f a
   ;;
+
+  let value option ~default =
+    match option with
+    | Some a -> M.return a
+    | None -> default ()
+  ;;
 end
 
 module Result (M : S) = struct

--- a/otherlibs/stdune/src/monad_intf.ml
+++ b/otherlibs/stdune/src/monad_intf.ml
@@ -43,6 +43,7 @@ module type Option = sig
   val iter : 'a option -> f:('a -> unit t) -> unit t
   val map : 'a option -> f:('a -> 'b t) -> 'b option t
   val bind : 'a option -> f:('a -> 'b option t) -> 'b option t
+  val value : 'a option -> default:(unit -> 'a t) -> 'a t
 end
 
 module type Result = sig

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -217,19 +217,15 @@ let create
       ~modules
       ~for_
   and+ bin_annot =
-    match bin_annot with
-    | Some b -> Memo.return b
-    | None -> Env_stanza_db.bin_annot ~dir:(Obj_dir.dir obj_dir)
+    Memo.Option.value bin_annot ~default:(fun () ->
+      Env_stanza_db.bin_annot ~dir:(Obj_dir.dir obj_dir))
   and+ bin_annot_cms =
-    match bin_annot_cms with
-    | Some b -> Memo.return b
-    | None -> Env_stanza_db.bin_annot_cms ~dir:(Obj_dir.dir obj_dir)
+    Memo.Option.value bin_annot_cms ~default:(fun () ->
+      Env_stanza_db.bin_annot_cms ~dir:(Obj_dir.dir obj_dir))
   and+ cms_cmt_dependency =
-    match cms_cmt_dependency with
-    | Some v -> Memo.return v
-    | None ->
+    Memo.Option.value cms_cmt_dependency ~default:(fun () ->
       let context = Super_context.context super_context in
-      Memo.return (Context.cms_cmt_dependency context)
+      Memo.return (Context.cms_cmt_dependency context))
   in
   { super_context
   ; scope

--- a/src/dune_rules/env_node.ml
+++ b/src/dune_rules/env_node.ml
@@ -11,12 +11,10 @@ let external_env t = Memo.Lazy.force t.external_env
 let artifacts t = Memo.Lazy.force t.artifacts
 
 let expand_str_lazy expander sw =
-  match String_with_vars.text_only sw with
-  | Some s -> Memo.return s
-  | None ->
+  Memo.Option.value (String_with_vars.text_only sw) ~default:(fun () ->
     let open Memo.O in
     let* expander = expander in
-    Expander.No_deps.expand_str expander sw
+    Expander.No_deps.expand_str expander sw)
 ;;
 
 let make

--- a/src/dune_rules/env_stanza_db.ml
+++ b/src/dune_rules/env_stanza_db.ml
@@ -100,13 +100,11 @@ let bin_annot_cms ~dir =
     value ~default:None ~dir ~f:(fun (t : Dune_env.config) ->
       Memo.return (Option.map t.bin_annot_cms ~f:Option.some))
   in
-  match explicit with
-  | Some b -> Memo.return b
-  | None ->
+  Memo.Option.value explicit ~default:(fun () ->
     (* Enabled by default for OxCaml *)
     let* context = Context.DB.by_dir dir in
     let+ ocaml = Context.ocaml context in
-    Ocaml_config.ox ocaml.ocaml_config
+    Ocaml_config.ox ocaml.ocaml_config)
 ;;
 
 let inline_tests ~dir =
@@ -116,11 +114,9 @@ let inline_tests ~dir =
     match t.inline_tests with
     | None -> None
     | Some s -> Some (Some s))
-  >>= function
-  | Some s -> Memo.return s
-  | None ->
+  >>= Memo.Option.value ~default:(fun () ->
     let+ profile = profile ~dir in
-    if Profile.is_inline_test profile then Dune_env.Inline_tests.Enabled else Disabled
+    if Profile.is_inline_test profile then Dune_env.Inline_tests.Enabled else Disabled)
 ;;
 
 module Inherit = struct

--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -1060,9 +1060,9 @@ let jsoo_compilation_mode
       ~(in_context : Js_of_ocaml.In_context.t Js_of_ocaml.Mode.Pair.t)
       ~mode
   =
-  match (Js_of_ocaml.Mode.Pair.select ~mode in_context).compilation_mode with
-  | None -> js_of_ocaml_compilation_mode t ~dir ~mode
-  | Some x -> Memo.return x
+  Memo.Option.value
+    (Js_of_ocaml.Mode.Pair.select ~mode in_context).compilation_mode
+    ~default:(fun () -> js_of_ocaml_compilation_mode t ~dir ~mode)
 ;;
 
 let jsoo_is_whole_program t ~dir ~in_context =
@@ -1090,9 +1090,8 @@ let build_standalone_runtime cc ~loc ~in_context ~jsoo_mode:mode =
     in_context
   in
   let* cmode =
-    match compilation_mode with
-    | None -> js_of_ocaml_compilation_mode sctx ~dir ~mode
-    | Some x -> Memo.return x
+    Memo.Option.value compilation_mode ~default:(fun () ->
+      js_of_ocaml_compilation_mode sctx ~dir ~mode)
   in
   match (cmode : Js_of_ocaml.Compilation_mode.t) with
   | Whole_program -> Memo.return None
@@ -1158,13 +1157,10 @@ let build_exe
     Rule_mode_expand.expand_optional_promote ~expander ~dir promote
   in
   let* cmode =
-    match compilation_mode with
-    | None -> js_of_ocaml_compilation_mode sctx ~dir ~mode
-    | Some x -> Memo.return x
+    Memo.Option.value compilation_mode ~default:(fun () ->
+      js_of_ocaml_compilation_mode sctx ~dir ~mode)
   and* sourcemap =
-    match sourcemap with
-    | None -> js_of_ocaml_sourcemap sctx ~dir ~mode
-    | Some x -> Memo.return x
+    Memo.Option.value sourcemap ~default:(fun () -> js_of_ocaml_sourcemap sctx ~dir ~mode)
   in
   assert (Js_of_ocaml.Mode.select ~mode ~js:(wasm_files = []) ~wasm:true);
   let runtime_files = javascript_files @ wasm_files in

--- a/src/dune_rules/rocq/rocq_rules.ml
+++ b/src/dune_rules/rocq/rocq_rules.ml
@@ -58,17 +58,15 @@ let rocq ~loc ~dir ~sctx =
 ;;
 
 let select_native_mode ~sctx ~dir (buildable : Rocq_stanza.Buildable.t) =
-  match buildable.mode with
-  | Some x -> Memo.return x
-  | None ->
+  Memo.Option.value buildable.mode ~default:(fun () ->
     let* rocq = rocq ~sctx ~dir ~loc:buildable.loc in
     let+ config = Rocq_config.make ~rocq in
-    (match config with
-     | Error _ -> Rocq_mode.VoOnly
-     | Ok config ->
-       (match Rocq_config.by_name config "rocq_native_compiler_default" with
-        | Some (String "yes") | Some (String "ondemand") -> Rocq_mode.Native
-        | _ -> Rocq_mode.VoOnly))
+    match config with
+    | Error _ -> Rocq_mode.VoOnly
+    | Ok config ->
+      (match Rocq_config.by_name config "rocq_native_compiler_default" with
+       | Some (String "yes") | Some (String "ondemand") -> Rocq_mode.Native
+       | _ -> Rocq_mode.VoOnly))
 ;;
 
 let rocq_env =

--- a/src/dune_rules/sub_system.ml
+++ b/src/dune_rules/sub_system.ml
@@ -82,9 +82,8 @@ module Register_backend (M : Backend) = struct
   open Selection_error
 
   let written_by_user_or_scan ~written_by_user ~to_scan =
-    (match written_by_user with
-     | Some l -> Memo.return l
-     | None -> Memo.parallel_map to_scan ~f:get >>| List.filter_opt)
+    Memo.Option.value written_by_user ~default:(fun () ->
+      Memo.parallel_map to_scan ~f:get >>| List.filter_opt)
     >>| function
     | [] -> Error No_backend_found
     | l -> Ok l


### PR DESCRIPTION
Several memoized rule paths repeat the same operation: return an optional value when present, otherwise lazily compute a monadic default.

Add `Option.value` to the monad interface and use it across executable configuration, environment lookup, JavaScript and Rocq rules, and subsystem selection. The default remains a thunk, so existing short-circuiting behavior is preserved.
