### PR TITLE
refactor(copy-files): reuse build context

### DIFF
--- a/src/dune_rules/simple_rules.ml
+++ b/src/dune_rules/simple_rules.ml
@@ -247,11 +247,11 @@ let copy_files sctx ~dir ~expander ~src_dir (def : Copy_files.t) =
            (Path.Source.to_string_maybe_quoted src_dir));
   let src_in_src = Path.parent_exn glob_in_src in
   let glob = Path.basename glob_in_src |> Filename.to_string |> Glob.of_string_exn loc in
+  let context = Super_context.context sctx in
   let src_in_build =
     match Path.as_in_source_tree src_in_src with
     | None -> src_in_src
     | Some src_in_src ->
-      let context = Super_context.context sctx in
       Path.Build.append_source (Context.build_dir context) src_in_src |> Path.build
   in
   let* exists_or_generated =
@@ -299,7 +299,6 @@ let copy_files sctx ~dir ~expander ~src_dir (def : Copy_files.t) =
     |> Memo.parallel_iter ~f:(fun basename ->
       let file_src = Path.relative_fname src_in_build basename in
       let file_dst = Path.Build.relative_fname dir basename in
-      let context = Super_context.context sctx in
       Super_context.add_rule
         sctx
         ~loc


### PR DESCRIPTION
Resolve the build context once for source mapping and per-file copy rules.