### PR TITLE
fix(include-qualified): hint dotted module references

### DIFF
--- a/src/dune_lang/module_reference.ml
+++ b/src/dune_lang/module_reference.ml
@@ -50,8 +50,34 @@ let is_qualified t =
 
 let make ~loc ~mode path = { loc; path; mode }
 
-let parse_component loc component =
-  Module_name.of_string_user_error (loc, component) |> User_error.ok_exn
+let slash_separated_path value =
+  match String.split value ~on:'/' with
+  | first :: second :: rest ->
+    Option.List.traverse (first :: second :: rest) ~f:Module_name.of_string_opt
+    |> Option.map ~f:Nonempty_list.of_list_exn
+  | [] | [ _ ] -> None
+;;
+
+let parse_component loc ~mode component =
+  match Module_name.of_string_user_error (loc, component) with
+  | Ok name -> name
+  | Error message ->
+    let message =
+      match mode with
+      | Legacy -> message
+      | Path ->
+        (match slash_separated_path component with
+         | None -> message
+         | Some suggestion ->
+           { message with
+             User_message.hints =
+               [ Pp.textf
+                   "%s would be a correct module reference"
+                   (Module_name.Path.to_string suggestion)
+               ]
+           })
+    in
+    User_error.ok_exn (Error message)
 ;;
 
 let of_string version (loc, value) =
@@ -65,7 +91,9 @@ let of_string version (loc, value) =
        (3, 25)
        ~what:"Using qualified module references"
    | (Legacy | Path), _ -> ());
-  let path = List.map components ~f:(parse_component loc) |> Nonempty_list.of_list_exn in
+  let path =
+    List.map components ~f:(parse_component loc ~mode) |> Nonempty_list.of_list_exn
+  in
   make ~loc ~mode path
 ;;
 

--- a/test/blackbox-tests/test-cases/include-qualified/preprocess-per-module.t
+++ b/test/blackbox-tests/test-cases/include-qualified/preprocess-per-module.t
@@ -18,7 +18,8 @@ Regression test for GH-15578: qualified modules can be selected in
 
   $ dune build
 
-Using a slash instead does not work either:
+A slash-separated source path is rejected with a hint for the corresponding
+logical module reference:
 
   $ cat >dune <<'EOF'
   > (include_subdirs qualified)
@@ -37,7 +38,7 @@ Using a slash instead does not work either:
   Error: "foo/bar" is an invalid module name.
   Module names must be non-empty, start with a letter, and composed only of the
   following characters: 'A'..'Z', 'a'..'z', '_', ''' or '0'..'9'.
-  Hint: foobar would be a correct module name
+  Hint: Foo.Bar would be a correct module reference
   [1]
 
 Qualified references are only available starting with Dune 3.25:


### PR DESCRIPTION
Suggest dotted qualified module references when slash-separated source paths are used.

Depends on #15633.