### PR TITLE
refactor(pp): share preprocessed module mapping

### DIFF
--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -215,8 +215,7 @@ let preprocessed_modules_of_local_lib ~sctx lib ~for_ =
       ~instrumentation_backend:(Lib.DB.instrumentation_backend (Scope.libs scope))
     |> Resolve.Memo.read_memo
   in
-  let pped_map = Staged.unstage (Pp_spec.pped_modules_map preprocess version) in
-  Modules.map_user_written modules ~f:(fun m -> Memo.return (pped_map m))
+  Pp_spec.pped_modules preprocess version modules
 ;;
 
 type imported_vlib_deps =

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -125,8 +125,7 @@ let modules_in_obj_dir ~sctx ~scope ~preprocess modules =
     let+ ocaml = Context.ocaml (Super_context.context sctx) in
     ocaml.version
   and* preprocess = instrument_preprocess ~scope preprocess in
-  let pped_map = Staged.unstage (Pp_spec.pped_modules_map preprocess version) in
-  Modules.map_user_written modules ~f:(fun m -> Memo.return @@ pped_map m)
+  Pp_spec.pped_modules preprocess version modules
 ;;
 
 let emit_modules_and_obj_dir ~dir_contents ~scope (mel : Melange_stanzas.Emit.t) =

--- a/src/dune_rules/pp_spec.ml
+++ b/src/dune_rules/pp_spec.ml
@@ -18,3 +18,8 @@ let pped_modules_map preprocess v =
   in
   Staged.stage (fun m -> Module_name.Per_item.get map (Module.name m) m)
 ;;
+
+let pped_modules preprocess version modules =
+  let map = Staged.unstage (pped_modules_map preprocess version) in
+  Modules.map_user_written modules ~f:(fun m -> Memo.return (map m))
+;;

--- a/src/dune_rules/pp_spec.mli
+++ b/src/dune_rules/pp_spec.mli
@@ -20,3 +20,9 @@ val pped_modules_map
   :  Preprocess.Without_instrumentation.t Preprocess.t Module_name.Per_item.t
   -> Ocaml.Version.t
   -> (Module.t -> Module.t) Staged.t
+
+val pped_modules
+  :  Preprocess.Without_instrumentation.t Preprocess.t Module_name.Per_item.t
+  -> Ocaml.Version.t
+  -> Modules.t
+  -> Modules.t Memo.t

--- a/src/dune_rules/vimpl.ml
+++ b/src/dune_rules/vimpl.ml
@@ -48,11 +48,7 @@ let make ~sctx ~scope ~(lib : Library.t) ~info ~vlib ~for_ =
         >>= Ml_sources.modules
               ~libs:db
               ~for_:(Library (Lib_info.lib_id info |> Lib_id.to_local_exn))
-        >>=
-        let pp_spec =
-          Staged.unstage (Pp_spec.pped_modules_map preprocess ocaml.version)
-        in
-        Modules.map_user_written ~f:(fun m -> Memo.return (pp_spec m))
+        >>= Pp_spec.pped_modules preprocess ocaml.version
       in
       let+ foreign_objects =
         Dir_contents.foreign_sources dir_contents


### PR DESCRIPTION
Share preprocessed module mapping across dependency, Melange, and virtual-library rules.