### PR TITLE
test(melange): cover empty module systems

### DIFF
--- a/test/blackbox-tests/test-cases/melange/module-systems.t
+++ b/test/blackbox-tests/test-cases/melange/module-systems.t
@@ -83,6 +83,19 @@ Defaults to commonjs / `.js` if no config present at all
   $ ls _build/default/output
   main.js
 
+dune shouldn't accept an empty module_systems field
+
+  $ dune clean
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (alias mel)
+  >  (target output)
+  >  (emit_stdlib false)
+  >  (module_systems))
+  > EOF
+
+  $ dune build @mel
+
 Errors out if extension starts with dot
 
   $ cat > dune <<EOF


### PR DESCRIPTION
dune shouldn't accept an empty module_systems field