### PR TITLE
fix(melange): reject empty module systems

### DIFF
--- a/doc/changes/fixed/16162.md
+++ b/doc/changes/fixed/16162.md
@@ -1,0 +1,2 @@
+- Reject empty `module_systems` fields in `melange.emit` stanzas instead of
+  silently producing no JavaScript files (#16162, @anmonteiro)

--- a/src/dune_rules/melange/melange_stanzas.ml
+++ b/src/dune_rules/melange/melange_stanzas.ml
@@ -56,7 +56,7 @@ module Emit = struct
             ]
       in
       let+ module_systems =
-        repeat
+        repeat1
           (pair module_system extension_field
            <|> let+ loc, module_system = located module_system in
                let _, ext = Module_system.default in

--- a/test/blackbox-tests/test-cases/melange/module-systems.t
+++ b/test/blackbox-tests/test-cases/melange/module-systems.t
@@ -95,6 +95,11 @@ dune shouldn't accept an empty module_systems field
   > EOF
 
   $ dune build @mel
+  File "dune", line 5, characters 1-17:
+  5 |  (module_systems))
+       ^^^^^^^^^^^^^^^^
+  Error: Not enough arguments for "module_systems"
+  [1]
 
 Errors out if extension starts with dot
 


### PR DESCRIPTION
Reject explicitly empty module_systems fields with repeat1. Follows #16161.