### PR TITLE
refactor(melange): make module systems nonempty

### DIFF
--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -95,22 +95,19 @@ let output_of_lib =
 ;;
 
 let js_outputs_of_module ~module_systems ~output m =
-  match module_systems with
-  | [] -> []
-  | _ :: _ ->
-    let dst_dir =
-      let src_dir =
-        Module.source m ~ml_kind:Impl
-        |> Option.value_exn
-        |> Module.File.original_path
-        |> Path.parent_exn
-      in
-      Output_kind.output_path output src_dir
+  let dst_dir =
+    let src_dir =
+      Module.source m ~ml_kind:Impl
+      |> Option.value_exn
+      |> Module.File.original_path
+      |> Path.parent_exn
     in
-    let basename = Module_compilation.melange_js_basename m in
-    List.map module_systems ~f:(fun (module_system, js_ext) ->
-      let basename = Filename.add_extension basename js_ext in
-      module_system, Path.Build.relative_fname dst_dir basename)
+    Output_kind.output_path output src_dir
+  in
+  let basename = Module_compilation.melange_js_basename m in
+  Nonempty_list.to_list_map module_systems ~f:(fun (module_system, js_ext) ->
+    let basename = Filename.add_extension basename js_ext in
+    module_system, Path.Build.relative_fname dst_dir basename)
 ;;
 
 let instrument_preprocess ~scope preprocess =

--- a/src/dune_rules/melange/melange_stanzas.ml
+++ b/src/dune_rules/melange/melange_stanzas.ml
@@ -6,7 +6,7 @@ module Emit = struct
     { loc : Loc.t
     ; target : string
     ; alias : Alias.Name.t option
-    ; module_systems : (Melange.Module_system.t * Filename.Extension.t) list
+    ; module_systems : (Melange.Module_system.t * Filename.Extension.t) Nonempty_list.t
     ; modules : Modules_settings.t
     ; emit_stdlib : bool
     ; libraries : Lib_dep.t list
@@ -67,7 +67,9 @@ module Emit = struct
           Filename.Extension.Map.of_list_map module_systems ~f:(fun (ms, (loc, ext)) ->
             ext, (loc, ms))
         with
-        | Ok m -> Filename.Extension.Map.to_list_map m ~f:(fun ext (_loc, ms) -> ms, ext)
+        | Ok m ->
+          Filename.Extension.Map.to_list_map m ~f:(fun ext (_loc, ms) -> ms, ext)
+          |> Nonempty_list.of_list_exn
         | Error (ext, (_, (loc1, _)), (_, (loc2, _))) ->
           let main_message =
             Pp.textf
@@ -114,7 +116,10 @@ module Emit = struct
          field "target" (plain_string (fun ~loc s -> of_string ~loc s))
        and+ alias = field_o "alias" Dune_lang.Alias.decode
        and+ module_systems =
-         field "module_systems" module_systems ~default:[ Melange.Module_system.default ]
+         field
+           "module_systems"
+           module_systems
+           ~default:Nonempty_list.[ Melange.Module_system.default ]
        and+ libraries =
          field "libraries" (Lib_dep.L.decode ~allow_re_export:false) ~default:[]
        and+ package = Stanza_pkg.field_opt () >>| Option.map ~f:snd

--- a/src/dune_rules/melange/melange_stanzas.mli
+++ b/src/dune_rules/melange/melange_stanzas.mli
@@ -6,7 +6,7 @@ module Emit : sig
     { loc : Loc.t
     ; target : string
     ; alias : Alias.Name.t option
-    ; module_systems : (Melange.Module_system.t * Filename.Extension.t) list
+    ; module_systems : (Melange.Module_system.t * Filename.Extension.t) Nonempty_list.t
     ; modules : Modules_settings.t
     ; emit_stdlib : bool
     ; libraries : Lib_dep.t list


### PR DESCRIPTION
Encode the module_systems decoder invariant with Nonempty_list.t. Follows #16162.