### PR TITLE
refactor(stdune): add Nonempty_list operations

### DIFF
--- a/otherlibs/stdune/src/nonempty_list.ml
+++ b/otherlibs/stdune/src/nonempty_list.ml
@@ -1,6 +1,14 @@
 type 'a t = ( :: ) of 'a * 'a list
 
 let hd (x :: _) = x
+let length (_ :: xs) = 1 + List.length xs
+
+let iter (x :: xs) ~f =
+  f x;
+  List.iter xs ~f
+;;
+
+let for_all (x :: xs) ~f = f x && List.for_all xs ~f
 
 let last =
   let rec loop last = function
@@ -40,6 +48,7 @@ let of_list_exn = function
 let to_list (x :: xs) = List.cons x xs
 let to_list_map (x :: xs) ~f = List.map (x :: xs) ~f
 let map (x :: xs) ~f = f x :: List.map xs ~f
+let map2 (x :: xs) (y :: ys) ~f = f x y :: List.map2 xs ys ~f
 
 let compare (x :: xs) (y :: ys) ~compare =
   match compare x y with

--- a/otherlibs/stdune/src/nonempty_list.mli
+++ b/otherlibs/stdune/src/nonempty_list.mli
@@ -3,6 +3,9 @@
 type 'a t = ( :: ) of 'a * 'a list
 
 val hd : 'a t -> 'a
+val length : 'a t -> int
+val iter : 'a t -> f:('a -> unit) -> unit
+val for_all : 'a t -> f:('a -> bool) -> bool
 val last : 'a t -> 'a
 val destruct_last : 'a t -> 'a list * 'a
 val rev : 'a t -> 'a t
@@ -11,6 +14,10 @@ val of_list_exn : 'a list -> 'a t
 val to_list : 'a t -> 'a list
 val to_list_map : 'a t -> f:('a -> 'b) -> 'b list
 val map : 'a t -> f:('a -> 'b) -> 'b t
+
+(** Raises [Invalid_argument] if the lists have different lengths. *)
+val map2 : 'a t -> 'b t -> f:('a -> 'b -> 'c) -> 'c t
+
 val compare : 'a t -> 'a t -> compare:('a -> 'a -> Ordering.t) -> Ordering.t
 val concat : 'a list -> 'a t -> 'a t
 

--- a/otherlibs/stdune/test/nonempty_list_tests.ml
+++ b/otherlibs/stdune/test/nonempty_list_tests.ml
@@ -1,0 +1,26 @@
+open Stdune
+
+let%expect_test "collection operations" =
+  let values = Nonempty_list.[ 1; 2; 3 ] in
+  Printf.printf "length: %d\n" (Nonempty_list.length values);
+  Nonempty_list.iter values ~f:(Printf.printf "value: %d\n");
+  Printf.printf
+    "all positive: %b\n"
+    (Nonempty_list.for_all values ~f:(fun value -> value > 0));
+  Printf.printf
+    "all even: %b\n"
+    (Nonempty_list.for_all values ~f:(fun value -> value mod 2 = 0));
+  let sums = Nonempty_list.map2 values Nonempty_list.[ 10; 20; 30 ] ~f:( + ) in
+  Nonempty_list.iter sums ~f:(Printf.printf "sum: %d\n");
+  [%expect
+    {|
+    length: 3
+    value: 1
+    value: 2
+    value: 3
+    all positive: true
+    all even: false
+    sum: 11
+    sum: 22
+    sum: 33 |}]
+;;


### PR DESCRIPTION
Add length, iter, for_all, and map2 to Nonempty_list.