### PR TITLE
fix(pkg): compare dev-tool compiler packages semantically

### DIFF
--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -197,28 +197,67 @@ let lockdir_status dev_tool =
            with
            | false -> Memo.return (`Lockdir_ok_with_tool_pkg pkg)
            | true ->
-             let open Memo.O in
-             let* compiler = compiler_package () in
+             let+ compiler = compiler_package () in
              (match Package_name.Map.find packages compiler.info.name with
-              | None -> Memo.return `No_compiler_lockfile_in_lockdir
-              | Some pkg ->
-                let+ ocaml_compiler = compiler_package () in
-                (match Lock_dir.Pkg.equal pkg ocaml_compiler with
-                 | true -> `Lockdir_ok_with_tool_pkg pkg
-                 | false ->
-                   `Dev_tool_needs_to_be_relocked_because_project_compiler_version_changed
-                     (User_message.make
-                        [ Pp.textf
-                            "The version of the compiler package (%S) in this project's \
-                             lockdir has changed to %s (formerly the compiler version \
-                             was %s). The dev-tool %S will be re-locked and rebuilt with \
-                             this version of the compiler."
-                            (Package_name.to_string compiler.info.name)
-                            (Package_version.to_string ocaml_compiler.info.version)
-                            (Package_version.to_string pkg.info.version)
-                            (Dune_pkg.Dev_tool.package_name dev_tool
-                             |> Package_name.to_string)
-                        ]))))))
+              | None -> `No_compiler_lockfile_in_lockdir
+              | Some locked_compiler ->
+                let package_on_platform (pkg : Lock_dir.Pkg.t) =
+                  let choose choice =
+                    match
+                      Lock_dir.Conditional_choice.choose_for_platform choice ~platform
+                    with
+                    | None -> Lock_dir.Conditional_choice.empty
+                    | Some value ->
+                      Lock_dir.Conditional_choice.singleton
+                        Dune_pkg.Solver_env.empty
+                        value
+                  in
+                  { pkg with
+                    build_command = choose pkg.build_command
+                  ; install_command = choose pkg.install_command
+                  ; depends = choose pkg.depends
+                  ; enabled_on_platforms = [ Dune_pkg.Solver_env.empty ]
+                  }
+                  |> Lock_dir.Pkg.remove_locs
+                in
+                let same_compiler_package =
+                  Lock_dir.Pkg.equal
+                    (package_on_platform locked_compiler)
+                    (package_on_platform compiler)
+                in
+                if same_compiler_package
+                then `Lockdir_ok_with_tool_pkg pkg
+                else (
+                  let compiler_name = Package_name.to_string compiler.info.name in
+                  let dev_tool_name =
+                    Dune_pkg.Dev_tool.package_name dev_tool |> Package_name.to_string
+                  in
+                  let message =
+                    if
+                      Package_version.equal
+                        compiler.info.version
+                        locked_compiler.info.version
+                    then
+                      Pp.textf
+                        "The compiler package (%S) in this project's lockdir has changed \
+                         without changing its version (%s). The dev-tool %S will be \
+                         re-locked and rebuilt with the updated compiler package."
+                        compiler_name
+                        (Package_version.to_string compiler.info.version)
+                        dev_tool_name
+                    else
+                      Pp.textf
+                        "The version of the compiler package (%S) in this project's \
+                         lockdir has changed to %s (formerly the compiler version was \
+                         %s). The dev-tool %S will be re-locked and rebuilt with this \
+                         version of the compiler."
+                        compiler_name
+                        (Package_version.to_string compiler.info.version)
+                        (Package_version.to_string locked_compiler.info.version)
+                        dev_tool_name
+                  in
+                  `Dev_tool_needs_to_be_relocked_because_project_compiler_changed
+                    (User_message.make [ message ]))))))
 ;;
 
 (* [lock_dev_tool_at_version dev_tool version] generates the lockdir for the
@@ -261,7 +300,7 @@ let lock_dev_tool_at_version dev_tool version =
             "ocaml"
         ];
       true
-    | `Dev_tool_needs_to_be_relocked_because_project_compiler_version_changed message ->
+    | `Dev_tool_needs_to_be_relocked_because_project_compiler_changed message ->
       Console.print_user_message message;
       true
     | `Lockdir_missing_entry_for_tool message ->

--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-package-change.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-package-change.t
@@ -23,7 +23,7 @@ Use an extra file to distinguish reuse from an identical regenerated lockdir.
   > else
   >   echo 'unchanged dev-tool lock regenerated'
   > fi
-  unchanged dev-tool lock regenerated
+  unchanged dev-tool lock reused
   $ rm -f "${dev_tool_lock_dir}"/relock-sentinel
 
 Change the compiler package's build recipe without changing its version, then
@@ -42,10 +42,9 @@ Executing Merlin must notice the changed compiler package and regenerate its
 lock directory from the updated recipe.
 
   $ dune tools exec ocamlmerlin
-  The version of the compiler package ("ocaml-base-compiler") in this project's
-  lockdir has changed to 5.2.0 (formerly the compiler version was 5.2.0). The
-  dev-tool "merlin" will be re-locked and rebuilt with this version of the
-  compiler.
+  The compiler package ("ocaml-base-compiler") in this project's lockdir has
+  changed without changing its version (5.2.0). The dev-tool "merlin" will be
+  re-locked and rebuilt with the updated compiler package.
   Solution for _build/.dev-tools.locks/merlin:
   - merlin.0.0.1
   - ocaml-base-compiler.5.2.0

--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-package-change.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-package-change.t
@@ -1,0 +1,58 @@
+A dev tool that must use the project's compiler must be relocked when the
+compiler package changes, even if its name and version stay the same.
+
+  $ mkrepo
+  $ make_mock_merlin_package
+  $ mk_ocaml 5.2.0
+
+  $ setup_merlin_workspace
+  $ make_named_package_project foo 3.16 "(ocaml (= 5.2.0))"
+  $ dune build
+
+Create the initial dev-tool lock directory.
+
+  $ dune tools exec ocamlmerlin >/dev/null 2>&1
+
+An unchanged compiler package must keep the existing dev-tool lock directory.
+Use an extra file to distinguish reuse from an identical regenerated lockdir.
+
+  $ touch "${dev_tool_lock_dir}"/relock-sentinel
+  $ dune tools exec ocamlmerlin >/dev/null 2>&1
+  $ if test -e "${dev_tool_lock_dir}"/relock-sentinel; then
+  >   echo 'unchanged dev-tool lock reused'
+  > else
+  >   echo 'unchanged dev-tool lock regenerated'
+  > fi
+  unchanged dev-tool lock regenerated
+  $ rm -f "${dev_tool_lock_dir}"/relock-sentinel
+
+Change the compiler package's build recipe without changing its version, then
+regenerate only the project lock directory.
+
+  $ cat >>mock-opam-repository/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0/opam <<'EOF'
+  > build: [ [ "echo" "compiler-recipe-v2" ] ]
+  > EOF
+  $ rm -rf dune.lock
+  $ dune pkg lock >/dev/null 2>&1
+  $ grep -q compiler-recipe-v2 dune.lock/ocaml-base-compiler*.pkg \
+  > && echo 'project compiler updated'
+  project compiler updated
+
+Executing Merlin must notice the changed compiler package and regenerate its
+lock directory from the updated recipe.
+
+  $ dune tools exec ocamlmerlin
+  The version of the compiler package ("ocaml-base-compiler") in this project's
+  lockdir has changed to 5.2.0 (formerly the compiler version was 5.2.0). The
+  dev-tool "merlin" will be re-locked and rebuilt with this version of the
+  compiler.
+  Solution for _build/.dev-tools.locks/merlin:
+  - merlin.0.0.1
+  - ocaml-base-compiler.5.2.0
+  - ocaml-compiler.5.2.0
+       Running 'ocamlmerlin'
+  hello from fake ocamlmerlin
+  $ grep -q compiler-recipe-v2 "${dev_tool_lock_dir}"/ocaml-base-compiler*.pkg \
+  > && echo 'dev-tool compiler updated'
+  dev-tool compiler updated
+

--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-version-change.t
@@ -29,14 +29,6 @@ Initially merlin will depend on ocaml-base-compiler.5.2.0 to match the project.
 
 We can re-run "dune tools exec ocamlmerlin" without relocking or rebuilding.
   $ dune tools exec ocamlmerlin
-  The version of the compiler package ("ocaml-base-compiler") in this project's
-  lockdir has changed to 5.2.0 (formerly the compiler version was 5.2.0). The
-  dev-tool "merlin" will be re-locked and rebuilt with this version of the
-  compiler.
-  Solution for _build/.dev-tools.locks/merlin:
-  - merlin.0.0.1
-  - ocaml-base-compiler.5.2.0
-  - ocaml-compiler.5.2.0
        Running 'ocamlmerlin'
   hello from fake ocamlmerlin
 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-pinned-compiler.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-pinned-compiler.t
@@ -56,12 +56,5 @@ rather than "ocaml-base-compiler.5.2.0" from opam-repository.
   - ocaml-lsp-server.0.0.1
 
   $ dune tools exec ocamllsp
-  The version of the compiler package ("ocaml-base-compiler") in this project's
-  lockdir has changed to dev (formerly the compiler version was dev). The
-  dev-tool "ocaml-lsp-server" will be re-locked and rebuilt with this version
-  of the compiler.
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
-  - ocaml-base-compiler.dev
-  - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'
   hello from fake ocamllsp

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
@@ -29,14 +29,6 @@ Initially ocamllsp will depend on ocaml-base-compiler.5.2.0 to match the project
 
 We can re-run "dune tools exec ocamllsp" without relocking or rebuilding.
   $ dune tools exec ocamllsp
-  The version of the compiler package ("ocaml-base-compiler") in this project's
-  lockdir has changed to 5.2.0 (formerly the compiler version was 5.2.0). The
-  dev-tool "ocaml-lsp-server" will be re-locked and rebuilt with this version
-  of the compiler.
-  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
-  - ocaml-base-compiler.5.2.0
-  - ocaml-compiler.5.2.0
-  - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'
   hello from fake ocamllsp
 

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
@@ -34,14 +34,6 @@ Initially odoc will depend on ocaml-base-compiler.5.2.0 to match the project.
 
 We can re-run "dune ocaml doc" without relocking or rebuilding.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune ocaml doc
-  The version of the compiler package ("ocaml-base-compiler") in this project's
-  lockdir has changed to 5.2.0 (formerly the compiler version was 5.2.0). The
-  dev-tool "odoc" will be re-locked and rebuilt with this version of the
-  compiler.
-  Solution for _build/.dev-tools.locks/odoc:
-  - ocaml-base-compiler.5.2.0
-  - ocaml-compiler.5.2.0
-  - odoc.0.0.1
   hello from fake odoc
   hello from fake odoc
   File "_doc/_html/_unknown_", line 1, characters 0-0:


### PR DESCRIPTION
## Description

Compare the project and dev-tool compiler packages after selecting the current-platform conditional fields and removing parser source locations.

This prevents an unchanged compiler package from needlessly regenerating the dev-tool lock directory, while still relocking when the compiler recipe changes without a version bump. It also reports same-version package changes separately from actual version changes.

## Related Issue and Motivation

Dune currently compares the two lock-directory package values structurally. Equivalent packages can differ in conditional representation or source locations, causing the dev-tool lock directory to be regenerated even when the effective compiler package is unchanged.

## Tests

The regression test uses a sentinel file to distinguish lock-directory reuse from identical regeneration. It also changes the compiler build recipe without changing version 5.2.0 and verifies that this real package change causes relocking.

## Checklist

- [x] Tests added.
- [ ] Change log entry added, if required.
- [ ] Documentation added, if required.