### PR TITLE
test(pkg): snapshot host platform selection in build contexts

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-build-context-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-build-context-solver-env.t
@@ -1,0 +1,38 @@
+Build-time conditional package selection currently uses the host platform even
+when the selected lock stanza's solver environment overrides it.
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Create a package whose build result records the selected operating system.
+
+  $ mkpkg foo <<'EOF'
+  > build: [
+  >   ["mkdir" "-p" share "%{lib}%/%{name}%"]
+  >   ["touch" "%{lib}%/%{name}%/META"]
+  >   ["sh" "-c" "echo Darwin > %{share}%/kernel"] { os = "macos" }
+  >   ["sh" "-c" "echo Linux > %{share}%/kernel"] { os = "linux" }
+  > ]
+  > EOF
+
+  $ make_portable_lockdirs_project
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.20)
+  > (repository
+  >  (name mock)
+  >  (url "file://$(pwd)/mock-opam-repository"))
+  > (lock_dir
+  >  (repositories mock)
+  >  (solver_env (os macos))
+  >  (solve_for_platforms
+  >   ((arch x86_64) (os linux))
+  >   ((arch x86_64) (os macos))))
+  > (pkg enabled)
+  > EOF
+
+The lock stanza selects macOS, but the build context still selects Linux.
+
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock >/dev/null 2>&1
+  $ dune build
+  $ cat $pkg_root/$(dune pkg print-digest foo)/target/share/kernel
+  Linux


### PR DESCRIPTION
## Description

Add a focused regression scenario for build-time conditional package selection when a lock stanza overrides the host platform through `solver_env`.

The test records the current bug: on a Linux host, a lock stanza selecting macOS still causes the package's Linux build command to run. A follow-up fix can change the expected result from `Linux` to `Darwin`.

## Related Issue and Motivation

This isolates the existing build-context behavior before changing how the effective solver environment is computed.

## Checklist

- [x] Tests added.
- [ ] Change log entry added, if required.
- [ ] Documentation added, if required.