### PR TITLE
test(pkg): cover dev-tool compiler package relocking

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-package-change.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-package-change.t
@@ -1,0 +1,58 @@
+A dev tool that must use the project's compiler must be relocked when the
+compiler package changes, even if its name and version stay the same.
+
+  $ mkrepo
+  $ make_mock_merlin_package
+  $ mk_ocaml 5.2.0
+
+  $ setup_merlin_workspace
+  $ make_named_package_project foo 3.16 "(ocaml (= 5.2.0))"
+  $ dune build
+
+Create the initial dev-tool lock directory.
+
+  $ dune tools exec ocamlmerlin >/dev/null 2>&1
+
+An unchanged compiler package must keep the existing dev-tool lock directory.
+Use an extra file to distinguish reuse from an identical regenerated lockdir.
+
+  $ touch "${dev_tool_lock_dir}"/relock-sentinel
+  $ dune tools exec ocamlmerlin >/dev/null 2>&1
+  $ if test -e "${dev_tool_lock_dir}"/relock-sentinel; then
+  >   echo 'unchanged dev-tool lock reused'
+  > else
+  >   echo 'unchanged dev-tool lock regenerated'
+  > fi
+  unchanged dev-tool lock regenerated
+  $ rm -f "${dev_tool_lock_dir}"/relock-sentinel
+
+Change the compiler package's build recipe without changing its version, then
+regenerate only the project lock directory.
+
+  $ cat >>mock-opam-repository/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0/opam <<'EOF'
+  > build: [ [ "echo" "compiler-recipe-v2" ] ]
+  > EOF
+  $ rm -rf dune.lock
+  $ dune pkg lock >/dev/null 2>&1
+  $ grep -q compiler-recipe-v2 dune.lock/ocaml-base-compiler*.pkg \
+  > && echo 'project compiler updated'
+  project compiler updated
+
+Executing Merlin must notice the changed compiler package and regenerate its
+lock directory from the updated recipe.
+
+  $ dune tools exec ocamlmerlin
+  The version of the compiler package ("ocaml-base-compiler") in this project's
+  lockdir has changed to 5.2.0 (formerly the compiler version was 5.2.0). The
+  dev-tool "merlin" will be re-locked and rebuilt with this version of the
+  compiler.
+  Solution for _build/.dev-tools.locks/merlin:
+  - merlin.0.0.1
+  - ocaml-base-compiler.5.2.0
+  - ocaml-compiler.5.2.0
+       Running 'ocamlmerlin'
+  hello from fake ocamlmerlin
+  $ grep -q compiler-recipe-v2 "${dev_tool_lock_dir}"/ocaml-base-compiler*.pkg \
+  > && echo 'dev-tool compiler updated'
+  dev-tool compiler updated
+


### PR DESCRIPTION
## Description

Add regression coverage for deciding whether an existing dev-tool lock directory can be reused after examining the project compiler package.

The test records two current behaviors:

- An unchanged compiler package unnecessarily regenerates the dev-tool lock directory; a sentinel distinguishes regeneration from reuse.
- Changing the compiler build recipe without changing version `5.2.0` regenerates the dev-tool lock, but reports the change as `5.2.0` to `5.2.0`.

A follow-up fix can flip the first expectation to reuse and provide a same-version package-change diagnostic for the second case.

## Related Issue and Motivation

This separates the regression proof from the compiler-package comparison fix.

## Checklist

- [x] Tests added.
- [ ] Change log entry added, if required.
- [ ] Documentation added, if required.