### PR TITLE
test(pkg): cover interrupted lockdir recovery

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/lock-directory-interrupted-recovery.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-interrupted-recovery.t
@@ -1,0 +1,37 @@
+Recover from interruption after the canonical lock directory was moved to its
+hidden staging path.
+
+Start with a generated, validated lock directory and reproduce the filesystem
+state persisted at the interruption point.
+
+  $ mkrepo
+  $ mkpkg a
+  $ mkpkg b
+  $ add_mock_repo_if_needed
+  $ make_project a > dune-project
+  $ dune_pkg_lock_normalized
+  Solution for dune.lock:
+  - a.0.0.1
+  $ dune pkg validate-lockdir
+  $ mv ${default_lock_dir} .${default_lock_dir}
+  $ if [ -e ${default_lock_dir} ]; then echo "dune.lock present"; else echo "dune.lock absent"; fi
+  dune.lock absent
+  $ if [ -d .${default_lock_dir} ]; then echo ".dune.lock present"; else echo ".dune.lock absent"; fi
+  .dune.lock present
+
+Rerunning for a different solution must install the newly requested canonical
+lock directory rather than silently restoring the stale backup.
+
+  $ make_project b > dune-project
+  $ dune_pkg_lock_normalized
+  Solution for dune.lock:
+  - b.0.0.1
+  $ if [ -d ${default_lock_dir} ]; then echo "dune.lock present"; else echo "dune.lock absent"; fi
+  dune.lock present
+  $ cat ${default_lock_dir}/b.0.0.1.pkg
+  (version 0.0.1)
+  $ if [ -e ${default_lock_dir}/a.0.0.1.pkg ]; then echo "stale solution restored"; else echo "requested solution installed"; fi
+  requested solution installed
+  $ dune pkg validate-lockdir
+  $ if [ -e .${default_lock_dir} ]; then echo ".dune.lock present"; else echo ".dune.lock absent"; fi
+  .dune.lock absent


### PR DESCRIPTION
## Description

Add a standalone cram regression for the persisted state left when lock-directory regeneration is interrupted after the canonical `dune.lock` has been moved to `.dune.lock`.

The test starts with a generated and validated solution for package `a`, moves it to the hidden path, changes the project to require package `b`, and requires the next `dune pkg lock` to install the newly requested canonical solution and remove the staging backup. Using distinct solutions prevents an implementation that merely restores the stale backup from passing.

This is intentionally a **test-only draft**. The expected fixed behavior remains in the cram, so the new test is red on `main`.

## Current Failure

Current Dune refuses regeneration because the occupied `.dune.lock` path blocks the old canonical-to-hidden rename. `dune.lock` remains absent and the validated hidden backup remains present.

## Related Issue and Motivation

#10852 introduced the hidden backup as part of atomic lock-directory replacement and noted that it could be restored after failure. This regression fixes the desired recovery behavior in place before any implementation PR is proposed.

## Verification

- The new cram failed at the intended rerun assertion in five consecutive local runs with byte-identical diagnostics.
- `nix develop path:. -c dune fmt` passed.
- `nix develop path:. -c dune build @check` passed.
- Existing `lock-directory-regeneration-safety.t` passed.

## Checklist

- [x] Test added.
- [x] Changelog not applicable: test-only reproducer.
- [x] Documentation not applicable: test-only reproducer.