### PR TITLE
fix(pkg): make lock platform selection unambiguous

### DIFF
--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -106,9 +106,7 @@ let compiler_package () =
   let open Memo.O in
   let context = Context_name.default in
   let* result = Dune_rules.Lock_dir.get context
-  and* platform =
-    Pkg.Pkg_common.poll_solver_env_from_current_system () |> Memo.of_reproducible_fiber
-  in
+  and* platform = Dune_rules.Lock_dir.solver_env_for_context context in
   match result with
   | Error _ ->
     User_error.raise

--- a/doc/changes/fixed/16172.md
+++ b/doc/changes/fixed/16172.md
@@ -1,0 +1,3 @@
+- Use lock stanza solver variables when selecting package build actions, and
+  reject variables specified by more than one lock stanza field. (#16172,
+  @Alizter)

--- a/src/dune_pkg/solver_env.ml
+++ b/src/dune_pkg/solver_env.ml
@@ -94,6 +94,13 @@ let get = Package_variable_name.Map.find
 let extend a b = Package_variable_name.Map.superpose b a
 let contains = Package_variable_name.Map.mem
 
+let variable_names t =
+  Package_variable_name.Map.foldi
+    t
+    ~init:Package_variable_name.Set.empty
+    ~f:(fun variable _ variables -> Package_variable_name.Set.add variables variable)
+;;
+
 let with_defaults =
   [ ( Package_variable_name.opam_version
     , OpamVersion.to_string OpamVersion.current |> Variable_value.string )

--- a/src/dune_pkg/solver_env.mli
+++ b/src/dune_pkg/solver_env.mli
@@ -19,6 +19,9 @@ val decode : t Decoder.t
 val set : t -> Package_variable_name.t -> Variable_value.t -> t
 val get : t -> Package_variable_name.t -> Variable_value.t option
 
+(** Return the names bound in the environment. *)
+val variable_names : t -> Package_variable_name.Set.t
+
 (** [extend a b] adds all variables from [b] to [a] overwriting any
     existing values of those variables in [a]. *)
 val extend : t -> t -> t

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -207,6 +207,23 @@ let get_workspace_lock_dir ctx =
   Workspace.find_lock_dir workspace path
 ;;
 
+let solver_env_for_context ctx =
+  let* system = Sys_vars.solver_env
+  and* workspace_lock_dir = get_workspace_lock_dir ctx in
+  Memo.return
+    (match workspace_lock_dir with
+     | None -> system
+     | Some workspace_lock_dir ->
+       let solver_env =
+         match workspace_lock_dir.solver_env with
+         | None -> system
+         | Some solver_env -> Solver_env.extend system solver_env
+       in
+       (match workspace_lock_dir.unset_solver_vars with
+        | None -> solver_env
+        | Some unset_solver_vars -> Solver_env.unset_multi solver_env unset_solver_vars))
+;;
+
 let get_with_path =
   let read_lockdir =
     Memo.exec

--- a/src/dune_rules/lock_dir.mli
+++ b/src/dune_rules/lock_dir.mli
@@ -14,6 +14,10 @@ val of_dev_tool_if_lock_dir_exists : Dune_pkg.Dev_tool.t -> t option Memo.t
 val lock_dir_active : Context_name.t -> bool Memo.t
 val get_path : Context_name.t -> Path.t option Memo.t
 
+(** The current system's solver environment with the selected lock directory's
+    [solver_env] and [unset_solver_vars] applied. *)
+val solver_env_for_context : Context_name.t -> Dune_pkg.Solver_env.t Memo.t
+
 (** The default filesystem location where the lock dir is going to get created *)
 val default_path : Path.t
 

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -98,6 +98,11 @@ module Package_universe = struct
     | Dependencies ctx -> Lock_dir.get_exn ctx
     | Dev_tool dev_tool -> Lock_dir.of_dev_tool dev_tool
   ;;
+
+  let platform = function
+    | Dependencies ctx -> Lock_dir.solver_env_for_context ctx
+    | Dev_tool _ -> Lock_dir.Sys_vars.solver_env
+  ;;
 end
 
 module Pkg_digest = struct
@@ -1455,7 +1460,7 @@ module DB = struct
              let system_provided = default_system_provided in
              let+ pkg_digest_table =
                let* lock_dir = Lock_dir.get_exn ctx
-               and* platform = Lock_dir.Sys_vars.solver_env in
+               and* platform = Lock_dir.solver_env_for_context ctx in
                (if allow_sharing
                 then Memo.Lazy.force Pkg_table.all_existing_dev_tools
                 else Memo.return Pkg_table.empty)
@@ -1471,7 +1476,7 @@ module DB = struct
      within that context. *)
   let of_project_pkg ctx pkg_name =
     let* lock_dir = Lock_dir.get_exn ctx
-    and* platform = Lock_dir.Sys_vars.solver_env in
+    and* platform = Lock_dir.solver_env_for_context ctx in
     let+ t = of_ctx ctx ~allow_sharing:true in
     t, pkg_digest_of_name lock_dir platform pkg_name ~system_provided:t.system_provided
   ;;
@@ -1586,7 +1591,7 @@ end = struct
         ; pkg_digest = _
         } ->
       assert (Package.Name.equal pkg_digest.name info.name);
-      let* platform = Lock_dir.Sys_vars.solver_env in
+      let* platform = Package_universe.platform package_universe in
       let choose_for_current_platform field =
         Dune_pkg.Lock_dir.Conditional_choice.choose_for_platform field ~platform
       in

--- a/src/source/workspace.ml
+++ b/src/source/workspace.ml
@@ -128,6 +128,23 @@ module Lock_dir = struct
     && List.equal Solver_env.equal solve_for_platforms t.solve_for_platforms
   ;;
 
+  let check_variable_overlap ~loc ~field_a variables_a ~field_b variables_b =
+    match
+      Package_variable_name.Set.inter variables_a variables_b
+      |> Package_variable_name.Set.choose
+    with
+    | None -> ()
+    | Some variable ->
+      User_error.raise
+        ~loc
+        [ Pp.textf
+            "Variable %S appears in both '%s' and '%s', which is not allowed."
+            (Package_variable_name.to_string variable)
+            field_a
+            field_b
+        ]
+  ;;
+
   let decode ~dir =
     let repositories_of_ordered_set ordered_set =
       Dune_lang.Ordered_set_lang.eval
@@ -153,25 +170,24 @@ module Lock_dir = struct
         field ~default:[] "constraints" (repeat Dune_lang.Package_dependency.decode)
       and+ depopts = field ~default:[] "depopts" (repeat (located Package.Name.decode))
       and+ pins = field ~default:[] "pins" (repeat (located string))
-      and+ solve_for_platforms =
+      and+ solve_for_platforms, solve_for_platforms_is_explicit =
         let+ loc, solve_for_platforms =
-          located
-          @@ field
-               ~default:Solver_env.popular_platform_envs
-               "solve_for_platforms"
-               (repeat @@ enter Solver_env.decode)
+          located @@ field_o "solve_for_platforms" (repeat @@ enter Solver_env.decode)
         in
-        if List.is_empty solve_for_platforms
-        then
-          User_error.raise
-            ~loc
-            [ Pp.text "No platforms were specified for solving dependencies." ]
-            ~hints:
-              [ Pp.text
-                  "Specify at least one platform here, or remove this field to solve for \
-                   the default platforms."
-              ];
-        solve_for_platforms
+        match solve_for_platforms with
+        | None -> Solver_env.popular_platform_envs, false
+        | Some solve_for_platforms ->
+          if List.is_empty solve_for_platforms
+          then
+            User_error.raise
+              ~loc
+              [ Pp.text "No platforms were specified for solving dependencies." ]
+              ~hints:
+                [ Pp.text
+                    "Specify at least one platform here, or remove this field to solve \
+                     for the default platforms."
+                ];
+          solve_for_platforms, true
       in
       Option.iter solver_env ~f:(fun solver_env ->
         Option.iter
@@ -188,9 +204,33 @@ module Lock_dir = struct
                        (Package_variable_name.to_string variable)
                    ])));
       let unset_solver_vars =
-        Option.map unset_solver_vars ~f:(fun x ->
-          List.map x ~f:snd |> Package_variable_name.Set.of_list)
+        Option.map unset_solver_vars ~f:(fun variables ->
+          List.map variables ~f:snd |> Package_variable_name.Set.of_list)
       in
+      if solve_for_platforms_is_explicit
+      then (
+        let solve_for_platform_variables =
+          List.fold_left
+            solve_for_platforms
+            ~init:Package_variable_name.Set.empty
+            ~f:(fun variables platform_env ->
+              Solver_env.variable_names platform_env
+              |> Package_variable_name.Set.union variables)
+        in
+        Option.iter solver_env ~f:(fun solver_env ->
+          check_variable_overlap
+            ~loc
+            ~field_a:"solver_env"
+            (Solver_env.variable_names solver_env)
+            ~field_b:"solve_for_platforms"
+            solve_for_platform_variables);
+        Option.iter unset_solver_vars ~f:(fun unset_solver_vars ->
+          check_variable_overlap
+            ~loc
+            ~field_a:"unset_solver_vars"
+            unset_solver_vars
+            ~field_b:"solve_for_platforms"
+            solve_for_platform_variables));
       { loc
       ; path
       ; solver_env

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-build-context-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-build-context-solver-env.t
@@ -1,5 +1,5 @@
-Build-time conditional package selection currently uses the host platform even
-when the selected lock stanza's solver environment overrides it.
+Build-time conditional package selection uses the selected lock stanza's solver
+environment rather than the host platform.
 
   $ mkrepo
   $ add_mock_repo_if_needed
@@ -23,16 +23,13 @@ Create a package whose build result records the selected operating system.
   >  (url "file://$(pwd)/mock-opam-repository"))
   > (lock_dir
   >  (repositories mock)
-  >  (solver_env (os macos))
-  >  (solve_for_platforms
-  >   ((arch x86_64) (os linux))
-  >   ((arch x86_64) (os macos))))
+  >  (solver_env (os macos)))
   > (pkg enabled)
   > EOF
 
-The lock stanza selects macOS, but the build context still selects Linux.
+Although the host is Linux, the build context selects the macOS package fields.
 
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock >/dev/null 2>&1
   $ dune build
   $ cat $pkg_root/$(dune pkg print-digest foo)/target/share/kernel
-  Linux
+  Darwin

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-solver-env-platform-precedence.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-solver-env-platform-precedence.t
@@ -1,5 +1,5 @@
-Explicit solve_for_platforms entries take precedence over conflicting platform
-variables in the lock stanza's solver_env.
+There is no precedence between solver_env and explicit solve_for_platforms:
+their variables must be disjoint.
 
   $ mkrepo
   $ add_mock_repo_if_needed
@@ -28,7 +28,35 @@ variables in the lock stanza's solver_env.
   >  (url "file://$(pwd)/mock-opam-repository"))
   > (lock_dir
   >  (repositories mock)
-  >  (solver_env (os windows))
+  >  (solver_env (with-doc true))
+  >  (solve_for_platforms
+  >   ((arch x86_64) (os linux) (with-doc true))
+  >   ((arch x86_64) (os macos))))
+  > (pkg enabled)
+  > EOF
+
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  File "dune-workspace", lines 5-10, characters 0-158:
+   5 | (lock_dir
+   6 |  (repositories mock)
+   7 |  (solver_env (with-doc true))
+   8 |  (solve_for_platforms
+   9 |   ((arch x86_64) (os linux) (with-doc true))
+  10 |   ((arch x86_64) (os macos))))
+  Error: Variable "with-doc" appears in both 'solver_env' and
+  'solve_for_platforms', which is not allowed.
+  [1]
+
+Variables cannot be unset globally while being set by an explicit platform.
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.20)
+  > (repository
+  >  (name mock)
+  >  (url "file://$(pwd)/mock-opam-repository"))
+  > (lock_dir
+  >  (repositories mock)
+  >  (unset_solver_vars os)
   >  (solve_for_platforms
   >   ((arch x86_64) (os linux))
   >   ((arch x86_64) (os macos))))
@@ -36,15 +64,31 @@ variables in the lock stanza's solver_env.
   > EOF
 
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
-  Solution for dune.lock
-  
-  Dependencies common to all supported platforms:
-  (none)
-  
-  Additionally, some packages will only be built on specific platforms.
-  
-  arch = x86_64; os = linux:
-  - linux-only.0.0.1
-  
-  arch = x86_64; os = macos:
-  - macos-only.0.0.1
+  File "dune-workspace", lines 5-10, characters 0-136:
+   5 | (lock_dir
+   6 |  (repositories mock)
+   7 |  (unset_solver_vars os)
+   8 |  (solve_for_platforms
+   9 |   ((arch x86_64) (os linux))
+  10 |   ((arch x86_64) (os macos))))
+  Error: Variable "os" appears in both 'unset_solver_vars' and
+  'solve_for_platforms', which is not allowed.
+  [1]
+
+Disjoint variables remain valid.
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.20)
+  > (repository
+  >  (name mock)
+  >  (url "file://$(pwd)/mock-opam-repository"))
+  > (lock_dir
+  >  (repositories mock)
+  >  (solver_env (with-doc true))
+  >  (solve_for_platforms
+  >   ((arch x86_64) (os linux))
+  >   ((arch x86_64) (os macos))))
+  > (pkg enabled)
+  > EOF
+
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock >/dev/null 2>&1


### PR DESCRIPTION
## Description

Make the environment used for lock solving and package builds unambiguous.

When `solve_for_platforms` is explicitly configured, variable names in `solver_env`, `unset_solver_vars`, and the requested platform environments must be pairwise disjoint. This applies to every variable name and rejects repeated identical values as well as conflicting values.

For each dependency build context, use the selected lock stanza's effective `solver_env` and `unset_solver_vars` when selecting conditional package fields, computing package digests, and comparing dev-tool compiler packages instead of using only the host environment.

## Relationship to other package changes

This PR is based directly on `main`. It is independent of the joint-platform solver in #15982 and the semantic compiler-package comparison in #16173; all three can be reviewed and landed independently.

## Regression coverage

- #16167 provides the build-context precursor. On a Linux host, a lock stanza selecting macOS through `solver_env` previously ran the package's Linux build command; this PR makes it run the macOS command.
- #16169 provides the original `solver_env` and `solve_for_platforms` overlap precursor; that formerly accepted precedence is now rejected as ambiguous.
- Additional regressions reject arbitrary-variable and identical-value overlaps.
- A regression rejects a variable appearing in both `unset_solver_vars` and `solve_for_platforms`.
- Disjoint non-platform variables remain accepted.

## Checklist

- [x] Regression tests included.
- [x] Change log entry added.
- [ ] Documentation added, if required.