### PR TITLE
test(ppx): demonstrate unsandboxed lint action

### DIFF
--- a/test/blackbox-tests/test-cases/lint.t/correct/dune
+++ b/test/blackbox-tests/test-cases/lint.t/correct/dune
@@ -1,3 +1,7 @@
 (executable
  (name add)
  (lint (pps correct_static_add)))
+
+(rule
+ (target lint-secret)
+ (action (write-file %{target} "secret")))

--- a/test/blackbox-tests/test-cases/lint.t/correct_static_add/correct_static_add.ml
+++ b/test/blackbox-tests/test-cases/lint.t/correct_static_add/correct_static_add.ml
@@ -13,8 +13,11 @@ let detect_static_add = object
       ; pexp_loc = loc
       ; _
       } ->
-      let sum = int_of_string a + int_of_string b in
-      let repl = string_of_int sum in
+      let repl =
+        if Sys.file_exists "correct/lint-secret"
+        then string_of_int (int_of_string a + int_of_string b)
+        else "42"
+      in
       Ppxlib.Driver.register_correction ~loc ~repl
     | _ -> super#expression e
 end

--- a/test/blackbox-tests/test-cases/lint.t/dune-project
+++ b/test/blackbox-tests/test-cases/lint.t/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.2)
+(lang dune 3.25)

--- a/test/blackbox-tests/test-cases/lint.t/run.t
+++ b/test/blackbox-tests/test-cases/lint.t/run.t
@@ -1,9 +1,12 @@
 The lint alias will run preprocessing actions listed under (lint). It also
-defines corrections that may be promoted.
+defines corrections that may be promoted. The PPX checks for an undeclared
+build target and replaces the expression with 42 when that target is hidden by
+a sandbox.
 
   $ cat > correct/add.ml << EOF
   > let () = Printf.printf "%d\n" @@ 1 + 2
   > EOF
+  $ dune build correct/lint-secret
   $ dune build @correct/lint
   File "correct/add.ml", line 1, characters 0-0:
   --- correct/add.ml


### PR DESCRIPTION
Add a lint regression case whose PPX behavior depends on whether an undeclared generated target is visible.

The test records the current target visibility during linting, demonstrating that lint PPX execution is not sandboxed. This is the test-only precursor to sandboxing lint actions in a follow-up change.
