### PR TITLE
feat(mdx): sandbox generator actions from version 0.6

### DIFF
--- a/doc/changes/changed/16177.md
+++ b/doc/changes/changed/16177.md
@@ -1,0 +1,2 @@
+- Sandbox `ocaml-mdx dune-gen` when using MDX extension 0.6, available from
+  Dune 3.25. (#16177, @rgrinberg)

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -200,6 +200,7 @@ let syntax =
     ; (0, 3), `Since (3, 2)
     ; (0, 4), `Since (3, 8)
     ; (0, 5), `Since (3, 22)
+    ; (0, 6), `Since (3, 25)
     ]
 ;;
 
@@ -435,6 +436,10 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~mdx_prog =
     (* We call mdx to generate the testing executable source *)
     Command.run_dyn_prog
       ~dir:(Path.build dir)
+      ~sandbox:
+        (if Dune_lang.Syntax.Version.Infix.(t.version >= (0, 6))
+         then Sandbox_config.needs_sandboxing
+         else Sandbox_config.no_special_requirements)
       mdx_prog
       ~stdout_to
       [ A "dune-gen"

--- a/test/blackbox-tests/test-cases/stanzas/mdx-stanza/lang-version.t/run.t
+++ b/test/blackbox-tests/test-cases/stanzas/mdx-stanza/lang-version.t/run.t
@@ -34,3 +34,20 @@ The version 0.2 requires dune 3.0
   Supported versions of this extension in version 2.9 of the dune language:
   - 0.1
   [1]
+
+The version 0.6 requires dune 3.25
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (using mdx 0.6)
+  > (cram disable)
+  > EOF
+  $ dune build @install
+  File "dune-project", line 2, characters 11-14:
+  2 | (using mdx 0.6)
+                 ^^^
+  Error: Version 0.6 of mdx extension to verify code blocks in .md files is not
+  supported until version 3.25 of the dune language.
+  Supported versions of this extension in version 3.24 of the dune language:
+  - 0.1 to 0.5
+  [1]

--- a/test/blackbox-tests/test-cases/stanzas/mdx-stanza/sandboxing.t
+++ b/test/blackbox-tests/test-cases/stanzas/mdx-stanza/sandboxing.t
@@ -43,3 +43,25 @@ Mdx tests run in a sandbox, so undeclared files are not visible.
   +top secret
    ```
   [1]
+
+The mdx generator is also sandboxed starting with version 0.6.
+
+  $ mdx_generator_is_sandboxed() {
+  >   dune trace cat | jq_dune -sc '
+  >     [ .[]
+  >     | processes
+  >     | select(.args.prog | basename == "ocaml-mdx")
+  >     | select(.args.process_args[0] == "dune-gen")
+  >     | (.args.dir | contains(".sandbox"))
+  >     ][0]'
+  > }
+
+  $ make_mdx_project 3.25 0.5
+  $ dune build mdx_gen.ml-gen
+  $ mdx_generator_is_sandboxed
+  false
+
+  $ make_mdx_project 3.25 0.6
+  $ dune build mdx_gen.ml-gen
+  $ mdx_generator_is_sandboxed
+  true


### PR DESCRIPTION
Introduce MDX extension version 0.6 with Dune language 3.25 and require sandboxing for `ocaml-mdx dune-gen`. Version 0.5 retains its existing behavior for compatibility.

This prevents the generator from observing undeclared workspace inputs, matching the sandboxing already applied to MDX test actions.
