### PR TITLE
feat(pkg-config): sandbox queries from Dune 3.25

### DIFF
--- a/doc/changes/changed/16178.md
+++ b/doc/changes/changed/16178.md
@@ -1,0 +1,2 @@
+- Sandbox `pkg-config` queries starting with Dune language 3.25 so they cannot
+  observe undeclared workspace inputs. (#16178, @rgrinberg)

--- a/src/dune_rules/pkg_config.ml
+++ b/src/dune_rules/pkg_config.ml
@@ -46,15 +46,24 @@ module Query = struct
         Super_context.env_node sctx ~dir >>= Env_node.external_env
       in
       let action =
-        let* env =
-          Action_builder.of_memo
-            (let open Memo.O in
-             let* dune_version =
-               Dune_load.find_project ~dir >>| Dune_project.dune_version
-             in
-             if dune_version >= (3, 8) then external_env else Memo.return Env.empty)
+        let* dune_version =
+          Dune_load.find_project ~dir
+          |> Memo.map ~f:Dune_project.dune_version
+          |> Action_builder.of_memo
         in
-        Command.run' ~dir:(Path.build dir) bin (to_args t ~env)
+        let* env =
+          if dune_version >= (3, 8)
+          then Action_builder.of_memo external_env
+          else Action_builder.return Env.empty
+        in
+        Command.run'
+          ~dir:(Path.build dir)
+          ~sandbox:
+            (if dune_version >= (3, 25)
+             then Sandbox_config.needs_sandboxing
+             else Sandbox_config.no_special_requirements)
+          bin
+          (to_args t ~env)
       in
       Super_context.execute_action_stdout sctx ~loc ~dir action
       |> Memo.map ~f:(fun contents ->

--- a/test/blackbox-tests/test-cases/ctypes/exe-pkg_config-multiple-fd.t/run.t
+++ b/test/blackbox-tests/test-cases/ctypes/exe-pkg_config-multiple-fd.t/run.t
@@ -9,5 +9,18 @@ This test also tests multiple function description modules.
 
   $ LIBEX=$(realpath "$PWD/../libexample")
 
+Pkg-config remains unsandboxed before Dune language 3.25.
+
+  $ PKG_CONFIG_PATH="$LIBEX/pkgconfig" PKG_CONFIG_ARGN="--define-prefix" \
+  > dune build ./example.exe
+  $ dune trace cat | jq_dune -sc '
+  >   [ .[]
+  >   | processes
+  >   | select(.args.prog | basename == "pkg-config")
+  >   | select(.args.process_args | index("--cflags"))
+  >   | (.args.dir | contains(".sandbox"))
+  >   ][0]'
+  false
+
   $ DYLD_LIBRARY_PATH="$LIBEX" LD_LIBRARY_PATH="$LIBEX" PKG_CONFIG_PATH="$LIBEX/pkgconfig" PKG_CONFIG_ARGN="--define-prefix" dune exec ./example.exe
   6

--- a/test/blackbox-tests/test-cases/ctypes/exe-pkg_config.t/dune-project
+++ b/test/blackbox-tests/test-cases/ctypes/exe-pkg_config.t/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.8)
+(lang dune 3.25)
 
 (using ctypes 0.3)
 

--- a/test/blackbox-tests/test-cases/ctypes/exe-pkg_config.t/run.t
+++ b/test/blackbox-tests/test-cases/ctypes/exe-pkg_config.t/run.t
@@ -6,5 +6,19 @@ Then generate cstubs for it, build an executable that uses those cstubs, and
 run the executable that tests the library through the cstubs.
 
   $ LIBEX=$(realpath "$PWD/../libexample")
+
+Pkg-config runs in a sandbox starting with Dune language 3.25.
+
+  $ PKG_CONFIG_PATH="$LIBEX/pkgconfig" PKG_CONFIG_ARGN="--define-prefix" \
+  > dune build ./example.exe
+  $ dune trace cat | jq_dune -sc '
+  >   [ .[]
+  >   | processes
+  >   | select(.args.prog | basename == "pkg-config")
+  >   | select(.args.process_args | index("--cflags"))
+  >   | (.args.dir | contains(".sandbox"))
+  >   ][0]'
+  true
+
   $ DYLD_LIBRARY_PATH="$LIBEX" LD_LIBRARY_PATH="$LIBEX" PKG_CONFIG_PATH="$LIBEX/pkgconfig" PKG_CONFIG_ARGN="--define-prefix" dune exec ./example.exe
   4


### PR DESCRIPTION
Require sandboxing for `pkg-config` queries starting with Dune language 3.25, preventing them from observing undeclared workspace inputs. Earlier language versions retain their existing behavior.

The external environment handling introduced in Dune 3.8 remains unchanged.
