### PR TITLE
fix(mdx): sandbox dependency discovery from version 0.6

### DIFF
--- a/doc/changes/fixed/16183.md
+++ b/doc/changes/fixed/16183.md
@@ -1,0 +1,2 @@
+- Sandbox `ocaml-mdx deps` when using MDX extension 0.6 so dependency
+  discovery cannot observe undeclared workspace inputs. (#16183, @rgrinberg)

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -46,11 +46,12 @@ module Deps = struct
     | Error (_, msg) -> Error msg
   ;;
 
-  let read ~sctx ~dir ~loc ~mdx_prog (files : Files.t) =
+  let read ~sctx ~dir ~loc ~sandbox ~mdx_prog (files : Files.t) =
     let open Action_builder.O in
     (let* prog = mdx_prog in
      Command.run'
        ~dir:(Path.build dir)
+       ~sandbox
        prog
        [ Command.Args.A "deps"; Lazy.force color_always; Dep (Path.build files.src) ])
     |> Super_context.execute_action_stdout sctx ~loc ~dir
@@ -298,7 +299,12 @@ let gen_rules_for_single_file stanza ~sctx ~dir ~expander ~mdx_prog ~mdx_prog_ge
   let mdx_action =
     let mdx_input_dependencies =
       let open Action_builder.O in
-      let* dep_set = Deps.read ~sctx ~dir ~loc ~mdx_prog files in
+      let sandbox =
+        if version >= (0, 6)
+        then Sandbox_config.needs_sandboxing
+        else Sandbox_config.no_special_requirements
+      in
+      let* dep_set = Deps.read ~sctx ~dir ~loc ~sandbox ~mdx_prog files in
       Action_builder.of_memo
         (let open Memo.O in
          let src_path_msg = Pp.seq (Pp.text "Source path: ") (Path.pp (Path.build src)) in

--- a/test/blackbox-tests/test-cases/stanzas/mdx-stanza/sandboxing.t
+++ b/test/blackbox-tests/test-cases/stanzas/mdx-stanza/sandboxing.t
@@ -77,4 +77,4 @@ Use a stable markdown file when testing the dependency scanner.
   $ echo >> README.md
   $ dune runtest
   $ mdx_command_is_sandboxed deps
-  false
+  true

--- a/test/blackbox-tests/test-cases/stanzas/mdx-stanza/sandboxing.t
+++ b/test/blackbox-tests/test-cases/stanzas/mdx-stanza/sandboxing.t
@@ -46,22 +46,35 @@ Mdx tests run in a sandbox, so undeclared files are not visible.
 
 The mdx generator is also sandboxed starting with version 0.6.
 
-  $ mdx_generator_is_sandboxed() {
-  >   dune trace cat | jq_dune -sc '
+  $ mdx_command_is_sandboxed() {
+  >   dune trace cat | jq_dune -sc --arg command "$1" '
   >     [ .[]
   >     | processes
   >     | select(.args.prog | basename == "ocaml-mdx")
-  >     | select(.args.process_args[0] == "dune-gen")
+  >     | select(.args.process_args[0] == $command)
   >     | (.args.dir | contains(".sandbox"))
   >     ][0]'
   > }
 
+Use a stable markdown file when testing the dependency scanner.
+
+  $ cat > README.md <<'EOF'
+  > # Sandboxing
+  > EOF
+
   $ make_mdx_project 3.25 0.5
   $ dune build mdx_gen.ml-gen
-  $ mdx_generator_is_sandboxed
+  $ mdx_command_is_sandboxed dune-gen
+  false
+  $ dune runtest
+  $ mdx_command_is_sandboxed deps
   false
 
   $ make_mdx_project 3.25 0.6
   $ dune build mdx_gen.ml-gen
-  $ mdx_generator_is_sandboxed
+  $ mdx_command_is_sandboxed dune-gen
   true
+  $ echo >> README.md
+  $ dune runtest
+  $ mdx_command_is_sandboxed deps
+  false


### PR DESCRIPTION
Require sandboxing for `ocaml-mdx deps` when using MDX extension version 0.6, matching the generator and test actions. Version 0.5 retains its existing behavior for compatibility.

The regression test uses structured process trace events to verify the dependency scanner's working directory before and after the version gate.
