### PR TITLE
refactor(merlin): preserve nonempty reader commands

### DIFF
--- a/src/dune_lang/dialect.ml
+++ b/src/dune_lang/dialect.ml
@@ -36,7 +36,7 @@ module File_kind = struct
     ; preprocess : (Loc.t * Action.t) option
     ; format : Format.t option
     ; print_ast : (Loc.t * Action.t) option
-    ; merlin_reader : (Loc.t * string list) option
+    ; merlin_reader : (Loc.t * string Nonempty_list.t) option
     }
 
   let encode { kind; extension; preprocess; format; print_ast; merlin_reader } =
@@ -59,7 +59,11 @@ module File_kind = struct
                 "print_ast"
                 Action.encode
                 (Option.map ~f:(fun (_, x) -> x) print_ast)
-            ; field_o "merlin_reader" (list string) (Option.map ~f:snd merlin_reader)
+            ; field_o
+                "merlin_reader"
+                (list string)
+                (Option.map merlin_reader ~f:(fun (_, reader) ->
+                   Nonempty_list.to_list reader))
             ])
   ;;
 
@@ -71,7 +75,10 @@ module File_kind = struct
       ; "preprocess", option (fun (_, x) -> Action.to_dyn x) preprocess
       ; "format", option Format.to_dyn format
       ; "print_ast", option (fun (_, x) -> Action.to_dyn x) print_ast
-      ; "merlin_reader", option (fun (_, x) -> list string x) merlin_reader
+      ; ( "merlin_reader"
+        , option
+            (fun (_, reader) -> list string (Nonempty_list.to_list reader))
+            merlin_reader )
       ]
   ;;
 end
@@ -113,8 +120,7 @@ let decode =
     and+ merlin_reader =
       field_o
         "merlin_reader"
-        (Syntax.since Stanza.syntax (3, 16)
-         >>> located (repeat1 string >>| Nonempty_list.to_list))
+        (Syntax.since Stanza.syntax (3, 16) >>> located (repeat1 string))
     and+ syntax_ver = Syntax.get_exn Stanza.syntax in
     let ver = 3, 9 in
     if syntax_ver < ver && Option.is_some (String.index_from extension 1 '.')
@@ -294,7 +300,7 @@ module DB = struct
 
   and for_merlin =
     { extensions : string option Ml_kind.Dict.t list
-    ; readers : string list String.Map.t
+    ; readers : string Nonempty_list.t String.Map.t
     }
 
   let fold { by_name; _ } = String.Map.fold by_name

--- a/src/dune_lang/dialect.mli
+++ b/src/dune_lang/dialect.mli
@@ -54,7 +54,7 @@ module DB : sig
 
   type for_merlin =
     { extensions : string option Ml_kind.Dict.t list
-    ; readers : string list String.Map.t
+    ; readers : string Nonempty_list.t String.Map.t
     }
 
   val for_merlin : t -> for_:Compilation_mode.t -> for_merlin

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -106,7 +106,7 @@ module Processed = struct
   type module_config =
     { opens : Module_name.t list
     ; module_ : Module.t
-    ; reader : string list option
+    ; reader : string Nonempty_list.t option
     }
 
   let module_config_repr =
@@ -114,7 +114,10 @@ module Processed = struct
       "merlin-module-config"
       [ Repr.field "opens" (Repr.list Module_name.repr) ~get:(fun t -> t.opens)
       ; Repr.field "module_" (Repr.abstract Module.to_dyn) ~get:(fun t -> t.module_)
-      ; Repr.field "reader" (Repr.option (Repr.list Repr.string)) ~get:(fun t -> t.reader)
+      ; Repr.field
+          "reader"
+          (Repr.option (Repr.view (Repr.list Repr.string) ~to_:Nonempty_list.to_list))
+          ~get:(fun t -> t.reader)
       ]
   ;;
 
@@ -296,7 +299,9 @@ module Processed = struct
     let reader =
       match reader with
       | Some reader ->
-        [ make_directive "READER" (Sexp.List (List.map ~f:(fun r -> Sexp.Atom r) reader))
+        [ make_directive
+            "READER"
+            (Sexp.List (Nonempty_list.to_list_map reader ~f:(fun r -> Sexp.Atom r)))
         ]
       | None -> []
     in
@@ -575,7 +580,7 @@ module Unprocessed = struct
     ; libname : Lib_name.Local.t option
     ; objs_dirs : Path.Set.t
     ; extensions : string option Ml_kind.Dict.t list
-    ; readers : string list String.Map.t
+    ; readers : string Nonempty_list.t String.Map.t
     ; for_ : Compilation_mode.t
     ; parameters : Module_name.t list Resolve.t
     }


### PR DESCRIPTION
Preserve the nonempty Merlin reader invariant through dialect and Merlin configuration types.\n\nFollow-up to #16165.