### PR TITLE
fix(merlin): generate mode-aware configurations

### DIFF
--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -65,12 +65,11 @@ end = struct
     ; source_dirs : 'source_dirs
     }
 
-  let empty_none = { merlin = None; cctx = None; js = None; source_dirs = None }
+  let empty_none = { merlin = []; cctx = []; js = None; source_dirs = None }
   let empty_list = { merlin = []; cctx = Loc.Map.empty; js = []; source_dirs = [] }
 
-  let add_map_maybe hd_o tl =
-    match hd_o with
-    | Some (loc, hd) ->
+  let add_map hds tl =
+    List.fold_left hds ~init:tl ~f:(fun tl (loc, hd) ->
       Loc.Map.update tl loc ~f:(function
         | None ->
           Some
@@ -83,20 +82,16 @@ end = struct
             (Compilation_mode.Per_mode.of_list
                ~init:None
                ((Compilation_context.for_ hd, Some hd)
-                :: List.map current ~f:(fun (k, v) -> k, Some v))))
-    | None -> tl
-  ;;
-
-  let cons_maybe hd_o tl =
-    match hd_o with
-    | Some hd -> hd :: tl
-    | None -> tl
+                :: List.map current ~f:(fun (k, v) -> k, Some v)))))
   ;;
 
   let cons acc x =
-    { merlin = cons_maybe x.merlin acc.merlin
-    ; cctx = add_map_maybe x.cctx acc.cctx
-    ; source_dirs = cons_maybe x.source_dirs acc.source_dirs
+    { merlin = List.rev_append x.merlin acc.merlin
+    ; cctx = add_map x.cctx acc.cctx
+    ; source_dirs =
+        (match x.source_dirs with
+         | None -> acc.source_dirs
+         | Some source_dir -> source_dir :: acc.source_dirs)
     ; js =
         (match x.js with
          | None -> acc.js
@@ -113,8 +108,8 @@ end = struct
 
   let with_cctx_merlin ~loc (cctx, merlin) =
     { empty_none with
-      merlin = Some (Merlin.group ~default:merlin ~alternatives:[])
-    ; cctx = Some (loc, cctx)
+      merlin = [ Merlin.group ~default:merlin ~alternatives:[] ]
+    ; cctx = [ loc, cctx ]
     }
   ;;
 
@@ -137,12 +132,19 @@ end = struct
           (Scope.libs scope)
           (Local (Library.to_lib_id ~src_dir lib))
       in
-      if_available_buildable
-        ~loc:lib.buildable.loc
+      if_available
         (fun () ->
-           Lib_rules.rules lib ~sctx ~scope ~dir_contents ~expander
-           >>| Compilation_mode.Per_mode.choose
-           >>| Option.value_exn)
+           let+ cctx_merlins = Lib_rules.rules lib ~sctx ~scope ~dir_contents ~expander in
+           match cctx_merlins.ocaml, cctx_merlins.melange with
+           | None, None -> empty_none
+           | Some cctx_merlin, None | None, Some cctx_merlin ->
+             with_cctx_merlin ~loc:lib.buildable.loc cctx_merlin
+           | Some (ocaml_cctx, ocaml_merlin), Some (melange_cctx, melange_merlin) ->
+             { empty_none with
+               merlin =
+                 [ Merlin.group ~default:ocaml_merlin ~alternatives:[ melange_merlin ] ]
+             ; cctx = [ lib.buildable.loc, ocaml_cctx; lib.buildable.loc, melange_cctx ]
+             })
         enabled_if
     | Foreign_library.T lib ->
       Expander.eval_blang expander lib.enabled_if

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -448,7 +448,9 @@ module Processed = struct
     match load_file path with
     | Error msg -> Printf.eprintf "%s\n" msg
     | Ok configurations ->
-      Nonempty_list.hd configurations |> dump_entries |> List.iter ~f:print_entry
+      Nonempty_list.to_list_map configurations ~f:dump_entries
+      |> List.concat
+      |> List.iter ~f:print_entry
   ;;
 
   let print_files format paths =
@@ -459,7 +461,8 @@ module Processed = struct
          Result.List.map paths ~f:(fun path ->
            match load_file path with
            | Error msg -> Error msg
-           | Ok configurations -> Ok (dump_entries (Nonempty_list.hd configurations)))
+           | Ok configurations ->
+             Ok (Nonempty_list.to_list_map configurations ~f:dump_entries |> List.concat))
        with
        | Error msg -> Printf.eprintf "%s\n" msg
        | Ok entries ->

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -558,6 +558,16 @@ Mixed OCaml/Melange libraries store their Merlin data in one stanza file.
   >  (melange.preprocess
   >   (action
   >    (run sh %{dep:pp_melange.sh} %{input-file}))))
+  > (library
+  >  (name melange_only_lib)
+  >  (modules melange_only)
+  >  (modes melange)
+  >  (melange.preprocess
+  >   (action
+  >    (run sh %{dep:pp_melange.sh} %{input-file}))))
+  > (library
+  >  (name aaa)
+  >  (modules aaa))
   > EOF
   $ cat > mixed/foo.ml <<EOF
   > let x = "foo"
@@ -577,9 +587,17 @@ Mixed OCaml/Melange libraries store their Merlin data in one stanza file.
   $ cat > mixed/iface.melange.mli <<EOF
   > val target : string
   > EOF
+  $ cat > mixed/melange_only.ml <<EOF
+  > let target = "melange"
+  > EOF
+  $ cat > mixed/aaa.ml <<EOF
+  > let x = "aaa"
+  > EOF
 
   $ dune build --root mixed @check
   $ find mixed/_build/default/.merlin-conf -type f | sort
+  mixed/_build/default/.merlin-conf/lib-aaa
+  mixed/_build/default/.merlin-conf/lib-melange_only_lib
   mixed/_build/default/.merlin-conf/lib-mixed
 
 The old `File` query still returns the default OCaml Merlin configuration.
@@ -590,27 +608,19 @@ The old `File` query still returns the default OCaml Merlin configuration.
   $ query_ocaml_merlin_pp "$PWD/mixed/foo.ml" --root mixed | grep -E 'MELC_STDLIB|\.objs/melange|pp_melange'
   [1]
 
-An exact conditional source should use the configuration for its mode. The
-Melange configuration is currently missing from a mixed-mode library.
+The extensionless lookup remains available for preprocessed filenames.
 
-  $ query_ocaml_merlin_pp "$PWD/mixed/platform.ml" --root mixed | grep -q pp_ocaml
-  $ query_ocaml_merlin_pp "$PWD/mixed/iface.mli" --root mixed | grep -q pp_ocaml
-  $ query_ocaml_merlin_pp "$PWD/mixed/platform.melange.ml" --root mixed | grep -q pp_melange
-  [1]
-  $ query_ocaml_merlin_pp "$PWD/mixed/iface.melange.mli" --root mixed | grep -q pp_melange
-  [1]
+  $ query_ocaml_merlin_pp "$PWD/mixed/platform.pp.ml" --root mixed \
+  >   | grep -Eo 'pp_(ocaml|melange)' | sort -u
+  pp_ocaml
 
-The extensionless lookup remains a fallback for preprocessed filenames.
-
-  $ query_ocaml_merlin_pp "$PWD/mixed/platform.pp.ml" --root mixed | grep -q pp_ocaml
-
-Dump-dot-merlin should continue to use only the default OCaml configuration.
+Dump-dot-merlin continues to use only the default OCaml configuration.
 
   $ dune ocaml dump-dot-merlin --root mixed "$PWD/mixed" \
   >   | grep -E '^B .*\.mixed\.objs/(byte|melange)'
   B $TESTCASE_ROOT/mixed/_build/default/.mixed.objs/byte
 
-Only the default configuration is currently available to debug tooling.
+Both generated configurations remain available to debug tooling.
 
   $ dune ocaml merlin dump-config --root mixed --format=json "$PWD/mixed" | jq_dune '
   > def config($name): .config[] | select(.[0] == $name) | .[1];
@@ -632,6 +642,11 @@ Only the default configuration is currently available to debug tooling.
       "mode": "ocaml",
       "obj_dir": "_build/default/.mixed.objs/byte",
       "preprocess": "ocaml"
+    },
+    {
+      "mode": "melange",
+      "obj_dir": "_build/default/.mixed.objs/melange",
+      "preprocess": "melange"
     }
   ]
 
@@ -640,4 +655,3 @@ The mixed library should also expose its Melange configuration.
   $ dune ocaml merlin dump-config --root mixed --format=json "$PWD/mixed" | jq_dune -e '
   > [merlinEntry("Foo") | .config[] | select(.[0] == "B") | .[1]]
   > | any(contains(".mixed.objs/melange"))' >/dev/null
-  [1]


### PR DESCRIPTION
Generate and persist both OCaml and Melange Merlin configurations for mixed-mode libraries while preserving singular lookup behavior.

Builds on #15493. Exact-match precedence is handled in #16194.