### PR TITLE
test(melange): cover hidden private vlib dependencies

### DIFF
--- a/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps.t
+++ b/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps.t
@@ -31,6 +31,9 @@ The virtual library and its implementation are both Melange-only.
   $ cat > producer/vlib/helper.ml <<'EOF'
   > let answer = Leaf.answer
   > EOF
+  $ cat > producer/vlib/helper.mli <<'EOF'
+  > val answer : int
+  > EOF
   $ cat > producer/vlib/leaf.ml <<'EOF'
   > let answer = 42
   > EOF


### PR DESCRIPTION
Strengthen the installed Melange virtual-library regression test with a private module whose implementation-only dependency is hidden by an interface.

Follow-up to #16066; prepares anmonteiro/dune#78.