### PR TITLE
refactor(cram): abstract test names

### DIFF
--- a/bin/runtest_common.ml
+++ b/bin/runtest_common.ml
@@ -15,7 +15,7 @@ module Test_kind = struct
 
   let alias ~contexts = function
     | Cram (dir, cram) ->
-      let name = Dune_engine.Alias.Name.of_string (Source.Cram_test.name cram) in
+      let name = Source.Cram_test.name cram |> Source.Cram_test.Name.to_alias in
       Alias.in_dir ~name ~recursive:false ~contexts dir
     | Test_executable { dir; exe_name } ->
       let name = Dune_engine.Alias.Name.of_string ("runtest-" ^ exe_name) in

--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -256,7 +256,7 @@ let spec_for_test ~stanzas test =
     | Ok test -> Cram_test.name test
     | Error (Missing_run_t test) -> Cram_test.name test
   in
-  let test_name_alias = Alias.Name.of_string name in
+  let test_name_alias = Cram_test.Name.to_alias name in
   let init = None, Spec.make_empty ~test_name_alias in
   let* runtest_alias, acc =
     Memo.List.fold_left
@@ -267,7 +267,10 @@ let spec_for_test ~stanzas test =
           match stanza.applies_to with
           | Whole_subtree -> true
           | Files_matching_in_this_dir pred ->
-            Predicate_lang.Glob.test pred ~standard:Predicate_lang.true_ name
+            Predicate_lang.Glob.test
+              pred
+              ~standard:Predicate_lang.true_
+              (Cram_test.Name.to_string name)
         with
         | false -> Memo.return (runtest_alias, acc)
         | true ->
@@ -308,7 +311,9 @@ let spec_for_test ~stanzas test =
                    [ Pp.text
                        "enabling or disabling the runtest alias for a cram test may only \
                         be set once."
-                   ; Pp.textf "It's already set for the test %S" name
+                   ; Pp.textf
+                       "It's already set for the test %S"
+                       (Cram_test.Name.to_string name)
                    ]
                  in
                  let compound =

--- a/src/source/cram_test.ml
+++ b/src/source/cram_test.ml
@@ -7,6 +7,13 @@ type t =
       ; dir : Path.Source.t
       }
 
+module Name = struct
+  type t = string
+
+  let to_string s = s
+  let to_alias = Alias_name.of_string
+end
+
 let fname_in_dir_test = Filename.run_t
 let suffix = ".t"
 let is_cram_suffix fn = String.ends_with (Filename.to_string fn) ~suffix

--- a/src/source/cram_test.mli
+++ b/src/source/cram_test.mli
@@ -10,6 +10,14 @@ type t =
 
 val to_dyn : t -> Dyn.t
 
+module Name : sig
+  (** The basename used to identify a cram test. *)
+  type t
+
+  val to_string : t -> string
+  val to_alias : t -> Alias_name.t
+end
+
 (** Checks if a filename has the ".t" suffix for a cram test. *)
 val is_cram_suffix : Filename.t -> bool
 
@@ -19,7 +27,7 @@ val fname_in_dir_test : Filename.t
 (** The [name] of a cram test. If this is a file test, then it will be the file
     name without the cram suffix. If this is a directory test, then it will be
     the directory name without the cram suffix. *)
-val name : t -> string
+val name : t -> Name.t
 
 (** The [path] associated to a cram test. If this is a file test, then it will
     be the file. If this is a directory test, then it will be the directory. *)


### PR DESCRIPTION
Represent cram test names with an abstract Cram_test.Name.t and convert them to strings only at alias and predicate boundaries.