### PR TITLE
fix(oxcaml): odoc generation for parameter implementations

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -439,7 +439,7 @@ jobs:
           node-version: latest
 
       - name: Install deps
-        run: opam install csexp pp re spawn uutf ppx_expect ppx_inline_test wasm_of_ocaml-compiler
+        run: opam install csexp pp re spawn uutf odoc ppx_expect ppx_inline_test wasm_of_ocaml-compiler
 
       - name: Build dune
         run: opam exec -- make bootstrap

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -438,6 +438,9 @@ jobs:
         with:
           node-version: latest
 
+      - name: Install odoc deps
+        run: opam install result
+
       - name: Install deps
         run: opam install csexp pp re spawn uutf odoc ppx_expect ppx_inline_test wasm_of_ocaml-compiler
 

--- a/.github/workflows/workflow.yml.in
+++ b/.github/workflows/workflow.yml.in
@@ -437,6 +437,9 @@ jobs:
         with:
           node-version: latest
 
+      - name: Install odoc deps
+        run: opam install result
+
       - name: Install deps
         run: opam install csexp pp re spawn uutf odoc ppx_expect ppx_inline_test wasm_of_ocaml-compiler
 

--- a/.github/workflows/workflow.yml.in
+++ b/.github/workflows/workflow.yml.in
@@ -438,7 +438,7 @@ jobs:
           node-version: latest
 
       - name: Install deps
-        run: opam install csexp pp re spawn uutf ppx_expect ppx_inline_test wasm_of_ocaml-compiler
+        run: opam install csexp pp re spawn uutf odoc ppx_expect ppx_inline_test wasm_of_ocaml-compiler
 
       - name: Build dune
         run: opam exec -- make bootstrap

--- a/doc/changes/fixed/16200.md
+++ b/doc/changes/fixed/16200.md
@@ -1,0 +1,1 @@
+- Fix missing Odoc generation of OxCaml parameter implementations (#16200, @art-w)

--- a/nix/devShells/ox.nix
+++ b/nix/devShells/ox.nix
@@ -101,7 +101,6 @@ in
       "merlin"
       "ocaml-index"
       "ocaml-lsp-server"
-      "odoc"
       "ppx_quick_test"
     ];
     extraBuildInputs =

--- a/nix/ox-package-set.nix
+++ b/nix/ox-package-set.nix
@@ -74,4 +74,16 @@ overlay // {
     nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.binaryen ];
     patches = (old.patches or [ ]) ++ [ ./patches/wasm_of_ocaml-args-basename.patch ];
   });
+  # Use the OxCaml fork of Odoc for AST compatibility
+  odoc = osuper.odoc.overrideAttrs (old: {
+    version = "3.2.0+ox2";
+    src = pkgs.fetchFromGitHub {
+      owner = "oxcaml";
+      repo = "odoc";
+      # branch 5.2.0minus-39
+      rev = "b7b9090ac3dadc7b4b2108b2d21dd6667cd1be0f";
+      hash = "sha256-frnTw0yGFfN/Hh89z70jWTa4VXDzNDeuH0Miblrx2m0=";
+    };
+    buildInputs = (old.buildInputs or [ ]) ++ [ oself.result ];
+  });
 }

--- a/src/dune_rules/odoc/odoc.ml
+++ b/src/dune_rules/odoc/odoc.ml
@@ -761,15 +761,26 @@ let setup_toplevel_index_rule sctx output =
   add_rule sctx (Action_builder.write_file path content)
 ;;
 
+let is_documentation_relevant lib =
+  (* Filter out implementations of virtual modules. *)
+  match Lib.implements lib with
+  | None -> Memo.return true
+  | Some implements ->
+    let+ implements = implements in
+    (match Resolve.peek implements with
+     | Error () -> false
+     | Ok implements ->
+       (match Lib.info implements |> Lib_info.kind with
+        | Parameter -> true
+        | Virtual | Dune_file _ -> false))
+;;
+
 let libs_of_pkg ctx ~pkg =
-  let+ { Scope.DB.Lib_entry.Set.libraries; _ } =
+  let* { Scope.DB.Lib_entry.Set.libraries; _ } =
     Scope.DB.lib_entries_of_package ctx pkg
   in
-  (* Filter out all implementations of virtual libraries *)
-  List.filter_map libraries ~f:(fun lib ->
-    match Lib.Local.to_lib lib |> Lib.info |> Lib_info.implements with
-    | None -> Some lib
-    | Some _ -> None)
+  Memo.List.filter libraries ~f:(fun lib ->
+    is_documentation_relevant (Lib.Local.to_lib lib))
 ;;
 
 let entry_modules_by_lib sctx lib =

--- a/src/dune_rules/odoc/odoc.mli
+++ b/src/dune_rules/odoc/odoc.mli
@@ -9,6 +9,7 @@ end
 val lib_unique_name : Lib.t -> string
 val odoc_program : Super_context.t -> Path.Build.t -> Action.Prog.t Action_builder.t
 val odoc_files_in_dirs : Path.t list -> _ Command.Args.t
+val is_documentation_relevant : Lib.t -> bool Memo.t
 val libs_of_pkg : Context_name.t -> pkg:Package.Name.t -> Lib.Local.t list Memo.t
 
 val mlds

--- a/src/dune_rules/odoc/odoc_new.ml
+++ b/src/dune_rules/odoc/odoc_new.ml
@@ -437,7 +437,7 @@ module Valid = struct
       let* libs, packages = libs_and_pkgs in
       let+ libs_list =
         let+ libs_list =
-          let+ libs_list =
+          let* libs_list =
             let* stdlib = stdlib_lib (Context.name ctx) in
             Memo.parallel_map libs ~f:(fun (_, _lib_db, libs) ->
               Lib.Set.fold ~init:(Memo.return []) libs ~f:(fun lib acc ->
@@ -458,9 +458,7 @@ module Valid = struct
           |> List.concat
           |> Lib.Set.of_list
           |> Lib.Set.to_list
-          |> List.filter ~f:(fun lib ->
-            let is_impl = Lib.info lib |> Lib_info.implements |> Option.is_some in
-            not is_impl)
+          |> Memo.List.filter ~f:Odoc.is_documentation_relevant
         in
         if all
         then libs_list

--- a/test/blackbox-tests/test-cases/oxcaml/dune
+++ b/test/blackbox-tests/test-cases/oxcaml/dune
@@ -9,3 +9,8 @@
 (cram
  (deps %{bin:tree})
  (applies_to vendor-parameterised))
+
+(cram
+ (enabled_if %{bin-available:odoc})
+ (deps %{bin:odoc})
+ (applies_to parameterised-doc))

--- a/test/blackbox-tests/test-cases/oxcaml/parameterised-doc.t
+++ b/test/blackbox-tests/test-cases/oxcaml/parameterised-doc.t
@@ -1,0 +1,118 @@
+Documentation of parameterised libraries, their parameters, implementations and
+instantiations.
+
+  $ init_oxcaml_project
+  $ cat >> dune-project <<EOF
+  > (package (name project))
+  > EOF
+
+A parameter:
+
+  $ make_dir_with_dune "param" <<EOF
+  > (library_parameter
+  >  (public_name project.param)
+  >  (name param))
+  > EOF
+  $ cat > param/param.mli <<EOF
+  > (** The parameter's documentation. *)
+  > val v : string
+  > EOF
+
+An implementation of that parameter:
+
+  $ make_dir_with_dune "param_impl" <<EOF
+  > (library
+  >  (public_name project.param_impl)
+  >  (name param_impl)
+  >  (implements param))
+  > EOF
+  $ cat > param_impl/param_impl.ml <<EOF
+  > (** The implementation's documentation. *)
+  > let v = "impl"
+  > EOF
+
+A parameterised library and its instantiation:
+
+  $ make_dir_with_dune "plib" <<EOF
+  > (library
+  >  (public_name project.plib)
+  >  (name plib)
+  >  (parameters param))
+  > EOF
+  $ cat > plib/plib.ml <<EOF
+  > (** The parameterised library's documentation. *)
+  > let v = Param.v
+  > EOF
+
+  $ make_dir_with_dune "user" <<EOF
+  > (library
+  >  (public_name project.user)
+  >  (name user)
+  >  (libraries (instantiate plib param_impl)))
+  > EOF
+  $ cat > user/user.ml <<EOF
+  > (** The user's documentation. *)
+  > let v = Plib.v
+  > EOF
+
+A virtual library and its implementation, whose documentation is carried by the
+virtual library itself:
+
+  $ make_dir_with_dune "virt" <<EOF
+  > (library
+  >  (public_name project.virt)
+  >  (name virt)
+  >  (virtual_modules virt))
+  > EOF
+  $ cat > virt/virt.mli <<EOF
+  > (** The virtual library's documentation. *)
+  > val v : string
+  > EOF
+
+  $ make_dir_with_dune "virt_impl" <<EOF
+  > (library
+  >  (public_name project.virt_impl)
+  >  (name virt_impl)
+  >  (implements virt))
+  > EOF
+  $ cat > virt_impl/virt.ml <<EOF
+  > let v = "virt"
+  > EOF
+
+The implementation of the parameter is missing its documentation, unlike the
+implementation of the virtual library which is documented by the virtual library
+itself:
+
+  $ dune build @doc
+  $ find _build/default/_doc/_odocls -name '*.odocl' | sort
+  _build/default/_doc/_odocls/project/page-index.odocl
+  _build/default/_doc/_odocls/project/param.odocl
+  _build/default/_doc/_odocls/project/plib.odocl
+  _build/default/_doc/_odocls/project/user.odocl
+  _build/default/_doc/_odocls/project/virt.odocl
+
+The package index does not mention it either:
+
+  $ cat _build/default/_doc/_mlds/project/index.mld
+  {0 project index}
+  {1 Library project.param}
+  The entry point of this library is the module:
+  {!module-Param}.
+  {1 Library project.plib}
+  The entry point of this library is the module:
+  {!module-Plib}.
+  {1 Library project.user}
+  The entry point of this library is the module:
+  {!module-User}.
+  {1 Library project.virt}
+  The entry point of this library is the module:
+  {!module-Virt}.
+
+The new documentation generator misses it too:
+
+  $ dune build @doc-new 2>/dev/null
+  $ find _build/default/_doc_new/odoc/local -name '*.odocl' | sort
+  _build/default/_doc_new/odoc/local/project/param/param.odocl
+  _build/default/_doc_new/odoc/local/project/plib/plib.odocl
+  _build/default/_doc_new/odoc/local/project/user/user.odocl
+  _build/default/_doc_new/odoc/local/project/virt/virt.odocl

--- a/test/blackbox-tests/test-cases/oxcaml/parameterised-doc.t
+++ b/test/blackbox-tests/test-cases/oxcaml/parameterised-doc.t
@@ -79,25 +79,28 @@ virtual library itself:
   > let v = "virt"
   > EOF
 
-The implementation of the parameter is missing its documentation, unlike the
-implementation of the virtual library which is documented by the virtual library
-itself:
+Every library gets its documentation, except the implementation of the virtual
+library:
 
   $ dune build @doc
   $ find _build/default/_doc/_odocls -name '*.odocl' | sort
   _build/default/_doc/_odocls/project/page-index.odocl
   _build/default/_doc/_odocls/project/param.odocl
+  _build/default/_doc/_odocls/project/param_impl.odocl
   _build/default/_doc/_odocls/project/plib.odocl
   _build/default/_doc/_odocls/project/user.odocl
   _build/default/_doc/_odocls/project/virt.odocl
 
-The package index does not mention it either:
+The package index lists them all:
 
   $ cat _build/default/_doc/_mlds/project/index.mld
   {0 project index}
   {1 Library project.param}
   The entry point of this library is the module:
   {!module-Param}.
+  {1 Library project.param_impl}
+  The entry point of this library is the module:
+  {!module-Param_impl}.
   {1 Library project.plib}
   The entry point of this library is the module:
   {!module-Plib}.
@@ -108,11 +111,12 @@ The package index does not mention it either:
   The entry point of this library is the module:
   {!module-Virt}.
 
-The new documentation generator misses it too:
+The new documentation generator agrees:
 
   $ dune build @doc-new 2>/dev/null
   $ find _build/default/_doc_new/odoc/local -name '*.odocl' | sort
   _build/default/_doc_new/odoc/local/project/param/param.odocl
+  _build/default/_doc_new/odoc/local/project/param_impl/param_impl.odocl
   _build/default/_doc_new/odoc/local/project/plib/plib.odocl
   _build/default/_doc_new/odoc/local/project/user/user.odocl
   _build/default/_doc_new/odoc/local/project/virt/virt.odocl


### PR DESCRIPTION
The odoc generation was skipping all libraries with an `implements` field (= assuming virtual modules), which meant that the documentation of OxCaml parameterized libraries was missing important pages (see https://github.com/ocaml/odoc/pull/1464)