### PR TITLE
test: pforms in block strings

### DIFF
--- a/test/blackbox-tests/test-cases/formatting/raw-block-string-pform.t
+++ b/test/blackbox-tests/test-cases/formatting/raw-block-string-pform.t
@@ -1,0 +1,29 @@
+Pform-like text in raw block strings should be literal, not expanded.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.17)
+  > EOF
+
+  $ cat > dune << 'EOF'
+  > (rule
+  >  (alias default)
+  >  (action
+  >   (echo "\> %{name}
+  > )))
+  > EOF
+
+  $ dune build 2>&1
+  %{name}
+
+In escaped block strings, pforms are expanded as usual.
+
+  $ cat > dune << 'EOF'
+  > (rule
+  >  (alias default)
+  >  (action
+  >   (echo "\| %{project_root}
+  > )))
+  > EOF
+
+  $ dune build 2>&1
+  .


### PR DESCRIPTION
## Description

Add regression coverage for pforms in block strings. Pform-like text in raw block strings remains literal, while escaped block strings expand pforms normally.

## Motivation

This locks down existing parsing semantics ahead of the formatter work in #13758. Split from #13758 for independent review.