### PR TITLE
test: check newlines in block strings

### DIFF
--- a/test/blackbox-tests/test-cases/formatting/block-string-escape-n.t
+++ b/test/blackbox-tests/test-cases/formatting/block-string-escape-n.t
@@ -1,0 +1,41 @@
+Escaped \n in a block string should produce the same string value as a literal
+newline between block string lines.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.17)
+  > EOF
+
+With \n escape in a block string:
+
+  $ cat > dune << 'EOF'
+  > (rule
+  >  (alias escaped)
+  >  (action
+  >   (progn
+  >    (echo "\| foo\nbar
+  > )
+  >    (echo escaped))))
+  > EOF
+
+  $ dune build @escaped 2>&1
+  foo
+  bar
+  escaped
+
+With actual newline (two block string lines):
+
+  $ cat > dune << 'EOF'
+  > (rule
+  >  (alias literal)
+  >  (action
+  >   (progn
+  >    (echo "\| foo
+  >          "\| bar
+  > )
+  >    (echo literal))))
+  > EOF
+
+  $ dune build @literal 2>&1
+  foo
+  bar
+  literal


### PR DESCRIPTION
## Description

Add regression coverage showing that an escaped `\n` and a literal newline between block-string lines produce the same string value. Distinct action markers ensure both forms execute during the test.

## Motivation

This locks down existing parsing semantics ahead of the formatter work in #13758. Split from #13758 for independent review.