### PR TITLE
fix: rebuild consumers after private module interface changes

### DIFF
--- a/doc/changes/fixed/16204.md
+++ b/doc/changes/fixed/16204.md
@@ -1,0 +1,2 @@
+- Fixed missing dependencies with private modules (#16204, fixes #16071,
+  @Alizter)

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -4,7 +4,7 @@ open Memo.O
 module Includes = struct
   type t = Command.Args.without_targets Command.Args.t Lib_mode.Cm_kind.Map.t
 
-  let make ~project ~opaque ~direct_requires ~hidden_requires lib_config
+  let make ~sctx ~project ~opaque ~direct_requires ~hidden_requires lib_config
     : _ Lib_mode.Cm_kind.Map.t
     =
     (* TODO: some of the requires can filtered out using [ocamldep] info *)
@@ -12,12 +12,29 @@ module Includes = struct
     let iflags direct_libs hidden_libs mode =
       Lib_flags.L.include_flags ~project ~direct_libs ~hidden_libs mode lib_config
     in
-    let make_includes_args ~mode groups =
+    let private_cmi_deps_arg =
+      if Ocaml.Version.supports_hidden_includes lib_config.ocaml_version
+      then
+        (let* direct_libs = direct_requires
+         and* hidden_libs = hidden_requires in
+         let+ deps =
+           Lib_file_deps.private_cmi_deps ~sctx (direct_libs @ hidden_libs)
+           |> Resolve.Memo.lift_memo
+         in
+         Command.Args.Hidden_deps deps)
+        |> Resolve.Memo.args
+        |> Command.Args.memo
+      else Command.Args.empty
+    in
+    let make_includes_args ~(mode : Lib_mode.t) groups =
       (let+ direct_libs = direct_requires
        and+ hidden_libs = hidden_requires in
        Command.Args.S
          [ iflags direct_libs hidden_libs mode
          ; Hidden_deps (Lib_file_deps.deps (direct_libs @ hidden_libs) ~groups)
+         ; (match mode with
+            | Ocaml _ -> private_cmi_deps_arg
+            | Melange -> Command.Args.empty)
          ])
       |> Resolve.Memo.args
       |> Command.Args.memo
@@ -45,6 +62,7 @@ module Includes = struct
                        Lib_file_deps.deps
                          libs
                          ~groups:[ Lib_file_deps.Group.Ocaml Cmi; Ocaml Cmx ])
+                ; private_cmi_deps_arg
                 ])
              |> Resolve.Memo.args
              |> Command.Args.memo
@@ -239,7 +257,13 @@ let create
   ; implements
   ; parameters
   ; includes =
-      Includes.make ~project ~opaque ~direct_requires ~hidden_requires ocaml.lib_config
+      Includes.make
+        ~sctx:super_context
+        ~project
+        ~opaque
+        ~direct_requires
+        ~hidden_requires
+        ocaml.lib_config
   ; preprocessing
   ; opaque
   ; js_of_ocaml
@@ -328,6 +352,7 @@ let for_module_generated_at_link_time cctx ~requires ~module_ =
     let hidden_requires = Resolve.Memo.return [] in
     let direct_requires = requires in
     Includes.make
+      ~sctx:cctx.super_context
       ~project:(Scope.project cctx.scope)
       ~opaque
       ~direct_requires

--- a/src/dune_rules/lib_file_deps.ml
+++ b/src/dune_rules/lib_file_deps.ml
@@ -2,8 +2,8 @@ open Import
 open Memo.O
 
 (* This file builds dep specs for library files (cmi/cmx/cmj/header). Per-module
-   tight deps apply only to local unwrapped libraries; wrapped libraries take
-   directory globs over their cmi include dirs. [ocamldep -modules] outputs only
+   tight deps apply only to local unwrapped libraries; wrapped libraries take a
+   directory glob over their public cmi dir. [ocamldep -modules] outputs only
    top-level module names — for a consumer using [Foo.Bar.x] the output is
    [Foo], not [Foo.Bar] — so the filter cannot distinguish [Foo.Bar] from
    [Foo.Baz] consumers and a glob is the tightest sound dep. *)
@@ -28,13 +28,13 @@ module Group = struct
     | Header -> Foreign_language.header_extension
   ;;
 
-  let obj_dirs t obj_dir =
+  let obj_dir t obj_dir =
     match t with
-    | Ocaml Cmi -> Obj_dir.public_cmi_ocaml_dir obj_dir :: Obj_dir.all_cmis obj_dir
-    | Ocaml Cmx -> [ Obj_dir.native_dir obj_dir ]
-    | Melange Cmi -> [ Obj_dir.public_cmi_melange_dir obj_dir ]
-    | Melange Cmj -> [ Obj_dir.melange_dir obj_dir ]
-    | Header -> [ Obj_dir.dir obj_dir ]
+    | Ocaml Cmi -> Obj_dir.public_cmi_ocaml_dir obj_dir
+    | Ocaml Cmx -> Obj_dir.native_dir obj_dir
+    | Melange Cmi -> Obj_dir.public_cmi_melange_dir obj_dir
+    | Melange Cmj -> Obj_dir.melange_dir obj_dir
+    | Header -> Obj_dir.dir obj_dir
   ;;
 
   let to_glob =
@@ -49,15 +49,37 @@ end
 
 let deps_of_lib (lib : Lib.t) ~groups =
   let obj_dir = Lib.info lib |> Lib_info.obj_dir in
-  List.concat_map groups ~f:(fun g ->
-    let glob = Group.to_glob g in
-    List.map (Group.obj_dirs g obj_dir) ~f:(fun dir ->
-      File_selector.of_glob ~dir glob |> Dep.file_selector))
+  List.map groups ~f:(fun g ->
+    let dir = Group.obj_dir g obj_dir in
+    Group.to_glob g |> File_selector.of_glob ~dir |> Dep.file_selector)
   |> Dep.Set.of_list
 ;;
 
 let deps_with_exts = Dep.Set.union_map ~f:(fun (lib, groups) -> deps_of_lib lib ~groups)
 let deps libs ~groups = Dep.Set.union_map libs ~f:(deps_of_lib ~groups)
+
+let private_cmi_deps ~sctx libs =
+  Memo.List.fold_left libs ~init:Dep.Set.empty ~f:(fun deps lib ->
+    let obj_dir = Lib.info lib |> Lib_info.obj_dir in
+    let public_cmi_dir = Obj_dir.public_cmi_ocaml_dir obj_dir in
+    if
+      List.exists (Obj_dir.all_cmis obj_dir) ~f:(fun dir ->
+        not (Path.equal dir public_cmi_dir))
+    then
+      let+ modules = Dir_contents.modules_of_lib sctx lib ~for_:Compilation_mode.Ocaml in
+      match modules with
+      | None -> deps
+      | Some modules ->
+        let { Modules.With_vlib.vlib; impl } = Modules.With_vlib.split_by_lib modules in
+        List.fold_left (vlib @ impl) ~init:deps ~f:(fun deps m ->
+          if Module.visibility m = Private
+          then
+            Obj_dir.Module.cm_file_exn obj_dir m ~kind:(Ocaml Cmi)
+            |> Dep.file
+            |> Dep.Set.add deps
+          else deps)
+    else Memo.return deps)
+;;
 
 let groups_for_cm_kind ~opaque ~(cm_kind : Lib_mode.Cm_kind.t) lib =
   match cm_kind with

--- a/src/dune_rules/lib_file_deps.ml
+++ b/src/dune_rules/lib_file_deps.ml
@@ -2,8 +2,8 @@ open Import
 open Memo.O
 
 (* This file builds dep specs for library files (cmi/cmx/cmj/header). Per-module
-   tight deps apply only to local unwrapped libraries; wrapped libraries take a
-   directory glob over their public cmi dir. [ocamldep -modules] outputs only
+   tight deps apply only to local unwrapped libraries; wrapped libraries take
+   directory globs over their cmi include dirs. [ocamldep -modules] outputs only
    top-level module names — for a consumer using [Foo.Bar.x] the output is
    [Foo], not [Foo.Bar] — so the filter cannot distinguish [Foo.Bar] from
    [Foo.Baz] consumers and a glob is the tightest sound dep. *)
@@ -28,13 +28,13 @@ module Group = struct
     | Header -> Foreign_language.header_extension
   ;;
 
-  let obj_dir t obj_dir =
+  let obj_dirs t obj_dir =
     match t with
-    | Ocaml Cmi -> Obj_dir.public_cmi_ocaml_dir obj_dir
-    | Ocaml Cmx -> Obj_dir.native_dir obj_dir
-    | Melange Cmi -> Obj_dir.public_cmi_melange_dir obj_dir
-    | Melange Cmj -> Obj_dir.melange_dir obj_dir
-    | Header -> Obj_dir.dir obj_dir
+    | Ocaml Cmi -> Obj_dir.public_cmi_ocaml_dir obj_dir :: Obj_dir.all_cmis obj_dir
+    | Ocaml Cmx -> [ Obj_dir.native_dir obj_dir ]
+    | Melange Cmi -> [ Obj_dir.public_cmi_melange_dir obj_dir ]
+    | Melange Cmj -> [ Obj_dir.melange_dir obj_dir ]
+    | Header -> [ Obj_dir.dir obj_dir ]
   ;;
 
   let to_glob =
@@ -49,9 +49,10 @@ end
 
 let deps_of_lib (lib : Lib.t) ~groups =
   let obj_dir = Lib.info lib |> Lib_info.obj_dir in
-  List.map groups ~f:(fun g ->
-    let dir = Group.obj_dir g obj_dir in
-    Group.to_glob g |> File_selector.of_glob ~dir |> Dep.file_selector)
+  List.concat_map groups ~f:(fun g ->
+    let glob = Group.to_glob g in
+    List.map (Group.obj_dirs g obj_dir) ~f:(fun dir ->
+      File_selector.of_glob ~dir glob |> Dep.file_selector))
   |> Dep.Set.of_list
 ;;
 

--- a/src/dune_rules/lib_file_deps.mli
+++ b/src/dune_rules/lib_file_deps.mli
@@ -17,6 +17,9 @@ val deps : Lib.t list -> groups:Group.t list -> Dep.Set.t
 
 val deps_with_exts : (Lib.t * Group.t list) list -> Dep.Set.t
 
+(** Exact dependencies on private CMIs. *)
+val private_cmi_deps : sctx:Super_context.t -> Lib.t list -> Dep.Set.t Memo.t
+
 (** [deps_of_entries ~opaque ~cm_kind libs] computes the file dependencies (glob
     deps on .cmi/.cmx files) for the given libraries. *)
 val deps_of_entries : opaque:bool -> cm_kind:Lib_mode.Cm_kind.t -> Lib.t list -> Dep.Set.t

--- a/test/blackbox-tests/test-cases/private-modules/private-module-interface-rebuild.t
+++ b/test/blackbox-tests/test-cases/private-modules/private-module-interface-rebuild.t
@@ -29,8 +29,7 @@ Changing a private module's interface does not rebuild consumers (#16071).
 
   $ dune build ./main.exe
 
-Changing the private interface should rebuild [main]. Instead, its stale [.cmx]
-causes linking to fail.
+Changing the private interface rebuilds [main].
 
   $ cat > dep/priv.ml <<EOF
   > let v = 2
@@ -41,7 +40,3 @@ causes linking to fail.
   > val w : int
   > EOF
   $ dune build ./main.exe
-  File "_none_", line 1:
-  Error: Files .main.eobjs/native/dune__exe__Main.cmx and dep/dep.cmxa
-         make inconsistent assumptions over interface Dep__Priv
-  [1]


### PR DESCRIPTION
## Description

Track both public and hidden CMI directories in library compilation dependencies. This ensures that changing a private module interface invalidates consumers which read it through a public module alias, instead of leaving stale artifacts that fail during linking.

The regression test added in #16174 now succeeds.

## Related Issue and Motivation

Fixes #16071.
