### PR TITLE
fix(action-plugin): handle empty glob directories

### DIFF
--- a/doc/changes/fixed/16207.md
+++ b/doc/changes/fixed/16207.md
@@ -1,0 +1,2 @@
+- Make `Dune_action_plugin.V1.read_directory_with_glob` return an empty listing
+  for absent directories (#16207, fixes #4445, @rgrinberg)

--- a/otherlibs/dune-action-plugin/src/dune_action_plugin.ml
+++ b/otherlibs/dune-action-plugin/src/dune_action_plugin.ml
@@ -38,10 +38,12 @@ module V1 = struct
       in
       fun path ->
         catch_system_exceptions ~name:"read_directory" (fun () ->
-          let dh = Unix.opendir path in
-          Exn.protect
-            ~f:(fun () -> loop dh [] |> List.sort ~compare:String.compare)
-            ~finally:(fun () -> Unix.closedir dh))
+          match Unix.opendir path with
+          | exception Unix.Unix_error ((ENOENT | ENOTDIR), _, _) -> []
+          | dh ->
+            Exn.protect
+              ~f:(fun () -> loop dh [] |> List.sort ~compare:String.compare)
+              ~finally:(fun () -> Unix.closedir dh))
     ;;
 
     let read_file path =
@@ -117,8 +119,6 @@ module V1 = struct
       { action; dependencies = Dependency.Set.empty; targets = String.Set.singleton path }
   ;;
 
-  (* TODO jstaron: If program tries to read empty directory, dune does not copy
-     it to `_build` so we get a "No such file or directory" error. *)
   let read_directory_with_glob ~path ~glob =
     let path = Path.to_string path in
     let action () =

--- a/otherlibs/dune-action-plugin/src/dune_action_plugin.mli
+++ b/otherlibs/dune-action-plugin/src/dune_action_plugin.mli
@@ -96,8 +96,7 @@ module V1 : sig
       filtering, so dune won't re-run the action when the directory changes in
       an unimportant way.
 
-      BUG: [read_directory_with_glob] doesn't work correctly for empty
-      directories.
+      An absent directory is returned as an empty listing.
 
       BUG: the returned listing includes directories even though that dependency
       is not tracked. *)

--- a/otherlibs/dune-action-plugin/test/depend-on-directory-without-targets/run.t
+++ b/otherlibs/dune-action-plugin/test/depend-on-directory-without-targets/run.t
@@ -20,10 +20,15 @@
   $ dune runtest
   Directory listing: [some_file1; some_file2]
 
-A generated empty directory is not materialized by the glob dependency, so the
-plugin currently fails to read it.
+A missing directory has an empty listing when the plugin runs directly.
 
   $ rm -rf some_dir
+  $ ./foo.exe
+  Directory listing: []
+
+A generated empty directory also has an empty listing even though the glob
+dependency does not materialize it.
+
   $ cat > dune-project << EOF
   > (lang dune 3.24)
   > (using action-plugin 0.1)
@@ -38,9 +43,4 @@ plugin currently fails to read it.
   >  (action (dynamic-run ./foo.exe)))
   > EOF
   $ dune build @check-empty
-  File "dune", lines 4-6, characters 0-61:
-  4 | (rule
-  5 |  (alias check-empty)
-  6 |  (action (dynamic-run ./foo.exe)))
-  read_directory: opendir(some_dir): No such file or directory
-  [1]
+  Directory listing: []

--- a/test/expect-tests/dune_action_plugin/dune_action_test.ml
+++ b/test/expect-tests/dune_action_plugin/dune_action_test.ml
@@ -60,13 +60,10 @@ let%expect_test _ =
     read_directory_with_glob
       ~glob:Glob.universal
       ~path:(Path.of_string "directory_that_does_not_exist")
-    |> map ~f:ignore
+    |> map ~f:(fun entries -> Printf.printf "[%s]\n" (String.concat ";" entries))
   in
-  run_action_expect_throws action;
-  [%expect
-    {|
-    read_directory: opendir(directory_that_does_not_exist): No such file or directory
-  |}]
+  Private.do_run action;
+  [%expect {| [] |}]
 ;;
 
 let%expect_test _ =


### PR DESCRIPTION
`read_directory_with_glob` currently fails when its directory is absent, including when Dune does not materialize a generated directory whose glob has no matches. Treat `ENOENT` and `ENOTDIR` from opening the directory as an empty listing, consistently for direct and dynamic execution.

Fixes #4445