### PR TITLE
perf(blake3): mark reset as noalloc

### DIFF
--- a/src/ocaml-blake3-mini/blake3_mini.ml
+++ b/src/ocaml-blake3-mini/blake3_mini.ml
@@ -34,7 +34,7 @@ end
 type t
 
 external create : unit -> t = "blake3_mini_create"
-external reset : t -> unit = "blake3_mini_reset"
+external reset : t -> unit = "blake3_mini_reset" [@@noalloc]
 external digest : t -> Digest.t = "blake3_mini_digest"
 
 external feed_string


### PR DESCRIPTION
`Blake3_mini.reset`'s C stub only mutates an existing hasher and returns
`Val_unit`; it neither allocates on the OCaml heap nor raises. Mark its binding
`[@@noalloc]` so native callers use the optimized external-call convention.