### PR TITLE
test(pkg): cover platform-specific solver diagnostics

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-all-or-nothing.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-all-or-nothing.t
@@ -43,6 +43,62 @@ No partial lock directory is written:
 
   $ test ! -e dune.lock
 
+A package required on only one of several requested platforms fails only that
+platform. The later single-solve change will list the full requested platform
+set and qualify the package diagnostic:
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > (package
+  >  (name x)
+  >  (depends
+  >   (foo
+  >    (and
+  >     (= :arch x86_64)
+  >     (= :os linux)))))
+  > EOF
+
+  $ dune pkg lock
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.lock
+  
+  The dependency solver failed to find a solution for the following platforms:
+  - arch = x86_64; os = linux
+  ...with this error:
+  Couldn't solve the package dependency formula.
+  Selected candidates: x.dev
+  - foo -> (problem)
+      No usable implementations:
+        foo.0.0.1: Availability condition not satisfied
+  [1]
+
+Identical failures on both Linux platforms are grouped under those two
+platforms. Once a joint failure lists all four requested platforms, each
+affected platform must instead be named on its package diagnostic:
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > (package
+  >  (name x)
+  >  (depends
+  >   (foo (= :os linux))))
+  > EOF
+
+  $ dune pkg lock
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.lock
+  
+  The dependency solver failed to find a solution for the following platforms:
+  - arch = x86_64; os = linux
+  - arch = arm64; os = linux
+  ...with this error:
+  Couldn't solve the package dependency formula.
+  Selected candidates: x.dev
+  - foo -> (problem)
+      No usable implementations:
+        foo.0.0.1: Availability condition not satisfied
+  [1]
+
 When the platform set only contains platforms where the package is available,
 locking succeeds:
 
@@ -58,6 +114,7 @@ locking succeeds:
   >    (os macos))))
   > EOF
 
+  $ write_portable_lockdirs_project
   $ dune pkg lock
   Solution for dune.lock
   

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-rejection-reason.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-rejection-reason.t
@@ -38,3 +38,86 @@ reason must be derived from Linux rather than a platform-less environment.
       No usable implementations:
         foo.0.0.1: Availability condition not satisfied
   [1]
+
+Repository versions shadowed by a pin are not candidates and must not appear in
+the rejection list. The pin is available only on Linux:
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.20)
+  > (lock_dir
+  >  (repositories mock)
+  >  (solve_for_platforms
+  >   ((arch x86_64) (os linux))
+  >   ((arch arm64) (os linux))
+  >   ((arch x86_64) (os macos))
+  >   ((arch arm64) (os macos))))
+  > (repository
+  >  (name mock)
+  >  (url "file://$(pwd)/mock-opam-repository"))
+  > (pkg enabled)
+  > EOF
+  $ mkpkg bar <<EOF
+  > available: os = "macos"
+  > EOF
+  $ mkdir _pinned-foo
+  $ cat >_pinned-foo/foo.opam <<EOF
+  > opam-version: "2.0"
+  > available: os = "linux"
+  > EOF
+  $ cat >dune-project <<EOF
+  > (lang dune 3.20)
+  > (pin
+  >  (url "file://$PWD/_pinned-foo")
+  >  (package
+  >   (name foo)
+  >   (version 2)))
+  > EOF
+  $ cat >x.opam <<EOF
+  > opam-version: "2.0"
+  > depends: [ "foo" {= "2"} | "bar" ]
+  > EOF
+
+The local package can use the pin on Linux and the repository alternative on
+macOS. The successful solve selects the pin only where it is available:
+
+  $ dune pkg lock
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
+  (none)
+  
+  Additionally, some packages will only be built on specific platforms.
+  
+  arch = arm64; os = linux:
+  - foo.2
+  
+  arch = arm64; os = macos:
+  - bar.0.0.1
+  
+  arch = x86_64; os = linux:
+  - foo.2
+  
+  arch = x86_64; os = macos:
+  - bar.0.0.1
+
+Removing the alternative makes the dependency fail on the two macOS platforms.
+Only the pinned version appears in their rejection lists:
+
+  $ cat >x.opam <<EOF
+  > opam-version: "2.0"
+  > depends: [ "foo" {= "2"} ]
+  > EOF
+  $ dune pkg lock
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.lock
+  
+  The dependency solver failed to find a solution for the following platforms:
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
+  ...with this error:
+  Couldn't solve the package dependency formula.
+  Selected candidates: x.dev
+  - foo -> (problem)
+      No usable implementations:
+        foo.2: Availability condition not satisfied
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
@@ -109,9 +109,9 @@ version will be chosen on macos as that's the only version available on macos.
   Solution for dune.macos.lock:
   - macos-sometimes.0.0.2
 
-A warning will be printed as the undefined-var.0.0.1 package has an undefined
-variable in its `available` filter. The undefined-var.0.0.2 package has a valid
-`available` filter but is only available on linux.
+An undefined variable makes undefined-var.0.0.1 unavailable.
+undefined-var.0.0.2 has a valid `available` filter but is only available on
+linux.
   $ solve undefined-var
   Solution for dune.lock:
   - undefined-var.0.0.2
@@ -125,8 +125,8 @@ variable in its `available` filter. The undefined-var.0.0.2 package has a valid
         undefined-var.0.0.1: Availability condition not satisfied
   [1]
 
-Warnings will be printed and no solution will be found as the availability
-filter resolves to a string instead of to a boolean.
+Non-boolean availability filters make their package versions unavailable, so
+no solution will be found.
   $ solve availability-string
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dune.lock:


### PR DESCRIPTION
## Summary

- Record the current per-platform diagnostic behavior before joint multi-platform solving changes it.
- Cover a conditional dependency failing on one requested platform and identical failures on two of four requested platforms.
- Cover a pin whose availability differs by platform, including alternative selection and the mandatory-pin failure path without reporting repository versions shadowed by the pin.
- Correct stale prose for non-boolean availability filters, which are already treated as unavailable without printing a warning.

This is a green preparatory change for #15982; it does not change solver behavior.

## Checks

- `dune runtest test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-all-or-nothing.t test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-rejection-reason.t test/blackbox-tests/test-cases/pkg/unavailable-packages.t`