### PR TITLE
fix(include-qualified): use dotted module artifact references

### DIFF
--- a/bin/build.ml
+++ b/bin/build.ml
@@ -70,7 +70,7 @@ let build =
           directory target), that rule is run; otherwise, if $(i,PATH) is a
           source directory, dune builds the $(b,@@default) alias in that
           directory. The path may contain any percent form accepted in dune
-          stanzas, such as $(b,%{bin:foo}) or $(b,%{cmi:lib/mod}).|}
+          stanzas, such as $(b,%{bin:foo}) or $(b,%{cmi:mod}).|}
         )
     ; `I
         ( {|$(b,@)$(i,name)|}

--- a/doc/changes/fixed/14498.md
+++ b/doc/changes/fixed/14498.md
@@ -1,5 +1,4 @@
-- Fix crash when expanding module pforms (`%{cmi:..}` etc.) with
-  `(include_subdirs qualified)`. Module compilation units can now be
-  referenced by their source path, e.g. `%{cmi:sub_a/foo}` for
-  `sub_a/foo.ml`.
-  (#14498, fixes #14496, @Alizter)
+- Fix crashes when expanding module artifact pforms (`%{cmi:...}` etc.) with
+  `(include_subdirs qualified)`. Qualified modules can now be referenced by
+  dotted logical paths such as `%{cmi:Sub_a.Foo}`.
+  (#14498, #16214, fixes #14496, @Alizter, @anmonteiro)

--- a/src/dune_lang/module_reference.ml
+++ b/src/dune_lang/module_reference.ml
@@ -96,9 +96,8 @@ let parse_component loc ~mode component =
     User_error.ok_exn (Error message)
 ;;
 
-let of_string version (loc, value) =
+let of_string_with_mode ~mode (loc, value) =
   let components = String.split value ~on:'.' in
-  let mode = if version >= (3, 25) then Path else Legacy in
   (match mode, components with
    | Legacy, _ :: _ :: _ ->
      Syntax.Error.since
@@ -112,6 +111,13 @@ let of_string version (loc, value) =
   in
   make ~loc ~mode path
 ;;
+
+let of_string version value =
+  let mode = if version >= (3, 25) then Path else Legacy in
+  of_string_with_mode ~mode value
+;;
+
+let of_string_path value = of_string_with_mode ~mode:Path value
 
 let decode =
   let open Decoder in

--- a/src/dune_lang/module_reference.mli
+++ b/src/dune_lang/module_reference.mli
@@ -1,14 +1,18 @@
 open Import
 
-(** A reference to a module in a dune file.
-
-    Starting with version 3.25 of the dune language, references may contain
-    multiple components, for example [Foo.Bar]. *)
+(** A reference to a module, optionally containing multiple components, for
+    example [Foo.Bar]. *)
 type t
 
 val path : t -> Module_name.Path.t
 val to_string : t -> string
+
+(** Parse a module reference according to the dune language version. *)
 val of_string : Syntax.Version.t -> Loc.t * string -> t
+
+(** Parse a dotted logical module path independently of the dune language
+    version. *)
+val of_string_path : Loc.t * string -> t
 
 (** Reject a qualified reference unless subdirectories are included with
     qualified names. *)

--- a/src/dune_rules/artifacts_obj.ml
+++ b/src/dune_rules/artifacts_obj.ml
@@ -3,24 +3,37 @@ open Memo.O
 
 type t =
   { libraries : Lib_info.local Lib_name.Map.t
-  ; modules : (Path.Build.t Obj_dir.t * Module.t) Path.Build.Map.t
+  ; modules_by_source_path : (Path.Build.t Obj_dir.t * Module.t) Path.Build.Map.t
+  ; modules_by_logical_path :
+      (Path.Build.t Obj_dir.t * Module.t) list Module_name.Path.Map.t
+  ; include_subdirs : Include_subdirs.t
   ; melange_emits : Melange.Emit.t Path.Build.Map.t
   }
 
 let empty =
   { libraries = Lib_name.Map.empty
-  ; modules = Path.Build.Map.empty
+  ; modules_by_source_path = Path.Build.Map.empty
+  ; modules_by_logical_path = Module_name.Path.Map.empty
+  ; include_subdirs = No
   ; melange_emits = Path.Build.Map.empty
   }
 ;;
 
-let lookup_module { modules; _ } = Path.Build.Map.find modules
+let lookup_module_by_source_path { modules_by_source_path; _ } =
+  Path.Build.Map.find modules_by_source_path
+;;
+
+let lookup_modules_by_logical_path { modules_by_logical_path; _ } path =
+  Module_name.Path.Map.find modules_by_logical_path path |> Option.value ~default:[]
+;;
+
+let include_subdirs t = t.include_subdirs
 let lookup_library { libraries; _ } = Lib_name.Map.find libraries
 let lookup_melange_emit { melange_emits; _ } = Path.Build.Map.find melange_emits
 
 (* The source file build path of a module, with the [.ml]/[.mli] extension
-   stripped. This matches the form a user writes in a module artifact pform
-   (e.g. [%{cmi:sub_a/group}] for a source file [sub_a/group.ml]). *)
+   stripped. This is used to recognize a slash-separated source path and
+   suggest the corresponding logical module reference. *)
 let module_source_path_without_extension m =
   let source =
     match Module.source_without_pp m ~ml_kind:Impl with
@@ -31,7 +44,7 @@ let module_source_path_without_extension m =
   |> Option.map ~f:(fun p -> fst (Path.Build.split_extension p))
 ;;
 
-let make ~dir ~expander ~lib_config ~libs ~exes ~melange_emits =
+let make ~dir ~expander ~lib_config ~libs ~exes ~include_subdirs ~melange_emits =
   let+ libraries =
     Memo.List.map libs ~f:(fun ((lib : Library.t), _, _) ->
       let+ lib_config = lib_config in
@@ -42,19 +55,26 @@ let make ~dir ~expander ~lib_config ~libs ~exes ~melange_emits =
       name, info)
     >>| Lib_name.Map.of_list_exn
   in
-  let modules =
-    let by_path modules obj_dir =
-      Modules.fold_user_available ~init:modules ~f:(fun m modules ->
-        match module_source_path_without_extension m with
-        | None -> modules
-        | Some key -> Path.Build.Map.add_exn modules key (obj_dir, m))
+  let modules_by_source_path, modules_by_logical_path =
+    let add_modules modules obj_dir =
+      Modules.fold_user_available
+        ~init:modules
+        ~f:(fun m (by_source_path, by_logical_path) ->
+          match module_source_path_without_extension m with
+          | None -> by_source_path, by_logical_path
+          | Some source_path ->
+            ( Path.Build.Map.add_exn by_source_path source_path (obj_dir, m)
+            , Module_name.Path.Map.add_multi by_logical_path (Module.path m) (obj_dir, m)
+            ))
     in
     let init =
-      List.fold_left exes ~init:Path.Build.Map.empty ~f:(fun modules (m, obj_dir) ->
-        by_path modules obj_dir m)
+      List.fold_left
+        exes
+        ~init:(Path.Build.Map.empty, Module_name.Path.Map.empty)
+        ~f:(fun modules (m, obj_dir) -> add_modules modules obj_dir m)
     in
     List.fold_left libs ~init ~f:(fun modules (_, m, obj_dir) ->
-      by_path modules obj_dir m)
+      add_modules modules obj_dir m)
   in
   let melange_emits =
     match Path.Build.Map.of_list melange_emits with
@@ -68,5 +88,10 @@ let make ~dir ~expander ~lib_config ~libs ~exes ~melange_emits =
         ; Pp.textf "Already defined at %s" (Loc.to_file_colon_line loc2)
         ]
   in
-  { libraries; modules; melange_emits }
+  { libraries
+  ; modules_by_source_path
+  ; modules_by_logical_path
+  ; include_subdirs
+  ; melange_emits
+  }
 ;;

--- a/src/dune_rules/artifacts_obj.mli
+++ b/src/dune_rules/artifacts_obj.mli
@@ -10,9 +10,20 @@ val make
   -> lib_config:Lib_config.t Memo.t
   -> libs:(Library.t * Modules.t * Path.Build.t Obj_dir.t) list
   -> exes:(Modules.t * Path.Build.t Obj_dir.t) list
+  -> include_subdirs:Include_subdirs.t
   -> melange_emits:(Path.Build.t * (Melange.Emit.t * Loc.t)) list
   -> t Memo.t
 
-val lookup_module : t -> Path.Build.t -> (Path.Build.t Obj_dir.t * Module.t) option
+val lookup_module_by_source_path
+  :  t
+  -> Path.Build.t
+  -> (Path.Build.t Obj_dir.t * Module.t) option
+
+val lookup_modules_by_logical_path
+  :  t
+  -> Module_name.Path.t
+  -> (Path.Build.t Obj_dir.t * Module.t) list
+
+val include_subdirs : t -> Include_subdirs.t
 val lookup_library : t -> Lib_name.t -> Lib_info.local option
 val lookup_melange_emit : t -> Path.Build.t -> Melange.Emit.t option

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -191,21 +191,57 @@ let expand_artifact ~source t artifact arg =
   in
   match artifact with
   | Pform.Artifact.Mod kind ->
-    (match Artifacts_obj.lookup_module artifacts path with
-     | None ->
-       Module_name.of_string_allow_invalid (loc, Filename.to_string name)
-       |> Module_name.Unchecked.allow_invalid
-       |> Module_name.to_string
-       |> does_not_exist ~what:"Module"
-     | Some (t, m) ->
-       (match
-          match kind with
-          | Cm_kind kind -> Obj_dir.Module.cm_file t m ~kind:(Ocaml kind)
-          | Cmt -> Obj_dir.Module.cmt_file t m ~cm_kind:(Ocaml Cmi) ~ml_kind:Impl
-          | Cmti -> Some (Obj_dir.Module.cmti_file t m ~cm_kind:(Ocaml Cmi))
-        with
-        | None -> Action_builder.return [ Value.String "" ]
-        | Some path -> dep (Path.build path)))
+    let module_ =
+      let reference = Module_reference.of_string_path (loc, Filename.to_string name) in
+      Module_reference.validate_qualified
+        reference
+        ~include_subdirs:(Artifacts_obj.include_subdirs artifacts);
+      let reference_path = Module_reference.path reference in
+      let source_module = Artifacts_obj.lookup_module_by_source_path artifacts path in
+      let source_hints =
+        match source_module with
+        | None -> []
+        | Some (_, module_) ->
+          [ Pp.textf
+              "%s would be a correct module reference"
+              (Module.path module_ |> Module_name.Path.to_string)
+          ]
+      in
+      (match source_module with
+       | Some (_, module_)
+         when not (Module_name.Path.equal reference_path (Module.path module_)) ->
+         User_error.raise
+           ~loc
+           ~hints:source_hints
+           [ Pp.textf
+               "Module reference %s does not match the module at this source path."
+               (Module_reference.to_string reference)
+           ]
+       | None | Some _ -> ());
+      match Artifacts_obj.lookup_modules_by_logical_path artifacts reference_path with
+      | [ module_ ] -> module_
+      | _ :: _ ->
+        User_error.raise
+          ~loc
+          [ Pp.textf
+              "Module reference %s is ambiguous."
+              (Module_reference.to_string reference)
+          ]
+      | [] ->
+        User_error.raise
+          ~loc
+          ~hints:source_hints
+          [ Pp.textf "Module %s does not exist." (Module_reference.to_string reference) ]
+    in
+    let obj_dir, module_ = module_ in
+    (match
+       match kind with
+       | Cm_kind kind -> Obj_dir.Module.cm_file obj_dir module_ ~kind:(Ocaml kind)
+       | Cmt -> Obj_dir.Module.cmt_file obj_dir module_ ~cm_kind:(Ocaml Cmi) ~ml_kind:Impl
+       | Cmti -> Some (Obj_dir.Module.cmti_file obj_dir module_ ~cm_kind:(Ocaml Cmi))
+     with
+     | None -> Action_builder.return [ Value.String "" ]
+     | Some path -> dep (Path.build path))
   | Lib mode ->
     let name =
       Lib_name.parse_string_exn

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -197,22 +197,16 @@ let expand_artifact ~source t artifact arg =
         reference
         ~include_subdirs:(Artifacts_obj.include_subdirs artifacts);
       let reference_path = Module_reference.path reference in
-      let source_module = Artifacts_obj.lookup_module_by_source_path artifacts path in
-      let source_hints =
-        match source_module with
-        | None -> []
-        | Some (_, module_) ->
-          [ Pp.textf
-              "%s would be a correct module reference"
-              (Module.path module_ |> Module_name.Path.to_string)
-          ]
-      in
-      (match source_module with
+      (match Artifacts_obj.lookup_module_by_source_path artifacts path with
        | Some (_, module_)
          when not (Module_name.Path.equal reference_path (Module.path module_)) ->
          User_error.raise
            ~loc
-           ~hints:source_hints
+           ~hints:
+             [ Pp.textf
+                 "%s would be a correct module reference"
+                 (Module.path module_ |> Module_name.Path.to_string)
+             ]
            [ Pp.textf
                "Module reference %s does not match the module at this source path."
                (Module_reference.to_string reference)
@@ -230,7 +224,6 @@ let expand_artifact ~source t artifact arg =
       | [] ->
         User_error.raise
           ~loc
-          ~hints:source_hints
           [ Pp.textf "Module %s does not exist." (Module_reference.to_string reference) ]
     in
     let obj_dir, module_ = module_ in

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -1421,6 +1421,7 @@ let make
         ~lib_config
         ~libs
         ~exes
+        ~include_subdirs
         ~melange_emits)
   in
   { modules; artifacts; include_subdirs }

--- a/test/blackbox-tests/test-cases/include-qualified/module-artifact-ambiguity.t
+++ b/test/blackbox-tests/test-cases/include-qualified/module-artifact-ambiguity.t
@@ -25,16 +25,24 @@ they each generate a [Foo] alias, their leaf module artifacts are distinct.
   >    (unix -> foo/baz.unix.ml))))
   > EOF
 
-The qualified module references are not yet recognized as artifact references:
+The dotted module references identify the distinct leaf artifacts:
 
-  $ dune build '%{cmi:Foo.Bar}'
-  File "command line", line 1, characters 0-14:
-  Error: Module Foo.Bar does not exist.
-  [1]
-  $ dune build '%{cmi:Foo.Baz}'
-  File "command line", line 1, characters 0-14:
-  Error: Module Foo.Baz does not exist.
-  [1]
+  $ build_and_show() {
+  >   dune build "$@"
+  >   dune trace cat | jq 'select(.name == "targets") | .args'
+  > }
+  $ build_and_show '%{cmi:Foo.Bar}'
+  {
+    "targets": [
+      "_build/default/.left.objs/byte/left__Foo__Bar.cmi"
+    ]
+  }
+  $ build_and_show '%{cmi:Foo.Baz}'
+  {
+    "targets": [
+      "_build/default/.right.objs/byte/right__Foo__Baz.cmi"
+    ]
+  }
 
 Both generated group aliases can coexist:
 
@@ -42,9 +50,9 @@ Both generated group aliases can coexist:
   $ test -f _build/default/.left.objs/byte/left__Foo.cmi
   $ test -f _build/default/.right.objs/byte/right__Foo.cmi
 
-Nor is there a source module at [Foo]:
+The generated group reference itself is ambiguous:
 
   $ dune build '%{cmi:Foo}'
   File "command line", line 1, characters 0-10:
-  Error: Module Foo does not exist.
+  Error: Module reference Foo is ambiguous.
   [1]

--- a/test/blackbox-tests/test-cases/include-qualified/module-artifact-ambiguity.t
+++ b/test/blackbox-tests/test-cases/include-qualified/module-artifact-ambiguity.t
@@ -25,24 +25,16 @@ they each generate a [Foo] alias, their leaf module artifacts are distinct.
   >    (unix -> foo/baz.unix.ml))))
   > EOF
 
-The source-path artifact references remain unambiguous:
+The qualified module references are not yet recognized as artifact references:
 
-  $ build_and_show() {
-  >   dune build "$@"
-  >   dune trace cat | jq 'select(.name == "targets") | .args'
-  > }
-  $ build_and_show '%{cmi:foo/bar}'
-  {
-    "targets": [
-      "_build/default/.left.objs/byte/left__Foo__Bar.cmi"
-    ]
-  }
-  $ build_and_show '%{cmi:foo/baz}'
-  {
-    "targets": [
-      "_build/default/.right.objs/byte/right__Foo__Baz.cmi"
-    ]
-  }
+  $ dune build '%{cmi:Foo.Bar}'
+  File "command line", line 1, characters 0-14:
+  Error: Module Foo.Bar does not exist.
+  [1]
+  $ dune build '%{cmi:Foo.Baz}'
+  File "command line", line 1, characters 0-14:
+  Error: Module Foo.Baz does not exist.
+  [1]
 
 Both generated group aliases can coexist:
 
@@ -50,9 +42,9 @@ Both generated group aliases can coexist:
   $ test -f _build/default/.left.objs/byte/left__Foo.cmi
   $ test -f _build/default/.right.objs/byte/right__Foo.cmi
 
-There is no unique source-path artifact reference for the generated group:
+Nor is there a source module at [Foo]:
 
-  $ dune build '%{cmi:foo}'
+  $ dune build '%{cmi:Foo}'
   File "command line", line 1, characters 0-10:
   Error: Module Foo does not exist.
   [1]

--- a/test/blackbox-tests/test-cases/include-qualified/module-artifact-targets.t
+++ b/test/blackbox-tests/test-cases/include-qualified/module-artifact-targets.t
@@ -3,7 +3,7 @@ Building a module artifact target (%{cmi:...}, %{cmo:...}, %{cmx:...},
 used and two qualified subdirectories contain modules with the same leaf
 name.
 
-  $ make_dune_project 3.7
+  $ make_dune_project 3.25
 
   $ cat > dune <<EOF
   > (include_subdirs qualified)
@@ -13,9 +13,11 @@ name.
   > let _ = (Sub_a.Group.x, Sub_b.Group.x)
   > EOF
 
-  $ mkdir sub_a sub_b
+  $ mkdir -p foo sub_a/nested sub_b
+  $ echo 'let x = "group interface"' > foo/foo.ml
   $ echo 'let x = "a"' > sub_a/group.ml
   $ echo 'let x = "b"' > sub_b/group.ml
+  $ echo 'let x = "nested"' > sub_a/nested/group.ml
 
 A normal build succeeds:
 
@@ -36,6 +38,14 @@ A module artifact target for a module in a qualified subdirectory works:
   $ dune build %{cmo:sub_a/group}
   $ dune build %{cmo:sub_b/group}
 
+A module group interface is addressed by its source path:
+
+  $ dune build %{cmi:foo/foo}
+  $ dune build %{cmi:foo}
+  File "command line", line 1, characters 0-10:
+  Error: Module Foo does not exist.
+  [1]
+
 An unqualified leaf name [group] is not the module path of any module
 (the modules are [Sub_a.Group] and [Sub_b.Group]), so it is reported as
 missing:
@@ -45,17 +55,46 @@ missing:
   Error: Module Group does not exist.
   [1]
 
-A (rule ...) in a subdir dune file that references a module artifact
-pform with a leaf name %{cmi:group}:
+A (rule ...) in a subdir dune file can use a relative source path:
 
   $ cat > sub_a/dune <<EOF
-  > (rule (with-stdout-to out.txt (echo %{cmi:group})))
+  > (rule (with-stdout-to out.txt (echo %{cmi:nested/group})))
   > EOF
   $ dune build sub_a/out.txt
 
-Using a dot separator [sub_a.group] instead of a slash:
+Even in Dune 3.25, a dotted module reference [sub_a.group] does not work:
 
   $ dune build %{cmi:sub_a.group}
   File "command line", line 1, characters 0-18:
   Error: Module Sub_a.group does not exist.
   [1]
+
+Versions before Dune 3.25 use slash-separated source paths, both from the
+project root and relative to a subdirectory:
+
+  $ mkdir -p legacy/sub_a/nested
+  $ cat >legacy/dune-project <<'EOF'
+  > (lang dune 3.24)
+  > EOF
+  $ cat >legacy/dune <<'EOF'
+  > (include_subdirs qualified)
+  > (library (name legacy))
+  > EOF
+  $ echo 'let x = "legacy"' >legacy/sub_a/nested/group.ml
+  $ cat >legacy/sub_a/dune <<'EOF'
+  > (rule (with-stdout-to out.txt (echo %{cmi:nested/group})))
+  > EOF
+  $ dune build --root=legacy %{cmi:sub_a/nested/group}
+  $ dune build --root=legacy sub_a/out.txt
+
+A source directory prefix can select the artifacts of a standalone subdirectory:
+
+  $ mkdir -p standalone/sub
+  $ cat >standalone/dune-project <<'EOF'
+  > (lang dune 3.25)
+  > EOF
+  $ cat >standalone/sub/dune <<'EOF'
+  > (library (name bar))
+  > EOF
+  $ echo 'let x = "standalone"' >standalone/sub/x.ml
+  $ dune build --root=standalone %{cmo:sub/x}

--- a/test/blackbox-tests/test-cases/include-qualified/module-artifact-targets.t
+++ b/test/blackbox-tests/test-cases/include-qualified/module-artifact-targets.t
@@ -1,9 +1,9 @@
-Building a module artifact target (%{cmi:...}, %{cmo:...}, %{cmx:...},
-%{cmt:...}, %{cmti:...}) should work when (include_subdirs qualified) is
-used and two qualified subdirectories contain modules with the same leaf
-name.
+Module artifact targets (%{cmi:...}, %{cmo:...}, %{cmx:...}, %{cmt:...},
+%{cmti:...}) use dotted logical module references independently of the Dune
+language version. This disambiguates modules with the same leaf name under
+(include_subdirs qualified).
 
-  $ make_dune_project 3.25
+  $ make_dune_project 3.24
 
   $ cat > dune <<EOF
   > (include_subdirs qualified)
@@ -33,18 +33,16 @@ A module artifact target for the top-level module works:
 
 A module artifact target for a module in a qualified subdirectory works:
 
-  $ dune build %{cmi:sub_a/group}
-  $ dune build %{cmi:sub_b/group}
-  $ dune build %{cmo:sub_a/group}
-  $ dune build %{cmo:sub_b/group}
+  $ dune build %{cmi:sub_a.group}
+  $ dune build %{cmi:Sub_b.Group}
+  $ dune build %{cmo:sub_a.group}
+  $ dune build %{cmo:Sub_b.Group}
 
-A module group interface is addressed by its source path:
+A module group interface is addressed by its logical module reference. An
+optional source directory prefix may select the same module tree:
 
-  $ dune build %{cmi:foo/foo}
   $ dune build %{cmi:foo}
-  File "command line", line 1, characters 0-10:
-  Error: Module Foo does not exist.
-  [1]
+  $ dune build %{cmi:foo/foo}
 
 An unqualified leaf name [group] is not the module path of any module
 (the modules are [Sub_a.Group] and [Sub_b.Group]), so it is reported as
@@ -55,37 +53,29 @@ missing:
   Error: Module Group does not exist.
   [1]
 
-A (rule ...) in a subdir dune file can use a relative source path:
+A (rule ...) in a subdir dune file uses the full logical module reference:
 
   $ cat > sub_a/dune <<EOF
-  > (rule (with-stdout-to out.txt (echo %{cmi:nested/group})))
+  > (rule (with-stdout-to out.txt (echo %{cmi:Sub_a.Nested.Group})))
   > EOF
   $ dune build sub_a/out.txt
 
-Even in Dune 3.25, a dotted module reference [sub_a.group] does not work:
+The module reference is rooted at the module tree, not relative to the dune
+file's directory:
 
-  $ dune build %{cmi:sub_a.group}
-  File "command line", line 1, characters 0-18:
-  Error: Module Sub_a.group does not exist.
+  $ dune build %{cmi:sub_a/Nested.Group}
+  File "command line", line 1, characters 0-25:
+  Error: Module Nested.Group does not exist.
   [1]
 
-Versions before Dune 3.25 use slash-separated source paths, both from the
-project root and relative to a subdirectory:
+A slash selects a source directory; it does not separate module path
+components. Therefore this looks for [Group], not [Sub_a.Group]:
 
-  $ mkdir -p legacy/sub_a/nested
-  $ cat >legacy/dune-project <<'EOF'
-  > (lang dune 3.24)
-  > EOF
-  $ cat >legacy/dune <<'EOF'
-  > (include_subdirs qualified)
-  > (library (name legacy))
-  > EOF
-  $ echo 'let x = "legacy"' >legacy/sub_a/nested/group.ml
-  $ cat >legacy/sub_a/dune <<'EOF'
-  > (rule (with-stdout-to out.txt (echo %{cmi:nested/group})))
-  > EOF
-  $ dune build --root=legacy %{cmi:sub_a/nested/group}
-  $ dune build --root=legacy sub_a/out.txt
+  $ dune build %{cmi:sub_a/group}
+  File "command line", line 1, characters 0-18:
+  Error: Module reference Group does not match the module at this source path.
+  Hint: Sub_a.Group would be a correct module reference
+  [1]
 
 A source directory prefix can select the artifacts of a standalone subdirectory:
 
@@ -98,3 +88,11 @@ A source directory prefix can select the artifacts of a standalone subdirectory:
   > EOF
   $ echo 'let x = "standalone"' >standalone/sub/x.ml
   $ dune build --root=standalone %{cmo:sub/x}
+
+Qualified module references require (include_subdirs qualified):
+
+  $ dune build %{cmi:standalone/sub/Foo.Bar}
+  File "command line", line 1, characters 0-29:
+  Error: Qualified module reference "Foo.Bar" may only be used with
+  (include_subdirs qualified).
+  [1]

--- a/test/blackbox-tests/test-cases/include-qualified/repeated-directory-names.t
+++ b/test/blackbox-tests/test-cases/include-qualified/repeated-directory-names.t
@@ -2,7 +2,7 @@ Qualified module groups can repeat the same name at arbitrary depths.
 
   $ mkdir -p foo/foo/foo/foo
   $ cat >dune-project <<'EOF'
-  > (lang dune 3.24)
+  > (lang dune 3.25)
   > (package (name repeated))
   > EOF
   $ cat >dune <<'EOF'
@@ -18,6 +18,15 @@ Qualified module groups can repeat the same name at arbitrary depths.
   > EOF
 
   $ dune build @check
+
+The dotted logical module artifact reference is not yet recognized. The
+five-component source path still identifies the module:
+
+  $ dune build '%{cmi:Foo.Foo.Foo.Foo}'
+  File "command line", line 1, characters 0-22:
+  Error: Module Foo.Foo.Foo.Foo does not exist.
+  [1]
+  $ dune build '%{cmi:foo/foo/foo/foo/foo}'
 
 The installed format keeps the group-interface component that distinguishes
 the source-trie path from the four-component logical module path.

--- a/test/blackbox-tests/test-cases/include-qualified/repeated-directory-names.t
+++ b/test/blackbox-tests/test-cases/include-qualified/repeated-directory-names.t
@@ -19,14 +19,18 @@ Qualified module groups can repeat the same name at arbitrary depths.
 
   $ dune build @check
 
-The dotted logical module artifact reference is not yet recognized. The
-five-component source path still identifies the module:
+The logical module artifact reference has four components:
 
   $ dune build '%{cmi:Foo.Foo.Foo.Foo}'
-  File "command line", line 1, characters 0-22:
-  Error: Module Foo.Foo.Foo.Foo does not exist.
-  [1]
+
+A five-component source path must not silently resolve the shallow [Foo]
+group alias:
+
   $ dune build '%{cmi:foo/foo/foo/foo/foo}'
+  File "command line", line 1, characters 0-26:
+  Error: Module reference Foo does not match the module at this source path.
+  Hint: Foo.Foo.Foo.Foo would be a correct module reference
+  [1]
 
 The installed format keeps the group-interface component that distinguishes
 the source-trie path from the four-component logical module path.


### PR DESCRIPTION
Use dotted logical module references in module artifact pforms independently of the Dune language version, and diagnose ambiguous generated module groups.

Completes the unreleased fix from #14498.