### PR TITLE
test: isolate expect tests from Git configuration

### DIFF
--- a/test/expect-tests/dune
+++ b/test/expect-tests/dune
@@ -1,3 +1,11 @@
+;; Keep Git invocations independent of user and system configuration.
+
+(env
+ (_
+  (env-vars
+   (GIT_CONFIG_GLOBAL /dev/null)
+   (GIT_CONFIG_SYSTEM /dev/null))))
+
 (library
  (name dune_unit_tests)
  (libraries


### PR DESCRIPTION
## Description

Configure expect tests to ignore global and system Git configuration, matching the blackbox test setup. This prevents settings such as `commit.gpgsign=true` from leaking into temporary repositories and failing inside the test sandbox.

## Testing

- `./dune.exe runtest test/expect-tests/dune_pkg`
- `./dune.exe runtest test/expect-tests/vcs`
- `./dune.exe build @check @fmt`
