### PR TITLE
perf(pkg): make SAT decision search incremental

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -828,6 +828,10 @@ module Solver = struct
       | Selected of Input.dependency list
       | Unselected
 
+    type search_item =
+      | Visit_role of Input.Role.t
+      | Visit_dependencies of Input.dependency list
+
     type selection =
       { impl : Input.Impl.t (** The implementation chosen to fill the role *)
       ; var : Sat.lit
@@ -1193,33 +1197,56 @@ module Solver = struct
       in
       let+ impl_clauses = Fiber.Cache.to_table impl_clauses in
       (* Run the solve *)
+      let pending = ref [ Visit_role root_req ] in
+      let seen = Table.create (module Input.Role) 100 in
+      let previous_decision_level = ref 0 in
+      let reset_search () =
+        pending := [ Visit_role root_req ];
+        Table.clear seen
+      in
       let decider () =
-        (* Walk the current solution, depth-first, looking for the first
-           undecided interface. Then try the most preferred implementation of
-           it that hasn't been ruled out. *)
-        let seen = Table.create (module Input.Role) 100 in
-        let rec find_undecided req =
-          if Table.mem seen req
-          then None (* Break cycles *)
-          else (
-            Table.set seen req true;
-            match Table.find_exn impl_clauses req |> Candidates.state with
-            | Unselected -> None
-            | Undecided lit -> Some lit
-            | Selected deps ->
-              (* We've already selected a candidate for this component. Now
-                 check its dependencies. *)
-              List.find_map deps ~f:(fun (dep : Input.dependency) ->
-                match dep.importance with
-                | Ensure -> find_undecided dep.drole
-                | Prevent ->
-                  (* Restrictions don't express that we do or don't want the
-                     dependency, so skip them here. If someone else needs this,
-                     we'll handle it when we get to them.
-                     If noone wants it, it will be set to unselected at the end. *)
-                  None))
+        (* Resume the depth-first walk from the previous decision. Assignments
+           are monotonic until a backjump, so already visited roles cannot gain
+           a new undecided candidate. *)
+        let decision_level = Sat.get_decision_level sat in
+        if decision_level < !previous_decision_level then reset_search ();
+        previous_decision_level := decision_level;
+        let rec find_undecided () =
+          match !pending with
+          | [] -> None
+          | Visit_role req :: rest ->
+            if Table.mem seen req
+            then (
+              pending := rest;
+              find_undecided ())
+            else (
+              match Table.find_exn impl_clauses req |> Candidates.state with
+              | Unselected ->
+                Table.set seen req true;
+                pending := rest;
+                find_undecided ()
+              | Undecided lit -> Some lit
+              | Selected deps ->
+                (* We've already selected a candidate for this component. Now
+                   check its dependencies. *)
+                Table.set seen req true;
+                pending := Visit_dependencies deps :: rest;
+                find_undecided ())
+          | Visit_dependencies [] :: rest ->
+            pending := rest;
+            find_undecided ()
+          | Visit_dependencies (dep :: deps) :: rest ->
+            pending := Visit_dependencies deps :: rest;
+            (match dep.importance with
+             | Ensure -> pending := Visit_role dep.drole :: !pending
+             | Prevent ->
+               (* Restrictions don't express that we do or don't want the
+                  dependency. If another package needs it, it will be visited
+                  from that package. *)
+               ());
+            find_undecided ()
         in
-        find_undecided root_req
+        find_undecided ()
       in
       let start = Time.now () in
       let result = Sat.run_solver sat decider in

--- a/src/sat/sat.ml
+++ b/src/sat/sat.ml
@@ -126,6 +126,10 @@ module Make (User : USER) = struct
       (* The decision level at which we got a value (when not Undecided) *)
     ; mutable undo : undo list
       (* Functions to call if we become unbound (by backtracking) *)
+    ; (* Undecided variables form a linked list. Assigned variables retain their
+         neighbours so trail-ordered undo can restore them in constant time. *)
+      mutable previous_undecided : var option
+    ; mutable next_undecided : var option
     ; watch_queue : clause Queue.t (* Clauses to notify when var becomes True *)
     ; neg_watch_queue : clause Queue.t (* Clauses to notify when var becomes False *)
     ; obj : User.t (* The object this corresponds to (for our caller and for debugging) *)
@@ -137,6 +141,7 @@ module Make (User : USER) = struct
     { id_maker : VarID.mint
     ; (* Propagation *)
       mutable vars : var list
+    ; mutable first_undecided : var option
     ; propQ : lit Queue.t (* propagation queue *)
     ; (* Assignments *)
       mutable trail : lit list (* order of assignments, most recent first *)
@@ -195,6 +200,8 @@ module Make (User : USER) = struct
     ; reason = None
     ; level = -1
     ; undo = []
+    ; previous_undecided = None
+    ; next_undecided = None
     ; watch_queue = Queue.create ()
     ; neg_watch_queue = Queue.create ()
     ; obj
@@ -224,6 +231,7 @@ module Make (User : USER) = struct
     if debug then log_debug (Pp.text "--- new SAT problem ---");
     { id_maker = VarID.make_mint ()
     ; vars = []
+    ; first_undecided = None
     ; propQ = Queue.create ()
     ; trail = []
     ; trail_len = 0
@@ -292,13 +300,34 @@ module Make (User : USER) = struct
   let get_decision_level problem = problem.trail_lim_len
 
   let add_variable problem obj : lit =
+    if problem.trail_lim_len <> 0
+    then invalid_arg "Sat.add_variable: cannot add variables after decisions have begun";
     (* if debug then log_debug "add_variable('%s')" obj; *)
     let var =
       let i = VarID.issue problem.id_maker in
       make_var i obj
     in
+    var.next_undecided <- problem.first_undecided;
+    Option.iter problem.first_undecided ~f:(fun first ->
+      first.previous_undecided <- Some var);
+    problem.first_undecided <- Some var;
     problem.vars <- var :: problem.vars;
     Pos, var
+  ;;
+
+  let remove_undecided problem var =
+    (match var.previous_undecided with
+     | None -> problem.first_undecided <- var.next_undecided
+     | Some previous -> previous.next_undecided <- var.next_undecided);
+    Option.iter var.next_undecided ~f:(fun next ->
+      next.previous_undecided <- var.previous_undecided)
+  ;;
+
+  let restore_undecided problem var =
+    (match var.previous_undecided with
+     | None -> problem.first_undecided <- Some var
+     | Some previous -> previous.next_undecided <- Some var);
+    Option.iter var.next_undecided ~f:(fun next -> next.previous_undecided <- Some var)
   ;;
 
   (* [lit] is now [True].
@@ -318,6 +347,7 @@ module Make (User : USER) = struct
     | True -> true (* Already set (shouldn't happen) *)
     | Undecided ->
       let var_info = var_of_lit lit in
+      remove_undecided problem var_info;
       var_info.value <- (if fst lit == Neg then False else True);
       var_info.level <- get_decision_level problem;
       var_info.reason <- Some reason;
@@ -335,6 +365,7 @@ module Make (User : USER) = struct
       (* if debug then log_debug "(pop %s)" (name_lit lit); *)
       let var_info = var_of_lit lit in
       var_info.value <- Undecided;
+      restore_undecided problem var_info;
       var_info.reason <- None;
       var_info.level <- -1;
       problem.trail <- rest;
@@ -897,8 +928,8 @@ module Make (User : USER) = struct
                If it leads to a conflict, we'll backtrack and
                try it the other way. *)
             let undecided =
-              match List.find problem.vars ~f:(fun info -> info.value = Undecided) with
-              | Some s -> s
+              match problem.first_undecided with
+              | Some undecided -> undecided
               | None -> raise_notrace (SolveDone true)
             in
             let lit =

--- a/src/sat/sat.mli
+++ b/src/sat/sat.mli
@@ -22,6 +22,9 @@ module Make (User : USER) : sig
   type lit
 
   val neg : lit -> lit
+
+  (** [add_variable problem user_data] adds a variable while constructing [problem].
+      @raise Invalid_argument if a decision level is active. *)
   val add_variable : t -> User.t -> lit
 
   (** A clause is a boolean expression made up of literals. e.g. [A and B and not(C)] *)

--- a/src/sat/sat.mli
+++ b/src/sat/sat.mli
@@ -65,6 +65,11 @@ module Make (User : USER) : sig
       Use this to tidy up at the end, when you no longer care about the order. *)
   val run_solver : t -> (unit -> lit option) -> bool
 
+  (** Return the current decision level. A decrease between calls to the decider
+      indicates that the solver backtracked, allowing incremental deciders to
+      invalidate cached state. *)
+  val get_decision_level : t -> int
+
   (** Return the first literal in the list whose value is [Undecided], or [None] if they're all decided.
       The decider function may find this useful. *)
   val get_best_undecided : at_most_one_clause -> lit option

--- a/test/expect-tests/sat/sat_tests.ml
+++ b/test/expect-tests/sat/sat_tests.ml
@@ -101,6 +101,45 @@ let%expect_test "run_solver records decisions, and counters are cumulative" =
   |}]
 ;;
 
+let%expect_test "incremental deciders can detect non-chronological backtracking" =
+  let open Sat in
+  let p = create () in
+  let a = add_variable p 1 in
+  let c = add_variable p 2 in
+  let d = add_variable p 3 in
+  let x = add_variable p 4 in
+  (* Selecting [a] and [d] implies both [x] and [not x]. The unrelated
+     decision [c] makes conflict analysis backjump from level 3 to level 1. *)
+  at_least_one p [ neg a; neg d; x ];
+  at_least_one p [ neg a; neg d; neg x ];
+  let choices = ref [ a; c; d ] in
+  let previous_level = ref 0 in
+  let decide () =
+    let level = get_decision_level p in
+    if level < !previous_level
+    then Format.printf "backtracked from level %d to %d@." !previous_level level;
+    previous_level := level;
+    Format.printf "decide at level %d@." level;
+    match !choices with
+    | [] -> None
+    | choice :: rest ->
+      choices := rest;
+      Some choice
+  in
+  print_endline (string_of_bool (run_solver p decide));
+  print_stats p;
+  [%expect
+    {|
+    decide at level 0
+    decide at level 1
+    decide at level 2
+    backtracked from level 2 to 1
+    decide at level 1
+    true
+    num_variables=4 num_clauses=2 num_decisions=5 num_conflicts=1
+  |}]
+;;
+
 let%expect_test "impossible problems are rejected before solving" =
   let open Sat in
   let p = create () in

--- a/test/expect-tests/sat/sat_tests.ml
+++ b/test/expect-tests/sat/sat_tests.ml
@@ -101,6 +101,31 @@ let%expect_test "run_solver records decisions, and counters are cumulative" =
   |}]
 ;;
 
+let%expect_test "variables cannot be added at an active decision level" =
+  let open Sat in
+  let p = create () in
+  let a = add_variable p 1 in
+  let _b = add_variable p 2 in
+  let first_decision = ref true in
+  let decide () =
+    if !first_decision
+    then (
+      first_decision := false;
+      Some a)
+    else (
+      (match add_variable p 3 with
+       | exception Invalid_argument message -> print_endline message
+       | _ -> print_endline "unexpectedly added a variable");
+      None)
+  in
+  print_endline (string_of_bool (run_solver p decide));
+  [%expect
+    {|
+    Sat.add_variable: cannot add variables after decisions have begun
+    true
+  |}]
+;;
+
 let%expect_test "incremental deciders can detect non-chronological backtracking" =
   let open Sat in
   let p = create () in


### PR DESCRIPTION
## Summary

This separates the SAT contract from the two optimizations:

1. Expose the decision level and test that an incremental decider observes a decrease after non-chronological backtracking. This commit passes before either performance change.
2. Track undecided SAT variables in a linked list instead of rescanning every variable.
3. Resume the package solver's depth-first decision traversal between decisions, resetting it when the tested decision-level signal shows a backtrack.

## SAT-event speedup

Across ten real-world projects, complete `sat/solve` trace events were **2.83× faster by geometric mean for the four-platform solve** and **2.80× faster for a single-platform solve**. Every project improved in both configurations.

These numbers measure time inside `sat/solve`, not end-to-end `dune pkg lock` time. Each cell uses 10 measured runs after 2 warmups, with baseline and PR runs interleaved. Irmin was rerun with 20 measured runs after 3 warmups, pinned to a performance core with a 3 GHz preflight and median-frequency gate, because the original thermally throttled samples had excessive variance.

<details>
<summary>Per-project benchmark results</summary>

### Four-platform solve

| Project | Main mean ± SD (s) | PR mean ± SD (s) | Speedup |
|---|---:|---:|---:|
| re | 0.025557 ± 0.006168 | 0.011155 ± 0.002417 | 2.291× |
| cohttp | 0.547998 ± 0.087835 | 0.142115 ± 0.019302 | 3.856× |
| jsoo | 0.098637 ± 0.012977 | 0.029679 ± 0.004315 | 3.323× |
| lsp | 0.171643 ± 0.020435 | 0.052369 ± 0.007763 | 3.278× |
| opam | 0.050597 ± 0.007468 | 0.019356 ± 0.002736 | 2.614× |
| irmin | 0.113493 ± 0.002821 | 0.036411 ± 0.001870 | 3.117× |
| mirage | 0.013849 ± 0.002458 | 0.004736 ± 0.001849 | 2.924× |
| eio | 0.010773 ± 0.001951 | 0.003753 ± 0.001668 | 2.871× |
| owl | 0.010737 ± 0.001849 | 0.005824 ± 0.002847 | 1.843× |
| tezos | 0.029278 ± 0.002267 | 0.010965 ± 0.001481 | 2.670× |

### Single-platform solve

| Project | Main mean ± SD (s) | PR mean ± SD (s) | Speedup |
|---|---:|---:|---:|
| re | 0.002231 ± 0.000204 | 0.001117 ± 0.000051 | 1.998× |
| cohttp | 0.019991 ± 0.000986 | 0.004335 ± 0.000474 | 4.612× |
| jsoo | 0.002132 ± 0.000203 | 0.000899 ± 0.000112 | 2.372× |
| lsp | 0.004384 ± 0.000243 | 0.000859 ± 0.000078 | 5.105× |
| opam | 0.000492 ± 0.000128 | 0.000241 ± 0.000030 | 2.041× |
| irmin | 0.052453 ± 0.000707 | 0.009705 ± 0.000190 | 5.405× |
| mirage | 0.002342 ± 0.000074 | 0.001174 ± 0.000192 | 1.994× |
| eio | 0.001512 ± 0.000080 | 0.000733 ± 0.000117 | 2.061× |
| owl | 0.001480 ± 0.000078 | 0.000749 ± 0.000084 | 1.976× |
| tezos | 0.007892 ± 0.001320 | 0.002665 ± 0.000893 | 2.961× |

</details>

## Tests

- The decision-level/backtracking expect test passes before the performance commits
- `dune build @check @fmt`
- SAT expect and solver trace tests