### PR TITLE
feat(pkg): decouple versioned lock directory paths

### DIFF
--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -237,6 +237,7 @@ let solve_lock_dir
         (Package_name.Map.map local_packages ~f:Dune_pkg.Local_package.for_solver)
       ~constraints:(constraints_of_workspace workspace ~lock_dir_path)
       ~selected_depopts:(depopts_of_workspace workspace ~lock_dir_path)
+      ~package_paths:(Lock_dir.Package_paths.for_writing ~portable_lock_dir)
       ~portable_lock_dir
   in
   match result with

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -1055,6 +1055,55 @@ module Packages = struct
   ;;
 end
 
+module Package_paths = struct
+  type t =
+    | Versioned
+    | Unversioned
+
+  let equal = Poly.equal
+
+  let to_dyn = function
+    | Versioned -> Dyn.variant "Versioned" []
+    | Unversioned -> Dyn.variant "Unversioned" []
+  ;;
+
+  let versioned = function
+    | Versioned -> true
+    | Unversioned -> false
+  ;;
+
+  let env_var = Env.Var.of_string "DUNE_PKG_VERSIONED_LOCK_DIR_PATHS"
+
+  let for_writing ~portable_lock_dir =
+    match Env.get Env.initial env_var with
+    | None -> if portable_lock_dir then Versioned else Unversioned
+    | Some "enabled" -> Versioned
+    | Some "disabled" -> Unversioned
+    | Some value ->
+      User_error.raise
+        [ Pp.textf "Invalid value %S for %s." value (Env.Var.to_string env_var) ]
+        ~hints:[ Pp.text "Expected \"enabled\" or \"disabled\"." ]
+  ;;
+
+  let infer ~lock_dir_path ~default package_versions =
+    let has_versioned, has_unversioned =
+      List.fold_left package_versions ~init:(false, false) ~f:(fun (v, u) -> function
+        | Some _ -> true, u
+        | None -> v, true)
+    in
+    match has_versioned, has_unversioned with
+    | true, false -> Versioned
+    | false, true -> Unversioned
+    | false, false -> default
+    | true, true ->
+      User_error.raise
+        [ Pp.textf
+            "Lock directory %s mixes versioned and unversioned package paths."
+            (Path.to_string_maybe_quoted lock_dir_path)
+        ]
+  ;;
+end
+
 type t =
   { version : Syntax.Version.t
   ; dependency_hash : (Loc.t * Local_package.Dependency_hash.t) option
@@ -1063,6 +1112,7 @@ type t =
   ; repos : Repositories.t
   ; expanded_solver_variable_bindings : Solver_stats.Expanded_variable_bindings.t
   ; solved_for_platforms : Loc.t * Solver_env.t list
+  ; package_paths : Package_paths.t
   }
 
 let remove_locs t =
@@ -1080,6 +1130,7 @@ let equal
       ; repos
       ; expanded_solver_variable_bindings
       ; solved_for_platforms
+      ; package_paths
       }
       t
   =
@@ -1097,6 +1148,7 @@ let equal
   && (Tuple.T2.equal Loc.equal (List.equal Solver_env.equal))
        solved_for_platforms
        t.solved_for_platforms
+  && Package_paths.equal package_paths t.package_paths
 ;;
 
 let to_dyn
@@ -1107,6 +1159,7 @@ let to_dyn
       ; repos
       ; expanded_solver_variable_bindings
       ; solved_for_platforms
+      ; package_paths
       }
   =
   Dyn.record
@@ -1122,12 +1175,11 @@ let to_dyn
       , Solver_stats.Expanded_variable_bindings.to_dyn expanded_solver_variable_bindings )
     ; ( "solved_for_platforms"
       , Tuple.T2.to_dyn Loc.to_dyn_hum (Dyn.list Solver_env.to_dyn) solved_for_platforms )
+    ; "package_paths", Package_paths.to_dyn package_paths
     ]
 ;;
 
-(* CR-someday Alizter: Remove this when portable lock directories are
-   consolidated with non-portable lock directories. *)
-let uses_versioned_paths t = not (List.is_empty (snd t.solved_for_platforms))
+let uses_versioned_paths t = Package_paths.versioned t.package_paths
 
 type missing_dependency =
   { dependant_package : Pkg.t
@@ -1165,6 +1217,7 @@ let create_latest_version
       ~repos
       ~expanded_solver_variable_bindings
       ~solved_for_platforms
+      ~package_paths
       ~portable_lock_dir
   =
   let packages =
@@ -1215,6 +1268,7 @@ let create_latest_version
   ; repos = { complete; used }
   ; expanded_solver_variable_bindings
   ; solved_for_platforms = Loc.none, solved_for_platforms_platform_specific_only
+  ; package_paths
   }
 ;;
 
@@ -1233,6 +1287,7 @@ let encode_metadata
       ; packages = _
       ; expanded_solver_variable_bindings
       ; solved_for_platforms
+      ; package_paths = _
       }
   =
   let open Encoder in
@@ -1338,11 +1393,8 @@ let file_contents_by_path ~portable_lock_dir t =
   :: (Packages.to_pkg_list t.packages
       |> List.map ~f:(fun (pkg : Pkg.t) ->
         let _loc, solved_for_platforms = t.solved_for_platforms in
-        let package_filename =
-          if portable_lock_dir
-          then Package_filename.make pkg.info.name (Some pkg.info.version)
-          else Package_filename.make pkg.info.name None
-        in
+        let package_version = Option.some_if (uses_versioned_paths t) pkg.info.version in
+        let package_filename = Package_filename.make pkg.info.name package_version in
         ( Filename.to_string package_filename
         , Pkg.encode ~portable_lock_dir ~solved_for_platforms pkg )))
 ;;
@@ -1505,11 +1557,11 @@ module Write_disk = struct
         Format.asprintf "%a" Pp.to_fmt pp |> Io.write_file path;
         Package_name.Map.iteri files ~f:(fun package_name files_by_version ->
           Package_version.Map.iteri files_by_version ~f:(fun package_version files ->
+            let package_version =
+              Option.some_if (uses_versioned_paths lock_dir) package_version
+            in
             let files_dir =
-              let maybe_package_version =
-                if portable_lock_dir then Some package_version else None
-              in
-              Pkg.files_dir package_name maybe_package_version ~lock_dir:lock_dir_path
+              Pkg.files_dir package_name package_version ~lock_dir:lock_dir_path
             in
             Path.mkdir_p files_dir;
             List.iter files ~f:(fun { File_entry.original; local_file } ->
@@ -1693,7 +1745,7 @@ struct
       | Some x -> true, x
       | None -> false, (Loc.none, [])
     in
-    let+ packages =
+    let* package_filenames =
       Io.readdir_with_kinds lock_dir_path
       >>| List.filter_map ~f:(fun (name, (kind : Unix.file_kind)) ->
         match kind with
@@ -1701,7 +1753,15 @@ struct
         | _ ->
           (* TODO *)
           None)
-      >>= Io.parallel_map ~f:(fun (package_name, maybe_package_version) ->
+    in
+    let package_paths =
+      let default =
+        if portable_lock_dir then Package_paths.Versioned else Package_paths.Unversioned
+      in
+      List.map package_filenames ~f:snd |> Package_paths.infer ~lock_dir_path ~default
+    in
+    let+ packages =
+      Io.parallel_map package_filenames ~f:(fun (package_name, maybe_package_version) ->
         let _loc, solved_for_platforms = solved_for_platforms in
         let+ pkg =
           load_pkg
@@ -1725,6 +1785,7 @@ struct
         ; repos
         ; expanded_solver_variable_bindings
         ; solved_for_platforms
+        ; package_paths
         })
     in
     Option.iter (Dune_trace.global ()) ~f:(fun trace -> Dune_trace.Out.finish trace event);

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -105,6 +105,17 @@ module Packages : sig
   val pkgs_by_platform : t -> Pkg.t list Solver_env.Map.t
 end
 
+module Package_paths : sig
+  type t =
+    | Versioned
+    | Unversioned
+
+  (** Choose the package path layout for a newly generated lock directory.
+      [DUNE_PKG_VERSIONED_LOCK_DIR_PATHS=enabled|disabled] overrides the
+      existing default selected by [portable_lock_dir]. *)
+  val for_writing : portable_lock_dir:bool -> t
+end
+
 type t = private
   { version : Syntax.Version.t
   ; dependency_hash : (Loc.t * Local_package.Dependency_hash.t) option
@@ -119,15 +130,16 @@ type t = private
       dependencies. Can be used to determine if a lockdir is compatible
       with a particular system. *)
   ; solved_for_platforms : Loc.t * Solver_env.t list
+  ; package_paths : Package_paths.t
   }
 
 val remove_locs : t -> t
 val equal : t -> t -> bool
 val to_dyn : t -> Dyn.t
 
-(** Returns whether this lock directory uses versioned paths for package
-    files directories. Portable lock directories use versioned paths to
-    handle multiple versions of the same package. *)
+(** Returns whether this lock directory uses versioned paths for package files
+    and package file directories. The layout is detected while reading and does
+    not depend on the writer's environment variable. *)
 val uses_versioned_paths : t -> bool
 
 (** [create_latest_version packages ~ocaml ~repos
@@ -142,6 +154,7 @@ val create_latest_version
   -> repos:Opam_repo.t list option
   -> expanded_solver_variable_bindings:Solver_stats.Expanded_variable_bindings.t
   -> solved_for_platforms:Solver_env.t list
+  -> package_paths:Package_paths.t
   -> portable_lock_dir:bool
   -> t
 

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -828,6 +828,10 @@ module Solver = struct
       | Selected of Input.dependency list
       | Unselected
 
+    type search_item =
+      | Visit_role of Input.Role.t
+      | Visit_dependencies of Input.dependency list
+
     type selection =
       { impl : Input.Impl.t (** The implementation chosen to fill the role *)
       ; var : Sat.lit
@@ -1193,33 +1197,56 @@ module Solver = struct
       in
       let+ impl_clauses = Fiber.Cache.to_table impl_clauses in
       (* Run the solve *)
+      let pending = ref [ Visit_role root_req ] in
+      let seen = Table.create (module Input.Role) 100 in
+      let previous_decision_level = ref 0 in
+      let reset_search () =
+        pending := [ Visit_role root_req ];
+        Table.clear seen
+      in
       let decider () =
-        (* Walk the current solution, depth-first, looking for the first
-           undecided interface. Then try the most preferred implementation of
-           it that hasn't been ruled out. *)
-        let seen = Table.create (module Input.Role) 100 in
-        let rec find_undecided req =
-          if Table.mem seen req
-          then None (* Break cycles *)
-          else (
-            Table.set seen req true;
-            match Table.find_exn impl_clauses req |> Candidates.state with
-            | Unselected -> None
-            | Undecided lit -> Some lit
-            | Selected deps ->
-              (* We've already selected a candidate for this component. Now
-                 check its dependencies. *)
-              List.find_map deps ~f:(fun (dep : Input.dependency) ->
-                match dep.importance with
-                | Ensure -> find_undecided dep.drole
-                | Prevent ->
-                  (* Restrictions don't express that we do or don't want the
-                     dependency, so skip them here. If someone else needs this,
-                     we'll handle it when we get to them.
-                     If noone wants it, it will be set to unselected at the end. *)
-                  None))
+        (* Resume the depth-first walk from the previous decision. Assignments
+           are monotonic until a backjump, so already visited roles cannot gain
+           a new undecided candidate. *)
+        let decision_level = Sat.get_decision_level sat in
+        if decision_level < !previous_decision_level then reset_search ();
+        previous_decision_level := decision_level;
+        let rec find_undecided () =
+          match !pending with
+          | [] -> None
+          | Visit_role req :: rest ->
+            if Table.mem seen req
+            then (
+              pending := rest;
+              find_undecided ())
+            else (
+              match Table.find_exn impl_clauses req |> Candidates.state with
+              | Unselected ->
+                Table.set seen req true;
+                pending := rest;
+                find_undecided ()
+              | Undecided lit -> Some lit
+              | Selected deps ->
+                (* We've already selected a candidate for this component. Now
+                   check its dependencies. *)
+                Table.set seen req true;
+                pending := Visit_dependencies deps :: rest;
+                find_undecided ())
+          | Visit_dependencies [] :: rest ->
+            pending := rest;
+            find_undecided ()
+          | Visit_dependencies (dep :: deps) :: rest ->
+            pending := Visit_dependencies deps :: rest;
+            (match dep.importance with
+             | Ensure -> pending := Visit_role dep.drole :: !pending
+             | Prevent ->
+               (* Restrictions don't express that we do or don't want the
+                  dependency. If another package needs it, it will be visited
+                  from that package. *)
+               ());
+            find_undecided ()
         in
-        find_undecided root_req
+        find_undecided ()
       in
       let start = Time.now () in
       let result = Sat.run_solver sat decider in

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -2291,6 +2291,7 @@ let solve_lock_dir
       ~constraints
       ~selected_depopts
       ~portable_lock_dir
+      ~package_paths
   =
   match platform_overlays with
   | [] -> Code_error.raise "solve_lock_dir called with empty platform_overlays" []
@@ -2548,6 +2549,7 @@ let solve_lock_dir
               ~repos:(Some repos)
               ~expanded_solver_variable_bindings
               ~solved_for_platforms:full_solver_envs
+              ~package_paths
               ~portable_lock_dir
           in
           let+ files =

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -38,6 +38,7 @@ val solve_lock_dir
            handling both portable and non-portable lockdirs with the same code.
            Once portable lockdirs are enabled unconditionally, remove this
            argument. *)
+  -> package_paths:Lock_dir.Package_paths.t
   -> ( Solver_result.t
        , [ `Solve_error of User_message.Style.t Pp.t | `Manifest_error of User_message.t ]
        )

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -167,6 +167,7 @@ module Spec = struct
         ~local_packages
         ~constraints
         ~selected_depopts
+        ~package_paths:(Dune_pkg.Lock_dir.Package_paths.for_writing ~portable_lock_dir)
         ~portable_lock_dir
     in
     match solver_result with

--- a/src/sat/sat.ml
+++ b/src/sat/sat.ml
@@ -126,6 +126,10 @@ module Make (User : USER) = struct
       (* The decision level at which we got a value (when not Undecided) *)
     ; mutable undo : undo list
       (* Functions to call if we become unbound (by backtracking) *)
+    ; (* Undecided variables form a linked list. Assigned variables retain their
+         neighbours so trail-ordered undo can restore them in constant time. *)
+      mutable previous_undecided : var option
+    ; mutable next_undecided : var option
     ; watch_queue : clause Queue.t (* Clauses to notify when var becomes True *)
     ; neg_watch_queue : clause Queue.t (* Clauses to notify when var becomes False *)
     ; obj : User.t (* The object this corresponds to (for our caller and for debugging) *)
@@ -137,6 +141,7 @@ module Make (User : USER) = struct
     { id_maker : VarID.mint
     ; (* Propagation *)
       mutable vars : var list
+    ; mutable first_undecided : var option
     ; propQ : lit Queue.t (* propagation queue *)
     ; (* Assignments *)
       mutable trail : lit list (* order of assignments, most recent first *)
@@ -195,6 +200,8 @@ module Make (User : USER) = struct
     ; reason = None
     ; level = -1
     ; undo = []
+    ; previous_undecided = None
+    ; next_undecided = None
     ; watch_queue = Queue.create ()
     ; neg_watch_queue = Queue.create ()
     ; obj
@@ -224,6 +231,7 @@ module Make (User : USER) = struct
     if debug then log_debug (Pp.text "--- new SAT problem ---");
     { id_maker = VarID.make_mint ()
     ; vars = []
+    ; first_undecided = None
     ; propQ = Queue.create ()
     ; trail = []
     ; trail_len = 0
@@ -292,13 +300,34 @@ module Make (User : USER) = struct
   let get_decision_level problem = problem.trail_lim_len
 
   let add_variable problem obj : lit =
+    if problem.trail_lim_len <> 0
+    then invalid_arg "Sat.add_variable: cannot add variables after decisions have begun";
     (* if debug then log_debug "add_variable('%s')" obj; *)
     let var =
       let i = VarID.issue problem.id_maker in
       make_var i obj
     in
+    var.next_undecided <- problem.first_undecided;
+    Option.iter problem.first_undecided ~f:(fun first ->
+      first.previous_undecided <- Some var);
+    problem.first_undecided <- Some var;
     problem.vars <- var :: problem.vars;
     Pos, var
+  ;;
+
+  let remove_undecided problem var =
+    (match var.previous_undecided with
+     | None -> problem.first_undecided <- var.next_undecided
+     | Some previous -> previous.next_undecided <- var.next_undecided);
+    Option.iter var.next_undecided ~f:(fun next ->
+      next.previous_undecided <- var.previous_undecided)
+  ;;
+
+  let restore_undecided problem var =
+    (match var.previous_undecided with
+     | None -> problem.first_undecided <- Some var
+     | Some previous -> previous.next_undecided <- Some var);
+    Option.iter var.next_undecided ~f:(fun next -> next.previous_undecided <- Some var)
   ;;
 
   (* [lit] is now [True].
@@ -318,6 +347,7 @@ module Make (User : USER) = struct
     | True -> true (* Already set (shouldn't happen) *)
     | Undecided ->
       let var_info = var_of_lit lit in
+      remove_undecided problem var_info;
       var_info.value <- (if fst lit == Neg then False else True);
       var_info.level <- get_decision_level problem;
       var_info.reason <- Some reason;
@@ -335,6 +365,7 @@ module Make (User : USER) = struct
       (* if debug then log_debug "(pop %s)" (name_lit lit); *)
       let var_info = var_of_lit lit in
       var_info.value <- Undecided;
+      restore_undecided problem var_info;
       var_info.reason <- None;
       var_info.level <- -1;
       problem.trail <- rest;
@@ -897,8 +928,8 @@ module Make (User : USER) = struct
                If it leads to a conflict, we'll backtrack and
                try it the other way. *)
             let undecided =
-              match List.find problem.vars ~f:(fun info -> info.value = Undecided) with
-              | Some s -> s
+              match problem.first_undecided with
+              | Some undecided -> undecided
               | None -> raise_notrace (SolveDone true)
             in
             let lit =

--- a/src/sat/sat.mli
+++ b/src/sat/sat.mli
@@ -22,6 +22,9 @@ module Make (User : USER) : sig
   type lit
 
   val neg : lit -> lit
+
+  (** [add_variable problem user_data] adds a variable while constructing [problem].
+      @raise Invalid_argument if a decision level is active. *)
   val add_variable : t -> User.t -> lit
 
   (** A clause is a boolean expression made up of literals. e.g. [A and B and not(C)] *)

--- a/src/sat/sat.mli
+++ b/src/sat/sat.mli
@@ -65,6 +65,11 @@ module Make (User : USER) : sig
       Use this to tidy up at the end, when you no longer care about the order. *)
   val run_solver : t -> (unit -> lit option) -> bool
 
+  (** Return the current decision level. A decrease between calls to the decider
+      indicates that the solver backtracked, allowing incremental deciders to
+      invalidate cached state. *)
+  val get_decision_level : t -> int
+
   (** Return the first literal in the list whose value is [Undecided], or [None] if they're all decided.
       The decider function may find this useful. *)
   val get_best_undecided : at_most_one_clause -> lit option

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-versioned-package-paths.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-versioned-package-paths.t
@@ -1,0 +1,66 @@
+Package version numbers in lock-directory paths are a writer-only choice. Both
+layouts must load and produce the same build plan.
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ cat > data.txt <<'EOF'
+  > layout invariant
+  > EOF
+  $ data_checksum=$(md5sum data.txt | cut -d' ' -f1)
+
+  $ mkpkg layout 1.2 <<EOF
+  > build: [
+  >  ["sh" "-c" "mkdir -p %{share}% && cp data.txt %{share}%/result"]
+  > ]
+  > extra-files: ["data.txt" "md5=$data_checksum"]
+  > EOF
+  $ mkdir -p "$mock_packages/layout/layout.1.2/files"
+  $ cp data.txt "$mock_packages/layout/layout.1.2/files/data.txt"
+
+  $ cat > dune-project <<'EOF'
+  > (lang dune 3.22)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends layout))
+  > EOF
+
+Invalid values are rejected by the writer.
+
+  $ DUNE_PKG_VERSIONED_LOCK_DIR_PATHS=other dune pkg lock
+  Error: Invalid value "other" for DUNE_PKG_VERSIONED_LOCK_DIR_PATHS.
+  Hint: Expected "enabled" or "disabled".
+  [1]
+
+Generate the same solution with each package path layout.
+
+  $ DUNE_PKG_VERSIONED_LOCK_DIR_PATHS=enabled dune_pkg_lock_normalized >/dev/null
+  $ mv dune.lock versioned.lock
+  $ test -f versioned.lock/layout.1.2.pkg
+  $ test -f versioned.lock/layout.1.2.files/data.txt
+
+  $ DUNE_PKG_VERSIONED_LOCK_DIR_PATHS=disabled dune_pkg_lock_normalized >/dev/null
+  $ mv dune.lock unversioned.lock
+  $ test -f unversioned.lock/layout.pkg
+  $ test -f unversioned.lock/layout.files/data.txt
+
+The reader must detect the layout from the lock directory rather than consulting
+the writer flag. Build each lock directory with the opposite flag value.
+
+  $ cp -R versioned.lock dune.lock
+  $ versioned_digest=$(DUNE_PKG_VERSIONED_LOCK_DIR_PATHS=disabled dune pkg print-digest layout)
+  $ DUNE_PKG_VERSIONED_LOCK_DIR_PATHS=disabled build_pkg layout
+  $ cp "$(get_build_pkg_dir layout)/target/share/result" versioned-result
+
+  $ rm -rf dune.lock
+  $ cp -R unversioned.lock dune.lock
+  $ dune clean
+  $ unversioned_digest=$(DUNE_PKG_VERSIONED_LOCK_DIR_PATHS=enabled dune pkg print-digest layout)
+  $ DUNE_PKG_VERSIONED_LOCK_DIR_PATHS=enabled build_pkg layout
+  $ cp "$(get_build_pkg_dir layout)/target/share/result" unversioned-result
+
+  $ test "$versioned_digest" = "$unversioned_digest" && echo 'package digests match'
+  package digests match
+  $ cmp versioned-result unversioned-result && cat versioned-result
+  layout invariant

--- a/test/expect-tests/dune_pkg/encode_decode_tests.ml
+++ b/test/expect-tests/dune_pkg/encode_decode_tests.ml
@@ -111,6 +111,7 @@ let%expect_test "encode/decode round trip test for lockdir with no deps" =
          ~repos:None
          ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
          ~solved_for_platforms:[]
+         ~package_paths:Lock_dir.Package_paths.Unversioned
          ~portable_lock_dir:false)
     ();
   [%expect
@@ -124,6 +125,7 @@ let%expect_test "encode/decode round trip test for lockdir with no deps" =
     ; expanded_solver_variable_bindings =
         { variable_values = []; unset_variables = [] }
     ; solved_for_platforms = ("<none>:1", [])
+    ; package_paths = Unversioned
     }
     |}]
 ;;
@@ -164,6 +166,7 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
            ; unset_variables = [ Package_variable_name.os_family ]
            }
          ~solved_for_platforms:[]
+         ~package_paths:Lock_dir.Package_paths.Unversioned
          ~portable_lock_dir:false
          (Package_name.Map.of_list_exn
             [ mk_pkg_basic ~name:"foo" ~version:(Package_version.of_string "0.1.0")
@@ -223,6 +226,7 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
         ; unset_variables = [ "os-family" ]
         }
     ; solved_for_platforms = ("<none>:1", [])
+    ; package_paths = Unversioned
     }
     |}]
 ;;
@@ -326,6 +330,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
       ~repos:(Some [ opam_repo ])
       ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
       ~solved_for_platforms:[]
+      ~package_paths:Lock_dir.Package_paths.Unversioned
       ~portable_lock_dir:false
       (Package_name.Map.of_list_exn [ pkg_a; pkg_b; pkg_c ])
   in
@@ -439,6 +444,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
     ; expanded_solver_variable_bindings =
         { variable_values = []; unset_variables = [] }
     ; solved_for_platforms = ("<none>:1", [])
+    ; package_paths = Unversioned
     }
     |}]
 ;;
@@ -474,6 +480,7 @@ let%expect_test "encode/decode round trip test with locked repo revision" =
         ~repos:(Some [ opam_repo ])
         ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
         ~solved_for_platforms:[]
+        ~package_paths:Lock_dir.Package_paths.Unversioned
         ~portable_lock_dir:false
         (Package_name.Map.of_list_exn [ pkg_a; pkg_b; pkg_c ])
     in
@@ -559,6 +566,7 @@ let%expect_test "encode/decode round trip test with locked repo revision" =
     ; expanded_solver_variable_bindings =
         { variable_values = []; unset_variables = [] }
     ; solved_for_platforms = ("<none>:1", [])
+    ; package_paths = Unversioned
     }
     |}]
 ;;

--- a/test/expect-tests/sat/sat_tests.ml
+++ b/test/expect-tests/sat/sat_tests.ml
@@ -101,6 +101,45 @@ let%expect_test "run_solver records decisions, and counters are cumulative" =
   |}]
 ;;
 
+let%expect_test "incremental deciders can detect non-chronological backtracking" =
+  let open Sat in
+  let p = create () in
+  let a = add_variable p 1 in
+  let c = add_variable p 2 in
+  let d = add_variable p 3 in
+  let x = add_variable p 4 in
+  (* Selecting [a] and [d] implies both [x] and [not x]. The unrelated
+     decision [c] makes conflict analysis backjump from level 3 to level 1. *)
+  at_least_one p [ neg a; neg d; x ];
+  at_least_one p [ neg a; neg d; neg x ];
+  let choices = ref [ a; c; d ] in
+  let previous_level = ref 0 in
+  let decide () =
+    let level = get_decision_level p in
+    if level < !previous_level
+    then Format.printf "backtracked from level %d to %d@." !previous_level level;
+    previous_level := level;
+    Format.printf "decide at level %d@." level;
+    match !choices with
+    | [] -> None
+    | choice :: rest ->
+      choices := rest;
+      Some choice
+  in
+  print_endline (string_of_bool (run_solver p decide));
+  print_stats p;
+  [%expect
+    {|
+    decide at level 0
+    decide at level 1
+    decide at level 2
+    backtracked from level 2 to 1
+    decide at level 1
+    true
+    num_variables=4 num_clauses=2 num_decisions=5 num_conflicts=1
+  |}]
+;;
+
 let%expect_test "impossible problems are rejected before solving" =
   let open Sat in
   let p = create () in

--- a/test/expect-tests/sat/sat_tests.ml
+++ b/test/expect-tests/sat/sat_tests.ml
@@ -101,6 +101,31 @@ let%expect_test "run_solver records decisions, and counters are cumulative" =
   |}]
 ;;
 
+let%expect_test "variables cannot be added at an active decision level" =
+  let open Sat in
+  let p = create () in
+  let a = add_variable p 1 in
+  let _b = add_variable p 2 in
+  let first_decision = ref true in
+  let decide () =
+    if !first_decision
+    then (
+      first_decision := false;
+      Some a)
+    else (
+      (match add_variable p 3 with
+       | exception Invalid_argument message -> print_endline message
+       | _ -> print_endline "unexpectedly added a variable");
+      None)
+  in
+  print_endline (string_of_bool (run_solver p decide));
+  [%expect
+    {|
+    Sat.add_variable: cannot add variables after decisions have begun
+    true
+  |}]
+;;
+
 let%expect_test "incremental deciders can detect non-chronological backtracking" =
   let open Sat in
   let p = create () in


### PR DESCRIPTION
> Depends on #16217. Until that PR merges, GitHub will include its commit in this cumulative diff.

## Summary

- Treat versioned package filenames and `.files` directories as an independent lock-directory layout choice.
- Add the hidden writer-only `DUNE_PKG_VERSIONED_LOCK_DIR_PATHS=enabled|disabled` environment variable.
- Preserve existing defaults when the variable is absent: portable lock directories remain versioned and non-portable lock directories remain unversioned.
- Infer the layout from package filenames while reading; the environment variable is never consulted by the reader.
- Reject lock directories that mix versioned and unversioned package paths.

## Invariant

The regression test generates the same solution in both layouts, builds each while setting the opposite writer flag, and verifies identical package digests, extra-file contents, and build output.

## Checks

- `dune build @check @fmt`
- `dune runtest test/expect-tests/dune_pkg/encode_decode_tests.ml`
- `dune runtest test/blackbox-tests/test-cases/pkg/lock-directory-versioned-package-paths.t`