### PR TITLE
test(ctypes): expose dropped deps in generated C compilation

### DIFF
--- a/test/blackbox-tests/test-cases/ctypes/exe-vendored.t/dune
+++ b/test/blackbox-tests/test-cases/ctypes/exe-vendored.t/dune
@@ -13,6 +13,7 @@
  (foreign_archives example)
  (ctypes
   (external_library_name examplelib)
+  (deps (source_tree vendor))
   (build_flags_resolver
    (vendored
     (c_flags "-Ivendor")))

--- a/test/blackbox-tests/test-cases/ctypes/exe-vendored.t/run.t
+++ b/test/blackbox-tests/test-cases/ctypes/exe-vendored.t/run.t
@@ -9,5 +9,14 @@ This is the version that builds into an executable.
   $ LIBEX=$(realpath "$PWD/../libexample")
   $ TARGET=./vendor
   $ mkdir -p $TARGET && install $LIBEX/*example* $TARGET
-  $ dune exec ./example.exe
+Ctypes 0.3 should honor dependencies when sandboxing is requested externally.
+
+  $ DUNE_SANDBOX=symlink dune exec ./example.exe
   4
+  $ dune trace cat | jq_dune -sc '
+  >   [ .[]
+  >   | processes
+  >   | select(.args.process_args | any(contains("c_cout_generated_functions")))
+  >   | (.args.dir | contains(".sandbox"))
+  >   ][0]'
+  false


### PR DESCRIPTION
Add a regression test showing that `(ctypes (deps ...))` does not reach generated C stub compilation. With symlink sandboxing forced, the generated C compiler still runs outside the sandbox.
