### PR TITLE
fix(ctypes): sandbox stub generation

### DIFF
--- a/doc/changes/fixed/16223.md
+++ b/doc/changes/fixed/16223.md
@@ -1,0 +1,2 @@
+- Run Ctypes stub generation in a sandbox and honor its declared dependencies.
+  (#16223, @rgrinberg)

--- a/doc/foreign-code.rst
+++ b/doc/foreign-code.rst
@@ -303,9 +303,10 @@ descriptions by referencing them as the module specified in optional
    - ``(headers (preamble <preamble>)`` adds directly the preamble. Variables
      can be used in ``<preamble>`` such as ``%{read: }``.
 
-- Since the Dune's ``ctypes`` feature is still experimental, it could be useful to
-  add additional dependencies in order to make sure that local
-  headers or libraries are available: ``(deps <deps-conf list>)``. See
+- ``(deps <deps-conf list>)`` declares additional dependencies, such as local
+  headers or libraries. Ctypes stub generation is sandboxed, so all such
+  dependencies must be declared. For example, use
+  ``(deps (source_tree vendor))`` for headers kept in ``vendor``. See
   :doc:`concepts/dependency-spec` for more details.
 
 ``<optional-function-description-fields>`` are:

--- a/src/dune_rules/ctypes/ctypes_rules.ml
+++ b/src/dune_rules/ctypes/ctypes_rules.ml
@@ -170,6 +170,7 @@ let build_c_program
       ~cflags
       ~output
       ~env
+      ~sandbox
   =
   let ctx = Super_context.context sctx in
   let ocaml = Context.ocaml ctx in
@@ -250,7 +251,7 @@ let build_c_program
     in
     let open Action_builder.With_targets.O in
     Action_builder.with_no_targets extra_deps
-    >>> Command.run_dyn_prog ~dir:(Path.build dir) ~env exe args
+    >>> Command.run_dyn_prog ~dir:(Path.build dir) ~env ~sandbox exe args
   in
   Super_context.add_rule sctx ~dir action
 ;;
@@ -313,7 +314,7 @@ let gen_rules ~cctx ~(buildable : Buildable.t) ~loc ~scope ~dir ~sctx =
     gen_headers ~expander ctypes.headers |> Action_builder.memoize "ctypes-gen-headers"
   in
   let env, sandbox =
-    Dep_conf_eval.unnamed Sandbox_config.no_special_requirements ~expander ctypes.deps
+    Dep_conf_eval.unnamed Sandbox_config.needs_sandboxing ~expander ctypes.deps
   in
   let exe_link_only = exe_link_only ~dir ~shared_cctx:cctx ~sandbox ~env in
   (* Type_gen produces a .c file, taking your type description module above as
@@ -352,7 +353,7 @@ let gen_rules ~cctx ~(buildable : Buildable.t) ~loc ~scope ~dir ~sctx =
         ~loc:Loc.none
         (let exe = Ok (Path.build (Path.Build.relative dir (type_gen_script ^ ".exe"))) in
          let stdout_to = Path.Build.relative dir c_generated_types_cout_c in
-         Command.run ~stdout_to ~dir:(Path.build dir) ~env exe [])
+         Command.run ~stdout_to ~dir:(Path.build dir) ~env ~sandbox exe [])
     in
     let* () =
       let foreign_archives_deps =
@@ -374,6 +375,7 @@ let gen_rules ~cctx ~(buildable : Buildable.t) ~loc ~scope ~dir ~sctx =
         ~output:c_generated_types_cout_exe
         ~cflags
         ~env
+        ~sandbox
     in
     Super_context.add_rule
       sctx
@@ -385,7 +387,7 @@ let gen_rules ~cctx ~(buildable : Buildable.t) ~loc ~scope ~dir ~sctx =
          |> Path.Build.relative dir
        in
        let exe = Ok (Path.build (Path.Build.relative dir c_generated_types_cout_exe)) in
-       Command.run ~stdout_to ~dir:(Path.build dir) ~env exe [])
+       Command.run ~stdout_to ~dir:(Path.build dir) ~env ~sandbox exe [])
   in
   (* Function_gen is similar to type_gen above, though it produces both an .ml
      file and a .c file. These files correspond to the files you would have to
@@ -420,7 +422,13 @@ let gen_rules ~cctx ~(buildable : Buildable.t) ~loc ~scope ~dir ~sctx =
           External_lib_name.(external_library_name |> clean |> to_string) ^ "_stubs"
         in
         fun ~stdout_to ~what ->
-          Command.run ~stdout_to ~dir:(Path.build dir) ~env exe [ A what; A stubs_prefix ]
+          Command.run
+            ~stdout_to
+            ~dir:(Path.build dir)
+            ~env
+            ~sandbox
+            exe
+            [ A what; A stubs_prefix ]
       in
       let* () =
         Super_context.add_rule

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -273,16 +273,18 @@ let c_compile_args ~sctx ~dir ~expander ~loc ~src ~include_flags =
 ;;
 
 let build_c ~sctx ~dir ~expander ~include_flags (loc, (src : Foreign.Source.t), dst) =
-  let env, _sandbox =
-    (* We don't sandbox the C compiler, see comment at the
-       [Action.Full.add_sandbox Sandbox_config.no_sandboxing] call below. *)
+  let env, sandbox =
     match Foreign.Source.kind src with
     | Stubs stubs ->
-      Dep_conf_eval.unnamed
-        Sandbox_config.no_special_requirements
-        stubs.extra_deps
-        ~expander
-    | Ctypes _ -> Action_builder.return Env.empty, Sandbox_config.default
+      let env, _ =
+        Dep_conf_eval.unnamed
+          Sandbox_config.no_special_requirements
+          stubs.extra_deps
+          ~expander
+      in
+      env, Sandbox_config.no_sandboxing
+    | Ctypes ctypes ->
+      Dep_conf_eval.unnamed Sandbox_config.needs_sandboxing ctypes.deps ~expander
   in
   let ctx = Super_context.context sctx in
   let* ocaml = Context.ocaml ctx in
@@ -349,10 +351,7 @@ let build_c ~sctx ~dir ~expander ~include_flags (loc, (src : Foreign.Source.t), 
      Command.run_dyn_prog
        ~dir:(Path.build dir)
        ~env
-         (* With sandboxing we get errors like: bar.c:2:19: fatal error:
-            foo.cxx: No such file or directory #include "foo.cxx". (These
-            errors happen only when compiling c files.) *)
-       ~sandbox:Sandbox_config.no_sandboxing
+       ~sandbox
        c_compiler
        [ c_compile_args ~sctx ~dir ~expander ~loc ~src ~include_flags
        ; Hidden_deps (Dep.Set.singleton (Dep.file_selector caml_headers))

--- a/test/blackbox-tests/test-cases/ctypes/exe-vendored-multiple-fd.t/dune
+++ b/test/blackbox-tests/test-cases/ctypes/exe-vendored-multiple-fd.t/dune
@@ -13,6 +13,7 @@
  (foreign_archives example)
  (ctypes
   (external_library_name examplelib)
+  (deps (source_tree vendor))
   (build_flags_resolver
    (vendored
     (c_flags "-Ivendor")))

--- a/test/blackbox-tests/test-cases/ctypes/exe-vendored-override-types-generated.t/dune
+++ b/test/blackbox-tests/test-cases/ctypes/exe-vendored-override-types-generated.t/dune
@@ -13,6 +13,7 @@
  (foreign_archives example)
  (ctypes
   (external_library_name examplelib)
+  (deps (source_tree vendor))
   (build_flags_resolver
    (vendored
     (c_flags "-Ivendor")))

--- a/test/blackbox-tests/test-cases/ctypes/exe-vendored-preamble.t/dune
+++ b/test/blackbox-tests/test-cases/ctypes/exe-vendored-preamble.t/dune
@@ -13,6 +13,7 @@
  (foreign_archives example)
  (ctypes
   (external_library_name examplelib)
+  (deps (source_tree vendor))
   (build_flags_resolver
    (vendored
     (c_flags "-Ivendor")))

--- a/test/blackbox-tests/test-cases/ctypes/exe-vendored.t/run.t
+++ b/test/blackbox-tests/test-cases/ctypes/exe-vendored.t/run.t
@@ -9,14 +9,15 @@ This is the version that builds into an executable.
   $ LIBEX=$(realpath "$PWD/../libexample")
   $ TARGET=./vendor
   $ mkdir -p $TARGET && install $LIBEX/*example* $TARGET
-Ctypes 0.3 should honor dependencies when sandboxing is requested externally.
+Ctypes stub generation is sandboxed and honors its declared dependencies.
 
-  $ DUNE_SANDBOX=symlink dune exec ./example.exe
+  $ dune exec ./example.exe
   4
   $ dune trace cat | jq_dune -sc '
   >   [ .[]
   >   | processes
-  >   | select(.args.process_args | any(contains("c_cout_generated_functions")))
+  >   | select((.args.target_files // [])
+  >            | any(startswith("_build/default/examplelib__")))
   >   | (.args.dir | contains(".sandbox"))
-  >   ][0]'
-  false
+  >   ] | unique'
+  [true]

--- a/test/blackbox-tests/test-cases/ctypes/lib-vendored-multiple-fd.t/stubgen/dune
+++ b/test/blackbox-tests/test-cases/ctypes/lib-vendored-multiple-fd.t/stubgen/dune
@@ -13,6 +13,7 @@
  (foreign_archives example)
  (ctypes
   (external_library_name examplelib)
+  (deps (source_tree vendor))
   (build_flags_resolver
    (vendored
      ; hack: multiple -I directives to work around cc commands being run from different

--- a/test/blackbox-tests/test-cases/ctypes/lib-vendored.t/stubgen/dune
+++ b/test/blackbox-tests/test-cases/ctypes/lib-vendored.t/stubgen/dune
@@ -13,6 +13,7 @@
  (foreign_archives example)
  (ctypes
   (external_library_name examplelib)
+  (deps (source_tree vendor))
   (build_flags_resolver
    (vendored
     ;; hack: multiple -I directives to work around cc commands being run from


### PR DESCRIPTION
Require sandboxing for Ctypes stub-generation actions in every supported extension version, and propagate `ctypes.deps` to generated C compilation. Ordinary `foreign_stubs` retain their existing unsandboxed behavior.

The regression test landed separately in #16222.
