### PR TITLE
perf(stdune): use memchr for string searches

### DIFF
--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -66,12 +66,9 @@ let subst_string s path ~map =
     loop 1 0 0
   in
   let rec loop i acc =
-    if i = len
-    then acc
-    else (
-      match s.[i] with
-      | '%' -> after_percent (i + 1) acc
-      | _ -> loop (i + 1) acc)
+    match String.index_from_unchecked s i '%' with
+    | -1 -> acc
+    | percent -> after_percent (percent + 1) acc
   and after_percent i acc =
     if i = len
     then acc

--- a/otherlibs/stdune/src/bytes.ml
+++ b/otherlibs/stdune/src/bytes.ml
@@ -1,1 +1,10 @@
 include StdLabels.Bytes
+
+external index_in_range_unchecked
+  :  t
+  -> pos:int
+  -> len:int
+  -> char
+  -> int
+  = "dune_bytes_index_in_range"
+[@@noalloc]

--- a/otherlibs/stdune/src/bytes.mli
+++ b/otherlibs/stdune/src/bytes.mli
@@ -1,3 +1,8 @@
 include module type of struct
   include StdLabels.Bytes
 end
+
+(** [index_in_range_unchecked bytes ~pos ~len char] returns the first index of
+    [char] between [pos] and [pos + len], excluding the latter, or [-1] if it is
+    absent. The range must be within [bytes]. *)
+val index_in_range_unchecked : t -> pos:int -> len:int -> char -> int

--- a/otherlibs/stdune/src/dune
+++ b/otherlibs/stdune/src/dune
@@ -31,6 +31,7 @@
    platform_stubs
    copyfile_stubs
    signal_stubs
+   string_stubs
    time_stubs)))
 
 (rule

--- a/otherlibs/stdune/src/filename.ml
+++ b/otherlibs/stdune/src/filename.ml
@@ -18,18 +18,19 @@ let concat dirname filename =
   else String.append_with_char dirname ~sep:(String.unsafe_get dir_sep 0) filename
 ;;
 
-let rec contains_slash s i =
-  i >= 0 && (Char.equal (String.unsafe_get s i) '/' || contains_slash s (i - 1))
-;;
-
-let rec contains_dir_sep s i =
+let rec contains_windows_dir_sep s i =
   if i < 0
   then false
   else (
     match String.unsafe_get s i with
-    | '/' -> true
-    | ('\\' | ':') when Sys.win32 || Sys.cygwin -> true
-    | _ -> contains_dir_sep s (i - 1))
+    | '/' | '\\' | ':' -> true
+    | _ -> contains_windows_dir_sep s (i - 1))
+;;
+
+let contains_dir_sep s =
+  if Sys.win32 || Sys.cygwin
+  then contains_windows_dir_sep s (String.length s - 1)
+  else String.contains s '/'
 ;;
 
 let is_valid s =
@@ -40,7 +41,7 @@ let is_valid s =
       || not
            (Char.equal (String.unsafe_get s 0) '.'
             && Char.equal (String.unsafe_get s 1) '.'))
-  && not (contains_dir_sep s (len - 1))
+  && not (contains_dir_sep s)
 ;;
 
 let of_string s = Option.some_if (is_valid s) s
@@ -111,9 +112,7 @@ module Extension = struct
 
   let is_valid s =
     let len = String.length s in
-    len > 0
-    && Char.equal (String.unsafe_get s 0) '.'
-    && not (contains_dir_sep s (len - 1))
+    len > 0 && Char.equal (String.unsafe_get s 0) '.' && not (contains_dir_sep s)
   ;;
 
   let of_string s = Option.some_if (is_valid s) s
@@ -245,9 +244,7 @@ type program_name_kind =
 let analyze_program_name fn =
   if not (is_relative fn)
   then Absolute
-  else if
-    contains_slash fn (String.length fn - 1)
-    || (Stdlib.Sys.win32 && String.contains fn '\\')
+  else if String.contains fn '/' || (Stdlib.Sys.win32 && String.contains fn '\\')
   then Relative_to_current_dir
   else In_path
 ;;

--- a/otherlibs/stdune/src/path0.ml
+++ b/otherlibs/stdune/src/path0.ml
@@ -11,26 +11,47 @@ let is_dir_sep =
 let basename_opt ~is_root ~basename t = if is_root t then None else Some (basename t)
 
 let explode_path =
-  let rec start acc path i =
-    if i < 0
-    then acc
-    else if is_dir_sep (String.unsafe_get path i)
-    then start acc path (i - 1)
-    else component acc path i (i - 1)
-  and component acc path end_ i =
-    if i < 0
-    then String.take path (end_ + 1) :: acc
-    else if is_dir_sep (String.unsafe_get path i)
-    then start (String.sub path ~pos:(i + 1) ~len:(end_ - i) :: acc) path (i - 1)
-    else component acc path end_ (i - 1)
-  in
-  fun path ->
-    if path = Filename.current_dir_name
-    then [ path ]
-    else (
-      match start [] path (String.length path - 1) with
-      | "." :: xs -> xs
-      | xs -> xs)
+  if Sys.win32 || Sys.cygwin
+  then (
+    let rec start acc path i =
+      if i < 0
+      then acc
+      else if is_dir_sep (String.unsafe_get path i)
+      then start acc path (i - 1)
+      else component acc path i (i - 1)
+    and component acc path end_ i =
+      if i < 0
+      then String.take path (end_ + 1) :: acc
+      else if is_dir_sep (String.unsafe_get path i)
+      then start (String.sub path ~pos:(i + 1) ~len:(end_ - i) :: acc) path (i - 1)
+      else component acc path end_ (i - 1)
+    in
+    fun path ->
+      if path = Filename.current_dir_name
+      then [ path ]
+      else (
+        match start [] path (String.length path - 1) with
+        | "." :: xs -> xs
+        | xs -> xs))
+  else (
+    let rec components path length start =
+      if start = length
+      then []
+      else (
+        match String.index_from_unchecked path start '/' with
+        | -1 -> [ String.sub path ~pos:start ~len:(length - start) ]
+        | separator when separator = start -> components path length (start + 1)
+        | separator ->
+          String.sub path ~pos:start ~len:(separator - start)
+          :: components path length (separator + 1))
+    in
+    fun path ->
+      if path = Filename.current_dir_name
+      then [ path ]
+      else (
+        match components path (String.length path) 0 with
+        | "." :: xs -> xs
+        | xs -> xs))
 ;;
 
 module Local_gen = struct

--- a/otherlibs/stdune/src/spawn.ml
+++ b/otherlibs/stdune/src/spawn.ml
@@ -1,5 +1,3 @@
-external contains_null : string -> bool = "dune_spawn_contains_null" [@@noalloc]
-
 module Working_dir = struct
   type 'a gen =
     | Path of string
@@ -224,7 +222,7 @@ let spawn_windows
 ;;
 
 let no_null s =
-  if contains_null s
+  if String.contains s '\000'
   then
     Printf.ksprintf
       invalid_arg

--- a/otherlibs/stdune/src/spawn_stubs.c
+++ b/otherlibs/stdune/src/spawn_stubs.c
@@ -209,11 +209,6 @@ static int __pthread_fchdir(int fd) {
 
 #endif
 
-CAMLprim value dune_spawn_contains_null(value v_string)
-{
-  return Val_bool(memchr(String_val(v_string), '\0', caml_string_length(v_string)) != NULL);
-}
-
 #if !defined(_WIN32)
 
 # if defined(USE_POSIX_SPAWN)

--- a/otherlibs/stdune/src/string.ml
+++ b/otherlibs/stdune/src/string.ml
@@ -201,6 +201,8 @@ let rsplit2 s ~on =
 
 include String_split
 
+let split_on_char ~sep s = split s ~on:sep
+
 let escape_only c s =
   let n = ref 0 in
   let len = length s in

--- a/otherlibs/stdune/src/string.ml
+++ b/otherlibs/stdune/src/string.ml
@@ -76,19 +76,40 @@ module Caseless = Cased_functions (struct
 
 include Stdlib.StringLabels
 
-let index_from_unchecked s i c =
-  let length = length s in
-  let rec loop i =
-    if i = length then -1 else if Char.equal (unsafe_get s i) c then i else loop (i + 1)
-  in
-  loop i
-;;
+external index_from_unchecked : t -> int -> char -> int = "dune_string_index_from"
+[@@noalloc]
 
 let rindex_from_unchecked s i c =
   let rec loop i =
     if i = -1 then -1 else if Char.equal (unsafe_get s i) c then i else loop (i - 1)
   in
   loop i
+;;
+
+let index_from s i c =
+  let length = length s in
+  if i < 0 || i > length then invalid_arg "String.index_from_opt / Bytes.index_from_opt";
+  if i = length
+  then None
+  else (
+    match index_from_unchecked s i c with
+    | -1 -> None
+    | index -> Some index)
+;;
+
+let index_from_opt = index_from
+let index s c = index_from s 0 c
+let index_opt = index
+
+let contains_from s i c =
+  let length = length s in
+  if i < 0 || i > length then invalid_arg "String.contains_from / Bytes.contains_from";
+  i < length && index_from_unchecked s i c <> -1
+;;
+
+let contains s c =
+  let length = length s in
+  length > 0 && index_from_unchecked s 0 c <> -1
 ;;
 
 (* [StringLabels] shadows these implementations with versions that allocate a
@@ -116,8 +137,6 @@ let capitalize = capitalize_ascii
 let uncapitalize = uncapitalize_ascii
 let uppercase = uppercase_ascii
 let lowercase = lowercase_ascii
-let index = index_opt
-let index_from s i c = index_from_opt s i c
 let rindex = rindex_opt
 let rindex_from s i c = rindex_from_opt s i c
 let break s ~pos = sub s ~pos:0 ~len:pos, sub s ~pos ~len:(length s - pos)
@@ -226,7 +245,7 @@ let quoted = Printf.sprintf "%S"
 
 let maybe_quoted s =
   let escaped = escaped s in
-  if (s == escaped || s = escaped) && not (String.contains s ' ') then s else quoted s
+  if (s == escaped || s = escaped) && not (contains s ' ') then s else quoted s
 ;;
 
 include Comparable.Make (T)

--- a/otherlibs/stdune/src/string.mli
+++ b/otherlibs/stdune/src/string.mli
@@ -88,6 +88,7 @@ val rsplit2 : t -> on:char -> (t * t) option
     the original string [s]. *)
 val split : t -> on:char -> t list
 
+val split_on_char : sep:char -> t -> t list
 val split_lines : t -> t list
 
 (** Escape ONLY one character. {!escape} also escapes '\n',... and transforms

--- a/otherlibs/stdune/src/string.mli
+++ b/otherlibs/stdune/src/string.mli
@@ -48,8 +48,12 @@ val capitalize : t -> t
 val uncapitalize : t -> t
 val uppercase : t -> t
 val lowercase : t -> t
+val contains : t -> char -> bool
+val contains_from : t -> int -> char -> bool
 val index : t -> char -> int option
+val index_opt : t -> char -> int option
 val index_from : t -> int -> char -> int option
+val index_from_opt : t -> int -> char -> int option
 val rindex : t -> char -> int option
 val rindex_from : t -> int -> char -> int option
 

--- a/otherlibs/stdune/src/string_split.ml
+++ b/otherlibs/stdune/src/string_split.ml
@@ -2,39 +2,36 @@ module List = Stdlib.ListLabels
 module String = Stdlib.StringLabels
 open String
 
+external index_from : string -> int -> char -> int = "dune_string_index_from" [@@noalloc]
+
 let split s ~on =
   let len = length s in
-  let rec loop i j =
-    if j = len
-    then [ sub s ~pos:i ~len:(j - i) ]
-    else if String.unsafe_get s j = on
-    then sub s ~pos:i ~len:(j - i) :: loop (j + 1) (j + 1)
-    else loop i (j + 1)
+  let rec loop i =
+    let separator = if i = len then -1 else index_from s i on in
+    match separator with
+    | -1 -> [ sub s ~pos:i ~len:(len - i) ]
+    | j -> sub s ~pos:i ~len:(j - i) :: loop (j + 1)
   in
-  loop 0 0
+  loop 0
 ;;
 
 let split_lines s =
   let len = length s in
-  let rec loop ~last_is_cr ~acc i j =
-    if j = len
-    then (
+  let rec loop acc i =
+    let newline = if i = len then -1 else index_from s i '\n' in
+    match newline with
+    | -1 ->
       let acc =
-        if j = i || (j = i + 1 && last_is_cr)
+        if i = len || (i + 1 = len && String.unsafe_get s i = '\r')
         then acc
-        else sub s ~pos:i ~len:(j - i) :: acc
+        else sub s ~pos:i ~len:(len - i) :: acc
       in
-      List.rev acc)
-    else (
-      match String.unsafe_get s j with
-      | '\r' -> loop ~last_is_cr:true ~acc i (j + 1)
-      | '\n' ->
-        let line =
-          let len = if last_is_cr then j - i - 1 else j - i in
-          sub s ~pos:i ~len
-        in
-        loop ~acc:(line :: acc) (j + 1) (j + 1) ~last_is_cr:false
-      | _ -> loop ~acc i (j + 1) ~last_is_cr:false)
+      List.rev acc
+    | j ->
+      let line_len =
+        if j > i && String.unsafe_get s (j - 1) = '\r' then j - i - 1 else j - i
+      in
+      loop (sub s ~pos:i ~len:line_len :: acc) (j + 1)
   in
-  loop ~acc:[] 0 0 ~last_is_cr:false
+  loop [] 0
 ;;

--- a/otherlibs/stdune/src/string_stubs.c
+++ b/otherlibs/stdune/src/string_stubs.c
@@ -12,3 +12,14 @@ CAMLprim value dune_string_index_from(value v_string, value v_position, value v_
     (const unsigned char *)memchr(string + position, Int_val(v_char), length - position);
   return Val_long(result == NULL ? -1 : result - string);
 }
+
+CAMLprim value dune_bytes_index_in_range(
+  value v_bytes, value v_position, value v_length, value v_char)
+{
+  const unsigned char *bytes = (const unsigned char *)String_val(v_bytes);
+  size_t position = Long_val(v_position);
+  size_t length = Long_val(v_length);
+  const unsigned char *result =
+    (const unsigned char *)memchr(bytes + position, Int_val(v_char), length);
+  return Val_long(result == NULL ? -1 : result - bytes);
+}

--- a/otherlibs/stdune/src/string_stubs.c
+++ b/otherlibs/stdune/src/string_stubs.c
@@ -1,0 +1,14 @@
+#include <caml/mlvalues.h>
+
+#include <stddef.h>
+#include <string.h>
+
+CAMLprim value dune_string_index_from(value v_string, value v_position, value v_char)
+{
+  const unsigned char *string = (const unsigned char *)String_val(v_string);
+  size_t length = caml_string_length(v_string);
+  size_t position = Long_val(v_position);
+  const unsigned char *result =
+    (const unsigned char *)memchr(string + position, Int_val(v_char), length - position);
+  return Val_long(result == NULL ? -1 : result - string);
+}

--- a/otherlibs/stdune/test/path_tests.ml
+++ b/otherlibs/stdune/test/path_tests.ml
@@ -122,6 +122,20 @@ let%expect_test "canonical local component boundaries" =
     |}]
 ;;
 
+let%expect_test "normalize relative path separators" =
+  List.iter
+    [ "foo//bar/"; "./foo"; "foo///bar//baz"; "foo/./bar"; "foo/../bar" ]
+    ~f:(fun path -> Path.relative Path.root path |> Path.to_dyn |> print_dyn);
+  [%expect
+    {|
+    In_source_tree "foo/bar"
+    In_source_tree "foo"
+    In_source_tree "foo/bar/baz"
+    In_source_tree "foo/bar"
+    In_source_tree "bar"
+    |}]
+;;
+
 let%expect_test _ =
   let p = Path.(relative root) "foo" in
   descendant p ~of_:p;

--- a/otherlibs/stdune/test/string_tests.ml
+++ b/otherlibs/stdune/test/string_tests.ml
@@ -248,6 +248,8 @@ let%expect_test "forward searches agree with the standard library" =
         let char = Char.chr code in
         let expected = Stdlib.String.index_from_opt s pos char in
         assert (Option.equal Int.equal (String.index_from s pos char) expected);
+        assert (Option.equal Int.equal (String.index_from_opt s pos char) expected);
+        if pos = 0 then assert (Option.equal Int.equal (String.index_opt s char) expected);
         assert (
           Int.equal
             (String.index_from_unchecked s pos char)
@@ -260,6 +262,23 @@ let%expect_test "forward searches agree with the standard library" =
     done);
   print_endline "all searches agree";
   [%expect {| all searches agree |}]
+;;
+
+let%expect_test "checked forward searches reject invalid positions" =
+  let raises_invalid_argument f =
+    match f () with
+    | exception Invalid_argument _ -> true
+    | _ -> false
+  in
+  List.iter search_test_strings ~f:(fun s ->
+    List.iter
+      [ -1; String.length s + 1 ]
+      ~f:(fun pos ->
+        assert (raises_invalid_argument (fun () -> String.index_from s pos '\000'));
+        assert (raises_invalid_argument (fun () -> String.index_from_opt s pos '\000'));
+        assert (raises_invalid_argument (fun () -> String.contains_from s pos '\000'))));
+  print_endline "all invalid positions rejected";
+  [%expect {| all invalid positions rejected |}]
 ;;
 
 let%expect_test "reverse searches agree with the standard library" =

--- a/otherlibs/stdune/test/string_tests.ml
+++ b/otherlibs/stdune/test/string_tests.ml
@@ -208,6 +208,15 @@ let%expect_test _ =
   [%expect {| [ ""; ""; ""; "" ] |}]
 ;;
 
+let%expect_test "split functions agree with the standard library" =
+  List.iter [ ""; "a"; ":"; "a:b"; "::a::b::" ] ~f:(fun s ->
+    let expected = Stdlib.String.split_on_char ':' s in
+    assert (List.equal String.equal (String.split s ~on:':') expected);
+    assert (List.equal String.equal (String.split_on_char ~sep:':' s) expected));
+  print_endline "all splits agree";
+  [%expect {| all splits agree |}]
+;;
+
 let%expect_test "extract blank separated words" =
   List.iter [ ""; " \t "; "one"; " one\ttwo  three " ] ~f:(fun s ->
     String.extract_blank_separated_words s |> list string |> print_dyn);

--- a/otherlibs/stdune/test/string_tests.ml
+++ b/otherlibs/stdune/test/string_tests.ml
@@ -290,6 +290,41 @@ let%expect_test "checked forward searches reject invalid positions" =
   [%expect {| all invalid positions rejected |}]
 ;;
 
+let%expect_test "bounded bytes search agrees with a scalar search" =
+  let scalar_index_in_range bytes ~pos ~len char =
+    let stop = pos + len in
+    let rec loop i =
+      if i = stop
+      then -1
+      else if Char.equal (Bytes.unsafe_get bytes i) char
+      then i
+      else loop (i + 1)
+    in
+    loop pos
+  in
+  let bytes = Bytes.of_string (String.init 17 ~f:(fun i -> Char.chr (i * 47 land 255))) in
+  for pos = 0 to Bytes.length bytes do
+    for len = 0 to Bytes.length bytes - pos do
+      for code = 0 to 255 do
+        let char = Char.chr code in
+        assert (
+          Int.equal
+            (Bytes.index_in_range_unchecked bytes ~pos ~len char)
+            (scalar_index_in_range bytes ~pos ~len char))
+      done
+    done
+  done;
+  let all_bytes = Bytes.of_string (String.init 256 ~f:Char.chr) in
+  for code = 0 to 255 do
+    assert (
+      Int.equal
+        (Bytes.index_in_range_unchecked all_bytes ~pos:code ~len:1 (Char.chr code))
+        code)
+  done;
+  print_endline "all bounded searches agree";
+  [%expect {| all bounded searches agree |}]
+;;
+
 let%expect_test "reverse searches agree with the standard library" =
   List.iter search_test_strings ~f:(fun s ->
     for pos = -1 to String.length s - 1 do

--- a/src/dune_rules/artifact_substitution.ml
+++ b/src/dune_rules/artifact_substitution.ml
@@ -405,14 +405,9 @@ module Scanner = struct
      buffer is the less likely case. *)
 
   let rec scan0 ~buf ~pos ~end_of_data =
-    if pos < end_of_data
-    then (
-      let c = Bytes.unsafe_get buf pos in
-      let pos = pos + 1 in
-      match c with
-      | '%' -> scan1 ~buf ~pos ~end_of_data
-      | _ -> scan0 ~buf ~pos ~end_of_data)
-    else Scan0
+    match Bytes.index_in_range_unchecked buf ~pos ~len:(end_of_data - pos) '%' with
+    | -1 -> Scan0
+    | percent -> scan1 ~buf ~pos:(percent + 1) ~end_of_data
 
   and scan1 ~buf ~pos ~end_of_data =
     if pos < end_of_data


### PR DESCRIPTION
Generalizes the spawn-specific NUL search from #16117 into a reusable forward string-search primitive backed by `memchr`. `Stdune.String` uses it for filename validation, splitting, spawn arguments, Unix path decomposition, and other forward character searches. Reverse searches and unrelated string transformations are deliberately left unchanged.

Follow-up commits use the shared search while scanning `dune subst` inputs and Unix path components, and add a bounded bytes search for the performance-sensitive artifact-substitution scanner. Lower-level standalone libraries that cannot depend on Stdune are also left unchanged.
