### PR TITLE
refactor(engine): separate full action properties

### DIFF
--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -448,10 +448,9 @@ let is_useful_to memoize =
 let is_useful_to_memoize = is_useful_to true
 
 module Full = struct
-  module T = struct
-    type nonrec t =
-      { action : t
-      ; env : Env.t
+  module Props = struct
+    type t =
+      { env : Env.t
       ; locks : Path.t list
       ; can_go_in_shared_cache : bool
       ; can_use_sandbox_policy : bool
@@ -460,8 +459,7 @@ module Full = struct
       }
 
     let empty =
-      { action = Progn []
-      ; env = Env.empty
+      { env = Env.empty
       ; locks = []
       ; can_go_in_shared_cache = true
       ; can_use_sandbox_policy = true
@@ -483,24 +481,64 @@ module Full = struct
     ;;
 
     let combine
-          { action
-          ; env
+          { env
           ; locks
           ; can_go_in_shared_cache
           ; can_use_sandbox_policy
           ; sandbox
           ; corrections
           }
-          x
+          t
       =
-      { action = combine action x.action
-      ; env = Env.extend_env env x.env
-      ; locks = locks @ x.locks
-      ; can_go_in_shared_cache = can_go_in_shared_cache && x.can_go_in_shared_cache
-      ; can_use_sandbox_policy = can_use_sandbox_policy && x.can_use_sandbox_policy
-      ; sandbox = Sandbox_config.inter sandbox x.sandbox
-      ; corrections = combine_corrections corrections x.corrections
+      { env = Env.extend_env env t.env
+      ; locks = locks @ t.locks
+      ; can_go_in_shared_cache = can_go_in_shared_cache && t.can_go_in_shared_cache
+      ; can_use_sandbox_policy = can_use_sandbox_policy && t.can_use_sandbox_policy
+      ; sandbox = Sandbox_config.inter sandbox t.sandbox
+      ; corrections = combine_corrections corrections t.corrections
       }
+    ;;
+
+    let make ~env ~locks ~can_go_in_shared_cache ~sandbox ~corrections =
+      { env
+      ; locks
+      ; can_go_in_shared_cache
+      ; can_use_sandbox_policy = true
+      ; sandbox
+      ; corrections
+      }
+    ;;
+
+    let add_env t env = { t with env = Env.extend_env t.env env }
+    let add_locks t locks = { t with locks = t.locks @ locks }
+
+    let add_can_go_in_shared_cache t can_go_in_shared_cache =
+      { t with
+        can_go_in_shared_cache = t.can_go_in_shared_cache && can_go_in_shared_cache
+      }
+    ;;
+
+    let disable_sandbox_policy t = { t with can_use_sandbox_policy = false }
+
+    let add_sandbox t sandbox =
+      { t with sandbox = Sandbox_config.inter t.sandbox sandbox }
+    ;;
+
+    let add_corrections t corrections =
+      { t with corrections = combine_corrections (Some corrections) t.corrections }
+    ;;
+  end
+
+  module T = struct
+    type nonrec t =
+      { action : t
+      ; props : Props.t
+      }
+
+    let empty = { action = Progn []; props = Props.empty }
+
+    let combine { action; props } t =
+      { action = combine action t.action; props = Props.combine props t.props }
     ;;
   end
 
@@ -515,28 +553,26 @@ module Full = struct
         ?corrections
         action
     =
-    { action
-    ; env
-    ; locks
-    ; can_go_in_shared_cache
-    ; can_use_sandbox_policy = true
-    ; sandbox
-    ; corrections
-    }
+    let props = Props.make ~env ~locks ~can_go_in_shared_cache ~sandbox ~corrections in
+    { action; props }
   ;;
 
   let map t ~f = { t with action = f t.action }
-  let add_env e t = if Env.is_empty e then t else { t with env = Env.extend_env t.env e }
-  let add_locks l t = { t with locks = t.locks @ l }
 
-  let add_can_go_in_shared_cache b t =
-    { t with can_go_in_shared_cache = t.can_go_in_shared_cache && b }
+  let add_env env t =
+    if Env.is_empty env then t else { t with props = Props.add_env t.props env }
   ;;
 
-  let disable_sandbox_policy t = { t with can_use_sandbox_policy = false }
-  let add_sandbox s t = { t with sandbox = Sandbox_config.inter t.sandbox s }
+  let add_locks locks t = { t with props = Props.add_locks t.props locks }
+
+  let add_can_go_in_shared_cache can_go_in_shared_cache t =
+    { t with props = Props.add_can_go_in_shared_cache t.props can_go_in_shared_cache }
+  ;;
+
+  let disable_sandbox_policy t = { t with props = Props.disable_sandbox_policy t.props }
+  let add_sandbox sandbox t = { t with props = Props.add_sandbox t.props sandbox }
 
   let add_corrections corrections t =
-    { t with corrections = combine_corrections (Some corrections) t.corrections }
+    { t with props = Props.add_corrections t.props corrections }
   ;;
 end

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -99,16 +99,23 @@ val is_useful_to_memoize : t -> is_useful
 module Full : sig
   type action := t
 
-  (** A full action with its environment and list of locks *)
+  (** Properties that control how an action is executed. *)
+  module Props : sig
+    type t = private
+      { env : Env.t
+      ; locks : Path.t list
+      ; can_go_in_shared_cache : bool
+      ; can_use_sandbox_policy : bool
+        (** Whether spawned processes can be subject to an additional sandbox policy. *)
+      ; sandbox : Sandbox_config.t
+      ; corrections : Corrections.t option
+      }
+  end
+
+  (** An action together with its execution properties. *)
   type t = private
     { action : action
-    ; env : Env.t
-    ; locks : Path.t list
-    ; can_go_in_shared_cache : bool
-    ; can_use_sandbox_policy : bool
-      (** Whether spawned processes can be subject to an additional sandbox policy. *)
-    ; sandbox : Sandbox_config.t
-    ; corrections : Corrections.t option
+    ; props : Props.t
     }
 
   val make

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -272,8 +272,8 @@ module Internal = struct
         ~sandbox_mode
         ~execution_parameters
     =
-    let { Action.Full.action
-        ; env
+    let { Action.Full.action; props } = action in
+    let { Action.Full.Props.env
         ; locks
         ; can_go_in_shared_cache
         ; can_use_sandbox_policy
@@ -281,7 +281,7 @@ module Internal = struct
         ; corrections
         }
       =
-      action
+      props
     in
     let execution_parameters =
       if Action.runs_process action
@@ -428,8 +428,8 @@ module Internal = struct
     : Exec_result.t Fiber.t
     =
     let open Fiber.O in
-    let { Action.Full.action
-        ; env
+    let { Action.Full.action; props } = action in
+    let { Action.Full.Props.env
         ; locks
         ; can_go_in_shared_cache = _
         ; can_use_sandbox_policy
@@ -437,7 +437,7 @@ module Internal = struct
         ; corrections
         }
       =
-      action
+      props
     in
     let execute_action sandbox =
       let action_trace = Action_trace.create rule_digest in
@@ -568,6 +568,7 @@ module Internal = struct
        memoized, and the result is not expected to change often, so we do not
        sacrifice too much performance here by executing it sequentially. *)
     let* action, facts = Action_builder.evaluate_and_collect_facts action in
+    let { Action.Full.action = action_ast; props } = action in
     let wrap_fiber f =
       Memo.of_reproducible_fiber
         (match info with
@@ -584,11 +585,11 @@ module Internal = struct
     wrap_fiber (fun () ->
       let open Fiber.O in
       report_evaluated_rule_exn ();
-      let is_action_dynamic = Action.is_dynamic action.action in
+      let is_action_dynamic = Action.is_dynamic action_ast in
       let sandbox_mode =
         select_sandbox_mode
           ~rule
-          action.sandbox
+          props.sandbox
           ~sandboxing_preference:config.sandboxing_preference
       in
       (* CR-someday amokhov: More [always_rerun] and [can_go_in_shared_cache]
@@ -619,11 +620,11 @@ module Internal = struct
         compute_rule_digest rule ~facts ~action ~sandbox_mode ~execution_parameters
       in
       let can_go_in_shared_cache =
-        action.can_go_in_shared_cache
+        props.can_go_in_shared_cache
         && (not
               (always_rerun
                || is_action_dynamic
-               || Action.is_useful_to_memoize action.action = Clearly_not))
+               || Action.is_useful_to_memoize action_ast = Clearly_not))
         &&
         match sandbox_mode with
         | Some Patch_back_source_tree ->
@@ -637,7 +638,7 @@ module Internal = struct
           ~always_rerun
           ~rule_digest
           ~targets
-          ~env:action.env
+          ~env:props.env
           ~build_deps
         >>= function
         | Some produced_targets -> Fiber.return produced_targets
@@ -714,7 +715,7 @@ module Internal = struct
                   ~f:(fun (deps, fact_map) ->
                     ( deps
                     , let d = Digest.Manual.create () in
-                      Dep.Facts.digest fact_map d ~env:action.env;
+                      Dep.Facts.digest fact_map d ~env:props.env;
                       Digest.Manual.get d ))
               in
               Fiber.return (produced_targets, dynamic_deps_stages)
@@ -796,20 +797,17 @@ module Internal = struct
     let observing_facts = () in
     ignore observing_facts;
     let digest =
-      let { Rule.Anonymous_action.action =
-              { action
-              ; env
-              ; locks
-              ; can_go_in_shared_cache
-              ; can_use_sandbox_policy
-              ; sandbox
-              ; corrections
-              }
-          ; loc = _
-          ; dir
+      let { Rule.Anonymous_action.action = full_action; loc = _; dir } = act in
+      let { Action.Full.action; props } = full_action in
+      let { Action.Full.Props.env
+          ; locks
+          ; can_go_in_shared_cache
+          ; can_use_sandbox_policy
+          ; sandbox
+          ; corrections
           }
         =
-        act
+        props
       in
       let digest =
         let d = Digest.Manual.create () in

--- a/src/dune_rules/rocq/rocq_rules.ml
+++ b/src/dune_rules/rocq/rocq_rules.ml
@@ -558,11 +558,11 @@ let setup_rocqproject_for_theory_rule
         (Action_builder.path (Path.build rocqproject))
 ;;
 
-(* Cons the plugin layout's lib root onto whatever OCAMLPATH [action.env]
-   already carries (e.g. layout entries from [(deps (package ...))]) rather
-   than overwriting it. *)
+(* Cons the plugin layout's lib root onto whatever OCAMLPATH the action's
+   environment already carries (e.g. layout entries from [(deps (package ...))])
+   rather than overwriting it. *)
 let add_plugin_ocamlpath ~lib_root (action : Action.Full.t) =
-  let { Action.Full.env = action_env; _ } = action in
+  let action_env = action.props.env in
   let env =
     Install.Roots.cons_path action_env ~var:Findlib_config.ocamlpath_var lib_root
   in

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -162,10 +162,11 @@ let extend_action_env t ~dir action =
       (let open Memo.O in
        t.get_node dir >>= Env_node.external_env)
   in
-  (* Cons path-like vars from action.env (bin-layout PATH, package-layout
-     OCAMLPATH/etc.) onto the directory env so that both layout and system
-     entries remain visible. Other vars from action.env overwrite dir env. *)
-  let env = Install.Roots.extend_env_concat_path_vars env action.env in
+  (* Cons path-like vars from the action's environment (bin-layout PATH,
+     package-layout OCAMLPATH/etc.) onto the directory env so that both layout
+     and system entries remain visible. Other vars from the action's environment
+     overwrite dir env. *)
+  let env = Install.Roots.extend_env_concat_path_vars env action.props.env in
   Action.Full.add_env env action
 ;;
 


### PR DESCRIPTION
Move the execution metadata stored alongside `Action.t` into `Action.Full.Props.t`. `Action.Full.t` now contains the action and its properties as two fields, preparing the properties for sharing without changing behavior.