### PR TITLE
test(ctypes): record link sandbox and header dependencies

### DIFF
--- a/test/blackbox-tests/test-cases/ctypes/exe-vendored.t/dune
+++ b/test/blackbox-tests/test-cases/ctypes/exe-vendored.t/dune
@@ -16,7 +16,8 @@
   (deps (source_tree vendor))
   (build_flags_resolver
    (vendored
-    (c_flags "-Ivendor")))
+    (c_flags "-Ivendor")
+    (c_library_flags ("-Lvendor" "-lexample"))))
   (headers (include (:include includes.sexp)))
   (type_description
    (instance Types)

--- a/test/blackbox-tests/test-cases/ctypes/exe-vendored.t/run.t
+++ b/test/blackbox-tests/test-cases/ctypes/exe-vendored.t/run.t
@@ -11,7 +11,7 @@ This is the version that builds into an executable.
   $ mkdir -p $TARGET && install $LIBEX/*example* $TARGET
 Ctypes stub generation is sandboxed and honors its declared dependencies.
 
-  $ dune exec ./example.exe
+  $ DYLD_LIBRARY_PATH="$TARGET" LD_LIBRARY_PATH="$TARGET" dune exec ./example.exe
   4
   $ dune trace cat | jq_dune -sc '
   >   [ .[]
@@ -21,3 +21,34 @@ Ctypes stub generation is sandboxed and honors its declared dependencies.
   >   | (.args.dir | contains(".sandbox"))
   >   ] | unique'
   [true]
+
+With Ctypes 0.3, the final executable link runs outside a sandbox.
+
+  $ dune trace cat | jq_dune -sc '
+  >   [ .[]
+  >   | processes
+  >   | select((.args.target_files // [])
+  >            | index("_build/default/example.exe"))
+  >   | (.args.dir | contains(".sandbox"))
+  >   ][0]'
+  false
+
+The Ctypes headers found through its implicit include directory are not rule
+dependencies.
+
+  $ dune rules --format=json \
+  >   _build/default/examplelib__c_cout_generated_types.exe \
+  > | jq_dune -c '
+  >   ([ .[]
+  >    | select(.deps)
+  >    | ruleDepFilePaths
+  >    | select(endswith("ctypes_cstubs_internals.h"))
+  >    ]
+  >    +
+  >    [ .[]
+  >    | select(.deps)
+  >    | ruleDepGlobEntries
+  >    | select((.dir | endswith("ctypes"))
+  >             and (.predicate | tostring | contains(".h")))
+  >    ]) | length > 0'
+  false

--- a/test/blackbox-tests/test-cases/ctypes/lib-vendored.t/run.t
+++ b/test/blackbox-tests/test-cases/ctypes/lib-vendored.t/run.t
@@ -10,3 +10,15 @@ This is the version that builds into a library.
   $ mkdir -p $TARGET && install $LIBEX/*example* $TARGET
   $ dune exec ./example.exe
   4
+
+With Ctypes 0.3, the C stubs library link runs outside a sandbox.
+
+  $ dune trace cat | jq_dune -sc '
+  >   [ .[]
+  >   | processes
+  >   | select((.args.target_files // [])
+  >            | any(contains("dllexamplelib_stubs")))
+  >   | (.args.dir | contains(".sandbox"))
+  >   ][0]'
+  false
+

--- a/test/blackbox-tests/test-cases/ctypes/lib-vendored.t/stubgen/dune
+++ b/test/blackbox-tests/test-cases/ctypes/lib-vendored.t/stubgen/dune
@@ -18,7 +18,8 @@
    (vendored
     ;; hack: multiple -I directives to work around cc commands being run from
     ;; different relative directories.  Is there a cleaner way to do this?
-    (c_flags ("-Istubgen/vendor" "-Ivendor"))))
+    (c_flags ("-Istubgen/vendor" "-Ivendor"))
+    (c_library_flags ("-Lstubgen/vendor" "-Lvendor" "-lexample"))))
   (headers (include "example.h"))
   (type_description
    (instance Types)


### PR DESCRIPTION
Record that Ctypes 0.3 executable and C stubs library links consuming `c_library_flags` run outside a sandbox. A follow-up Ctypes version can add separate link dependencies and require sandboxing without changing 0.3 behavior.

Also record that generated helper compilation does not depend on headers from the implicit Ctypes include directory. That dependency-tracking bug should be fixed for every Ctypes version.
