### PR TITLE
test(opam): reproduce missing promotion after source deletion

### DIFF
--- a/test/blackbox-tests/test-cases/dune-project-meta/removed-opam-file.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/removed-opam-file.t
@@ -1,0 +1,27 @@
+The [@opam] diff action conditionally depends on the source opam file while it
+exists. Removing that file must invalidate the action so Dune records a
+creation promotion.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.24)
+  > (generate_opam_files)
+  > (package
+  >  (name foo)
+  >  (allow_empty))
+  > EOF
+
+Create [foo.opam], then prime [@opam]'s rule cache with a successful build
+while the source file exists.
+
+  $ dune build @opam > /dev/null 2>&1
+  [1]
+  $ dune promote
+  Promoting _build/default/foo.opam.generated to foo.opam.
+  $ dune build @opam
+
+The cached action is incorrectly reused after deleting [foo.opam].
+
+  $ rm foo.opam
+  $ dune build @opam
+  $ dune promotion list
+  $ test ! -e foo.opam


### PR DESCRIPTION
## Description

Reproduction case for #16233.

Add a minimal cram regression test for generated OPAM files. The test primes
the `@opam` diff action while `foo.opam` exists, removes the source file, and
captures the current behavior: `dune build @opam` succeeds without registering
a creation promotion, leaving `foo.opam` missing.

The fix is in #16234.

## Related Issue and Motivation

This was reported while upgrading to Dune 3.24.2 with `(lang dune 3.24)` and
`(generate_opam_files)`. Removing a generated OPAM file should cause `@opam` to
offer the regenerated file for promotion.

## Testing

- `dune build @check @fmt`
- `dune runtest test/blackbox-tests/test-cases/dune-project-meta`
