### PR TITLE
fix(opam): restore promotion after generated file deletion

### DIFF
--- a/doc/changes/fixed/16234.md
+++ b/doc/changes/fixed/16234.md
@@ -1,0 +1,2 @@
+- Fix `@opam` failing to promote a generated opam file after it is deleted
+  (#16234, fixes #16233, @Alizter)

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -464,7 +464,9 @@ let add_alias_rule (ctx : Build_context.t) ~profile ~project ~pkg =
              ~then_:(Action_builder.path (Path.build opam_path))
              ~else_:(Action_builder.return ())
          in
-         Action.Full.make (Action.diff (Path.build opam_path) generated_opam_path))
+         Action.diff (Path.build opam_path) generated_opam_path
+         |> Action.Full.make
+         |> Action.Full.add_sandbox Sandbox_config.needs_sandboxing)
     | Exists _ | Generated | Generated_with_diff -> Memo.return ()
   in
   Memo.parallel_iter aliases ~f:(fun alias ->

--- a/test/blackbox-tests/test-cases/dune-project-meta/removed-opam-file.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/removed-opam-file.t
@@ -1,5 +1,5 @@
 The [@opam] diff action conditionally depends on the source opam file while it
-exists. Removing that file must invalidate the action so Dune records a
+exists. Removing that file must not let a stale build-tree copy hide the
 creation promotion.
 
   $ cat > dune-project << EOF
@@ -10,8 +10,8 @@ creation promotion.
   >  (allow_empty))
   > EOF
 
-Create [foo.opam], then prime [@opam]'s rule cache with a successful build
-while the source file exists.
+Create [foo.opam], then leave its build-tree copy behind by successfully
+building [@opam] while the source file exists.
 
   $ dune build @opam > /dev/null 2>&1
   [1]
@@ -19,9 +19,13 @@ while the source file exists.
   Promoting _build/default/foo.opam.generated to foo.opam.
   $ dune build @opam
 
-The cached action is incorrectly reused after deleting [foo.opam].
+Deleting [foo.opam] must expose the generated file as a creation promotion.
 
   $ rm foo.opam
-  $ dune build @opam
+  $ dune build @opam > /dev/null 2>&1
+  [1]
   $ dune promotion list
-  $ test ! -e foo.opam
+  foo.opam
+  $ dune promote
+  Promoting _build/default/foo.opam.generated to foo.opam.
+  $ test -e foo.opam


### PR DESCRIPTION
## Description

Run generated OPAM-file diff actions in a sandbox. After a generated OPAM file
is deleted, the stale build-tree copy is no longer a declared dependency and is
therefore excluded from the sandbox. The diff then treats the source as missing
and records a creation promotion.

The regression test was added separately in #16232. This PR updates its
expectations to cover the fix.

## Related Issue and Motivation

Fixes #16233

Deleting a generated OPAM file should allow `@opam` to regenerate and promote
it again.

## Testing

- `dune build @check @fmt`
- `dune runtest test/blackbox-tests/test-cases/dune-project-meta`
