### PR TITLE
test: reproduce predicated findlib tool crash

### DIFF
--- a/test/blackbox-tests/test-cases/custom-cross-compilation/findlib-conf-predicated-tool-github16226.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/findlib-conf-predicated-tool-github16226.t
@@ -1,0 +1,16 @@
+Reproduce #16226. A tool defined only for a Findlib toolchain causes Dune to
+interpret its value as the empty string when initializing the default context.
+
+  $ make_dune_project 2.7
+  $ mkdir -p findlib.conf.d
+  $ export OCAMLFIND_CONF=$PWD/findlib.conf
+  $ cat >findlib.conf.d/solo5.conf <<EOF
+  > ocamlmklib(solo5) = "/does/not/matter"
+  > EOF
+
+The base configuration file does not need to exist for Dune to load snippets
+from the corresponding .d directory.
+
+  $ dune build 2>&1 | grep 'Internal error'
+  Internal error! Please report to https://github.com/ocaml/dune/issues,
+  [1]


### PR DESCRIPTION
## Description

Reproduction case for #16226.

Add a minimal cram test for a Findlib tool defined only under a toolchain
predicate. When Dune initializes the default context, the unmatched tool value
is interpreted as an empty string and currently causes an internal error.

A fix will follow in a separate PR.

## Related Issue and Motivation

#16226 reports a regression when `OCAMLFIND_CONF` supplies the Solo5 toolchain
through a `findlib.conf.d` snippet. The test reduces that configuration to the
predicated `ocamlmklib` entry which triggers the crash.

## Testing

- `dune build @check @fmt`
- `dune runtest test/blackbox-tests/test-cases/custom-cross-compilation`
