### PR TITLE
test: fix OPAMSWITCH in opam-var-os.t

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-os.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-os.t
@@ -7,6 +7,7 @@ between systems, we can't hardcode them in the test. Instead, we use the opam va
 to compare their values.
 
   $ export OPAMROOT=$(mktemp -d)
+  $ export OPAMSWITCH=default
   $ mkdir -p $OPAMROOT/default/.opam-switch/
   $ cat >$OPAMROOT/default/.opam-switch/switch-config <<EOF
   > opam-version: "2.0"


### PR DESCRIPTION
## Description

`OPAMSWITCH` is set in some dev env to point to a users local opam switch. This creates a conflict with the other opam related overrides in this test, resulting in test failures along these lines:

```
 |  $ export OPAMROOT=$(mktemp -d)
 |  $ mkdir -p $OPAMROOT/default/.opam-switch/
 |  $ cat >$OPAMROOT/default/.opam-switch/switch-config <<EOF
 |  > opam-version: "2.0"
 |  > EOF
 |  $ cat >$OPAMROOT/config <<EOF
 |  > opam-version: "2.0"
 |  > switch: "default"
 |  > installed-switches: ["default"]
 |  > EOF
 |  $ v() { opam --cli 2.1 var $1; }
 |  $ { v arch ; v os ; v os-distribution ; v os-family ; v os-version ; } > opam-vars
+|  [ERROR] The selected switch $HOME/dune is not installed. Please fix the value of the OPAMSWITCH environment variable, or use the '--switch <name>' flag
+|  [ERROR] The selected switch $HOME/dune is not installed. Please fix the value of the OPAMSWITCH environment variable, or use the '--switch <name>' flag
+|  [ERROR] The selected switch $HOME/dune is not installed. Please fix the value of the OPAMSWITCH environment variable, or use the '--switch <name>' flag
+|  [ERROR] The selected switch $HOME/dune is not installed. Please fix the value of the OPAMSWITCH environment variable, or use the '--switch <name>' flag
+|  [ERROR] The selected switch $HOME/dune is not installed. Please fix the value of the OPAMSWITCH environment variable, or use the '--switch <name>' flag
+|  [50]
```

The brittle test is fixed here by ensuring we set the OPAMSWITCH variable to be consistent with the opam mock set up for the test.

## Related Issue and Motivation

Encountered while setting up to work on https://github.com/ocaml/dune/issues/15642

## Checklist

- [x] Tests added, if applicable.
- [x] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [x] Documentation added for any user-facing changes.
