### PR TITLE
fix(findlib): distinguish unmatched tool definitions

### DIFF
--- a/doc/changes/fixed/16239.md
+++ b/doc/changes/fixed/16239.md
@@ -1,0 +1,2 @@
+- Avoid an internal error when a Findlib tool is defined only for a
+  non-default toolchain. (#16239, fixes #16226, @Alizter)

--- a/src/dune_findlib/config.ml
+++ b/src/dune_findlib/config.ml
@@ -56,6 +56,7 @@ module File = struct
   ;;
 
   let get { vars; preds } var = Vars.get vars var preds
+  let find_matching { vars; preds } var = Vars.find_matching vars var preds
   let toolchain t ~toolchain = { t with preds = Ps.singleton (P.make toolchain) }
 end
 
@@ -106,11 +107,21 @@ let ocamlpath t =
 ;;
 
 let tool t ~prog =
-  match File.get t.config prog with
+  match File.find_matching t.config prog with
   | None -> Memo.return None
   | Some s ->
     (match Filename.analyze_program_name s with
-     | In_path -> t.which (Filename.of_string_exn s)
+     | In_path ->
+       (match Filename.of_string s with
+        | Some prog -> t.which prog
+        | None ->
+          User_error.raise
+            [ Pp.textf
+                "The effective Findlib configuration specifies an invalid program name \
+                 %S for program %S."
+                s
+                prog
+            ])
      | Relative_to_current_dir ->
        User_error.raise
          [ Pp.textf

--- a/src/dune_findlib/vars.ml
+++ b/src/dune_findlib/vars.ml
@@ -4,6 +4,10 @@ type t = Rules.t String.Map.t
 
 let to_dyn = String.Map.to_dyn Rules.to_dyn
 
+let find_matching (t : t) var preds =
+  Option.bind (String.Map.find t var) ~f:(Rules.interpret ~preds)
+;;
+
 let get (t : t) var preds =
   Option.map (String.Map.find t var) ~f:(fun r ->
     Option.value ~default:"" (Rules.interpret r ~preds))

--- a/src/dune_findlib/vars.mli
+++ b/src/dune_findlib/vars.mli
@@ -2,6 +2,10 @@ open Import
 
 type t
 
+(** Return the effective value of a variable, or [None] when the variable does
+    not exist or none of its rules match the predicates. *)
+val find_matching : t -> string -> Variant.Set.t -> string option
+
 val get_words : t -> string -> Variant.Set.t -> string list
 val get : t -> string -> Variant.Set.t -> string option
 val to_dyn : t -> Dyn.t

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/findlib-conf-predicated-tool-github16226.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/findlib-conf-predicated-tool-github16226.t
@@ -11,6 +11,15 @@ interpret its value as the empty string when initializing the default context.
 The base configuration file does not need to exist for Dune to load snippets
 from the corresponding .d directory.
 
-  $ dune build 2>&1 | grep 'Internal error'
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
+  $ dune build
+
+An explicitly invalid tool name is still an error.
+
+  $ cat >findlib.conf <<EOF
+  > ocamlmklib = ""
+  > EOF
+  $ dune build
+  Error: The effective Findlib configuration specifies an invalid program name
+  "" for program "ocamlmklib".
+  -> required by loading the OCaml compiler for context "default"
   [1]


### PR DESCRIPTION
## Description

Preserve the distinction between a Findlib variable with no matching predicate
and an explicitly invalid tool value. A tool with no matching rule is now
represented by `None`, allowing normal tool discovery to continue. An explicit
empty or otherwise invalid in-path name produces a user error, and only a valid
`Filename.t` reaches the tool lookup.

Update the regression test from #16236 to expect the default context to
initialize successfully, and cover the explicit-invalid-value error.

## Related Issue and Motivation

Fixes #16226

A tool defined only under a Findlib toolchain predicate has no matching value
while Dune initializes the default context. `Vars.get` previously represented
that state as the empty string. Since #14545, converting the empty value with
`Filename.of_string_exn` raises an internal error instead of falling back to
normal lookup.

## Testing

- `dune build @check @fmt`
- `dune runtest test/blackbox-tests/test-cases/custom-cross-compilation`
- `dune runtest test/expect-tests/findlib`
