### PR TITLE
test(ctypes): avoid linking vendored libraries twice

### DIFF
--- a/test/blackbox-tests/test-cases/ctypes/exe-vendored.t/dune
+++ b/test/blackbox-tests/test-cases/ctypes/exe-vendored.t/dune
@@ -1,16 +1,6 @@
-(rule
- (targets libexample.a dllexample%{ext_dll})
- (deps (source_tree vendor))
- (action
-  (no-infer
-   (progn
-    (copy vendor/libexample.a libexample.a)
-    (copy vendor/libexample%{ext_dll} dllexample%{ext_dll})))))
-
 (executable
  (name example)
  (flags (:standard -w -9-27))
- (foreign_archives example)
  (ctypes
   (external_library_name examplelib)
   (deps (source_tree vendor))

--- a/test/blackbox-tests/test-cases/ctypes/exe-vendored.t/run.t
+++ b/test/blackbox-tests/test-cases/ctypes/exe-vendored.t/run.t
@@ -29,9 +29,12 @@ With Ctypes 0.3, the final executable link runs outside a sandbox.
   >   | processes
   >   | select((.args.target_files // [])
   >            | index("_build/default/example.exe"))
-  >   | (.args.dir | contains(".sandbox"))
+  >   | { sandbox: (.args.dir | contains(".sandbox"))
+  >     , example_flags:
+  >         ([.args.process_args[] | select(. == "-lexample")] | length)
+  >     }
   >   ][0]'
-  false
+  {"sandbox":false,"example_flags":1}
 
 The Ctypes headers found through its implicit include directory are not rule
 dependencies.

--- a/test/blackbox-tests/test-cases/ctypes/lib-vendored.t/run.t
+++ b/test/blackbox-tests/test-cases/ctypes/lib-vendored.t/run.t
@@ -8,17 +8,25 @@ This is the version that builds into a library.
   $ LIBEX=$(realpath "$PWD/../libexample")
   $ TARGET=./stubgen/vendor
   $ mkdir -p $TARGET && install $LIBEX/*example* $TARGET
-  $ dune exec ./example.exe
+  $ DYLD_LIBRARY_PATH="$TARGET" LD_LIBRARY_PATH="$TARGET" dune exec ./example.exe
   4
 
 With Ctypes 0.3, the C stubs library link runs outside a sandbox.
 
   $ dune trace cat | jq_dune -sc '
-  >   [ .[]
-  >   | processes
-  >   | select((.args.target_files // [])
-  >            | any(contains("dllexamplelib_stubs")))
-  >   | (.args.dir | contains(".sandbox"))
-  >   ][0]'
-  false
+  >   [.[] | processes] as $processes
+  >   | { sandbox:
+  >         ([$processes[]
+  >          | select((.args.target_files // [])
+  >                   | any(contains("dllexamplelib_stubs")))
+  >          | (.args.dir | contains(".sandbox"))
+  >          ][0])
+  >     , example_flags:
+  >         ([$processes[]
+  >          | select((.args.target_files // [])
+  >                   | index("_build/default/stubgen/examplelib.cmxa"))
+  >          | [.args.process_args[] | select(. == "-lexample")] | length
+  >          ][0])
+  >     }'
+  {"sandbox":false,"example_flags":1}
 

--- a/test/blackbox-tests/test-cases/ctypes/lib-vendored.t/stubgen/dune
+++ b/test/blackbox-tests/test-cases/ctypes/lib-vendored.t/stubgen/dune
@@ -1,16 +1,6 @@
-(rule
- (targets libexample.a dllexample%{ext_dll})
- (deps (source_tree vendor))
- (action
-  (no-infer
-   (progn
-    (copy vendor/libexample.a libexample.a)
-    (copy vendor/libexample%{ext_dll} dllexample%{ext_dll})))))
-
 (library
  (name examplelib)
  (flags (:standard -w -9-27))
- (foreign_archives example)
  (ctypes
   (external_library_name examplelib)
   (deps (source_tree vendor))
@@ -19,7 +9,7 @@
     ;; hack: multiple -I directives to work around cc commands being run from
     ;; different relative directories.  Is there a cleaner way to do this?
     (c_flags ("-Istubgen/vendor" "-Ivendor"))
-    (c_library_flags ("-Lstubgen/vendor" "-Lvendor" "-lexample"))))
+    (c_library_flags ("-Lstubgen/vendor" "-lexample"))))
   (headers (include "example.h"))
   (type_description
    (instance Types)


### PR DESCRIPTION
Use `c_library_flags` as the sole linkage mechanism in the vendored Ctypes fixtures instead of also linking the same library through `foreign_archives`.

This avoids duplicate-library and invalid-search-path warnings from the macOS linker while continuing to exercise the Ctypes link actions.
