### PR TITLE
fix(cram): invalidate cached output on format changes

### DIFF
--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -798,12 +798,15 @@ let run_produce_correction
   >>| compose_cram_output
 ;;
 
+let cram_result_name = "CRAM-RESULT"
+let cram_result_version = 3
+
 module Script = Persistent.Make (struct
     type nonrec t = command_out list
 
-    let name = "CRAM-RESULT"
+    let name = cram_result_name
     let sharing = false
-    let version = 3
+    let version = cram_result_version
     let repr = Repr.list command_out_repr
   end)
 
@@ -897,7 +900,9 @@ module Run = struct
       : Sexp.t
       =
       List
-        [ path dir
+        [ Atom cram_result_name
+        ; Atom (Int.to_string cram_result_version)
+        ; path dir
         ; path script
         ; target output
         ; Dune_sexp.Encoder.(


### PR DESCRIPTION
Include the persistent cram-result format name and version in the run action cache key. Changing the format now invalidates cached `cram.out` data instead of reusing incompatible serialized output.