### PR TITLE
test(engine): cover missing dynamic-run programs

### DIFF
--- a/otherlibs/dune-action-plugin/test/ordinary-executable/run.t
+++ b/otherlibs/dune-action-plugin/test/ordinary-executable/run.t
@@ -27,3 +27,15 @@ ordinary executable instead of one linked against dune-action-plugin.
   consider changing 'dynamic-run' to 'run' in your rule definition.
   [1]
 
+A missing executable should produce the usual program-not-found diagnostic
+rather than an internal error.
+
+  $ cat >> dune << EOF
+  > (rule
+  >  (alias missing)
+  >  (action (dynamic-run program-that-does-not-exist)))
+  > EOF
+
+  $ dune build @missing 2>&1 | grep -E '^Assertion failed|^Error: Program'
+  Assertion failed
+


### PR DESCRIPTION
A missing executable in `dynamic-run` currently reaches an assertion while
encoding the action instead of producing the usual program-not-found diagnostic.

Record that behavior in the action-plugin cram suite. A follow-up change will
replace the assertion and update the expectation.
