### PR TITLE
fix(engine): retain action builder memo names

### DIFF
--- a/src/dune_engine/action_builder.ml
+++ b/src/dune_engine/action_builder.ml
@@ -285,19 +285,19 @@ and exec_memo_eval : type i o m. (i, o) memo -> i -> m eval_mode -> (o * m) Memo
   | Eager -> Memo.exec (Lazy.force memo.eager) i
 ;;
 
-let memoize ?cutoff _name t =
+let memoize ?cutoff name t =
   let lazy_ =
     lazy
       (let cutoff =
          Option.map cutoff ~f:(fun equal x y -> Tuple.T2.equal equal Dep.Set.equal x y)
        in
-       Memo.lazy_ ?cutoff ~name:"action-builder-lazy" (fun () -> eval t Lazy))
+       Memo.lazy_ ?cutoff ~name:(name ^ "(lazy)") (fun () -> eval t Lazy))
   in
   let eager =
     let cutoff =
       Option.map cutoff ~f:(fun equal x y -> Tuple.T2.equal equal Dep.Facts.equal x y)
     in
-    Memo.lazy_ ?cutoff ~name:"action-builder-eager" (fun () -> eval t Eager)
+    Memo.lazy_ ?cutoff ~name:(name ^ "(eager)") (fun () -> eval t Eager)
   in
   Memoize { lazy_; eager }
 ;;


### PR DESCRIPTION
`Action_builder.memoize` accepts a caller-provided name but currently discards it
in favor of generic labels shared by every action builder.

Retain the supplied name and append phase-specific suffixes, restoring useful
identities in memo diagnostics while keeping lazy and eager evaluations distinct.
