### PR TITLE
test(engine): cover duplicate action locks

### DIFF
--- a/test/blackbox-tests/test-cases/tests-locks.t/run.t
+++ b/test/blackbox-tests/test-cases/tests-locks.t/run.t
@@ -7,3 +7,20 @@ These tests are run without locks. They should end together (= expected)
   $ dune build --root=. -j 2 --diff-command=diff @all-tests-nolocks 2>&1 |
   > grep "^> *" | uniq -c | [ $(wc -l) -eq 1 ] && echo '=' || echo '<>'
   =
+
+Duplicate lock declarations currently deadlock a rule by making it acquire the same
+non-reentrant mutex twice.
+
+  $ mkdir duplicate-lock
+  $ cat >duplicate-lock/dune <<EOF
+  > (rule
+  >  (target done)
+  >  (locks same same)
+  >  (action (write-file done done)))
+  > EOF
+  $ if $timeout 2 dune build --root=. duplicate-lock/done >/dev/null 2>&1; then
+  >   cat _build/default/duplicate-lock/done
+  > else
+  >   echo timed-out
+  > fi
+  timed-out


### PR DESCRIPTION
A rule that declares the same lock twice currently tries to acquire the same
non-reentrant mutex twice and deadlocks.

Add a cram regression that snapshots the timeout instead of the requested
target. A follow-up change will deduplicate lock acquisition.
