### PR TITLE
test(engine): cover failed action trace collection

### DIFF
--- a/test/blackbox-tests/test-cases/trace/action-traces/invalid-trace.t
+++ b/test/blackbox-tests/test-cases/trace/action-traces/invalid-trace.t
@@ -16,3 +16,18 @@ Invalid traces should be an error
   Error: invalid action trace in
   _build/REDACTED
   [1]
+
+A failed action currently leaves its trace event uncollected.
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (alias failed)
+  >  (action
+  >   (bash "action_trace -name failed -cat bar -arg baz; exit 1")))
+  > EOF
+
+  $ dune build @failed >/dev/null 2>&1 ||
+  >   dune trace cat --only-actions |
+  >   jq_dune -s '
+  >     redactedActionTraces | select(.name == "failed")
+  >   '


### PR DESCRIPTION
Add a regression showing that action trace collection is skipped when result
validation raises for a failed action. The failure branch displays only events
supplied by actions with `dune trace cat --only-actions`; its empty snapshot
records the current behavior for a follow-up fix.
