### PR TITLE
fix(engine): collect traces from failed actions

### DIFF
--- a/doc/changes/fixed/16250.md
+++ b/doc/changes/fixed/16250.md
@@ -1,0 +1,2 @@
+- Collect action-provided trace events when an action fails instead of dropping
+  them during result validation. (#16250, @rgrinberg)

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -496,8 +496,11 @@ module Internal = struct
             let build_deps deps = Memo.run (build_deps deps) in
             Action_exec.exec input ~build_deps
           in
-          let* action_exec_result = Action_exec.Exec_result.ok_exn action_exec_result in
-          let* () = Action_trace.collect action_trace in
+          let* action_exec_result, () =
+            Fiber.fork_and_join
+              (fun () -> Action_exec.Exec_result.ok_exn action_exec_result)
+              (fun () -> Action_trace.collect action_trace)
+          in
           let+ () =
             if not is_sandboxed
             then Fiber.return ()

--- a/test/blackbox-tests/test-cases/trace/action-traces/invalid-trace.t
+++ b/test/blackbox-tests/test-cases/trace/action-traces/invalid-trace.t
@@ -17,7 +17,7 @@ Invalid traces should be an error
   _build/REDACTED
   [1]
 
-A failed action currently leaves its trace event uncollected.
+A failed action still collects its trace event.
 
   $ cat >dune <<'EOF'
   > (rule
@@ -31,3 +31,12 @@ A failed action currently leaves its trace event uncollected.
   >   jq_dune -s '
   >     redactedActionTraces | select(.name == "failed")
   >   '
+  {
+    "cat": "bar",
+    "name": "failed",
+    "ts": 0,
+    "args": {
+      "arg": "baz",
+      "digest": "REDACTED"
+    }
+  }


### PR DESCRIPTION
Collect action-provided trace events even when result validation reports that
the action failed. Validation and trace collection now run in sibling fibers,
so neither can prevent the other from completing and both errors remain
reportable.

The regression is covered by #16249.
