### PR TITLE
fix(engine): report missing dynamic-run programs

### DIFF
--- a/doc/changes/fixed/16251.md
+++ b/doc/changes/fixed/16251.md
@@ -1,0 +1,2 @@
+- Report the usual program-not-found error when a `dynamic-run` executable is
+  missing instead of failing with an assertion. (#16251, @rgrinberg)

--- a/otherlibs/dune-action-plugin/test/ordinary-executable/run.t
+++ b/otherlibs/dune-action-plugin/test/ordinary-executable/run.t
@@ -37,5 +37,5 @@ rather than an internal error.
   > EOF
 
   $ dune build @missing 2>&1 | grep -E '^Assertion failed|^Error: Program'
-  Assertion failed
+  Error: Program program-that-does-not-exist not found in the tree or in PATH
 

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -81,6 +81,7 @@ module Prog = struct
       }
 
     let create ?hint ~context ~program ~loc () = { hint; context; program; loc }
+    let program t = t.program
 
     let raise { context; program; hint; loc } =
       Utils.program_not_found ?hint ~loc ~context (Filename.to_string program)

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -28,6 +28,7 @@ module Prog : sig
       -> t
 
     val raise : t -> _
+    val program : t -> Filename.t
   end
 
   type t = (Path.t, Not_found.t) result

--- a/src/dune_engine/action_plugin.ml
+++ b/src/dune_engine/action_plugin.ml
@@ -131,8 +131,8 @@ module Spec = struct
       [ Atom name
       ; Atom (Int.to_string version)
       ; (match prog with
-         | Ok s -> f s
-         | Error _ -> assert false)
+         | Ok path -> f path
+         | Error error -> Atom (Filename.to_string (Action.Prog.Not_found.program error)))
       ; List (List.map args ~f:(fun s -> Atom s))
       ]
   ;;


### PR DESCRIPTION
Represent an unresolved `dynamic-run` program by its requested filename when
encoding the dynamic action, while retaining the structured lookup error for
execution. Missing programs now produce the normal location-aware
program-not-found diagnostic instead of an assertion failure.

The regression is covered by #16244.
