### PR TITLE
fix(engine): canonicalize action locks during construction

### DIFF
--- a/doc/changes/fixed/16252.md
+++ b/doc/changes/fixed/16252.md
@@ -1,0 +1,2 @@
+- Prevent rules with duplicate lock declarations from deadlocking by acquiring
+  each lock only once. (#16252, @rgrinberg)

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -452,7 +452,7 @@ module Full = struct
   module Props = struct
     type t =
       { env : Env.t
-      ; locks : Path.t list
+      ; locks : Path.Set.t
       ; can_go_in_shared_cache : bool
       ; can_use_sandbox_policy : bool
       ; sandbox : Sandbox_config.t
@@ -461,7 +461,7 @@ module Full = struct
 
     let empty =
       { env = Env.empty
-      ; locks = []
+      ; locks = Path.Set.empty
       ; can_go_in_shared_cache = true
       ; can_use_sandbox_policy = true
       ; sandbox = Sandbox_config.default
@@ -492,7 +492,7 @@ module Full = struct
           t
       =
       { env = Env.extend_env env t.env
-      ; locks = locks @ t.locks
+      ; locks = Path.Set.union locks t.locks
       ; can_go_in_shared_cache = can_go_in_shared_cache && t.can_go_in_shared_cache
       ; can_use_sandbox_policy = can_use_sandbox_policy && t.can_use_sandbox_policy
       ; sandbox = Sandbox_config.inter sandbox t.sandbox
@@ -502,7 +502,7 @@ module Full = struct
 
     let make ~env ~locks ~can_go_in_shared_cache ~sandbox ~corrections =
       { env
-      ; locks
+      ; locks = Path.Set.of_list locks
       ; can_go_in_shared_cache
       ; can_use_sandbox_policy = true
       ; sandbox
@@ -511,7 +511,10 @@ module Full = struct
     ;;
 
     let add_env t env = { t with env = Env.extend_env t.env env }
-    let add_locks t locks = { t with locks = t.locks @ locks }
+
+    let add_locks t locks =
+      { t with locks = Path.Set.union t.locks (Path.Set.of_list locks) }
+    ;;
 
     let add_can_go_in_shared_cache t can_go_in_shared_cache =
       { t with

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -104,7 +104,7 @@ module Full : sig
   module Props : sig
     type t = private
       { env : Env.t
-      ; locks : Path.t list
+      ; locks : Path.Set.t
       ; can_go_in_shared_cache : bool
       ; can_use_sandbox_policy : bool
         (** Whether spawned processes can be subject to an additional sandbox policy. *)

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -155,12 +155,15 @@ module State = struct
   ;;
 end
 
-let rec with_locks ~f = function
-  | [] -> f ()
-  | m :: mutexes ->
-    Fiber.Mutex.with_lock
-      (Table.find_or_add State.locks m ~f:(fun _ -> Fiber.Mutex.create ()))
-      ~f:(fun () -> with_locks ~f mutexes)
+let with_locks ~f locks =
+  let rec loop = function
+    | [] -> f ()
+    | lock :: locks ->
+      Fiber.Mutex.with_lock
+        (Table.find_or_add State.locks lock ~f:(fun _ -> Fiber.Mutex.create ()))
+        ~f:(fun () -> loop locks)
+  in
+  Path.Set.to_list locks |> loop
 ;;
 
 type rule_execution_result =
@@ -228,8 +231,8 @@ module Internal = struct
   ;;
 
   let digest_locks d locks =
-    Digest.Manual.list d locks ~f:(fun d path ->
-      Digest.Manual.string d (Path.to_string path))
+    Digest.Manual.int d (Path.Set.cardinal locks);
+    Path.Set.iter locks ~f:(fun path -> Digest.Manual.string d (Path.to_string path))
   ;;
 
   let digest_sandbox_config d sandbox =
@@ -263,7 +266,7 @@ module Internal = struct
 
   (* The current version of the rule digest scheme. We should increment it when
      making any changes to the scheme, to avoid collisions. *)
-  let rule_digest_version = 33
+  let rule_digest_version = 34
 
   let compute_rule_digest
         (rule : Rule.t)

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t
@@ -80,7 +80,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune_build_sorted_actions --config-file config reproducible non-reproducible
-  Warning: cache store error [1ce77805b0b209e689d1ddac29fa75b5]: ((in_cache
+  Warning: cache store error [ec544297636df4b8a35a7a4cb367c872]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   action at dune:6
@@ -136,7 +136,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune_build_sorted_actions --cache=enabled reproducible non-reproducible
-  Warning: cache store error [1ce77805b0b209e689d1ddac29fa75b5]: ((in_cache
+  Warning: cache store error [ec544297636df4b8a35a7a4cb367c872]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   action at dune:6
@@ -148,7 +148,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune_build_sorted_actions --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [1ce77805b0b209e689d1ddac29fa75b5]: ((in_cache
+  Warning: cache store error [ec544297636df4b8a35a7a4cb367c872]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   action at dune:6

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -82,8 +82,8 @@ entries uniformly.
   $ metadata_dir="$PWD/.xdg-cache/dune/db/meta/v5"
   $ (cd "$metadata_dir"; find . -mindepth 2 -maxdepth 2 -type f | sort) > metadata-paths
   $ cat metadata-paths | censor
-  ./42/$DIGEST1
-  ./54/$DIGEST2
+  ./62/$DIGEST1
+  ./9f/$DIGEST2
 
   $ while read path; do dune internal cache-metadata "$metadata_dir/$path"; done < metadata-paths \
   > | jq_dune -S -s 'sortCacheMetadataByFirstPath' \

--- a/test/blackbox-tests/test-cases/tests-locks.t/run.t
+++ b/test/blackbox-tests/test-cases/tests-locks.t/run.t
@@ -8,8 +8,7 @@ These tests are run without locks. They should end together (= expected)
   > grep "^> *" | uniq -c | [ $(wc -l) -eq 1 ] && echo '=' || echo '<>'
   =
 
-Duplicate lock declarations currently deadlock a rule by making it acquire the same
-non-reentrant mutex twice.
+Duplicate lock declarations are harmless; a rule acquires each lock only once.
 
   $ mkdir duplicate-lock
   $ cat >duplicate-lock/dune <<EOF
@@ -23,4 +22,4 @@ non-reentrant mutex twice.
   > else
   >   echo timed-out
   > fi
-  timed-out
+  done


### PR DESCRIPTION
Canonicalize action lock paths as a set when constructing and combining action
properties. Duplicate declarations can no longer make a rule acquire the same
non-reentrant mutex twice, and digesting and acquisition consume the same
canonical ordering without repeated sorting.

The regression is covered by #16247.
