### PR TITLE
test: censor unstable action digests

### DIFF
--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t
@@ -15,7 +15,9 @@ Test reproducibility check
   >     cat dune-build-output
   >     return $status
   >   }
-  >   sed -n '/^Warning:/,/^action at dune:6/p' dune-build-output
+  >   if grep -q '^Warning:' dune-build-output; then
+  >     sed -n '/^Warning:/,/^action at dune:6/p' dune-build-output | censor
+  >   fi
   >   sed -n '/^build /p' dune-build-output | sort
   >   sed '/^Warning:/,/^action at dune:6/d; /^build /d' dune-build-output
   > }
@@ -80,9 +82,9 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune_build_sorted_actions --config-file config reproducible non-reproducible
-  Warning: cache store error [ec544297636df4b8a35a7a4cb367c872]: ((in_cache
-  ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
-  ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
+  Warning: cache store error [$DIGEST1]: ((in_cache
+  ((non-reproducible $DIGEST2))) (computed
+  ((non-reproducible $DIGEST3)))) after executing
   action at dune:6
   build non-reproducible
   build reproducible
@@ -136,9 +138,9 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune_build_sorted_actions --cache=enabled reproducible non-reproducible
-  Warning: cache store error [ec544297636df4b8a35a7a4cb367c872]: ((in_cache
-  ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
-  ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
+  Warning: cache store error [$DIGEST1]: ((in_cache
+  ((non-reproducible $DIGEST2))) (computed
+  ((non-reproducible $DIGEST3)))) after executing
   action at dune:6
   build non-reproducible
   build reproducible
@@ -148,9 +150,9 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune_build_sorted_actions --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [ec544297636df4b8a35a7a4cb367c872]: ((in_cache
-  ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
-  ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
+  Warning: cache store error [$DIGEST1]: ((in_cache
+  ((non-reproducible $DIGEST2))) (computed
+  ((non-reproducible $DIGEST3)))) after executing
   action at dune:6
   build non-reproducible
   build reproducible

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -81,9 +81,10 @@ entries uniformly.
 
   $ metadata_dir="$PWD/.xdg-cache/dune/db/meta/v5"
   $ (cd "$metadata_dir"; find . -mindepth 2 -maxdepth 2 -type f | sort) > metadata-paths
-  $ cat metadata-paths | censor
-  ./62/$DIGEST1
-  ./9f/$DIGEST2
+  $ cat metadata-paths \
+  > | dune_cmd subst-unique '[0-9a-f]{2}/[0-9a-f]{32}' '$DIGEST'
+  ./$DIGEST1
+  ./$DIGEST2
 
   $ while read path; do dune internal cache-metadata "$metadata_dir/$path"; done < metadata-paths \
   > | jq_dune -S -s 'sortCacheMetadataByFirstPath' \


### PR DESCRIPTION
## Description

Censor unstable action digests in cache cram output, including cache shard directory components. This keeps digest scheme bumps from requiring unrelated expected-output updates while preserving the cache behavior checks.

## Related Issue and Motivation

Changing action digest computation currently changes cache warning IDs and metadata shard paths, producing unrelated cram diffs. These values are now represented by stable digest placeholders.