### PR TITLE
test(engine): cover concurrent process redirections

### DIFF
--- a/test/blackbox-tests/test-cases/actions/concurrent.t
+++ b/test/blackbox-tests/test-cases/actions/concurrent.t
@@ -52,3 +52,24 @@ When we run the rule, we see that the two actions are indeed run concurrently.
 
 Notice the need for a -j2. If Dune was configured with -j1 then the action would
 never terminate.
+
+Concurrent process actions currently share a single-use redirection.
+
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (action
+  >   (with-stdout-to concurrent-output
+  >    (concurrent
+  >     (run sh -c "echo output")
+  >     (run sh -c "echo output")))))
+  > EOF
+
+  $ dune build -j2 concurrent-output >escaped-output 2>&1
+  $ echo 'concurrent-output:'
+  concurrent-output:
+  $ cat _build/default/concurrent-output
+  output
+  $ echo 'escaped-output:'
+  escaped-output:
+  $ cat escaped-output
+  output


### PR DESCRIPTION
Add a regression demonstrating that concurrent process actions beneath one
stdout redirection share and close a single-use `Process.Io` value. One child's
output reaches the target while the other escapes to Dune's own output.

This intentionally records the current faulty behavior so a follow-up fix can
update the snapshot.
