### PR TITLE
refactor(engine): remove unused helpers and interfaces

### DIFF
--- a/src/dune_engine/action_ext.ml
+++ b/src/dune_engine/action_ext.ml
@@ -23,7 +23,6 @@ struct
     include S
 
     let is_dynamic = false
-    let runs_process = runs_process
 
     let encode t f g =
       let open Sexp in

--- a/src/dune_engine/alias.mli
+++ b/src/dune_engine/alias.mli
@@ -21,5 +21,4 @@ val name : t -> Name.t
 val dir : t -> Path.Build.t
 val to_dyn : t -> Dyn.t
 val of_user_written_path : loc:Loc.t -> Path.t -> t
-val fully_qualified_name : t -> Path.Build.t
 val describe : ?loc:Loc.t -> t -> _ Pp.t

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -35,9 +35,6 @@ val eval_pred : File_selector.t -> Filename_set.t Memo.t
 (** Same as [eval_pred] with [Predicate.true_] as predicate. *)
 val files_of : dir:Path.t -> Filename_set.t Memo.t
 
-(** Execute an action. The execution is cached. *)
-val execute_action : observing_facts:Dep.Facts.t -> Rule.Anonymous_action.t -> unit Memo.t
-
 (** Execute an action and capture its stdout. The execution is cached. *)
 val execute_action_stdout : Rule.Anonymous_action.t Action_builder.t -> string Memo.t
 

--- a/src/dune_engine/dep.mli
+++ b/src/dune_engine/dep.mli
@@ -12,7 +12,6 @@ val env : Env.Var.t -> t
 val universe : t
 val file_selector : File_selector.t -> t
 val alias : Alias.t -> t
-val compare : t -> t -> Ordering.t
 val repr : t Repr.t
 
 module Map : sig

--- a/src/dune_engine/dir_set.ml
+++ b/src/dune_engine/dir_set.ml
@@ -44,16 +44,6 @@ let create ~default ~here ~exceptions =
   else Nontrivial { here; default; exceptions }
 ;;
 
-let is_empty = function
-  | Empty -> true
-  | _ -> false
-;;
-
-let is_universal = function
-  | Universal -> true
-  | _ -> false
-;;
-
 let merge_exceptions a b ~default ~f =
   Filename.Map.merge a.exceptions b.exceptions ~f:(fun _ x y ->
     let x = Option.value x ~default:(trivial a.default) in
@@ -96,17 +86,6 @@ let rec negate x =
       ; default = not default
       ; exceptions = Filename.Map.map exceptions ~f:negate
       }
-;;
-
-let rec diff x y =
-  match x with
-  | Empty -> Empty
-  | Universal -> negate y
-  | Nontrivial nx ->
-    (match y with
-     | Empty -> x
-     | Universal -> Empty
-     | Nontrivial ny -> merge_nontrivial nx ny ~f_one:(fun a b -> a && not b) ~f_set:diff)
 ;;
 
 let rec mem t dir =
@@ -199,8 +178,4 @@ let toplevel_subdirs t =
   | Empty -> Finite Filename.Set.empty
   | Nontrivial t ->
     if t.default then Infinite else Finite (Filename.Set.of_keys t.exceptions)
-;;
-
-let of_list paths =
-  union_all (List.map paths ~f:(fun p -> singleton' (Path.Local_gen.explode p)))
 ;;

--- a/src/dune_engine/dir_set.mli
+++ b/src/dune_engine/dir_set.mli
@@ -18,18 +18,6 @@ val empty : 'w t
 (** The set of all possible directories *)
 val universal : 'w t
 
-(** [trivial b] is such that for all path [p]:
-
-    {[
-      mem (trivial b) p = b
-    ]}
-
-    i.e. [trivial false] is [empty] and [trivial true] is [universal]. *)
-val trivial : bool -> 'w t
-
-val is_empty : 'w t -> bool
-val is_universal : 'w t -> bool
-
 (** [descend t comp] is the set [t'] such that for all path [p], [p] is in [t']
     iff [comp/p] is in [t]. [comp] must be a path component, i.e. without
     directory separator characters. *)
@@ -49,12 +37,6 @@ val exceptions : 'w t -> Path.Local.w t Filename.Map.t
     [exceptions t], [mem t p = default t]. *)
 val default : 'w t -> bool
 
-val create
-  :  default:bool
-  -> here:bool
-  -> exceptions:Path.Unspecified.w t Filename.Map.t
-  -> Path.Unspecified.w t
-
 (** [singleton p] is the set containing only [p] *)
 val singleton : 'w Path.Local_gen.t -> 'w t
 
@@ -65,7 +47,6 @@ val is_subset : 'w t -> of_:'w t -> bool
 val union : 'w t -> 'w t -> 'w t
 val union_all : 'w t list -> 'w t
 val inter : 'w t -> 'w t -> 'w t
-val diff : 'w t -> 'w t -> 'w t
 val negate : 'w t -> 'w t
 val to_dyn : 'w t -> Dyn.t
 val forget_root : 'w t -> Path.Unspecified.w t
@@ -75,5 +56,4 @@ type toplevel_subdirs =
   | Finite of Filename.Set.t
 
 val toplevel_subdirs : 'w t -> toplevel_subdirs
-val of_list : 'w Path.Local_gen.t list -> 'w t
 val just_the_root : 'w t

--- a/src/dune_engine/dpath.ml
+++ b/src/dune_engine/dpath.ml
@@ -90,19 +90,6 @@ let describe_target fn =
   | Other fn -> Path.Build.to_string_maybe_quoted fn
 ;;
 
-let describe_path (p : Path.t) =
-  match p with
-  | External _ | In_source_tree _ -> Path.to_string_maybe_quoted p
-  | In_build_dir p -> describe_target p
-;;
-
-let analyse_path (fn : Path.t) =
-  match fn with
-  | In_source_tree src -> Source src
-  | External e -> External e
-  | In_build_dir build -> Build (analyse_target build)
-;;
-
 let analyse_dir (fn : Path.t) =
   match fn with
   | In_source_tree src -> Source src

--- a/src/dune_engine/dpath.mli
+++ b/src/dune_engine/dpath.mli
@@ -29,13 +29,10 @@ type 'build path_kind =
 (** Return the name of an alias from its stamp file *)
 val analyse_target : Path.Build.t -> target_kind
 
-val analyse_path : Path.t -> target_kind path_kind
 val analyse_dir : Path.t -> Target_dir.t path_kind
 
 (** Nice description of a target *)
 val describe_target : Path.Build.t -> string
-
-val describe_path : Path.t -> string
 
 type t = Path.t
 

--- a/src/dune_engine/execution_parameters.ml
+++ b/src/dune_engine/execution_parameters.ml
@@ -5,10 +5,8 @@ module Action_output_limit = struct
   type t = int
 
   let default = 100_000
-  let to_string = Int.to_string
   let equal = Int.equal
   let repr = Repr.int
-  let to_dyn = Repr.to_dyn repr
 end
 
 module Workspace_root_for_build_prefix_map = struct
@@ -33,8 +31,6 @@ module Workspace_root_for_build_prefix_map = struct
           | Set root -> Some root)
       ]
   ;;
-
-  let to_dyn = Repr.to_dyn repr
 end
 
 type t =
@@ -78,32 +74,6 @@ let equal
        t.should_remove_write_permissions_on_generated_files
   && Bool.equal sandbox_actions t.sandbox_actions
   && Bool.equal use_sandbox_policy t.use_sandbox_policy
-;;
-
-let hash
-      { action_stdout_on_success
-      ; action_stderr_on_success
-      ; action_stdout_limit
-      ; action_stderr_limit
-      ; expand_aliases_in_sandbox
-      ; workspace_root_to_build_path_prefix_map
-      ; action_project_root
-      ; should_remove_write_permissions_on_generated_files
-      ; sandbox_actions
-      ; use_sandbox_policy
-      }
-  =
-  Poly.hash
-    ( Action_output_on_success.hash action_stdout_on_success
-    , Action_output_on_success.hash action_stderr_on_success
-    , action_stdout_limit
-    , action_stderr_limit
-    , expand_aliases_in_sandbox
-    , workspace_root_to_build_path_prefix_map
-    , action_project_root
-    , should_remove_write_permissions_on_generated_files
-    , sandbox_actions
-    , use_sandbox_policy )
 ;;
 
 let bool_to_int b = if b then 1 else 0
@@ -203,8 +173,6 @@ let repr =
     ; Repr.field "use_sandbox_policy" Repr.bool ~get:(fun t -> t.use_sandbox_policy)
     ]
 ;;
-
-let to_dyn = Repr.to_dyn repr
 
 let builtin_default =
   make

--- a/src/dune_engine/execution_parameters.mli
+++ b/src/dune_engine/execution_parameters.mli
@@ -21,22 +21,17 @@ open Action_types
 type t
 
 val equal : t -> t -> bool
-val hash : t -> int
 val repr : t Repr.t
 val digest : t -> Digest.t
-val to_dyn : t -> Dyn.t
 
 module Action_output_limit : sig
   (** Maximum size for output (stdout/stderr) of actions, above which the output is
-      truncated. [None] means no limit, and [Some n] means a limit of [n] bytes. *)
+      truncated. *)
 
   type t = int
 
   val default : t
-  val to_string : t -> string
-  val equal : t -> t -> bool
   val repr : t Repr.t
-  val to_dyn : t -> Dyn.t
 end
 
 (** {1 Constructors} *)
@@ -48,7 +43,6 @@ module Workspace_root_for_build_prefix_map : sig
     | Set of string (** [Set root] substitute the root with [root] *)
 
   val repr : t Repr.t
-  val to_dyn : t -> Dyn.t
 end
 
 val builtin_default : t

--- a/src/dune_engine/file_selector.ml
+++ b/src/dune_engine/file_selector.ml
@@ -49,13 +49,6 @@ let hash { dir; predicate; only_generated_files } =
     (dir, predicate, only_generated_files)
 ;;
 
-let test t path =
-  Predicate_lang.Glob.test
-    t.predicate
-    ~standard:Predicate_lang.false_
-    (Path.basename path |> Filename.to_string)
-;;
-
 let test_basename t ~basename =
   Predicate_lang.Glob.test
     t.predicate

--- a/src/dune_engine/file_selector.mli
+++ b/src/dune_engine/file_selector.mli
@@ -25,6 +25,5 @@ val compare : t -> t -> Ordering.t
 val repr : t Repr.t
 
 val to_dyn : t -> Dyn.t
-val test : t -> Path.t -> bool
 val test_basename : t -> basename:Filename.t -> bool
 val digest : t -> Digest.t

--- a/src/dune_engine/fs.ml
+++ b/src/dune_engine/fs.ml
@@ -30,13 +30,6 @@ let file_exists file =
   | `Inside _ -> exists file Unix.S_REG
 ;;
 
-let dir_exists dir =
-  let* () = Memo.return () in
-  match Path.destruct_build_dir dir with
-  | `Outside dir -> Fs_memo.dir_exists dir
-  | `Inside _ -> exists dir Unix.S_DIR
-;;
-
 let with_lexbuf_from_file file ~f =
   let* () = Memo.return () in
   match Path.destruct_build_dir file with

--- a/src/dune_engine/fs.mli
+++ b/src/dune_engine/fs.mli
@@ -8,5 +8,4 @@ val dir_contents
   -> ((Filename.t * File_kind.t) list, Unix_error.Detailed.t) result Memo.t
 
 val file_exists : Path.t -> bool Memo.t
-val dir_exists : Path.t -> bool Memo.t
 val with_lexbuf_from_file : Path.t -> f:(Lexing.lexbuf -> 'a) -> 'a Memo.t

--- a/src/dune_engine/rules.ml
+++ b/src/dune_engine/rules.ml
@@ -81,7 +81,6 @@ module Dir_rules = struct
     Id.Map.set t id data
   ;;
 
-  let is_subset t ~of_ = Id.Map.is_subset t ~of_ ~f:(fun _ ~of_:_ -> true)
   let is_empty = Id.Map.is_empty
 
   module Nonempty : sig
@@ -229,10 +228,6 @@ let map t ~f =
       | `Changed data -> Id.gen (), data)
     |> Dir_rules.Nonempty.create
     |> Option.value_exn)
-;;
-
-let is_subset t ~of_ =
-  Path.Build.Map.is_subset (to_map t) ~of_:(to_map of_) ~f:Dir_rules.is_subset
 ;;
 
 let map_rules t ~f =

--- a/src/dune_engine/rules.mli
+++ b/src/dune_engine/rules.mli
@@ -37,7 +37,6 @@ module Dir_rules : sig
     }
 
   val consume : t -> ready
-  val is_subset : t -> of_:t -> bool
   val is_empty : t -> bool
   val to_dyn : t -> Dyn.t
 end
@@ -85,8 +84,6 @@ val union : t -> t -> t
 val of_dir_rules : dir:Path.Build.t -> Dir_rules.t -> t
 val of_rules : Rule.t list -> t
 val produce : t -> unit Memo.t
-val is_subset : t -> of_:t -> bool
-val map_rules : t -> f:(Rule.t -> Rule.t) -> t
 val collect : (unit -> 'a Memo.t) -> ('a * t) Memo.t
 val collect_unit : (unit -> unit Memo.t) -> t Memo.t
 

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -101,7 +101,6 @@ let root = function
   | No_sandbox _ -> None
 ;;
 
-let is_sandboxed t = Option.is_some (root t)
 let map_real_path t p = Path.Build.append t.dir p
 
 let map_path t p =

--- a/src/dune_engine/sandbox.mli
+++ b/src/dune_engine/sandbox.mli
@@ -6,9 +6,6 @@ type t
 
 val root : t -> Path.t option
 
-(** [is_sandboxed t] is [true] when [t] represents a real sandbox. *)
-val is_sandboxed : t -> bool
-
 (** [map_path t p] returns the path corresponding to [p] inside the sandbox. *)
 val map_path : t -> Path.Build.t -> Path.Build.t
 

--- a/src/dune_engine/sandbox_config.ml
+++ b/src/dune_engine/sandbox_config.ml
@@ -74,7 +74,3 @@ module Partial = struct
       if Sandbox_mode.equal mode mode' then Some false else None)
   ;;
 end
-
-let disallow (mode : Sandbox_mode.t) =
-  Sandbox_mode.Set.of_func (fun mode' -> not (Sandbox_mode.equal mode mode'))
-;;

--- a/src/dune_engine/sandbox_config.mli
+++ b/src/dune_engine/sandbox_config.mli
@@ -12,7 +12,6 @@ open Import
 (** A set of sandbox modes in which the rule is expected to work correctly. *)
 type t = Sandbox_mode.Set.t
 
-val compare : t -> t -> Ordering.t
 val equal : t -> t -> bool
 
 (** Computes the intersection of allowed sandbox modes *)
@@ -32,7 +31,6 @@ val needs_sandboxing : t
     Currently we have [default = no_special_requirements]. *)
 val default : t
 
-val disallow : Sandbox_mode.t -> t
 val mem : t -> Sandbox_mode.t -> bool
 
 module Partial : sig

--- a/src/dune_engine/subdir_set.ml
+++ b/src/dune_engine/subdir_set.ml
@@ -24,11 +24,6 @@ let of_dir_set d =
 let of_list l = These (Filename.Set.of_list l)
 let empty = These Filename.Set.empty
 
-let is_empty = function
-  | All -> false
-  | These set -> Filename.Set.is_empty set
-;;
-
 let mem t dir =
   match t with
   | All -> true
@@ -40,5 +35,3 @@ let union a b =
   | All, _ | _, All -> All
   | These a, These b -> These (Filename.Set.union a b)
 ;;
-
-let union_all = List.fold_left ~init:empty ~f:union

--- a/src/dune_engine/subdir_set.mli
+++ b/src/dune_engine/subdir_set.mli
@@ -10,7 +10,5 @@ val to_dir_set : t -> Path.Unspecified.w Dir_set.t
 val of_dir_set : 'a Dir_set.t -> t
 val of_list : Filename.t list -> t
 val empty : t
-val is_empty : t -> bool
 val mem : t -> Filename.t -> bool
 val union : t -> t -> t
-val union_all : t list -> t

--- a/src/dune_engine/utils.ml
+++ b/src/dune_engine/utils.ml
@@ -21,8 +21,3 @@ let program_not_found_message ?context ?hint ~loc prog =
 let program_not_found ?context ?hint ~loc prog =
   raise (User_error.E (program_not_found_message ?context ?hint ~loc prog))
 ;;
-
-let pp_command_hint command =
-  let open Pp.O in
-  Pp.textf "try:" ++ Pp.newline ++ Pp.cut ++ Pp.hbox (Pp.textf "  " ++ Pp.verbatim command)
-;;

--- a/src/dune_engine/utils.mli
+++ b/src/dune_engine/utils.mli
@@ -9,6 +9,3 @@ val program_not_found
   -> loc:Loc.t option
   -> string
   -> _
-
-(** Pretty-printer for suggesting a given shell command to the user *)
-val pp_command_hint : string -> _ Pp.t


### PR DESCRIPTION
Remove unreferenced private helpers and interface entries from `dune_engine`,
including obsolete directory-set operations, unused path and sandbox queries,
and a redundant action-extension binding.

The library's representation definitions and indirectly required operations are
left intact. This is implementation-only cleanup with no user-visible behavior
change.
