### PR TITLE
fix(engine): share concurrent action redirections safely

### DIFF
--- a/doc/changes/fixed/16257.md
+++ b/doc/changes/fixed/16257.md
@@ -1,0 +1,2 @@
+- Prevent concurrent action children from closing shared redirections before
+  their siblings use them (#16257, @rgrinberg)

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -130,7 +130,15 @@ let rec exec t ~ectx ~eenv : Done_or_more_deps.t Fiber.t =
   | Ignore (outputs, t) -> redirect_out t ~ectx ~eenv ~perm:Normal outputs Dev_null.path
   | Progn ts -> exec_list ts ~ectx ~eenv
   | Concurrent ts ->
-    Fiber.parallel_map ts ~f:(exec ~ectx ~eenv)
+    Fiber.parallel_map ts ~f:(fun t ->
+      let eenv =
+        { eenv with
+          stdout_to = Process.Io.multi_use eenv.stdout_to
+        ; stderr_to = Process.Io.multi_use eenv.stderr_to
+        ; stdin_from = Process.Io.multi_use eenv.stdin_from
+        }
+      in
+      exec t ~ectx ~eenv)
     >>| List.fold_left ~f:Done_or_more_deps.union ~init:Done
   | Echo strs ->
     let () =

--- a/test/blackbox-tests/test-cases/actions/concurrent.t
+++ b/test/blackbox-tests/test-cases/actions/concurrent.t
@@ -53,7 +53,7 @@ When we run the rule, we see that the two actions are indeed run concurrently.
 Notice the need for a -j2. If Dune was configured with -j1 then the action would
 never terminate.
 
-Concurrent process actions currently share a single-use redirection.
+Concurrent process actions clone a shared redirection without closing it early.
 
   $ cat > dune <<'EOF'
   > (rule
@@ -69,7 +69,7 @@ Concurrent process actions currently share a single-use redirection.
   concurrent-output:
   $ cat _build/default/concurrent-output
   output
+  output
   $ echo 'escaped-output:'
   escaped-output:
   $ cat escaped-output
-  output


### PR DESCRIPTION
Concurrent children inherited the same single-use `Process.Io` values. The
first process spawn could close a redirected descriptor before its siblings
used it, causing their output to escape the redirection.

Give each child a multi-use view while leaving ownership with the enclosing
action. The regression added in #16254 now records both lines in the target and
no escaped output.
