### PR TITLE
test(engine): reproduce spawn failure capture leaks

### DIFF
--- a/test/blackbox-tests/test-cases/actions/process-cleanup.t
+++ b/test/blackbox-tests/test-cases/actions/process-cleanup.t
@@ -1,0 +1,36 @@
+A failed spawn currently retains captured output while Dune remains running.
+
+  $ make_dune_project 3.0
+  $ mkdir "$TMPDIR/process-cleanup"
+  $ export TMPDIR="$TMPDIR/process-cleanup"
+
+  $ cat >disappearing-executable <<'EOF'
+  > #!/bin/sh
+  > echo unexpected
+  > EOF
+  $ chmod 755 disappearing-executable
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (alias spawn-failure)
+  >  (deps disappearing-executable)
+  >  (action
+  >   (progn
+  >    (run rm -f disappearing-executable)
+  >    (run ./disappearing-executable))))
+  > EOF
+
+  $ start_dune
+  $ build "(alias spawn-failure)"
+  Failure
+  [1]
+
+  $ for f in "$TMPDIR"/dune*stdout "$TMPDIR"/dune*stderr; do
+  >   if test -e "$f"; then
+  >     basename "$f" | sed -E 's/^dune.*(stdout|stderr)$/dune<ID>\1/'
+  >   fi
+  > done
+  dune<ID>stdout
+  dune<ID>stderr
+
+  $ stop_dune_quiet


### PR DESCRIPTION
Add a cram regression that keeps Dune alive after an executable disappears
immediately before spawning. The snapshot shows that both stdout and stderr
capture files remain in Dune's temporary directory until shutdown.

This intentionally records the current faulty behavior for a follow-up cleanup
fix.
