### PR TITLE
refactor(stdune): use Filename.null for dev null

### DIFF
--- a/otherlibs/stdune/src/dev_null.ml
+++ b/otherlibs/stdune/src/dev_null.ml
@@ -1,8 +1,7 @@
-let dev_null_fn = if Sys.win32 then "nul" else "/dev/null"
-let path = Path.of_filename_relative_to_initial_cwd dev_null_fn
+let path = Path.of_filename_relative_to_initial_cwd Filename.null
 
 let open_null flags =
-  lazy (Fd.unsafe_of_unix_file_descr (Unix.openfile dev_null_fn flags 0o666))
+  lazy (Fd.unsafe_of_unix_file_descr (Unix.openfile Filename.null flags 0o666))
 ;;
 
 let in_ = open_null [ Unix.O_RDONLY; Unix.O_CLOEXEC ]

--- a/otherlibs/stdune/src/filename.mli
+++ b/otherlibs/stdune/src/filename.mli
@@ -6,6 +6,7 @@
 val current_dir_name : string
 val parent_dir_name : string
 val dir_sep : string
+val null : string
 val concat : string -> string -> string
 val is_relative : string -> bool
 val check_suffix : string -> string -> bool


### PR DESCRIPTION
Use OCaml's platform-specific `Filename.null` rather than maintaining a duplicate `Sys.win32` conditional. Expose the existing value through `Stdune.Filename` and use it directly at both dev-null call sites.
