### PR TITLE
fix(action-plugin): exclude directories from glob listings

### DIFF
--- a/doc/changes/fixed/16262.md
+++ b/doc/changes/fixed/16262.md
@@ -1,0 +1,2 @@
+- Exclude directories from `dune-action-plugin` glob listings so returned
+  entries match the dependencies tracked by Dune (#16262, @rgrinberg)

--- a/otherlibs/dune-action-plugin/src/dune_action_plugin.ml
+++ b/otherlibs/dune-action-plugin/src/dune_action_plugin.ml
@@ -30,10 +30,14 @@ module V1 = struct
     ;;
 
     let read_directory =
-      let rec loop dh acc =
+      let rec loop path dh acc =
         match Unix.readdir dh with
-        | "." | ".." -> loop dh acc
-        | s -> loop dh (s :: acc)
+        | "." | ".." -> loop path dh acc
+        | entry ->
+          let entry_path = Filename.concat path entry in
+          (match (Unix.lstat entry_path).st_kind with
+           | S_DIR -> loop path dh acc
+           | _ -> loop path dh (entry :: acc))
         | exception End_of_file -> acc
       in
       fun path ->
@@ -42,7 +46,7 @@ module V1 = struct
           | exception Unix.Unix_error ((ENOENT | ENOTDIR), _, _) -> []
           | dh ->
             Exn.protect
-              ~f:(fun () -> loop dh [] |> List.sort ~compare:String.compare)
+              ~f:(fun () -> loop path dh [] |> List.sort ~compare:String.compare)
               ~finally:(fun () -> Unix.closedir dh))
     ;;
 

--- a/otherlibs/dune-action-plugin/src/dune_action_plugin.mli
+++ b/otherlibs/dune-action-plugin/src/dune_action_plugin.mli
@@ -96,10 +96,7 @@ module V1 : sig
       filtering, so dune won't re-run the action when the directory changes in
       an unimportant way.
 
-      An absent directory is returned as an empty listing.
-
-      BUG: the returned listing includes directories even though that dependency
-      is not tracked. *)
+      An absent directory is returned as an empty listing. *)
   val read_directory_with_glob : path:Path.t -> glob:Dune_glob.V1.t -> string list t
 
   (** {1:running Running the computation} *)

--- a/test/expect-tests/dune_action_plugin/dune_action_test.ml
+++ b/test/expect-tests/dune_action_plugin/dune_action_test.ml
@@ -29,7 +29,7 @@ let%expect_test _ =
   Private.do_run action;
   [%expect
     {|
-    some_file,subdir
+    some_file
   |}]
 ;;
 


### PR DESCRIPTION
`read_directory_with_glob` declared a file-selector dependency but returned
subdirectories as well, exposing entries that Dune did not track.

Filter real directories from the returned listing so it matches the declared
dependency. Symlink entries remain in the listing.