### PR TITLE
fix(engine): clean pipe action temporary files

### DIFF
--- a/doc/changes/fixed/16264.md
+++ b/doc/changes/fixed/16264.md
@@ -1,0 +1,2 @@
+- Clean intermediate pipe-action files immediately after failed actions instead
+  of retaining them until the build finishes (#16264, @rgrinberg)

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -288,45 +288,48 @@ and exec_pipe outputs ts ~ectx ~eenv : Done_or_more_deps.t Fiber.t =
   let tmp_file () =
     Dtemp.file ~prefix:"dune-pipe-action-" ~suffix:("." ^ Outputs.to_string outputs)
   in
+  let with_tmp_file ~f =
+    let tmp = tmp_file () in
+    Fiber.finalize
+      (fun () -> f tmp)
+      ~finally:(fun () ->
+        Dtemp.destroy File tmp;
+        Fiber.return ())
+  in
   let rec loop ~in_ ts =
     match ts with
     | [] -> assert false
     | [ last_t ] ->
-      let+ result =
-        let eenv =
-          match outputs with
-          | Stderr -> { eenv with stdout_to = Process.Io.multi_use eenv.stderr_to }
-          | _ -> eenv
-        in
-        redirect_in last_t ~ectx ~eenv Stdin in_
+      let eenv =
+        match outputs with
+        | Stderr -> { eenv with stdout_to = Process.Io.multi_use eenv.stderr_to }
+        | _ -> eenv
       in
-      Dtemp.destroy File in_;
-      result
+      redirect_in last_t ~ectx ~eenv Stdin in_
     | t :: ts ->
-      let out = tmp_file () in
-      let* done_or_deps =
-        let eenv = { eenv with stderr_to = Process.Io.multi_use eenv.stderr_to } in
-        redirect t ~ectx ~eenv ~in_:(Stdin, in_) ~out:(Stdout, out, Normal) ()
-      in
-      Dtemp.destroy File in_;
-      (match done_or_deps with
-       | Need_more_deps _ as need -> Fiber.return need
-       | Done -> loop ~in_:out ts)
+      with_tmp_file ~f:(fun out ->
+        let* done_or_deps =
+          let eenv = { eenv with stderr_to = Process.Io.multi_use eenv.stderr_to } in
+          redirect t ~ectx ~eenv ~in_:(Stdin, in_) ~out:(Stdout, out, Normal) ()
+        in
+        match done_or_deps with
+        | Need_more_deps _ as need -> Fiber.return need
+        | Done -> loop ~in_:out ts)
   in
   match ts with
   | [] -> assert false
   | t1 :: ts ->
-    let out = tmp_file () in
-    let eenv =
-      match outputs with
-      | Outputs -> eenv
-      | Stdout -> { eenv with stderr_to = Process.Io.multi_use eenv.stderr_to }
-      | Stderr -> { eenv with stdout_to = Process.Io.multi_use eenv.stdout_to }
-    in
-    redirect_out t1 ~ectx ~eenv ~perm:Normal outputs out
-    >>= (function
-     | Need_more_deps _ as need -> Fiber.return need
-     | Done -> loop ~in_:out ts)
+    with_tmp_file ~f:(fun out ->
+      let eenv =
+        match outputs with
+        | Outputs -> eenv
+        | Stdout -> { eenv with stderr_to = Process.Io.multi_use eenv.stderr_to }
+        | Stderr -> { eenv with stdout_to = Process.Io.multi_use eenv.stdout_to }
+      in
+      redirect_out t1 ~ectx ~eenv ~perm:Normal outputs out
+      >>= function
+      | Need_more_deps _ as need -> Fiber.return need
+      | Done -> loop ~in_:out ts)
 ;;
 
 let exec_until_all_deps_ready ~ectx ~eenv t =

--- a/test/blackbox-tests/test-cases/pipe-actions.t/run.t
+++ b/test/blackbox-tests/test-cases/pipe-actions.t/run.t
@@ -114,7 +114,7 @@ The makefile version of pipe actions uses actual pipes:
   o a | o b | e c
   e a | o b | e c
 
-A failed pipe currently retains its temporary file until the build finishes.
+A failed pipe releases its temporary file before the build finishes.
 
   $ mkdir "$TMPDIR/pipe-cleanup"
   $ export TMPDIR="$TMPDIR/pipe-cleanup"
@@ -149,7 +149,6 @@ A failed pipe currently retains its temporary file until the build finishes.
 
   $ find "$TMPDIR" -type f -name 'dune-pipe-action-*' -exec basename {} \; |
   > sed -E 's/^dune-pipe-action-.*$/dune-pipe-action-<id>/'
-  dune-pipe-action-<id>
 
   $ touch "$release"
   $ wait "$build_pid"


### PR DESCRIPTION
Pipe actions manually removed intermediate files only after successful stage
completion. Failures and dynamic-dependency exits retained them until global
end-of-build cleanup.

Give each intermediate file a fiber finalizer so its lifetime matches the pipe
stage that owns it. The regression from #16260 now observes no retained file
while another target keeps the build active.
