### PR TITLE
test(action-plugin): reproduce directories in glob listings

### DIFF
--- a/otherlibs/dune-action-plugin/test/depend-on-directory-without-targets/run.t
+++ b/otherlibs/dune-action-plugin/test/depend-on-directory-without-targets/run.t
@@ -20,6 +20,13 @@
   $ dune runtest
   Directory listing: [some_file1; some_file2]
 
+A direct run includes directories even though glob dependencies only track
+files.
+
+  $ mkdir some_dir/subdir
+  $ ./foo.exe
+  Directory listing: [some_file1; some_file2; subdir]
+
 A missing directory has an empty listing when the plugin runs directly.
 
   $ rm -rf some_dir


### PR DESCRIPTION
Record the current `read_directory_with_glob` behavior when the action plugin
runs directly: returned listings include subdirectories even though glob
dependencies only track files.