### PR TITLE
fix(rpc): rebase forwarded paths to the workspace root

### DIFF
--- a/bin/build.ml
+++ b/bin/build.ml
@@ -188,7 +188,9 @@ let build =
          an RPC server in the background to schedule the fiber which will
          perform the RPC call.
       *)
-      let targets = Rpc.Rpc_common.prepare_targets targets in
+      let targets =
+        Rpc.Rpc_common.prepare_targets_relative_to_root (Common.root common) targets
+      in
       Scheduler_setup.go_without_rpc_server ~common ~config (fun () ->
         let open Fiber.O in
         Rpc.Rpc_common.fire_request

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1203,15 +1203,17 @@ let action_builder_of_rpc_request request =
   Dune_engine.Action_builder.of_memo (Memo.of_thunk Util.setup) >>= request
 ;;
 
-let rpc_request_action ~root (kind : Dune_rpc_impl.Server.build_request) =
+let rpc_request_action
+      ~(root : Workspace_root.t)
+      (kind : Dune_rpc_impl.Server.build_request)
+  =
   action_builder_of_rpc_request (fun setup ->
     match kind with
-    | Build targets -> Target.interpret_targets root setup targets
+    | Build targets ->
+      let root = { root with to_cwd = []; reach_from_root_prefix = "" } in
+      Target.interpret_targets root setup targets
     | Runtest test_paths ->
-      Runtest_common.make_request
-        ~scontexts:setup.scontexts
-        ~to_cwd:root.to_cwd
-        ~test_paths)
+      Runtest_common.make_request ~scontexts:setup.scontexts ~to_cwd:[] ~test_paths)
 ;;
 
 (* CR-someday rleshchinskiy: The split between `build` and `init` seems quite arbitrary,

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -304,10 +304,14 @@ let prepare_exec_via_rpc_server ~common ~prog ~args ~no_rebuild builder lock_hel
         ]
   in
   let context = Common.x common |> Option.value ~default:Context_name.default in
-  let dir = Context_name.build_dir context in
-  let prog = ensure_terminal prog in
   let args = List.map args ~f:ensure_terminal in
   let+ prog =
+    let prog = ensure_terminal prog in
+    let dir =
+      Path.Build.relative
+        (Context_name.build_dir context)
+        (Common.prefix_target common "")
+    in
     build_prog_via_rpc_if_necessary ~dir ~no_rebuild builder lock_held_by prog
   in
   let env = extend_with_staging_env context Env.initial in

--- a/bin/rpc/rpc_common.ml
+++ b/bin/rpc/rpc_common.ml
@@ -105,6 +105,31 @@ let prepare_targets targets =
     Dune_lang.to_string sexp)
 ;;
 
+let prepare_targets_relative_to_root (root : Workspace_root.t) targets =
+  let prefix = root.reach_from_root_prefix in
+  let prefix_path path =
+    let loc = Dune_lang.String_with_vars.loc path in
+    match Dune_lang.String_with_vars.known_prefix path with
+    | Full path ->
+      let path = if Filename.is_relative path then prefix ^ path else path in
+      Path.relative Path.root path
+      |> Path.to_string
+      |> Dune_lang.String_with_vars.make_text loc
+    | Partial { prefix = ""; source_pform = _ } ->
+      Dune_lang.String_with_vars.add_prefix path prefix
+    | Partial { prefix = path_prefix; source_pform = _ } ->
+      if Filename.is_relative path_prefix
+      then Dune_lang.String_with_vars.add_prefix path prefix
+      else path
+  in
+  List.map targets ~f:(function
+    | Dune_lang.Dep_conf.File path -> Dune_lang.Dep_conf.File (prefix_path path)
+    | Alias path -> Dune_lang.Dep_conf.Alias (prefix_path path)
+    | Alias_rec path -> Dune_lang.Dep_conf.Alias_rec (prefix_path path)
+    | target -> target)
+  |> prepare_targets
+;;
+
 let warn_ignore_arguments lock_held_by =
   User_warning.emit
     [ Pp.paragraphf

--- a/bin/rpc/rpc_common.mli
+++ b/bin/rpc/rpc_common.mli
@@ -17,6 +17,13 @@ val wait_term : bool Cmdliner.Term.t
     be sent via RPC. *)
 val prepare_targets : Dune_lang.Dep_conf.t list -> string list
 
+(** Rebase relative target paths from the client's directory to its workspace
+    root. *)
+val prepare_targets_relative_to_root
+  :  Workspace_root.t
+  -> Dune_lang.Dep_conf.t list
+  -> string list
+
 (** Send a request to the RPC server. If [wait], it will poll forever until a server is listening.
     Should be scheduled by a scheduler that does not come with a RPC server on its own.
 

--- a/bin/runtest.ml
+++ b/bin/runtest.ml
@@ -47,6 +47,13 @@ let runtest_term =
         ~to_cwd:(Common.root common).to_cwd
         ~test_paths)
   | Error lock_held_by ->
+    let test_paths =
+      List.map test_paths ~f:(fun path ->
+        let path =
+          if Filename.is_relative path then Common.prefix_target common path else path
+        in
+        Path.relative Path.root path |> Path.to_string)
+    in
     Scheduler_setup.no_build_no_rpc ~config (fun () ->
       let open Fiber.O in
       Rpc.Rpc_common.fire_request

--- a/doc/changes/fixed/16267.md
+++ b/doc/changes/fixed/16267.md
@@ -1,0 +1,3 @@
+- Resolve relative paths in forwarded build, runtest, and exec commands from
+  the client's directory instead of the RPC server's directory (#16267,
+  @rgrinberg)

--- a/src/dune_lang/string_with_vars.ml
+++ b/src/dune_lang/string_with_vars.ml
@@ -41,6 +41,19 @@ let compare_no_loc { quoted; parts; loc = _ } t =
 ;;
 
 let equal_no_loc t1 t2 = Ordering.is_eq (compare_no_loc t1 t2)
+
+let add_prefix t prefix =
+  if String.equal prefix ""
+  then t
+  else (
+    let parts =
+      match t.parts with
+      | Text text :: parts -> Text (prefix ^ text) :: parts
+      | parts -> Text prefix :: parts
+    in
+    { t with parts })
+;;
+
 let make_text ?(quoted = false) loc s = { quoted; loc; parts = [ Text s ] }
 
 let part_of_pform loc pform =

--- a/src/dune_lang/string_with_vars.mli
+++ b/src/dune_lang/string_with_vars.mli
@@ -13,6 +13,9 @@ val compare : t -> t -> Ordering.t
 val compare_no_loc : t -> t -> Ordering.t
 val equal_no_loc : t -> t -> bool
 
+(** Add text before the first part of the string. *)
+val add_prefix : t -> string -> t
+
 (** [loc t] returns the location of [t] — typically, in the [dune] file. *)
 val loc : t -> Loc.t
 

--- a/test/blackbox-tests/test-cases/watching/rpc-relative-paths.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-relative-paths.t
@@ -1,5 +1,4 @@
-RPC build requests currently interpret relative paths from the server's working
-directory rather than the client's working directory.
+RPC build requests interpret relative paths from the client's working directory.
 
 Root discovery is disabled inside tests, so add a workspace file and unset
 INSIDE_DUNE for commands run from subdirectories.
@@ -33,8 +32,8 @@ INSIDE_DUNE for commands run from subdirectories.
   > EOF
   $ echo 'let ()=print_int (6+5)' > sub/nested.ml
 
-Start the server from a third directory so that incorrect resolution from its
-working directory is visible.
+Start the server from a third directory so its working directory cannot affect
+how it interprets the paths sent by the client.
 
   $ mkdir server
   $ cat > server/dune <<'EOF'
@@ -55,28 +54,28 @@ working directory is visible.
   $ start_dune
   $ cd ..
 
-A forwarded build resolves its target from the server's directory.
+A forwarded build resolves its target from the client's directory.
 
   $ (cd sub && unset INSIDE_DUNE; dune build rpc-build-target) 2>/dev/null
   $ find _build/default -name rpc-build-target -type f -print
-  _build/default/server/rpc-build-target
+  _build/default/sub/rpc-build-target
 
-The build request made by exec also loses the client's directory.
+Exec also builds relative programs from the client's directory.
 
   $ (cd sub && dune exec ./nested.exe) >/dev/null 2>&1
-  [1]
   $ find _build/default -name nested.exe -type f -print
+  _build/default/sub/nested.exe
 
-The default target also resolves from the server's directory.
+The default target is also relative to the client's directory.
 
   $ (cd sub && dune build) 2>/dev/null
   $ find _build/default -name '*.exe' -type f -print
-  _build/default/server/server.exe
+  _build/default/sub/nested.exe
 
-A forwarded runtest request does the same.
+A forwarded runtest request also uses the client's directory.
 
   $ (cd sub && unset INSIDE_DUNE; dune runtest) 2>/dev/null
   $ find _build/default -name 'rpc-runtest-*' -type f -print
-  _build/default/server/rpc-runtest-server
+  _build/default/sub/rpc-runtest-sub
 
   $ stop_dune_quiet


### PR DESCRIPTION
Relative build, runtest, and exec paths forwarded to a running Dune process were interpreted from the server's startup directory. Rebase them from the client invocation to the workspace root before sending, and interpret them from that root on the server.