### PR TITLE
fix(melange): prefer melobjinfo for imported virtual-library dependencies

### DIFF
--- a/doc/changes/fixed/16211.md
+++ b/doc/changes/fixed/16211.md
@@ -1,3 +1,3 @@
 - Fix compiling Melange implementations of installed virtual libraries, both
   with and without binary annotations, including transitive private module
-  dependencies (#16211, #16212, @anmonteiro)
+  dependencies (#16211, #16212, #16272, @anmonteiro)

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -148,6 +148,16 @@ let transitive_dep m =
     Some (Module.obj_name m, if Module.has m ~ml_kind:Intf then Ml_kind.Intf else Impl)
 ;;
 
+let imported_vlib_modules ~vlib_obj_map ~self imports =
+  Module_name.Unique.Set.to_list imports
+  |> List.filter_map ~f:(fun dep ->
+    if Module_name.Unique.equal self dep
+    then None
+    else
+      Module_name.Unique.Map.find vlib_obj_map dep
+      |> Option.map ~f:Modules.Sourced_module.to_module)
+;;
+
 let ooi_deps
       ~vimpl
       ~sctx
@@ -172,13 +182,7 @@ let ooi_deps
       | [] | _ :: _ -> assert false)
     |> Action_builder.memoize "ocamlobjinfo"
     |> Action_builder.map ~f:(fun (ooi : Ocamlobjinfo.t) ->
-      Module_name.Unique.Set.to_list ooi.intf
-      |> List.filter_map ~f:(fun dep ->
-        if Module.obj_name m = dep
-        then None
-        else
-          Module_name.Unique.Map.find vlib_obj_map dep
-          |> Option.map ~f:Modules.Sourced_module.to_module))
+      imported_vlib_modules ~vlib_obj_map ~self:(Module.obj_name m) ooi.intf)
   in
   let read_copied kind =
     Obj_dir.Module.cm_file_exn obj_dir m ~kind |> Path.build |> read
@@ -199,6 +203,58 @@ let ooi_deps
         with
         | None -> no_deps
         | Some cmt -> Action_builder.if_file_exists cmt ~then_:(read cmt) ~else_:no_deps))
+;;
+
+let make_melobjinfo_deps ~sctx ~dir ~sandbox ~vlib_obj_dir ~vlib_obj_map =
+  let files =
+    Module_name.Unique.Map.values vlib_obj_map
+    |> List.filter_map ~f:(fun sourced_module ->
+      let m = Modules.Sourced_module.to_module sourced_module in
+      Obj_dir.Module.cm_file vlib_obj_dir m ~kind:(Melange Cmj)
+      |> Option.map ~f:(fun path -> m, path))
+  in
+  Memo.lazy_ ~name:"installed-melange-vlib-melobjinfo-deps" (fun () ->
+    let* program = Melange_binary.melobjinfo sctx ~loc:None ~dir in
+    match program with
+    | Error _ -> Memo.return None
+    | Ok _ ->
+      let deps =
+        match files with
+        | [] -> Action_builder.return Module_name.Unique.Map.empty
+        | _ :: _ ->
+          let action =
+            let open Action_builder.O in
+            let+ action =
+              Command.run'
+                ?sandbox
+                ~dir:(Path.build dir)
+                program
+                [ Deps (List.map files ~f:snd) ]
+            in
+            { Rule.Anonymous_action.action; loc = Loc.none; dir }
+          in
+          Build_system.execute_action_stdout action
+          |> Memo.map ~f:Ocamlobjinfo.parse
+          |> Action_builder.of_memo
+          |> Action_builder.map ~f:(fun results ->
+            let expected = List.length files in
+            let actual = List.length results in
+            if expected <> actual
+            then
+              Code_error.raise
+                "unexpected number of melobjinfo results"
+                [ "expected", Dyn.int expected; "actual", Dyn.int actual ];
+            List.combine files results
+            |> List.fold_left
+                 ~init:Module_name.Unique.Map.empty
+                 ~f:(fun deps ((m, _), (ooi : Ocamlobjinfo.t)) ->
+                   let self = Module.obj_name m in
+                   let imports = imported_vlib_modules ~vlib_obj_map ~self ooi.impl in
+                   Module_name.Unique.Map.set deps self imports))
+      in
+      Action_builder.memoize "installed Melange vlib melobjinfo deps" deps
+      |> Option.some
+      |> Memo.return)
 ;;
 
 let wrapped_compat_deps modules m =
@@ -225,16 +281,16 @@ let preprocessed_modules_of_local_lib ~sctx lib ~for_ =
   Pp_spec.pped_modules preprocess version modules
 ;;
 
-type imported_vlib_impl_deps =
-  | Transitive
-  | Immediate of { stage_copied_objects_if_cmt_missing : unit Action_builder.t Lazy.t }
+type imported_vlib_deps_result =
+  | Transitive of Module.t list
+  | Immediate of (Module.t * Ml_kind.t) list
 
 type imported_vlib_deps =
   { deps_of :
       Modules.Sourced_module.t
       -> ml_kind:Ml_kind.t
-      -> Module.t list Action_builder.t Memo.t
-  ; impl_deps : imported_vlib_impl_deps
+      -> imported_vlib_deps_result Action_builder.t Memo.t
+  ; stage_copied_objects_if_cmt_missing : unit Action_builder.t Lazy.t option
   }
 
 type memoized_transitive_deps =
@@ -330,28 +386,31 @@ and transitive_deps_output_of_imported_vlib t m ~ml_kind =
       ; "ml_kind", Ml_kind.to_dyn ml_kind
       ; "dir", Path.Build.to_dyn t.dir
       ]
-  | Some { deps_of; impl_deps } ->
+  | Some { deps_of; _ } ->
     let open Action_builder.O in
     let* deps =
       Action_builder.of_memo
         (deps_of (Modules.Sourced_module.Imported_from_vlib m) ~ml_kind)
     in
     let* deps = deps in
-    (match ml_kind, impl_deps with
-     | Intf, _ | Impl, Transitive ->
-       Transitive_deps_output.of_modules deps |> Action_builder.return
-     | Impl, Immediate _ ->
+    (match deps with
+     | Transitive deps -> Transitive_deps_output.of_modules deps |> Action_builder.return
+     | Immediate deps ->
        let transitive =
-         List.filter_map deps ~f:(fun dep ->
+         List.filter_map deps ~f:(fun (dep, ml_kind) ->
            match Module.kind dep with
            | Root | Alias _ -> None
            | _ ->
-             let ml_kind = if Module.has dep ~ml_kind:Impl then Ml_kind.Impl else Intf in
+             let ml_kind =
+               match ml_kind with
+               | Ml_kind.Intf -> Ml_kind.Intf
+               | Impl -> if Module.has dep ~ml_kind:Impl then Ml_kind.Impl else Intf
+             in
              Some
                (Action_builder.exec_memo (Lazy.force t.memo) (Module.obj_name dep, ml_kind)
                 |> Action_builder.map ~f:(fun memoized -> memoized.output)))
        in
-       let immediate = List.map deps ~f:Module.obj_name in
+       let immediate = List.map deps ~f:(fun (dep, _) -> Module.obj_name dep) in
        Transitive_deps_output.merge ~dir:t.dir ~transitive ~immediate)
 ;;
 
@@ -372,11 +431,12 @@ let transitive_deps_of t ~ml_kind unit =
               (Ml_kind.to_string ml_kind))
   in
   match ml_kind, t.imported_vlib_deps with
-  | Intf, _ | Impl, None | Impl, Some { impl_deps = Transitive; _ } -> deps
-  | Impl, Some { impl_deps = Immediate { stage_copied_objects_if_cmt_missing }; _ } ->
+  | Impl, Some { stage_copied_objects_if_cmt_missing = Some stage; _ } ->
     let open Action_builder.O in
     let+ deps = deps
-    and+ () = Lazy.force stage_copied_objects_if_cmt_missing in
+    and+ () = Lazy.force stage in
+    deps
+  | Intf, _ | Impl, None | Impl, Some { stage_copied_objects_if_cmt_missing = None; _ } ->
     deps
 ;;
 
@@ -387,58 +447,105 @@ let make_imported_vlib_deps ~obj_dir ~vimpl ~dir ~sctx ~sandbox ~for_ : imported
   | None ->
     let vlib_obj_map = Vimpl.vlib_obj_map vimpl in
     let vlib_obj_dir = Lib.info vlib |> Lib_info.obj_dir in
-    let impl_deps =
-      match for_ with
-      | Compilation_mode.Ocaml -> Transitive
-      | Compilation_mode.Melange ->
-        let stage_copied_objects_if_cmt_missing =
-          lazy
-            (let modules =
-               Module_name.Unique.Map.values vlib_obj_map
-               |> List.map ~f:Modules.Sourced_module.to_module
-             in
-             (* Without CMTs, stage every copied vlib object directly. Adding them as
-                module-graph edges could introduce cycles that aren't in the source. *)
-             let cmts =
-               List.filter_map modules ~f:(fun m ->
-                 Obj_dir.Module.cmt_file
-                   vlib_obj_dir
-                   m
-                   ~ml_kind:Impl
-                   ~cm_kind:(Melange Cmj))
-             in
-             (let open Action_builder.O in
-              let* cmts_exist =
-                List.map cmts ~f:Action_builder.file_exists |> Action_builder.all
-              in
-              if List.for_all cmts_exist ~f:Fun.id
-              then Action_builder.return ()
-              else (
-                let files =
-                  Obj_dir.Module.L.cm_files obj_dir modules ~kind:(Melange Cmi)
-                  @ Obj_dir.Module.L.cm_files obj_dir modules ~kind:(Melange Cmj)
-                in
-                Action_builder.paths files))
-             |> Action_builder.memoize "stage copied vlib objects if CMT missing")
-        in
-        Immediate { stage_copied_objects_if_cmt_missing }
-    in
     let dune_version =
       let impl = Vimpl.impl vimpl in
       Dune_project.dune_version impl.project
     in
-    { deps_of =
-        ooi_deps
-          ~vimpl
-          ~sctx
-          ~dir
-          ~obj_dir
-          ~vlib_obj_dir
-          ~dune_version
-          ~vlib_obj_map
-          ~for_
-    ; impl_deps
-    }
+    let deps_from_ooi =
+      ooi_deps ~vimpl ~sctx ~dir ~obj_dir ~vlib_obj_dir ~dune_version ~vlib_obj_map ~for_
+    in
+    (match for_ with
+     | Compilation_mode.Ocaml ->
+       let deps_of sourced_module ~ml_kind =
+         let+ deps = deps_from_ooi sourced_module ~ml_kind in
+         Action_builder.map deps ~f:(fun deps -> Transitive deps)
+       in
+       { deps_of; stage_copied_objects_if_cmt_missing = None }
+     | Compilation_mode.Melange ->
+       let object_info_sandbox =
+         if dune_version >= (3, 3) then Some Sandbox_config.needs_sandboxing else None
+       in
+       let melobjinfo_deps =
+         make_melobjinfo_deps
+           ~sctx
+           ~dir
+           ~sandbox:object_info_sandbox
+           ~vlib_obj_dir
+           ~vlib_obj_map
+       in
+       let fallback_impl_deps sourced_module =
+         let+ deps = deps_from_ooi sourced_module ~ml_kind:Impl in
+         Action_builder.map deps ~f:(fun deps ->
+           Immediate
+             (List.map deps ~f:(fun dep ->
+                let ml_kind =
+                  if Module.has dep ~ml_kind:Impl then Ml_kind.Impl else Intf
+                in
+                dep, ml_kind)))
+       in
+       let deps_of sourced_module ~(ml_kind : Ml_kind.t) =
+         match ml_kind with
+         | Ml_kind.Intf ->
+           let+ deps = deps_from_ooi sourced_module ~ml_kind:Intf in
+           Action_builder.map deps ~f:(fun deps -> Transitive deps)
+         | Impl ->
+           let* melobjinfo_deps = Memo.Lazy.force melobjinfo_deps in
+           (match melobjinfo_deps with
+            | None -> fallback_impl_deps sourced_module
+            | Some impl_deps ->
+              let+ intf_deps = deps_from_ooi sourced_module ~ml_kind:Intf in
+              let obj_name =
+                Modules.Sourced_module.to_module sourced_module |> Module.obj_name
+              in
+              let open Action_builder.O in
+              let+ intf_deps = intf_deps
+              and+ impl_deps =
+                Action_builder.map impl_deps ~f:(fun deps ->
+                  Module_name.Unique.Map.find deps obj_name |> Option.value ~default:[])
+              in
+              Immediate
+                (List.map intf_deps ~f:(fun dep -> dep, Ml_kind.Intf)
+                 @ List.map impl_deps ~f:(fun dep -> dep, Ml_kind.Impl)))
+       in
+       let stage_copied_objects_if_cmt_missing =
+         lazy
+           ((let open Action_builder.O in
+             let* melobjinfo_deps =
+               Action_builder.of_memo (Memo.Lazy.force melobjinfo_deps)
+             in
+             match melobjinfo_deps with
+             | Some _ -> Action_builder.return ()
+             | None ->
+               let modules =
+                 Module_name.Unique.Map.values vlib_obj_map
+                 |> List.map ~f:Modules.Sourced_module.to_module
+               in
+               (* Without CMTs, stage every copied vlib object directly. Adding them as
+                  module-graph edges could introduce cycles that aren't in the source. *)
+               let cmts =
+                 List.filter_map modules ~f:(fun m ->
+                   Obj_dir.Module.cmt_file
+                     vlib_obj_dir
+                     m
+                     ~ml_kind:Impl
+                     ~cm_kind:(Melange Cmj))
+               in
+               let* cmts_exist =
+                 List.map cmts ~f:Action_builder.file_exists |> Action_builder.all
+               in
+               if List.for_all cmts_exist ~f:Fun.id
+               then Action_builder.return ()
+               else (
+                 let files =
+                   Obj_dir.Module.L.cm_files obj_dir modules ~kind:(Melange Cmi)
+                   @ Obj_dir.Module.L.cm_files obj_dir modules ~kind:(Melange Cmj)
+                 in
+                 Action_builder.paths files))
+            |> Action_builder.memoize "stage copied vlib objects if CMT missing")
+       in
+       { deps_of
+       ; stage_copied_objects_if_cmt_missing = Some stage_copied_objects_if_cmt_missing
+       })
   | Some lib ->
     let vlib_obj_dir =
       let info = Lib.Local.info lib in
@@ -459,9 +566,11 @@ let make_imported_vlib_deps ~obj_dir ~vimpl ~dir ~sctx ~sandbox ~for_ : imported
     let deps_of sourced_module ~ml_kind =
       let* transitive_deps = Memo.Lazy.force transitive_deps in
       let m = Modules.Sourced_module.to_module sourced_module in
-      transitive_deps_of transitive_deps ~ml_kind m |> Memo.return
+      transitive_deps_of transitive_deps ~ml_kind m
+      |> Action_builder.map ~f:(fun deps -> Transitive deps)
+      |> Memo.return
     in
-    { deps_of; impl_deps = Transitive }
+    { deps_of; stage_copied_objects_if_cmt_missing = None }
 ;;
 
 let make_transitive_deps ~obj_dir ~modules ~sandbox ~impl ~dir ~sctx ~for_ =
@@ -530,7 +639,11 @@ let rec deps_of
        | None -> Code_error.raise "imported vlib module without vlib deps" []
        | Some imported_vlib_deps ->
          skip_if_source_absent
-           (fun sourced_module -> imported_vlib_deps.deps_of sourced_module ~ml_kind)
+           (fun sourced_module ->
+              let+ deps = imported_vlib_deps.deps_of sourced_module ~ml_kind in
+              Action_builder.map deps ~f:(function
+                | Transitive deps -> deps
+                | Immediate deps -> List.map deps ~f:fst))
            m)
     | Normal _ ->
       skip_if_source_absent

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -223,17 +223,13 @@ let make_melobjinfo_deps ~sctx ~dir ~sandbox ~vlib_obj_dir ~vlib_obj_map =
         | [] -> Action_builder.return Module_name.Unique.Map.empty
         | _ :: _ ->
           let action =
-            let open Action_builder.O in
-            let+ action =
-              Command.run'
-                ?sandbox
-                ~dir:(Path.build dir)
-                program
-                [ Deps (List.map files ~f:snd) ]
-            in
-            { Rule.Anonymous_action.action; loc = Loc.none; dir }
+            Command.run'
+              ?sandbox
+              ~dir:(Path.build dir)
+              program
+              [ Deps (List.map files ~f:snd) ]
           in
-          Build_system.execute_action_stdout action
+          Super_context.execute_action_stdout sctx ~loc:Loc.none ~dir action
           |> Memo.map ~f:Ocamlobjinfo.parse
           |> Action_builder.of_memo
           |> Action_builder.map ~f:(fun results ->

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -286,7 +286,7 @@ type imported_vlib_deps =
       Modules.Sourced_module.t
       -> ml_kind:Ml_kind.t
       -> imported_vlib_deps_result Action_builder.t Memo.t
-  ; stage_copied_objects_if_cmt_missing : unit Action_builder.t Lazy.t option
+  ; stage_copied_objects_if_dep_info_missing : unit Action_builder.t Lazy.t option
   }
 
 type memoized_transitive_deps =
@@ -427,13 +427,14 @@ let transitive_deps_of t ~ml_kind unit =
               (Ml_kind.to_string ml_kind))
   in
   match ml_kind, t.imported_vlib_deps with
-  | Impl, Some { stage_copied_objects_if_cmt_missing = Some stage; _ } ->
+  | Impl, Some { stage_copied_objects_if_dep_info_missing = Some stage; _ } ->
     let open Action_builder.O in
     let+ deps = deps
     and+ () = Lazy.force stage in
     deps
-  | Intf, _ | Impl, None | Impl, Some { stage_copied_objects_if_cmt_missing = None; _ } ->
-    deps
+  | Intf, _
+  | Impl, None
+  | Impl, Some { stage_copied_objects_if_dep_info_missing = None; _ } -> deps
 ;;
 
 let make_imported_vlib_deps ~obj_dir ~vimpl ~dir ~sctx ~sandbox ~for_ : imported_vlib_deps
@@ -456,7 +457,7 @@ let make_imported_vlib_deps ~obj_dir ~vimpl ~dir ~sctx ~sandbox ~for_ : imported
          let+ deps = deps_from_ooi sourced_module ~ml_kind in
          Action_builder.map deps ~f:(fun deps -> Transitive deps)
        in
-       { deps_of; stage_copied_objects_if_cmt_missing = None }
+       { deps_of; stage_copied_objects_if_dep_info_missing = None }
      | Compilation_mode.Melange ->
        let object_info_sandbox =
          if dune_version >= (3, 3) then Some Sandbox_config.needs_sandboxing else None
@@ -503,7 +504,7 @@ let make_imported_vlib_deps ~obj_dir ~vimpl ~dir ~sctx ~sandbox ~for_ : imported
                 (List.map intf_deps ~f:(fun dep -> dep, Ml_kind.Intf)
                  @ List.map impl_deps ~f:(fun dep -> dep, Ml_kind.Impl)))
        in
-       let stage_copied_objects_if_cmt_missing =
+       let stage_copied_objects_if_dep_info_missing =
          lazy
            ((let open Action_builder.O in
              let* melobjinfo_deps =
@@ -537,10 +538,12 @@ let make_imported_vlib_deps ~obj_dir ~vimpl ~dir ~sctx ~sandbox ~for_ : imported
                    @ Obj_dir.Module.L.cm_files obj_dir modules ~kind:(Melange Cmj)
                  in
                  Action_builder.paths files))
-            |> Action_builder.memoize "stage copied vlib objects if CMT missing")
+            |> Action_builder.memoize
+                 "stage copied vlib objects if dependency info missing")
        in
        { deps_of
-       ; stage_copied_objects_if_cmt_missing = Some stage_copied_objects_if_cmt_missing
+       ; stage_copied_objects_if_dep_info_missing =
+           Some stage_copied_objects_if_dep_info_missing
        })
   | Some lib ->
     let vlib_obj_dir =
@@ -566,7 +569,7 @@ let make_imported_vlib_deps ~obj_dir ~vimpl ~dir ~sctx ~sandbox ~for_ : imported
       |> Action_builder.map ~f:(fun deps -> Transitive deps)
       |> Memo.return
     in
-    { deps_of; stage_copied_objects_if_cmt_missing = None }
+    { deps_of; stage_copied_objects_if_dep_info_missing = None }
 ;;
 
 let make_transitive_deps ~obj_dir ~modules ~sandbox ~impl ~dir ~sctx ~for_ =

--- a/src/dune_rules/melange/melange_binary.ml
+++ b/src/dune_rules/melange/melange_binary.ml
@@ -1,15 +1,18 @@
 open Import
 open Memo.O
 
-let melc sctx ~loc ~dir =
+let resolve_program sctx ~loc ~dir name =
   Super_context.resolve_program_memo
     sctx
     ~loc
     ~dir
     ~where:Original_path
     ~hint:"opam install melange"
-    "melc"
+    name
 ;;
+
+let melc sctx ~loc ~dir = resolve_program sctx ~loc ~dir "melc"
+let melobjinfo sctx ~loc ~dir = resolve_program sctx ~loc ~dir "melobjinfo"
 
 let available sctx ~dir =
   let+ melc = melc sctx ~loc:None ~dir in

--- a/src/dune_rules/melange/melange_binary.mli
+++ b/src/dune_rules/melange/melange_binary.mli
@@ -1,5 +1,12 @@
 open Import
 
 val melc : Super_context.t -> loc:Loc.t option -> dir:Path.Build.t -> Action.Prog.t Memo.t
+
+val melobjinfo
+  :  Super_context.t
+  -> loc:Loc.t option
+  -> dir:Path.Build.t
+  -> Action.Prog.t Memo.t
+
 val available : Super_context.t -> dir:Path.Build.t -> bool Memo.t
 val where : Super_context.t -> loc:Loc.t option -> dir:Path.Build.t -> Path.t list Memo.t

--- a/src/dune_rules/ocamlobjinfo.mli
+++ b/src/dune_rules/ocamlobjinfo.mli
@@ -21,7 +21,8 @@ val archive_rules
   -> archive:Path.t
   -> Module_name.Unique.Set.t Action_builder.t
 
-(** For testing only *)
+(** Parse the output of an object-info tool that follows the [ocamlobjinfo]
+    format. *)
 val parse : string -> t list
 
 (** Parse archive output to extract module names defined in the archive *)

--- a/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps-no-cmt.t
+++ b/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps-no-cmt.t
@@ -46,6 +46,21 @@ stage copied objects when binary annotations are unavailable.
   $ test -e "$PWD/prefix/lib/repro/vlib/melange/.private/vlib__Helper.cmi"
   $ test ! -e "$PWD/prefix/lib/repro/vlib/melange/.private/vlib__Helper.cmt"
 
+Keep the fallback independent of whether the test environment provides
+melobjinfo.
+
+  $ mkdir no-melobjinfo-bin
+  $ for program in dune melc ocamlc ocamlopt ocamldep ocamlobjinfo; do
+  >   command -v "$program" > "no-melobjinfo-bin/$program.target"
+  >   cat > "no-melobjinfo-bin/$program" <<'EOF'
+  > #!/bin/sh
+  > IFS= read -r target < "$0.target"
+  > exec "$target" "$@"
+  > EOF
+  >   chmod +x "no-melobjinfo-bin/$program"
+  > done
+  $ no_melobjinfo_path="$PWD/no-melobjinfo-bin"
+
   $ cat > consumer/dune-project <<'EOF'
   > (lang dune 3.24)
   > (using melange 1.0)
@@ -76,10 +91,10 @@ not turn copied artifacts into a Virt-to-Reverse module dependency cycle.
   >  (libraries impl))
   > EOF
 
-  $ OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
+  $ PATH="$no_melobjinfo_path" OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
   > dune build --root consumer --sandbox=symlink @melange
 
-  $ OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
+  $ PATH="$no_melobjinfo_path" OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
   > dune rules --root consumer --recursive --format=json --deps --display=quiet \
   > impl/.impl.objs/melange/vlib__Virt.cmj > deps.json
   $ jq_dune -r '

--- a/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps-no-cmt.t
+++ b/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps-no-cmt.t
@@ -117,8 +117,8 @@ not turn copied artifacts into a Virt-to-Reverse module dependency cycle.
   _build/default/impl/.impl.objs/melange/vlib__Unused.cmj
   _build/default/impl/.impl.objs/melange/vlib__Virt.cmi
 
-The current implementation ignores melobjinfo, so every copied object is still
-staged.
+melobjinfo makes precise dependencies available without CMTs, so unrelated
+copied objects no longer need to be staged.
 
   $ cat > fake-bin/melobjinfo <<'EOF'
   > #!/bin/sh
@@ -151,6 +151,3 @@ staged.
   > ' deps-with-melobjinfo.json
   _build/default/impl/.impl.objs/melange/vlib__Helper.cmi
   _build/default/impl/.impl.objs/melange/vlib__Helper.cmj
-  _build/default/impl/.impl.objs/melange/vlib__Reverse.cmi
-  _build/default/impl/.impl.objs/melange/vlib__Unused.cmi
-  _build/default/impl/.impl.objs/melange/vlib__Unused.cmj

--- a/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps-no-cmt.t
+++ b/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps-no-cmt.t
@@ -1,7 +1,7 @@
 An implementation of an installed Melange virtual library must conservatively
 stage copied objects when binary annotations are unavailable.
 
-  $ mkdir -p producer/vlib consumer/impl
+  $ mkdir -p producer/vlib consumer/impl fake-bin
 
   $ cat > producer/dune-project <<'EOF'
   > (lang dune 3.24)
@@ -116,3 +116,41 @@ not turn copied artifacts into a Virt-to-Reverse module dependency cycle.
   _build/default/impl/.impl.objs/melange/vlib__Unused.cmi
   _build/default/impl/.impl.objs/melange/vlib__Unused.cmj
   _build/default/impl/.impl.objs/melange/vlib__Virt.cmi
+
+The current implementation ignores melobjinfo, so every copied object is still
+staged.
+
+  $ cat > fake-bin/melobjinfo <<'EOF'
+  > #!/bin/sh
+  > for unit do
+  >   printf 'File %s\n' "$unit"
+  >   printf 'Implementations imported:\n'
+  >   case "$unit" in
+  >     *vlib__Shared.cmj)
+  >       printf '  --------------------------------  Vlib__Helper\n'
+  >       ;;
+  >   esac
+  > done
+  > EOF
+  $ chmod +x fake-bin/melobjinfo
+
+  $ PATH="$PWD/fake-bin:$no_melobjinfo_path" \
+  > OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
+  > dune rules --root consumer --recursive --format=json --deps --display=quiet \
+  > impl/.impl.objs/melange/vlib__Virt.cmj > deps-with-melobjinfo.json
+  $ jq_dune -r '
+  >   [.[] | depsFilePaths
+  >    | select(endswith("vlib__Helper.cmi")
+  >             or endswith("vlib__Helper.cmj")
+  >             or endswith("vlib__Reverse.cmi")
+  >             or endswith("vlib__Reverse.cmj")
+  >             or endswith("vlib__Unused.cmi")
+  >             or endswith("vlib__Unused.cmj"))
+  >    | select(startswith("_build/default/impl/.impl.objs/melange/"))]
+  >   | unique[]
+  > ' deps-with-melobjinfo.json
+  _build/default/impl/.impl.objs/melange/vlib__Helper.cmi
+  _build/default/impl/.impl.objs/melange/vlib__Helper.cmj
+  _build/default/impl/.impl.objs/melange/vlib__Reverse.cmi
+  _build/default/impl/.impl.objs/melange/vlib__Unused.cmi
+  _build/default/impl/.impl.objs/melange/vlib__Unused.cmj

--- a/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps.t
+++ b/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps.t
@@ -151,9 +151,9 @@ CMT, including private modules but excluding unused ones.
   _build/default/impl/.impl.objs/melange/vlib__Type_runtime.cmj
   _build/default/impl/.impl.objs/melange/vlib__Virt.cmi
 
-The current implementation ignores melobjinfo. It therefore still follows
-Type_only's implementation dependency on Type_runtime, even though Shared only
-imports Type_only through its interface.
+When melobjinfo is available, it takes precedence over CMT analysis.
+Implementation dependencies are followed through CMJs, while interface-only
+dependencies are followed through CMIs.
 
   $ cat > fake-bin/melobjinfo <<'EOF'
   > #!/bin/sh
@@ -197,7 +197,7 @@ imports Type_only through its interface.
   $ dune trace cat --trace-file "$PWD/trace" \
   > | jq_dune -s \
   >   '[.[] | processesBrief | select(.prog == "melobjinfo")] | length'
-  0
+  1
 
   $ PATH="$PWD/fake-bin:$no_melobjinfo_path" \
   > OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
@@ -224,8 +224,10 @@ imports Type_only through its interface.
   _build/default/impl/.impl.objs/melange/vlib__Other_type.cmj
   _build/default/impl/.impl.objs/melange/vlib__Type_only.cmi
   _build/default/impl/.impl.objs/melange/vlib__Type_only.cmj
-  _build/default/impl/.impl.objs/melange/vlib__Type_runtime.cmi
-  _build/default/impl/.impl.objs/melange/vlib__Type_runtime.cmj
+
+Other is virtual, so its implementation dependency is normalized to an
+interface dependency and leads to Other_type. Type_only is also part of
+Shared's interface, so its CMJ-only dependency on Type_runtime is not followed.
 
 The missing-annotation fallback is deliberately conservative at the library
 level. Even when the missing CMT belongs to an unreachable module, every copied

--- a/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps.t
+++ b/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps.t
@@ -47,6 +47,21 @@ The virtual library and its implementation are both Melange-only.
   $ test -e "$PWD/prefix/lib/repro/vlib/melange/.private/vlib__Helper.cmt"
   $ test -e "$PWD/prefix/lib/repro/vlib/melange/.private/vlib__Leaf.cmt"
 
+Keep the fallback independent of whether the test environment provides
+melobjinfo.
+
+  $ mkdir no-melobjinfo-bin
+  $ for program in dune melc ocamlc ocamlopt ocamldep ocamlobjinfo; do
+  >   command -v "$program" > "no-melobjinfo-bin/$program.target"
+  >   cat > "no-melobjinfo-bin/$program" <<'EOF'
+  > #!/bin/sh
+  > IFS= read -r target < "$0.target"
+  > exec "$target" "$@"
+  > EOF
+  >   chmod +x "no-melobjinfo-bin/$program"
+  > done
+  $ no_melobjinfo_path="$PWD/no-melobjinfo-bin"
+
   $ cat > consumer/dune-project <<'EOF'
   > (lang dune 3.24)
   > (using melange 1.0)
@@ -73,13 +88,13 @@ The virtual library and its implementation are both Melange-only.
   >  (libraries impl))
   > EOF
 
-  $ OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
+  $ PATH="$no_melobjinfo_path" OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
   > dune build --root consumer --sandbox=symlink @melange
 
 With annotations, dependency analysis should read the precise imports from the
 CMT, including private modules but excluding unused ones.
 
-  $ OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
+  $ PATH="$no_melobjinfo_path" OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
   > dune rules --root consumer --recursive --format=json --deps --display=quiet \
   > impl/.impl.objs/melange/vlib__Virt.cmj > deps.json
   $ jq_dune -r '
@@ -110,7 +125,7 @@ level. Even when the missing CMT belongs to an unreachable module, every copied
 object is staged.
 
   $ rm "$PWD/prefix/lib/repro/vlib/melange/.private/vlib__Unused.cmt"
-  $ OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
+  $ PATH="$no_melobjinfo_path" OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
   > dune rules --root consumer --recursive --format=json --deps --display=quiet \
   > impl/.impl.objs/melange/vlib__Virt.cmj > deps-with-missing-cmt.json
   $ jq_dune -r '

--- a/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps.t
+++ b/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps.t
@@ -1,7 +1,7 @@
 An implementation of an installed Melange virtual library must analyze the
 installed modules using Melange object files.
 
-  $ mkdir -p producer/vlib consumer/impl
+  $ mkdir -p producer/vlib consumer/impl fake-bin
 
   $ cat > producer/dune-project <<'EOF'
   > (lang dune 3.24)
@@ -16,17 +16,24 @@ The virtual library and its implementation are both Melange-only.
   >  (name vlib)
   >  (public_name repro.vlib)
   >  (modes melange)
-  >  (private_modules helper leaf unused)
+  >  (private_modules helper leaf other_type type_only type_runtime unused)
   >  (virtual_modules virt other))
   > EOF
   $ cat > producer/vlib/virt.mli <<'EOF'
   > val run : unit -> int
   > EOF
   $ cat > producer/vlib/other.mli <<'EOF'
-  > val run : unit -> int
+  > val run : Other_type.t -> int
+  > EOF
+  $ cat > producer/vlib/other_type.ml <<'EOF'
+  > type t = int
+  > EOF
+  $ cat > producer/vlib/other_type.mli <<'EOF'
+  > type t = int
   > EOF
   $ cat > producer/vlib/shared.ml <<'EOF'
-  > let answer = Helper.answer + Other.run ()
+  > type t = Type_only.t
+  > let answer = Helper.answer + Other.run 0
   > EOF
   $ cat > producer/vlib/helper.ml <<'EOF'
   > let answer = Leaf.answer
@@ -36,6 +43,17 @@ The virtual library and its implementation are both Melange-only.
   > EOF
   $ cat > producer/vlib/leaf.ml <<'EOF'
   > let answer = 42
+  > EOF
+  $ cat > producer/vlib/type_only.ml <<'EOF'
+  > type t = int
+  > let ignored = Type_runtime.value
+  > EOF
+  $ cat > producer/vlib/type_only.mli <<'EOF'
+  > type t = int
+  > val ignored : int
+  > EOF
+  $ cat > producer/vlib/type_runtime.ml <<'EOF'
+  > let value = 0
   > EOF
   $ cat > producer/vlib/unused.ml <<'EOF'
   > let ignored = 0
@@ -75,10 +93,11 @@ melobjinfo.
   >  (implements repro.vlib))
   > EOF
   $ cat > consumer/impl/virt.ml <<'EOF'
+  > let _coerce (x : Shared.t) : int = x
   > let run () = Shared.answer
   > EOF
   $ cat > consumer/impl/other.ml <<'EOF'
-  > let run () = 1
+  > let run _ = 1
   > EOF
   $ cat > consumer/dune <<'EOF'
   > (melange.emit
@@ -105,6 +124,12 @@ CMT, including private modules but excluding unused ones.
   >             or endswith("vlib__Leaf.cmj")
   >             or endswith("vlib__Other.cmi")
   >             or endswith("vlib__Other.cmj")
+  >             or endswith("vlib__Other_type.cmi")
+  >             or endswith("vlib__Other_type.cmj")
+  >             or endswith("vlib__Type_only.cmi")
+  >             or endswith("vlib__Type_only.cmj")
+  >             or endswith("vlib__Type_runtime.cmi")
+  >             or endswith("vlib__Type_runtime.cmj")
   >             or endswith("vlib__Unused.cmi")
   >             or endswith("vlib__Unused.cmj")
   >             or endswith("vlib__Virt.cmi")
@@ -118,7 +143,89 @@ CMT, including private modules but excluding unused ones.
   _build/default/impl/.impl.objs/melange/vlib__Leaf.cmj
   _build/default/impl/.impl.objs/melange/vlib__Other.cmi
   _build/default/impl/.impl.objs/melange/vlib__Other.cmj
+  _build/default/impl/.impl.objs/melange/vlib__Other_type.cmi
+  _build/default/impl/.impl.objs/melange/vlib__Other_type.cmj
+  _build/default/impl/.impl.objs/melange/vlib__Type_only.cmi
+  _build/default/impl/.impl.objs/melange/vlib__Type_only.cmj
+  _build/default/impl/.impl.objs/melange/vlib__Type_runtime.cmi
+  _build/default/impl/.impl.objs/melange/vlib__Type_runtime.cmj
   _build/default/impl/.impl.objs/melange/vlib__Virt.cmi
+
+The current implementation ignores melobjinfo. It therefore still follows
+Type_only's implementation dependency on Type_runtime, even though Shared only
+imports Type_only through its interface.
+
+  $ cat > fake-bin/melobjinfo <<'EOF'
+  > #!/bin/sh
+  > set -eu
+  > seen_shared=false
+  > seen_helper=false
+  > seen_other_type=false
+  > seen_type_only=false
+  > for unit do
+  >   printf 'File %s\n' "$unit"
+  >   printf 'Implementations imported:\n'
+  >   case "$unit" in
+  >     *vlib__Shared.cmj)
+  >       seen_shared=true
+  >       printf '  --------------------------------  Vlib__Helper\n'
+  >       printf '  --------------------------------  Vlib__Other\n'
+  >       ;;
+  >     *vlib__Helper.cmj)
+  >       seen_helper=true
+  >       printf '  --------------------------------  Vlib__Leaf\n'
+  >       ;;
+  >     *vlib__Other_type.cmj)
+  >       seen_other_type=true
+  >       ;;
+  >     *vlib__Type_only.cmj)
+  >       seen_type_only=true
+  >       printf '  --------------------------------  Vlib__Type_runtime\n'
+  >       ;;
+  >   esac
+  > done
+  > test "$seen_shared" = true
+  > test "$seen_helper" = true
+  > test "$seen_other_type" = true
+  > test "$seen_type_only" = true
+  > EOF
+  $ chmod +x fake-bin/melobjinfo
+
+  $ PATH="$PWD/fake-bin:$no_melobjinfo_path" \
+  > OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
+  > dune build --root consumer --sandbox=symlink --trace-file "$PWD/trace" @melange
+  $ dune trace cat --trace-file "$PWD/trace" \
+  > | jq_dune -s \
+  >   '[.[] | processesBrief | select(.prog == "melobjinfo")] | length'
+  0
+
+  $ PATH="$PWD/fake-bin:$no_melobjinfo_path" \
+  > OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
+  > dune rules --root consumer --recursive --format=json --deps --display=quiet \
+  > impl/.impl.objs/melange/vlib__Virt.cmj > deps-with-melobjinfo.json
+  $ jq_dune -r '
+  >   [.[] | depsFilePaths
+  >    | select(endswith("vlib__Leaf.cmi")
+  >             or endswith("vlib__Leaf.cmj")
+  >             or endswith("vlib__Other_type.cmi")
+  >             or endswith("vlib__Other_type.cmj")
+  >             or endswith("vlib__Type_only.cmi")
+  >             or endswith("vlib__Type_only.cmj")
+  >             or endswith("vlib__Type_runtime.cmi")
+  >             or endswith("vlib__Type_runtime.cmj")
+  >             or endswith("vlib__Unused.cmi")
+  >             or endswith("vlib__Unused.cmj"))
+  >    | select(startswith("_build/default/impl/.impl.objs/melange/"))]
+  >   | unique[]
+  > ' deps-with-melobjinfo.json
+  _build/default/impl/.impl.objs/melange/vlib__Leaf.cmi
+  _build/default/impl/.impl.objs/melange/vlib__Leaf.cmj
+  _build/default/impl/.impl.objs/melange/vlib__Other_type.cmi
+  _build/default/impl/.impl.objs/melange/vlib__Other_type.cmj
+  _build/default/impl/.impl.objs/melange/vlib__Type_only.cmi
+  _build/default/impl/.impl.objs/melange/vlib__Type_only.cmj
+  _build/default/impl/.impl.objs/melange/vlib__Type_runtime.cmi
+  _build/default/impl/.impl.objs/melange/vlib__Type_runtime.cmj
 
 The missing-annotation fallback is deliberately conservative at the library
 level. Even when the missing CMT belongs to an unreachable module, every copied


### PR DESCRIPTION
Use melobjinfo to read precise implementation dependencies from installed Melange virtual-library CMJs, while retaining the CMT and conservative fallbacks.

Follow-up to #16211, #16212, and #16213. Test isolation is #16276. Uses melobjinfo from melange-re/melange#1858; the Nix development-shell update is #16271.