### PR TITLE
• Add directory target support to the action plugin

### DIFF
--- a/bin/describe/describe_pp.ml
+++ b/bin/describe/describe_pp.ml
@@ -69,6 +69,7 @@ let execute_pp_action ~sctx file pp_file dump_file =
       | File_and_directory_target_with_the_same_name _ -> assert false
     in
     { Dune_engine.Action_exec.targets = Some targets
+    ; action_targets = Some targets
     ; root = Path.build build_dir
     ; context = Some (Dune_engine.Build_context.create ~name:context)
     ; env

--- a/doc/changes/added/16273.md
+++ b/doc/changes/added/16273.md
@@ -1,0 +1,3 @@
+- Add directory target support to the dynamic action plugin, including an API
+  for constructing and writing non-empty directory trees (#16273,
+  @SR-Lut3t1um)

--- a/otherlibs/dune-action-plugin/src/dune_action_plugin.ml
+++ b/otherlibs/dune-action-plugin/src/dune_action_plugin.ml
@@ -16,9 +16,44 @@ module V1 = struct
     ;;
   end
 
+  module Directory = struct
+    type entry =
+      | File of string
+      | Directory of t
+
+    and t = entry String.Map.t
+
+    let iter t ~f = String.Map.iteri t ~f
+
+    module Builder = struct
+      type empty
+      type nonempty
+      type 'state builder = t
+
+      let empty = String.Map.empty
+
+      let add_entry t ~name entry =
+        if
+          String.is_empty name
+          || Fpath.contains_path_sep name
+          || name = "."
+          || name = ".."
+        then invalid_arg "Directory entry must be a single path component";
+        match String.Map.add t name entry with
+        | Ok t -> t
+        | Error _ -> invalid_arg (Printf.sprintf "duplicate directory entry %s" name)
+      ;;
+
+      let add_file t ~name ~data = add_entry t ~name (File data)
+      let add_directory t ~name ~directory = add_entry t ~name (Directory directory)
+      let build t = t
+    end
+  end
+
   module Fs : sig
     val read_directory : string -> (string list, string) result
     val read_file : string -> (string, string) result
+    val write_directory : string -> Directory.t -> (unit, string) result
     val write_file : string -> string -> (unit, string) result
   end = struct
     let catch_system_exceptions f ~name =
@@ -54,13 +89,33 @@ module V1 = struct
       catch_system_exceptions ~name:"write_file" (fun () ->
         Io.String_path.write_file path data)
     ;;
+
+    let mkdir_p path =
+      match Fpath.mkdir_p_strict path with
+      | `Created | `Already_exists -> ()
+      | `Not_a_dir ->
+        raise (Sys_error (Printf.sprintf "%s exists but is not a directory" path))
+    ;;
+
+    let write_directory path directory =
+      catch_system_exceptions ~name:"write_directory" (fun () ->
+        let rec write path directory =
+          mkdir_p path;
+          Directory.iter directory ~f:(fun name entry ->
+            let path = Filename.concat path name in
+            match entry with
+            | Directory.File data -> Io.String_path.write_file path data
+            | Directory.Directory directory -> write path directory)
+        in
+        write path directory)
+    ;;
   end
 
   module Stage = struct
     type 'a t =
       { action : unit -> 'a
       ; dependencies : Dependency.Set.t
-      ; targets : String.Set.t
+      ; targets : Target.Set.t
       }
 
     let map (t : 'a t) ~f = { t with action = (fun () -> f (t.action ())) }
@@ -68,7 +123,7 @@ module V1 = struct
     let both (t1 : 'a t) (t2 : 'b t) =
       { action = (fun () -> t1.action (), t2.action ())
       ; dependencies = Dependency.Set.union t1.dependencies t2.dependencies
-      ; targets = String.Set.union t1.targets t2.targets
+      ; targets = Target.Set.union t1.targets t2.targets
       }
     ;;
   end
@@ -108,7 +163,7 @@ module V1 = struct
     lift_stage
       { action
       ; dependencies = Dependency.Set.singleton (File path)
-      ; targets = String.Set.empty
+      ; targets = Target.Set.empty
       }
   ;;
 
@@ -116,7 +171,22 @@ module V1 = struct
     let path = Path.to_string path in
     let action () = Fs.write_file path data |> Execution_error.raise_on_fs_error in
     lift_stage
-      { action; dependencies = Dependency.Set.empty; targets = String.Set.singleton path }
+      { action
+      ; dependencies = Dependency.Set.empty
+      ; targets = Target.Set.singleton (Target.File path)
+      }
+  ;;
+
+  let write_directory ~path ~directory =
+    let path = Path.to_string path in
+    let action () =
+      Fs.write_directory path directory |> Execution_error.raise_on_fs_error
+    in
+    lift_stage
+      { action
+      ; dependencies = Dependency.Set.empty
+      ; targets = Target.Set.singleton (Target.Directory path)
+      }
   ;;
 
   let read_directory_with_glob ~path ~glob =
@@ -130,31 +200,80 @@ module V1 = struct
       { action
       ; dependencies =
           Dependency.Set.singleton (Glob { path; glob = Glob.to_string glob })
-      ; targets = String.Set.empty
+      ; targets = Target.Set.empty
       }
   ;;
 
   let rec run_by_dune t context =
+    let is_descendant path ~of_ =
+      match String.drop_prefix path ~prefix:(of_ ^ Filename.dir_sep) with
+      | None -> false
+      | Some path ->
+        (match
+           Result.try_with (fun () ->
+             Stdune.Path.Local.relative Stdune.Path.Local.root path)
+         with
+         | Ok _ -> true
+         | Error _ -> false)
+    in
     match t with
     | Pure () -> Context.respond context Done
     | Stage at ->
       let allowed_targets = Context.targets context in
-      let disallowed_targets = String.Set.diff at.targets allowed_targets in
-      (match String.Set.to_list disallowed_targets with
+      let target_is_allowed ~declared ~produced =
+        match declared, produced with
+        | Target.File declared, Target.File produced -> String.equal declared produced
+        | File _, Directory _ -> false
+        | Directory declared, (File produced | Directory produced) ->
+          String.equal declared produced || is_descendant produced ~of_:declared
+      in
+      let is_allowed produced =
+        Target.Set.exists allowed_targets ~f:(fun declared ->
+          target_is_allowed ~declared ~produced)
+      in
+      let disallowed_targets =
+        Target.Set.filter at.targets ~f:(fun produced -> not (is_allowed produced))
+      in
+      let kind_mismatch = function
+        | Target.File path ->
+          if Target.Set.mem allowed_targets (Directory path)
+          then Some (path, "file", "directory")
+          else None
+        | Directory path ->
+          if Target.Set.mem allowed_targets (File path)
+          then Some (path, "directory", "file")
+          else None
+      in
+      (match Target.Set.to_list disallowed_targets with
        | [] -> ()
-       | [ t ] ->
+       | [ target ] ->
+         let message =
+           match kind_mismatch target with
+           | Some (path, produced_kind, declared_kind) ->
+             Printf.sprintf
+               "The %s target %S was produced, but %S is declared as a %s target in the \
+                dune file."
+               produced_kind
+               path
+               path
+               declared_kind
+           | None ->
+             Printf.sprintf
+               "The %s was produced despite not being declared in the dune file. To fix \
+                this, declare it as a target."
+               (Target.describe target)
+         in
+         Execution_error.raise message
+       | targets ->
          Execution_error.raise
            (Printf.sprintf
-              "%s is written despite not being declared as a target in dune file. To \
-               fix, add it to target list in dune file."
-              t)
-       | ts ->
-         Execution_error.raise
-           (Printf.sprintf
-              "Following files were written despite not being declared as targets in \
+              "The following targets were produced despite not being declared in the \
                dune file:\n\
-               %sTo fix, add them to target list in dune file."
-              (ts |> String.concat ~sep:"\n")));
+               %s\n\
+               To fix this, declare them as targets."
+              (targets
+               |> List.map ~f:(fun target -> "- " ^ Target.describe target)
+               |> String.concat ~sep:"\n")));
       let prepared_dependencies = Context.prepared_dependencies context in
       let required_dependencies =
         Dependency.Set.diff at.dependencies prepared_dependencies

--- a/otherlibs/dune-action-plugin/src/dune_action_plugin.mli
+++ b/otherlibs/dune-action-plugin/src/dune_action_plugin.mli
@@ -20,6 +20,48 @@ module V1 : sig
 
   module Path = Path
 
+  (** An in-memory non-empty directory tree. *)
+  module Directory : sig
+    type t
+
+    (** A builder that prevents constructing empty directory trees. Entry names must be
+        single path components and unique within their directory.
+
+        For example:
+
+        {[
+          let generated =
+            Directory.Builder.empty
+            |> Directory.Builder.add_file ~name:"code.ml" ~data:"let x = 1\n"
+            |> Directory.Builder.build
+          in
+          let output =
+            Directory.Builder.empty
+            |> Directory.Builder.add_file ~name:"README" ~data:"Generated files\n"
+            |> Directory.Builder.add_directory ~name:"lib" ~directory:generated
+            |> Directory.Builder.build
+          in
+          write_directory ~path:(Path.of_string "output") ~directory:output
+        ]} *)
+    module Builder : sig
+      type empty
+      type nonempty
+      type 'state builder
+
+      (** An empty builder. At least one entry must be added before calling [build]. *)
+      val empty : empty builder
+
+      (** Add a file named [name] containing [data]. *)
+      val add_file : _ builder -> name:string -> data:string -> nonempty builder
+
+      (** Add [directory] as a subdirectory named [name]. *)
+      val add_directory : _ builder -> name:string -> directory:t -> nonempty builder
+
+      (** Finish building a non-empty directory tree. *)
+      val build : nonempty builder -> t
+    end
+  end
+
   type 'a t
 
   (** {1:monadic_interface Applicative/monadic interface} *)
@@ -86,6 +128,13 @@ module V1 : sig
 
       Note: [file] must be declared as a target in dune build file. *)
   val write_file : path:Path.t -> data:string -> unit t
+
+  (** [write_directory ~path ~directory] returns a computation that recursively writes
+      the contents of [directory] to [path].
+
+      Note: [path] must be declared as a directory target in the corresponding
+      dune build file. *)
+  val write_directory : path:Path.t -> directory:Directory.t -> unit t
 
   (** [read_directory_with_glob ~path:directory ~glob] returns a computation
       depending on a listing of a [directory] (including source and target

--- a/otherlibs/dune-action-plugin/src/import.ml
+++ b/otherlibs/dune-action-plugin/src/import.ml
@@ -11,6 +11,7 @@ include struct
   module Comparable = Comparable
   module Result = Result
   module Map = Map
+  module Fpath = Fpath
 end
 
 module Conv = Dune_rpc.Private.Conv

--- a/otherlibs/dune-action-plugin/src/protocol.ml
+++ b/otherlibs/dune-action-plugin/src/protocol.ml
@@ -78,24 +78,64 @@ module Greeting = struct
   include Sexpable_intf.Make (T)
 end
 
+module Target = struct
+  module T = struct
+    type t =
+      | File of string
+      | Directory of string
+
+    let conv =
+      let open Conv in
+      let file = constr "File" string (fun path -> File path) in
+      let directory = constr "Directory" string (fun path -> Directory path) in
+      sum
+        [ econstr file; econstr directory ]
+        (function
+          | File path -> case path file
+          | Directory path -> case path directory)
+    ;;
+
+    let compare x y =
+      match x, y with
+      | File x, File y -> String.compare x y
+      | File _, Directory _ -> Lt
+      | Directory _, File _ -> Gt
+      | Directory x, Directory y -> String.compare x y
+    ;;
+
+    let describe = function
+      | File path -> Printf.sprintf "file target %S" path
+      | Directory path -> Printf.sprintf "directory target %S" path
+    ;;
+
+    let to_dyn = Dyn.opaque
+  end
+
+  include T
+  module O = Comparable.Make (T)
+
+  module Set = struct
+    include O.Set
+
+    let conv : t Conv.value = Conv.iso (Conv.list conv) of_list to_list
+  end
+end
+
 module Run_arguments = struct
   module T = struct
     type t =
       { prepared_dependencies : Dependency.Set.t
-      ; targets : String.Set.t
+      ; targets : Target.Set.t
       }
 
     let conv =
       let from { prepared_dependencies; targets } = prepared_dependencies, targets in
       let to_ (prepared_dependencies, targets) = { prepared_dependencies; targets } in
-      let string_set =
-        Conv.iso Conv.(list string) String.Set.of_list String.Set.to_list
-      in
-      let conv = Conv.pair Dependency.Set.conv string_set in
+      let conv = Conv.pair Dependency.Set.conv Target.Set.conv in
       Conv.iso conv to_ from
     ;;
 
-    let version = 0
+    let version = 1
   end
 
   include T
@@ -132,7 +172,7 @@ module Context = struct
   type t =
     { response_fn : string
     ; prepared_dependencies : Dependency.Set.t
-    ; targets : String.Set.t
+    ; targets : Target.Set.t
     }
 
   type create_result =

--- a/otherlibs/dune-action-plugin/src/protocol.mli
+++ b/otherlibs/dune-action-plugin/src/protocol.mli
@@ -27,10 +27,22 @@ module Greeting : sig
   include Sexpable with type t := t
 end
 
+module Target : sig
+  type t =
+    | File of string
+    | Directory of string
+
+  val describe : t -> string
+
+  module Set : sig
+    include Set.S with type elt = t
+  end
+end
+
 module Run_arguments : sig
   type t =
     { prepared_dependencies : Dependency.Set.t
-    ; targets : String.Set.t
+    ; targets : Target.Set.t
     }
 
   include Sexpable with type t := t
@@ -57,6 +69,6 @@ module Context : sig
 
   val create : unit -> create_result
   val prepared_dependencies : t -> Dependency.Set.t
-  val targets : t -> String.Set.t
+  val targets : t -> Target.Set.t
   val respond : t -> Response.t -> unit
 end

--- a/otherlibs/dune-action-plugin/test/directory-target-escape/bin/dune
+++ b/otherlibs/dune-action-plugin/test/directory-target-escape/bin/dune
@@ -1,0 +1,3 @@
+(executable
+ (name foo)
+ (libraries dune-action-plugin))

--- a/otherlibs/dune-action-plugin/test/directory-target-escape/bin/foo.ml
+++ b/otherlibs/dune-action-plugin/test/directory-target-escape/bin/foo.ml
@@ -1,0 +1,10 @@
+open Dune_action_plugin.V1
+
+let directory =
+  Directory.Builder.empty
+  |> Directory.Builder.add_file ~name:"file.txt" ~data:"escaped\n"
+  |> Directory.Builder.build
+;;
+
+let action = write_directory ~path:(Path.of_string "output/../outside") ~directory
+let () = run action

--- a/otherlibs/dune-action-plugin/test/directory-target-escape/dune
+++ b/otherlibs/dune-action-plugin/test/directory-target-escape/dune
@@ -1,0 +1,3 @@
+(cram
+ (deps
+  (glob_files bin/*.exe)))

--- a/otherlibs/dune-action-plugin/test/directory-target-escape/run.t
+++ b/otherlibs/dune-action-plugin/test/directory-target-escape/run.t
@@ -1,0 +1,27 @@
+Producing a path that lexically starts with a directory target but escapes it
+via [..] is rejected.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.25)
+  > (using action-plugin 0.1)
+  > EOF
+
+  $ cat > dune << EOF
+  > (rule
+  >  (targets (dir output))
+  >  (action
+  >   (dynamic-run ./foo.exe)))
+  > EOF
+
+  $ cp ./bin/foo.exe ./
+
+  $ dune build output
+  File "dune", lines 1-4, characters 0-66:
+  1 | (rule
+  2 |  (targets (dir output))
+  3 |  (action
+  4 |   (dynamic-run ./foo.exe)))
+  The directory target "output/../outside" was produced despite not being declared in the dune file. To fix this, declare it as a target.
+  [1]
+
+  $ test ! -e _build/default/outside

--- a/otherlibs/dune-action-plugin/test/file-directory-kind-mismatch/bin/dune
+++ b/otherlibs/dune-action-plugin/test/file-directory-kind-mismatch/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names foo)
+ (libraries dune-action-plugin))

--- a/otherlibs/dune-action-plugin/test/file-directory-kind-mismatch/bin/foo.ml
+++ b/otherlibs/dune-action-plugin/test/file-directory-kind-mismatch/bin/foo.ml
@@ -1,0 +1,10 @@
+open Dune_action_plugin.V1
+
+let directory =
+  Directory.Builder.empty
+  |> Directory.Builder.add_file ~name:"placeholder" ~data:""
+  |> Directory.Builder.build
+;;
+
+let action = write_directory ~path:(Path.of_string "output") ~directory
+let () = run action

--- a/otherlibs/dune-action-plugin/test/file-directory-kind-mismatch/dune
+++ b/otherlibs/dune-action-plugin/test/file-directory-kind-mismatch/dune
@@ -1,0 +1,3 @@
+(cram
+ (deps
+  (glob_files bin/*.exe)))

--- a/otherlibs/dune-action-plugin/test/file-directory-kind-mismatch/run.t
+++ b/otherlibs/dune-action-plugin/test/file-directory-kind-mismatch/run.t
@@ -1,0 +1,26 @@
+  $ cat > dune-project << EOF
+  > (lang dune 3.25)
+  > (using action-plugin 0.1)
+  > EOF
+
+  $ cat > dune << EOF
+  > (rule
+  >  (targets output)
+  >  (action
+  >   (dynamic-run ./foo.exe)))
+  > \
+  > (rule
+  >  (alias runtest)
+  >  (action (cat output)))
+  > EOF
+
+  $ cp ./bin/foo.exe ./
+
+  $ dune runtest
+  File "dune", lines 1-4, characters 0-60:
+  1 | (rule
+  2 |  (targets output)
+  3 |  (action
+  4 |   (dynamic-run ./foo.exe)))
+  The directory target "output" was produced, but "output" is declared as a file target in the dune file.
+  [1]

--- a/otherlibs/dune-action-plugin/test/one-directory-target/bin/dune
+++ b/otherlibs/dune-action-plugin/test/one-directory-target/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names foo)
+ (libraries dune-action-plugin))

--- a/otherlibs/dune-action-plugin/test/one-directory-target/bin/foo.ml
+++ b/otherlibs/dune-action-plugin/test/one-directory-target/bin/foo.ml
@@ -1,0 +1,28 @@
+open Dune_action_plugin.V1
+
+let output =
+  let nested =
+    Directory.Builder.empty
+    |> Directory.Builder.add_file ~name:"file.txt" ~data:"nested\n"
+    |> Directory.Builder.build
+  in
+  Directory.Builder.empty
+  |> Directory.Builder.add_file ~name:"root.txt" ~data:"root\n"
+  |> Directory.Builder.add_directory ~name:"nested" ~directory:nested
+  |> Directory.Builder.build
+;;
+
+let second =
+  Directory.Builder.empty
+  |> Directory.Builder.add_file ~name:"file.txt" ~data:"second\n"
+  |> Directory.Builder.build
+;;
+
+let action =
+  let open O in
+  let+ () = write_directory ~path:(Path.of_string "output") ~directory:output
+  and+ () = write_directory ~path:(Path.of_string "second") ~directory:second in
+  ()
+;;
+
+let () = run action

--- a/otherlibs/dune-action-plugin/test/one-directory-target/dune
+++ b/otherlibs/dune-action-plugin/test/one-directory-target/dune
@@ -1,0 +1,3 @@
+(cram
+ (deps
+  (glob_files bin/*.exe)))

--- a/otherlibs/dune-action-plugin/test/one-directory-target/run.t
+++ b/otherlibs/dune-action-plugin/test/one-directory-target/run.t
@@ -1,0 +1,26 @@
+  $ cat > dune-project << EOF
+  > (lang dune 3.25)
+  > (using action-plugin 0.1)
+  > EOF
+
+  $ cat > dune << EOF
+  > (rule
+  >  (targets
+  >   (dir output)
+  >   (dir second))
+  >  (action
+  >   (dynamic-run ./foo.exe)))
+  > EOF
+
+  $ cp ./bin/foo.exe ./
+
+  $ dune build output second
+
+  $ cat _build/default/output/root.txt
+  root
+
+  $ cat _build/default/output/nested/file.txt
+  nested
+
+  $ cat _build/default/second/file.txt
+  second

--- a/otherlibs/dune-action-plugin/test/one-target-by-dir/bin/dune
+++ b/otherlibs/dune-action-plugin/test/one-target-by-dir/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names foo)
+ (libraries dune-action-plugin))

--- a/otherlibs/dune-action-plugin/test/one-target-by-dir/bin/foo.ml
+++ b/otherlibs/dune-action-plugin/test/one-target-by-dir/bin/foo.ml
@@ -1,0 +1,15 @@
+open Dune_action_plugin.V1
+
+let directory =
+  Directory.Builder.empty
+  |> Directory.Builder.add_file ~name:"placeholder" ~data:""
+  |> Directory.Builder.build
+;;
+
+let action =
+  write_directory ~path:(Path.of_string "output") ~directory
+  |> stage ~f:(fun () ->
+    write_file ~path:(Path.of_string "output/some_target") ~data:"Hello from some_target!")
+;;
+
+let () = run action

--- a/otherlibs/dune-action-plugin/test/one-target-by-dir/dune
+++ b/otherlibs/dune-action-plugin/test/one-target-by-dir/dune
@@ -1,0 +1,3 @@
+(cram
+ (deps
+  (glob_files bin/*.exe)))

--- a/otherlibs/dune-action-plugin/test/one-target-by-dir/run.t
+++ b/otherlibs/dune-action-plugin/test/one-target-by-dir/run.t
@@ -1,0 +1,20 @@
+  $ cat > dune-project << EOF
+  > (lang dune 3.25)
+  > (using action-plugin 0.1)
+  > EOF
+
+  $ cat > dune << EOF
+  > (rule
+  >  (targets (dir output))
+  >  (action
+  >   (dynamic-run ./foo.exe)))
+  > \
+  > (rule
+  >  (alias runtest)
+  >  (action (cat output/some_target)))
+  > EOF
+
+  $ cp ./bin/foo.exe ./
+
+  $ dune runtest
+  Hello from some_target!

--- a/otherlibs/dune-action-plugin/test/one-undeclared-directory-target/bin/dune
+++ b/otherlibs/dune-action-plugin/test/one-undeclared-directory-target/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names foo)
+ (libraries dune-action-plugin))

--- a/otherlibs/dune-action-plugin/test/one-undeclared-directory-target/bin/foo.ml
+++ b/otherlibs/dune-action-plugin/test/one-undeclared-directory-target/bin/foo.ml
@@ -1,0 +1,10 @@
+open Dune_action_plugin.V1
+
+let directory =
+  Directory.Builder.empty
+  |> Directory.Builder.add_file ~name:"file.txt" ~data:"hello world\n"
+  |> Directory.Builder.build
+;;
+
+let action = write_directory ~path:(Path.of_string "bar") ~directory
+let () = run action

--- a/otherlibs/dune-action-plugin/test/one-undeclared-directory-target/dune
+++ b/otherlibs/dune-action-plugin/test/one-undeclared-directory-target/dune
@@ -1,0 +1,3 @@
+(cram
+ (deps
+  (glob_files bin/*.exe)))

--- a/otherlibs/dune-action-plugin/test/one-undeclared-directory-target/run.t
+++ b/otherlibs/dune-action-plugin/test/one-undeclared-directory-target/run.t
@@ -1,5 +1,5 @@
   $ cat > dune-project << EOF
-  > (lang dune 2.0)
+  > (lang dune 3.25)
   > (using action-plugin 0.1)
   > EOF
 
@@ -16,5 +16,5 @@
   1 | (rule
   2 |  (alias runtest)
   3 |  (action (dynamic-run ./foo.exe)))
-  The file target "bar" was produced despite not being declared in the dune file. To fix this, declare it as a target.
+  The directory target "bar" was produced despite not being declared in the dune file. To fix this, declare it as a target.
   [1]

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -353,6 +353,9 @@ let exec_until_all_deps_ready ~ectx ~eenv t =
 
 type input =
   { targets : Targets.Validated.t option (* Some Jane Street actions use [None] *)
+    (** Original targets in the build directory. *)
+  ; action_targets : Targets.Validated.t option
+    (** [action_targets] mapped into the action's sandbox, if any. *)
   ; root : Path.t
   ; context : Build_context.t option
   ; env : Env.t
@@ -363,14 +366,23 @@ type input =
   }
 
 let exec
-      { targets; root; context; env; rule_loc; execution_parameters; sandbox; action = t }
+      { targets
+      ; action_targets
+      ; root
+      ; context
+      ; env
+      ; rule_loc
+      ; execution_parameters
+      ; sandbox
+      ; action = t
+      }
       ~build_deps
   =
   let ectx =
     let metadata =
       Process_metadata.create ~purpose:(Process_metadata.Build_job targets) ()
     in
-    { targets; metadata; context; sandbox; rule_loc; build_deps }
+    { targets = action_targets; metadata; context; sandbox; rule_loc; build_deps }
   and eenv =
     let env =
       match

--- a/src/dune_engine/action_exec.mli
+++ b/src/dune_engine/action_exec.mli
@@ -27,6 +27,9 @@ end
 
 type input =
   { targets : Targets.Validated.t option (* Some Jane Street actions use [None] *)
+    (** Original [targets] in the build directory. *)
+  ; action_targets : Targets.Validated.t option
+    (** [action_targets] mapped into the action's sandbox, if any. *)
   ; root : Path.t
     (** [root] should be the root of the current build context, or the root
       of the sandbox if the action is sandboxed. *)

--- a/src/dune_engine/action_plugin.ml
+++ b/src/dune_engine/action_plugin.ml
@@ -29,18 +29,17 @@ let exec ~(ectx : context) ~(eenv : env) prog args =
   let run_arguments =
     let targets =
       match ectx.targets with
-      | None -> String.Set.empty
+      | None -> DAP.Target.Set.empty
       | Some targets ->
-        if not (Filename.Set.is_empty targets.dirs)
-        then
-          User_error.raise
-            ~loc:ectx.rule_loc
-            [ Pp.text "Directory targets are not compatible with dynamic actions" ];
-        Filename.Set.to_list_map targets.files ~f:(fun target ->
-          Path.Build.relative_fname targets.root target
-          |> Path.build
-          |> Path.reach ~from:eenv.working_dir)
-        |> String.Set.of_list
+        Targets.Validated.fold
+          targets
+          ~init:DAP.Target.Set.empty
+          ~file:(fun target targets ->
+            let path = Path.build target |> Path.reach ~from:eenv.working_dir in
+            DAP.Target.Set.add targets (DAP.Target.File path))
+          ~dir:(fun target targets ->
+            let path = Path.build target |> Path.reach ~from:eenv.working_dir in
+            DAP.Target.Set.add targets (DAP.Target.Directory path))
     in
     { DAP.Run_arguments.prepared_dependencies = eenv.prepared_dependencies; targets }
   in

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -481,6 +481,9 @@ module Internal = struct
         | Some context -> context.build_dir
       in
       let root = Path.build (Sandbox.map_path sandbox root) in
+      let action_targets =
+        Targets.Validated.map_root targets ~f:(Sandbox.map_path sandbox)
+      in
       let execute () =
         with_locks locks ~f:(fun () ->
           let* action_exec_result =
@@ -490,6 +493,7 @@ module Internal = struct
               ; context (* can be derived from the root *)
               ; env
               ; targets = Some targets
+              ; action_targets = Some action_targets
               ; rule_loc = loc
               ; execution_parameters
               ; sandbox = process_sandbox

--- a/src/targets/targets.ml
+++ b/src/targets/targets.ml
@@ -118,6 +118,8 @@ module Validated = struct
     Path.Build.relative_fname root name
   ;;
 
+  let map_root t ~f = { t with root = f t.root }
+
   let to_dyn { root; files; dirs } =
     Dyn.Record
       [ "root", Path.Build.to_dyn root

--- a/src/targets/targets.mli
+++ b/src/targets/targets.mli
@@ -50,6 +50,9 @@ module Validated : sig
       target file. Otherwise, it's the lexicographically first target directory. *)
   val head : t -> Path.Build.t
 
+  (** Change the common root while preserving all relative file and directory names. *)
+  val map_root : t -> f:(Path.Build.t -> Path.Build.t) -> t
+
   val to_dyn : t -> Dyn.t
 end
 


### PR DESCRIPTION
  ## Description

  Extend the action-plugin protocol to distinguish file and directory
  targets,
  and pass validated directory targets to dynamic actions after mapping
  them
  into the action sandbox.

  Add a public API for constructing and writing non-empty directory
  trees.
  Directory contents are represented structurally through a builder,
  allowing
  files and nested directories without encoding the tree in relative
  paths.

  Permit dynamic actions to produce files below a declared directory
  target.
  Continue rejecting undeclared outputs, report file/directory kind
  mismatches,
  and prevent paths containing ".." from escaping their declared
  directory.

  Add tests covering nested directory creation, files written beneath
  directory
  targets, undeclared directory targets, target-kind mismatches, and
  directory
  escape attempts.




## Related Issue and Motivation
[#16268](https://github.com/ocaml/dune/issues/16268)
