### PR TITLE
test: fix linking test failures on macosx

### DIFF
--- a/test/blackbox-tests/test-cases/ctypes/libexample/dune
+++ b/test/blackbox-tests/test-cases/ctypes/libexample/dune
@@ -12,8 +12,30 @@
  (action
   (run ar rcs %{target} %{deps})))
 
+; On macOS, a shared library linked without -install_name records its
+; output path (e.g. "./libexample.so") as its install name. dlopen
+; treats any slash-containing name as a literal path and never consults
+; DYLD_LIBRARY_PATH, so stubs linked against it abort at load time.
+; Use @rpath and let consumers supply the rpath (see pkgconfig/libexample.pc).
+
 (rule
  (deps example.o)
  (target libexample.so)
+ (enabled_if
+  (= %{system} macosx))
+ (action
+  (run
+   %{cc}
+   -shared
+   -o
+   %{target}
+   -Wl,-install_name,@rpath/libexample.so
+   %{deps})))
+
+(rule
+ (deps example.o)
+ (target libexample.so)
+ (enabled_if
+  (<> %{system} macosx))
  (action
   (run %{cc} -shared -o %{target} %{deps})))

--- a/test/blackbox-tests/test-cases/ctypes/libexample/pkgconfig/libexample.pc
+++ b/test/blackbox-tests/test-cases/ctypes/libexample/pkgconfig/libexample.pc
@@ -11,5 +11,5 @@ Name: libexample
 Description: An example library for testing dune ctypes
 Requires:
 Version: 1.00.00
-Libs: -L${prefix}/libexample -lexample
+Libs: -L${prefix}/libexample -Wl,-rpath,${prefix}/libexample -lexample
 Cflags: -I${prefix}/libexample


### PR DESCRIPTION
## Description
<!-- Briefly describe your changes -->

On my macbook, the test as configured fails with

```
 |  > dune exec ./example.bc
-|  4
+|  Fatal error: cannot load shared library dllexamplelib_stubs +|  Reason: dlopen($TESTCASE_ROOT/_build/default/stubgen/dllexamplelib_stubs.so, 0x000A): Library not loaded: ./libexample.so
+|    Referenced from: <064997B2-F4C0-38D1-8CB8-05E156E97D58> $TESTCASE_ROOT/_build/default/stubgen/dllexamplelib_stubs.so
+|    Reason: tried: './libexample.so' (no such file), '/System/Volumes/Preboot/Cryptexes/OS./libexample.so' (no such file), './libexample.so' (no such file), '$TESTCASE_ROOT/libexample.so' (no such file), '/System/Volumes/Preboot/Cryptexes/OS$TESTCASE_ROOT/libexample.so' (no such file), '$TESTCASE_ROOT/libexample.so' (no such file)
+|  97713 Abort trap: 6              dune exec ./example.bc
+|  [134]
```

This patch proposes a fix based on explicit specification of rpath on macosx systems.

## Related Issue and Motivation

Still working on getting a clean build for https://github.com/ocaml/dune/issues/15642

## Checklist

- [x] Tests added, if applicable.
- [x] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [x] Documentation added for any user-facing changes.
