### PR TITLE
fix: conditional on XCode 15 compat for c++ flags

### DIFF
--- a/test/blackbox-tests/test-cases/foreign-stubs/cxx-flags.t/dune
+++ b/test/blackbox-tests/test-cases/foreign-stubs/cxx-flags.t/dune
@@ -17,17 +17,14 @@
 
 (rule
  (enabled_if
-  (or
-   (<> %{system} macosx)
-   (<> %{architecture} arm64)))
+  (<> %{system} macosx))
  (action
   (write-file extra_flags.sexp "()")))
 
 ; with XCode 15+, the linker complains about duplicate -lc++ libraries
+
 (rule
  (enabled_if
-  (and
-   (= %{system} macosx)
-   (= %{architecture} arm64)))
+  (= %{system} macosx))
  (action
   (write-file extra_flags.sexp "(-ccopt -Wl,-no_warn_duplicate_libraries)")))


### PR DESCRIPTION
## Description

XCode 15 is not limited to M chips, but is now standard, and any dev working on Mac stuff needs XCode 15 or better since April if they want to publish in the mac ecosystem (see
https://developer.apple.com/news/upcoming-requirements/).

This fix resolves another specious test failure on my old intel macbook.


## Related Issue and Motivation

Also part of trying go get a clean build for https://github.com/ocaml/dune/issues/15642

## Checklist

- [x] Tests added, if applicable.
- [x] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [x] Documentation added for any user-facing changes.
