### PR TITLE
test(stdune): enable path tests on Windows

### DIFF
--- a/otherlibs/stdune/test/dune
+++ b/otherlibs/stdune/test/dune
@@ -88,4 +88,5 @@
 (alias
  (name runtest-windows)
  (deps
+  (alias runtest-stdune_path_tests)
   (alias runtest-stdune_external_build_tests)))

--- a/otherlibs/stdune/test/path_tests.ml
+++ b/otherlibs/stdune/test/path_tests.ml
@@ -354,9 +354,19 @@ None
 |}]
 ;;
 
+let check_on_win_or_unix output ~wind ~unix =
+  let expected = String.trim (if Sys.win32 then wind else unix) in
+  let output = String.trim output in
+  if not (String.equal output expected)
+  then
+    Code_error.raise
+      "output mismatch"
+      [ "expected", String expected; "got", String output ]
+;;
+
 let%expect_test _ =
   reach "/foo/baz" ~from:"/foo/bar";
-  [%expect {| "../baz" |}]
+  check_on_win_or_unix [%expect.output] ~wind:{| "/foo/baz" |} ~unix:{| "../baz" |}
 ;;
 
 let%expect_test _ =


### PR DESCRIPTION
## Description

Run the stdune path tests as part of `@runtest-windows`.

Keep the existing platform-specific `Path.External.reach` result in the test so
this change only enables coverage; it does not change path behavior.

## Stack

1. This PR
2. #16279
3. #16280
