### PR TITLE
test(sat): expose non-chronological backtracking

### DIFF
--- a/src/sat/sat.mli
+++ b/src/sat/sat.mli
@@ -65,6 +65,11 @@ module Make (User : USER) : sig
       Use this to tidy up at the end, when you no longer care about the order. *)
   val run_solver : t -> (unit -> lit option) -> bool
 
+  (** Return the current decision level. A decrease between calls to the decider
+      indicates that the solver backtracked, allowing incremental deciders to
+      invalidate cached state. *)
+  val get_decision_level : t -> int
+
   (** Return the first literal in the list whose value is [Undecided], or [None] if they're all decided.
       The decider function may find this useful. *)
   val get_best_undecided : at_most_one_clause -> lit option

--- a/test/expect-tests/sat/sat_tests.ml
+++ b/test/expect-tests/sat/sat_tests.ml
@@ -101,6 +101,45 @@ let%expect_test "run_solver records decisions, and counters are cumulative" =
   |}]
 ;;
 
+let%expect_test "incremental deciders can detect non-chronological backtracking" =
+  let open Sat in
+  let p = create () in
+  let a = add_variable p 1 in
+  let c = add_variable p 2 in
+  let d = add_variable p 3 in
+  let x = add_variable p 4 in
+  (* Selecting [a] and [d] implies both [x] and [not x]. The unrelated
+     decision [c] makes conflict analysis backjump from level 3 to level 1. *)
+  at_least_one p [ neg a; neg d; x ];
+  at_least_one p [ neg a; neg d; neg x ];
+  let choices = ref [ a; c; d ] in
+  let previous_level = ref 0 in
+  let decide () =
+    let level = get_decision_level p in
+    if level < !previous_level
+    then Format.printf "backtracked from level %d to %d@." !previous_level level;
+    previous_level := level;
+    Format.printf "decide at level %d@." level;
+    match !choices with
+    | [] -> None
+    | choice :: rest ->
+      choices := rest;
+      Some choice
+  in
+  print_endline (string_of_bool (run_solver p decide));
+  print_stats p;
+  [%expect
+    {|
+    decide at level 0
+    decide at level 1
+    decide at level 2
+    backtracked from level 2 to 1
+    decide at level 1
+    true
+    num_variables=4 num_clauses=2 num_decisions=5 num_conflicts=1
+  |}]
+;;
+
 let%expect_test "impossible problems are rejected before solving" =
   let open Sat in
   let p = create () in


### PR DESCRIPTION
## Summary

Expose the current SAT decision level to custom deciders and add an expect test demonstrating that a non-chronological backjump is observable as a decrease between decider calls.

The test constructs a conflict involving decisions at levels 1 and 3, with an unrelated decision at level 2, and verifies that conflict analysis returns the decider from level 2 to level 1. This establishes the invalidation signal used by incremental deciders such as the package-solver optimization in #16217.

This change was split from #16217 so the SAT callback contract can be reviewed independently of the performance changes.

## Testing

- SAT expect test covering the non-chronological backjump
- The same change previously passed the full CI matrix as the first commit of #16217