### PR TITLE
test(sat): reject variables added during solving

### DIFF
--- a/test/expect-tests/sat/sat_tests.ml
+++ b/test/expect-tests/sat/sat_tests.ml
@@ -101,6 +101,31 @@ let%expect_test "run_solver records decisions, and counters are cumulative" =
   |}]
 ;;
 
+let%expect_test "variables cannot be added at an active decision level" =
+  let open Sat in
+  let p = create () in
+  let a = add_variable p 1 in
+  let _b = add_variable p 2 in
+  let first_decision = ref true in
+  let decide () =
+    if !first_decision
+    then (
+      first_decision := false;
+      Some a)
+    else (
+      (match add_variable p 3 with
+       | exception Invalid_argument message -> print_endline message
+       | _ -> print_endline "unexpectedly added a variable");
+      None)
+  in
+  print_endline (string_of_bool (run_solver p decide));
+  [%expect
+    {|
+    Sat.add_variable: cannot add variables after decisions have begun
+    true
+  |}]
+;;
+
 let%expect_test "incremental deciders can detect non-chronological backtracking" =
   let open Sat in
   let p = create () in


### PR DESCRIPTION
## Summary

Add a focused expect test that attempts to add a SAT variable after the first decision and verifies that `Sat.add_variable` rejects the operation. This covers the fixed-variable-set invariant required for trail-ordered restoration of the incremental undecided-variable list.

This is intentionally a parallel review change to #16284 rather than including the performance implementation in this PR. Its expected behavior is introduced by #16284, so the test-only branch is not independently green against current `main`; it can be rebased after the companion change lands.

## Testing

When combined with #16284:

- `./dune.exe build @check @fmt`
- `./dune.exe runtest test/expect-tests/sat`