### PR TITLE
fix(stdune): relativize ordinary same-drive Windows paths

### DIFF
--- a/doc/changes/fixed/16285.md
+++ b/doc/changes/fixed/16285.md
@@ -1,0 +1,1 @@
+- Relativize ordinary same-drive Windows paths (#16285, @Alizter)

--- a/otherlibs/stdune/src/path_external.ml
+++ b/otherlibs/stdune/src/path_external.ml
@@ -91,9 +91,6 @@ let cwd () = Sys.getcwd ()
 let initial_cwd = Fpath.initial_cwd
 let as_local t = "." ^ t
 
-(* Only relativize POSIX-style absolute paths on non-Windows systems. Other
-   absolute syntaxes, such as Windows drive-letter and UNC paths, keep their
-   absolute spelling. *)
 let local_part t =
   match String.drop_prefix t ~prefix:"/" with
   | None -> None
@@ -102,10 +99,36 @@ let local_part t =
   | Some t -> Some (Local.of_string t)
 ;;
 
+(* Other Windows namespaces have different root and normalization semantics, so
+   only ordinary drive-rooted paths are made relative here. *)
+let windows_drive_and_path t =
+  if
+    String.length t >= 3
+    && (match t.[0] with
+        | 'A' .. 'Z' | 'a' .. 'z' -> true
+        | _ -> false)
+    && Char.equal t.[1] ':'
+    && (Char.equal t.[2] '/' || Char.equal t.[2] '\\')
+  then Some (Char.lowercase_ascii t.[0], String.drop t 3)
+  else None
+;;
+
+let windows_local_part t =
+  if (not (Filename.is_relative t)) || String.contains t ':'
+  then None
+  else Local.parse_string_result t |> Result.to_option
+;;
+
 let reach t ~from =
-  (* CR-someday rgrinberg: I couldn't get this to work on Windows. *)
   if Sys.win32
-  then to_string t
+  then (
+    match windows_drive_and_path t, windows_drive_and_path from with
+    | Some (drive, t_path), Some (from_drive, from_path) when Char.equal drive from_drive
+      ->
+      (match windows_local_part t_path, windows_local_part from_path with
+       | Some target, Some from -> Local.reach target ~from
+       | _ -> to_string t)
+    | _ -> to_string t)
   else (
     match local_part t, local_part from with
     | Some t, Some from -> Local.reach t ~from

--- a/otherlibs/stdune/test/path_tests.ml
+++ b/otherlibs/stdune/test/path_tests.ml
@@ -386,7 +386,7 @@ let%expect_test "external path reach on Windows" =
   check_external_reach_on_windows
     ~to_:{|C:\foo\baz|}
     ~from:"c:/foo/bar"
-    ~expected:{|C:\foo\baz|};
+    ~expected:"../baz";
   check_external_reach_on_windows ~to_:"C:/foo" ~from:"D:/bar" ~expected:"C:/foo";
   check_external_reach_on_windows
     ~to_:{|C:foo\baz|}
@@ -408,6 +408,14 @@ let%expect_test "external path reach on Windows" =
     ~to_:{|\\?\UNC\server\share\foo\baz|}
     ~from:{|\\?\unc\SERVER\SHARE\foo\bar|}
     ~expected:{|\\?\UNC\server\share\foo\baz|};
+  check_external_reach_on_windows
+    ~to_:{|C:\foo\qux\..\baz|}
+    ~from:{|C:\foo\bar|}
+    ~expected:"../baz";
+  check_external_reach_on_windows
+    ~to_:{|C:\foo\file:stream|}
+    ~from:{|C:\foo|}
+    ~expected:{|C:\foo\file:stream|};
   check_external_reach_on_windows ~to_:"/foo" ~from:"C:/bar" ~expected:"/foo";
   [%expect {| |}]
 ;;


### PR DESCRIPTION
## Description

Relativize ordinary drive-rooted Windows paths when the source and destination
are on the same drive.

Conservatively keep current-drive-rooted, drive-relative, UNC, extended-length,
device, malformed, ADS, and different-drive paths absolute. The characterization
tests in #16279 cover these boundaries.

This follows #16278 and #16279 and completes the ordinary drive-path portion of
the Windows support left out of #15077. It supersedes the automatically closed
#16280.
