### PR TITLE
tests: fix brittle test logc in `vcs_tests_common.ml`

### DIFF
--- a/test/expect-tests/vcs/vcs_tests.ml
+++ b/test/expect-tests/vcs/vcs_tests.ml
@@ -5,8 +5,6 @@ let%expect_test _ =
   [%expect
     {|
 $ git init -q
-$ git config user.email dune@dune.com
-$ git config user.name 'Dune Dune'
 $ echo "-" > a
 $ git add a
 $ git commit -m 'commit message'

--- a/test/expect-tests/vcs/vcs_tests_common.ml
+++ b/test/expect-tests/vcs/vcs_tests_common.ml
@@ -71,13 +71,7 @@ type action =
 
 let run_action (vcs : Vcs.t) action =
   match action with
-  | Init ->
-    let* () = run vcs [ "init"; "-q" ] in
-    (match vcs.kind with
-     | Hg -> Fiber.return ()
-     | Git ->
-       let* () = run vcs [ "config"; "user.email"; "dune@dune.com" ] in
-       run vcs [ "config"; "user.name"; "Dune Dune" ])
+  | Init -> run vcs [ "init"; "-q" ]
   | Add fn -> run vcs [ "add"; fn ]
   | Commit ->
     (match vcs.kind with

--- a/test/expect-tests/vcs/vcs_tests_common.ml
+++ b/test/expect-tests/vcs/vcs_tests_common.ml
@@ -46,11 +46,17 @@ let run (vcs : Vcs.t) args =
     ~env:
       ((* One of the reasons to set GIT_DIR is to override any GIT_DIR set by
           the environment, which helps for example during [git rebase
-          --exec]. *)
-       Env.add
-         Env.initial
-         ~var:Env.Var._GIT_DIR
-         ~value:(Filename.concat (Path.to_absolute_filename vcs.root) ".git"))
+          --exec]. More generally, we need to configure the expected git variables
+          to give consistent results accross systems. *)
+       List.fold_left
+         [ Env.Var._GIT_DIR, Filename.concat (Path.to_absolute_filename vcs.root) ".git"
+         ; Env.Var.of_string "GIT_AUTHOR_NAME", "Dune Dune"
+         ; Env.Var.of_string "GIT_AUTHOR_EMAIL", "dune@dune.com"
+         ; Env.Var.of_string "GIT_COMMITTER_NAME", "Dune Dune"
+         ; Env.Var.of_string "GIT_COMMITTER_EMAIL", "dune@dune.com"
+         ]
+         ~init:Env.initial
+         ~f:(fun env (var, value) -> Env.add env ~var ~value))
     ~dir:vcs.root
     ~stdout_to:(Process.Io.file Dev_null.path Process.Io.Out)
 ;;


### PR DESCRIPTION
## Description

On my machine, this tests fails, as reported
https://github.com/ocaml/dune/pull/16286

IIUC, this is because it sets up a sandboxed git environment but is not
properly initializing the git config it tries to use when hg is not
installed.

The fix proposed here is to set the needed git config info in the
surrounding environment, to make it more thoroughly sandboxed.

[86e38ed](https://github.com/ocaml/dune/pull/16287/commits/86e38ed2592c2902d2d33613964b08dbafbeb245) is an additional tweak proposed to drop the git init logic which become logic if we set these config values in the environment instead. I'm happy to drop that if preferred.

## Related Issue and Motivation

Fixes #16286

## Checklist

- [x] Tests added, if applicable.
- [x] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [x] Documentation added for any user-facing changes.
