### PR TITLE
fix(env): give context env vars precedence over workspace vars

### DIFF
--- a/doc/changes/fixed/16290.md
+++ b/doc/changes/fixed/16290.md
@@ -1,0 +1,4 @@
+- `(env (env-vars ...))` in a `(context ...)` stanza of `dune-workspace` now
+  takes precedence over the root `env` stanza, as documented. This affects
+  commands such as `dune exec`; rules already used the documented order.
+  (#16290, @punchagan)

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -61,7 +61,7 @@ module Env_nodes = struct
          let+ (env : Dune_env.config) = env >>= Dune_env.find_opt ~profile in
          env.env_vars)
     in
-    Env.extend_env (make context) (make workspace)
+    Env.extend_env (make workspace) (make context)
   ;;
 end
 

--- a/test/blackbox-tests/test-cases/stanzas/env/env-variables/precedence.t
+++ b/test/blackbox-tests/test-cases/stanzas/env/env-variables/precedence.t
@@ -37,4 +37,4 @@ When a variable is set from both a context and a global one, the context one is
 used.
 
   $ dune exec -- dune_cmd printenv VARIABLE_FROM_BOTH
-  VARIABLE_FROM_BOTH=from_workspace
+  VARIABLE_FROM_BOTH=from_context


### PR DESCRIPTION
<!-- Thank you for contributing to dune!

 For general guidelines on contributing to dune, see
 https://github.com/ocaml/dune/blob/main/CONTRIBUTING.md#developing-dune -->

## Description
<!-- Briefly describe your changes -->
env vars defined in a (context ...) stanza are documented to have higher
precedence than env vars defined in the root env stanza of a workspace.
The prose in the cram test also indicates this, but the test asserted
incorrect precedence. This seems to have been indicated in a review
comment [here] and marked done, but may have been undone by an incorrect
rebase or something.

Only consumers of Super_context.context_env like `dune exec` were
affected by this. Rules were not affected since they resolved their
environment separately through `Env_node.external_env` which is not
affected by this bug.

[here]: https://github.com/ocaml/dune/pull/1147#discussion_r227334665


## Related Issue and Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it closes an open issue, link to the issue here. -->
<!-- Non-trivial contributions are expected to be preceded by an issue, as
     per CONTRIBUTING.md. -->

This issue was discovered while working on #15381 

## Checklist

- [ ] Tests added, if applicable.
- [x] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [ ] Documentation added for any user-facing changes.
