### PR TITLE
fix(sat): count at_most clauses in stats

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -879,7 +879,7 @@ module Solver = struct
           let impl_clause =
             match impls with
             | [] -> None
-            | _ :: _ -> Some (Sat.at_most_one (List.map impls ~f:(fun s -> s.var)))
+            | _ :: _ -> Some (Sat.at_most_one sat (List.map impls ~f:(fun s -> s.var)))
           in
           { role; clause = impl_clause; vars = impls }
         in
@@ -939,11 +939,11 @@ module Solver = struct
 
       (* Call this at the end to add the final clause with all discovered groups.
          [t] must not be used after this. *)
-      let seal t =
+      let seal sat t =
         Key_map.iter t.groups ~f:(fun impls ->
           match !impls with
           | _ :: _ :: _ ->
-            let (_ : Sat.at_most_one_clause) = Sat.at_most_one !impls in
+            let (_ : Sat.at_most_one_clause) = Sat.at_most_one sat !impls in
             ()
           | _ -> ())
       ;;
@@ -1027,7 +1027,7 @@ module Solver = struct
           (fun _name bucket ->
              match !bucket with
              | [] | [ _ ] -> ()
-             | vars -> ignore (Sat.at_most_one vars : Sat.at_most_one_clause))
+             | vars -> ignore (Sat.at_most_one t.sat vars : Sat.at_most_one_clause))
           t.per_name
       ;;
     end
@@ -1114,7 +1114,9 @@ module Solver = struct
                the [essential] case, because we must select a good version and we can't
                select two. *)
             (try
-               let (_ : Sat.at_most_one_clause) = Sat.at_most_one (user_var :: fail) in
+               let (_ : Sat.at_most_one_clause) =
+                 Sat.at_most_one sat (user_var :: fail)
+               in
                ()
              with
              | Invalid_argument reason ->
@@ -1140,12 +1142,12 @@ module Solver = struct
           process_dep `No_expand impl_var dep)
         (* All impl_candidates have now been added, so snapshot the cache. *)
       in
-      Conflict_classes.seal conflict_classes;
+      Conflict_classes.seal sat conflict_classes;
       Cross_platform_version.seal cross_platform_versions;
       (match max_avoids, OpamPackage.Map.bindings !avoids |> List.map ~f:snd with
        | None, _ | _, [] -> ()
        | Some max_avoids, avoids ->
-         let _ : Sat.at_most_clause = Sat.at_most max_avoids avoids in
+         let _ : Sat.at_most_clause = Sat.at_most sat max_avoids avoids in
          ());
       impl_cache
     ;;

--- a/src/sat/sat.ml
+++ b/src/sat/sat.ml
@@ -147,12 +147,9 @@ module Make (User : USER) = struct
     ; mutable set_to_false : bool
     ; conflict_vars : VarID.Hash_set.t
       (* we are finishing up by setting everything else to False *)
-      (* Counters for observability. [num_clauses] counts input clauses
-         added via [at_least_one] / [implies] / [impossible]; the
-         at-most clauses are not counted because they do not carry a
-         problem handle at their construction site (see sat.mli).
-         [num_decisions] and [num_conflicts] are incremented in
-         [run_solver]. *)
+      (* Counters for observability. [num_clauses] counts the clauses added
+         via [at_least_one] / [implies] / [at_most] / [impossible];
+         [num_decisions] and [num_conflicts] the work done by the solver. *)
     ; num_clauses : Counter.t
     ; num_decisions : Counter.t
     ; num_conflicts : Counter.t
@@ -675,7 +672,7 @@ module Make (User : USER) = struct
     | Exit -> true
   ;;
 
-  let at_most nb lits : at_most_clause =
+  let at_most problem nb lits : at_most_clause =
     assert (not (List.is_empty lits));
     (* if debug then log_debug (Pp.textf "at_most_%i(%s)" nb (string_of_lits lits)); *)
     (* If there are not enough literals then we're trivially true
@@ -693,6 +690,7 @@ module Make (User : USER) = struct
         Pp.text "at_most_one(" ++ pp_lits lits ++ Pp.paragraph "): duplicates in list!"
       in
       invalid_arg (Format.asprintf "%a." Pp.to_fmt msg));
+    Counter.incr problem.num_clauses;
     (* Ignore any literals already known to be False.
        If any are True then they're enqueued and we'll process them
        soon. *)
@@ -703,7 +701,7 @@ module Make (User : USER) = struct
     clause
   ;;
 
-  let at_most_one lits = at_most 1 lits
+  let at_most_one problem lits = at_most problem 1 lits
 
   let analyse problem (original_cause : clause) =
     (* After trying some assignments, we've discovered a conflict.

--- a/src/sat/sat.mli
+++ b/src/sat/sat.mli
@@ -50,13 +50,13 @@ module Make (User : USER) : sig
 
   (** Add a clause preventing more than one literal in the list from being [True].
       @raise Invalid_argument if the list contains duplicates. *)
-  val at_most_one : lit list -> at_most_one_clause
+  val at_most_one : t -> lit list -> at_most_one_clause
 
   type at_most_clause
 
   (** Add a clause preventing more than [n] literals in the list from being [True].
       @raise Invalid_argument if the list contains duplicates. *)
-  val at_most : int -> lit list -> at_most_clause
+  val at_most : t -> int -> lit list -> at_most_clause
 
   (** [run_solver decider] tries to solve the SAT problem. It simplifies it as much as possible first. When it
       has two paths which both appear possible, it calls [decider ()] to choose which to explore first. If this
@@ -91,11 +91,7 @@ module Make (User : USER) : sig
   (** Statistics describing a SAT problem and the work done to solve it.
       [num_variables] and [num_clauses] are structural (the problem size);
       [num_decisions] and [num_conflicts] are cumulative counters of work
-      performed by the solver. Note that [num_clauses] counts only
-      "at-least-one" / "implies" / "impossible" clauses; the
-      "at-most-{one,n}" clauses (used for conflict-class / mutual-exclusion
-      groupings) are not counted because they do not carry a problem handle
-      at their construction site. *)
+      performed by the solver. *)
   type stats =
     { num_variables : int
     ; num_clauses : int

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-single-platform-sat-size.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-single-platform-sat-size.t
@@ -29,6 +29,6 @@ The input is fixed, so the exact SAT problem size detects redundant encoding.
   [
     {
       "num_variables": 2,
-      "num_clauses": 2
+      "num_clauses": 4
     }
   ]

--- a/test/expect-tests/sat/sat_tests.ml
+++ b/test/expect-tests/sat/sat_tests.ml
@@ -55,22 +55,21 @@ let%expect_test "structural counters track added variables and input clauses" =
   |}]
 ;;
 
-let%expect_test "at-most clauses are not counted in num_clauses" =
+let%expect_test "at-most clauses are counted in num_clauses" =
   let open Sat in
   let p = create () in
   let a = add_variable p 1 in
   let b = add_variable p 2 in
   let c = add_variable p 3 in
-  let amo = at_most_one [ a; b ] in
-  let _am2 = at_most 2 [ a; b; c ] in
+  let amo = at_most_one p [ a; b ] in
+  let _am2 = at_most p 2 [ a; b; c ] in
   print_stats p;
-  (* The at-most clauses are real even though they are not counted:
-     nothing is selected yet, and [a] is still undecided. *)
+  (* Nothing is selected yet, and [a] is still undecided. *)
   print_endline (if is_some (get_selected amo) then "selected" else "unselected");
   print_endline (if is_some (get_best_undecided amo) then "undecided" else "decided");
   [%expect
     {|
-    num_variables=3 num_clauses=0 num_decisions=0 num_conflicts=0
+    num_variables=3 num_clauses=2 num_decisions=0 num_conflicts=0
     unselected
     undecided
   |}]
@@ -82,7 +81,7 @@ let%expect_test "run_solver records decisions, and counters are cumulative" =
   let a = add_variable p 1 in
   let b = add_variable p 2 in
   at_least_one p [ a; b ];
-  let amo = at_most_one [ a; b ] in
+  let amo = at_most_one p [ a; b ] in
   let decide () = get_best_undecided amo in
   print_endline (string_of_bool (run_solver p decide));
   print_stats p;
@@ -94,9 +93,9 @@ let%expect_test "run_solver records decisions, and counters are cumulative" =
   [%expect
     {|
     true
-    num_variables=2 num_clauses=1 num_decisions=1 num_conflicts=0
+    num_variables=2 num_clauses=2 num_decisions=1 num_conflicts=0
     true
-    num_variables=2 num_clauses=1 num_decisions=1 num_conflicts=0
+    num_variables=2 num_clauses=2 num_decisions=1 num_conflicts=0
     selected
   |}]
 ;;


### PR DESCRIPTION
Fixing the stats is not crucial, but I have some follow-up where it'll be useful to have access to the SAT `problem` in `at_most` constraints :)