### PR TITLE
refactor(opam_solver): drive the SAT solver

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -1196,36 +1196,45 @@ module Solver = struct
       in
       let+ impl_clauses = Fiber.Cache.to_table impl_clauses in
       (* Run the solve *)
-      let decider () =
-        (* Walk the current solution, depth-first, looking for the first
-           undecided interface. Then try the most preferred implementation of
-           it that hasn't been ruled out. *)
-        let seen = Table.create (module Input.Role) 100 in
-        let rec find_undecided req =
-          if Table.mem seen req
-          then None (* Break cycles *)
-          else (
-            Table.set seen req true;
-            match Table.find_exn impl_clauses req |> Candidates.state with
-            | Unselected -> None
-            | Undecided lit -> Some lit
-            | Selected deps ->
-              (* We've already selected a candidate for this component. Now
-                 check its dependencies. *)
-              List.find_map deps ~f:(fun (dep : Input.dependency) ->
-                match dep.importance with
-                | Ensure -> find_undecided dep.drole
-                | Prevent ->
-                  (* Restrictions don't express that we do or don't want the
-                     dependency, so skip them here. If someone else needs this,
-                     we'll handle it when we get to them.
-                     If noone wants it, it will be set to unselected at the end. *)
-                  None))
-        in
-        find_undecided root_req
+      let seen = Table.create (module Input.Role) 100 in
+      let rec decider requireds =
+        match requireds with
+        | [] -> progress `Any_false requireds
+        | req :: reqs when Table.mem seen req -> decider reqs
+        | req :: reqs ->
+          (match Table.find_exn impl_clauses req |> Candidates.state with
+           | Unselected -> decider reqs
+           | Undecided lit -> progress (`True lit) requireds
+           | Selected deps ->
+             Table.set seen req ();
+             (* TODO: lazy load this package constraints *)
+             let deps =
+               List.filter_map deps ~f:(fun dep ->
+                 match dep.Input.importance with
+                 | Ensure -> Some dep.drole
+                 | Prevent -> None)
+             in
+             let result = decider (deps @ reqs) in
+             Table.remove seen req;
+             result)
+      and progress choice requireds =
+        Sat.choose sat choice;
+        match solve requireds with
+        | (`Sat | `Unsat) as result -> result
+        | `Backtrack 1 -> solve requireds
+        | `Backtrack n -> `Backtrack (n - 1)
+      and solve requireds =
+        match Sat.step sat with
+        | `Decide -> decider requireds
+        | (`Sat | `Unsat | `Backtrack _) as result -> result
       in
       let start = Time.now () in
-      let result = Sat.run_solver sat decider in
+      let result =
+        match solve [ root_req ] with
+        | `Sat -> true
+        | `Unsat -> false
+        | `Backtrack _ -> assert false
+      in
       let stop = Time.now () in
       let num_opam_files = Context.count_expanded_packages context - opam_files_before in
       Dune_trace.emit Sat (fun () ->

--- a/src/sat/sat.ml
+++ b/src/sat/sat.ml
@@ -144,8 +144,8 @@ module Make (User : USER) = struct
     ; mutable trail_lim : int list (* decision levels (len(trail) at each decision) *)
     ; mutable trail_lim_len : int
     ; mutable toplevel_conflict : bool
-    ; mutable set_to_false : bool
     ; conflict_vars : VarID.Hash_set.t
+    ; mutable set_to_false : bool
       (* we are finishing up by setting everything else to False *)
       (* Counters for observability. [num_clauses] counts the clauses added
          via [at_least_one] / [implies] / [at_most] / [impossible];
@@ -211,7 +211,6 @@ module Make (User : USER) = struct
   ;;
 
   exception ConflictingClause of clause
-  exception SolveDone of bool
 
   type added_result =
     | AddedFact of bool (* Result of enqueing the new fact *)
@@ -287,6 +286,10 @@ module Make (User : USER) = struct
   ;;
 
   let get_decision_level problem = problem.trail_lim_len
+
+  let first_undecided problem =
+    List.find problem.vars ~f:(fun var -> var.value = Undecided)
+  ;;
 
   let add_variable problem obj : lit =
     (* if debug then log_debug "add_variable('%s')" obj; *)
@@ -875,90 +878,102 @@ module Make (User : USER) = struct
     learnt, !btlevel
   ;;
 
-  let run_solver problem decide =
-    (* Check whether we detected a trivial problem during setup. *)
+  let step problem =
     if problem.toplevel_conflict
     then (
       if debug then log_debug (Pp.text "FAIL: toplevel_conflict before starting solve!");
-      false)
+      `Unsat)
     else (
-      try
-        while true do
-          (* Use logical deduction to simplify the clauses
-             and assign literals where there is only one possibility. *)
-          match propagate problem with
-          | None ->
-            (* No conflicts *)
-            (* if debug then log_debug "new state: %s" problem.assigns *)
-
-            (* Pick a variable and try assigning it one way.
-               If it leads to a conflict, we'll backtrack and
-               try it the other way. *)
-            let undecided =
-              match List.find problem.vars ~f:(fun info -> info.value = Undecided) with
-              | Some s -> s
-              | None -> raise_notrace (SolveDone true)
-            in
-            let lit =
-              if problem.set_to_false
-              then (* Printf.printf "%s -> false\n" (name_lit undecided); *)
-                Neg, undecided
-              else (
-                match decide () with
-                | Some lit -> lit
-                | None ->
-                  (* Switch to set_to_false mode (until we backtrack). *)
-                  problem.set_to_false <- true;
-                  undecided.undo <- Decided :: undecided.undo;
-                  (* Printf.printf "%s -> false\n" (name_lit undecided); *)
-                  Neg, undecided)
-            in
-            if debug then log_debug (Pp.text "TRYING: " ++ name_lit lit);
-            let old = lit_value lit in
-            if old <> Undecided
-            then
-              Code_error.raise
-                "Decider chose already-decided variable"
-                [ "lit", Dyn.string (Format.asprintf "%a@." Pp.to_fmt (name_lit lit))
-                ; "was", Var_value.to_dyn old
-                ];
-            problem.trail_lim <- problem.trail_len :: problem.trail_lim;
-            problem.trail_lim_len <- problem.trail_lim_len + 1;
-            Counter.incr problem.num_decisions;
-            let r = enqueue problem lit (External "considering") in
-            assert r
-          | Some conflicting_clause ->
-            Counter.incr problem.num_conflicts;
-            if get_decision_level problem = 0
-            then (
-              if debug then log_debug (Pp.text "FAIL: conflict found at top level");
-              raise_notrace (SolveDone false))
-            else (
-              (* Figure out the root cause of this failure. *)
-              let learnt, backtrack_level = analyse problem conflicting_clause in
-              (* We have learnt that something in [learnt] must be True or we get a conflict. *)
-              cancel_until problem backtrack_level;
-              match
-                internal_at_least_one
-                  problem
-                  learnt
-                  ~learnt:true
-                  ~reason:(Clause conflicting_clause)
-              with
-              | AddedFact true -> ()
-              | AddedFact false ->
-                (* This is what the Python would do. Perhaps it can't happen? *)
-                let e = enqueue problem (List.hd learnt) (External "conflict!") in
-                assert e
-              | AddedClause c ->
-                (* Everything except the first literal in learnt is known to
+      (* Use logical deduction to simplify the clauses
+         and assign literals where there is only one possibility. *)
+      match propagate problem with
+      | None ->
+        (* No conflicts *)
+        (* if debug then log_debug "new state: %s" problem.assigns *)
+        (match first_undecided problem with
+         | None -> `Sat
+         | Some _ -> `Decide)
+      | Some conflicting_clause ->
+        Counter.incr problem.num_conflicts;
+        let current_level = get_decision_level problem in
+        if current_level = 0
+        then (
+          if debug then log_debug (Pp.text "FAIL: conflict found at top level");
+          `Unsat)
+        else (
+          (* Figure out the root cause of this failure. *)
+          let learnt, backtrack_level = analyse problem conflicting_clause in
+          (* We have learnt that something in [learnt] must be True or we get a conflict. *)
+          cancel_until problem backtrack_level;
+          (match
+             internal_at_least_one
+               problem
+               learnt
+               ~learnt:true
+               ~reason:(Clause conflicting_clause)
+           with
+           | AddedFact true -> ()
+           | AddedFact false ->
+             (* This is what the Python would do. Perhaps it can't happen? *)
+             let e = enqueue problem (List.hd learnt) (External "conflict!") in
+             assert e
+           | AddedClause c ->
+             (* Everything except the first literal in learnt is known to
                    be False, so the first must be True. *)
-                let e = enqueue problem (List.hd learnt) (Clause c) in
-                assert e)
-        done;
-        Code_error.raise "not reached" []
-      with
-      | SolveDone t -> t)
+             let e = enqueue problem (List.hd learnt) (Clause c) in
+             assert e);
+          let new_level = get_decision_level problem in
+          let nb_levels = current_level - new_level in
+          assert (nb_levels > 0);
+          `Backtrack nb_levels))
+  ;;
+
+  let choose problem choice =
+    let lit =
+      match choice with
+      | `True lit -> lit
+      | `Any_false ->
+        (match first_undecided problem with
+         | None -> assert false
+         | Some undecided ->
+           if not problem.set_to_false
+           then (
+             problem.set_to_false <- true;
+             undecided.undo <- Decided :: undecided.undo);
+           Neg, undecided)
+    in
+    if debug then log_debug (Pp.text "TRYING: " ++ name_lit lit);
+    let old = lit_value lit in
+    if old <> Undecided
+    then
+      Code_error.raise
+        "Decider chose already-decided variable"
+        [ "lit", Dyn.string (Format.asprintf "%a@." Pp.to_fmt (name_lit lit))
+        ; "was", Var_value.to_dyn old
+        ];
+    problem.trail_lim <- problem.trail_len :: problem.trail_lim;
+    problem.trail_lim_len <- problem.trail_lim_len + 1;
+    Counter.incr problem.num_decisions;
+    let r = enqueue problem lit (External "considering") in
+    assert r
+  ;;
+
+  let rec run_solver problem decide =
+    match step problem with
+    | `Sat -> true
+    | `Unsat -> false
+    | `Decide ->
+      let choice =
+        if problem.set_to_false
+        then `Any_false
+        else (
+          match decide () with
+          | Some lit -> `True lit
+          | None -> `Any_false)
+      in
+      choose problem choice;
+      run_solver problem decide
+    | `Backtrack _ -> run_solver problem decide
   ;;
 
   let pp_lit_reason lit =

--- a/src/sat/sat.mli
+++ b/src/sat/sat.mli
@@ -65,10 +65,23 @@ module Make (User : USER) : sig
       Use this to tidy up at the end, when you no longer care about the order. *)
   val run_solver : t -> (unit -> lit option) -> bool
 
-  (** Return the current decision level. A decrease between calls to the decider
-      indicates that the solver backtracked, allowing incremental deciders to
-      invalidate cached state. *)
-  val get_decision_level : t -> int
+  (** Alternative interface for [run_solver] as a loop of alternating calls to [step] and [choose]: *)
+
+  (** [step problem] performs one deductive step and returns either:
+      - [`Sat] if the problem is fully solved,
+      - [`Unsat] if the problem has no solution,
+      - [`Decide] if the problem still has undecided literals to be choosen,
+      - [`Backtrack nb_levels] if a contradiction was discovered with the [nb_levels] previous choice.
+
+      [step] must be called before any choice is made.
+  *)
+  val step : t -> [ `Sat | `Unsat | `Decide | `Backtrack of int ]
+
+  (** [choose problem choice] sets an undecided variable according to [choice],
+      either a specific literal to [true] or any remaining unknowns to [false].
+      [step problem] must be called right after to check for logical deductions
+      resulting from that choice. *)
+  val choose : t -> [ `True of lit | `Any_false ] -> unit
 
   (** Return the first literal in the list whose value is [Undecided], or [None] if they're all decided.
       The decider function may find this useful. *)

--- a/test/expect-tests/sat/sat_tests.ml
+++ b/test/expect-tests/sat/sat_tests.ml
@@ -112,29 +112,33 @@ let%expect_test "incremental deciders can detect non-chronological backtracking"
   at_least_one p [ neg a; neg d; x ];
   at_least_one p [ neg a; neg d; neg x ];
   let choices = ref [ a; c; d ] in
-  let previous_level = ref 0 in
-  let decide () =
-    let level = get_decision_level p in
-    if level < !previous_level
-    then Format.printf "backtracked from level %d to %d@." !previous_level level;
-    previous_level := level;
-    Format.printf "decide at level %d@." level;
-    match !choices with
-    | [] -> None
-    | choice :: rest ->
-      choices := rest;
-      Some choice
+  let rec solve level =
+    match step p with
+    | `Sat -> Format.printf "sat at level %d@." level
+    | `Unsat -> Format.printf "unsat@."
+    | `Backtrack nb_levels ->
+      Format.printf "backtracked %d level(s) from level %d@." nb_levels level;
+      solve (level - nb_levels)
+    | `Decide ->
+      Format.printf "decide at level %d@." level;
+      (match !choices with
+       | [] -> choose p `Any_false
+       | choice :: rest ->
+         choices := rest;
+         choose p (`True choice));
+      solve (level + 1)
   in
-  print_endline (string_of_bool (run_solver p decide));
+  solve 0;
   print_stats p;
   [%expect
     {|
     decide at level 0
     decide at level 1
     decide at level 2
-    backtracked from level 2 to 1
+    backtracked 2 level(s) from level 3
     decide at level 1
-    true
+    decide at level 2
+    sat at level 3
     num_variables=4 num_clauses=2 num_decisions=5 num_conflicts=1
   |}]
 ;;

--- a/test/expect-tests/sat/sat_tests.ml
+++ b/test/expect-tests/sat/sat_tests.ml
@@ -174,3 +174,32 @@ let%expect_test "run_solver records conflicts on an unsatisfiable problem" =
     num_variables=2 num_clauses=4 num_decisions=1 num_conflicts=2
   |}]
 ;;
+
+let%expect_test "run_solver stops calling the decider once None" =
+  let open Sat in
+  let p = create () in
+  let a = add_variable p 1 in
+  let b = add_variable p 2 in
+  let c = add_variable p 3 in
+  let d = add_variable p 4 in
+  at_least_one p [ a; b; c; d ];
+  let choices = ref [ neg a; d ] in
+  let calls = ref 0 in
+  let decide () =
+    incr calls;
+    match !choices with
+    | [] -> None
+    | choice :: rest ->
+      choices := rest;
+      Some choice
+  in
+  print_endline (string_of_bool (run_solver p decide));
+  Format.printf "decide calls=%d@." !calls;
+  print_stats p;
+  [%expect
+    {|
+    true
+    decide calls=3
+    num_variables=4 num_clauses=1 num_decisions=4 num_conflicts=0
+    |}]
+;;


### PR DESCRIPTION
Based on @Alizter's https://github.com/ocaml/dune/pull/16217 smart decider, but instead of having the SAT solver call the `decider` to pick the next undecided variable, this PR makes the `opam_solver` drive the SAT solver loop explicitly. As hinted in a TODO comment, this will allow on-demand loading of opam packages in the future (instead of preloading everything ahead of time, since we couldn't perform monadic effects once the SAT solver starts).