### PR TITLE
test(engine): stabilize process cleanup test on macOS

### DIFF
--- a/test/blackbox-tests/test-cases/actions/process-cleanup.t
+++ b/test/blackbox-tests/test-cases/actions/process-cleanup.t
@@ -20,7 +20,10 @@ A failed spawn currently retains captured output while Dune remains running.
   >    (run ./disappearing-executable))))
   > EOF
 
-  $ start_dune
+File-watcher invalidations can restart the build and create extra capture files,
+so disable the watcher to observe exactly one failed spawn.
+
+  $ start_dune --file-watcher manual
   $ build "(alias spawn-failure)"
   Failure
   [1]


### PR DESCRIPTION
## Description

Run the `process-cleanup.t` passive server with the manual file watcher. The
server is only needed to keep Dune alive while the test inspects temporary
capture files; automatic filesystem invalidations are outside the scope of the
test.

On macOS, FSEvents can invalidate and restart the pending RPC build while the
rule removes its executable. Each retry creates another leaked stdout/stderr
capture pair, making the expected count nondeterministic and sometimes causing
the RPC helper to time out. Disabling automatic watching ensures the test
observes exactly one failed spawn.

## Related Issue and Motivation

Fixes #16282.

## Testing

- `dune runtest test/blackbox-tests/test-cases/actions/process-cleanup.t`
- `dune build @check @fmt`
