### PR TITLE
refactor(opam_solver): no priority avoidance for avoid-version

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -22,38 +22,19 @@ let with_test solver_env =
 ;;
 
 module Priority = struct
-  (* A priority defines a package's position in the list of candidates
-     fed to the solver. Any change to package selection should be reflected in
-     this priority rather than implemented in an ad-hoc manner *)
-  type t =
-    { (* We prefer packages with [avoid-version: false] *)
-      avoid : bool
-    ; version : OpamPackage.Version.t
-    }
+  (* A priority defines a package's position in the list of candidates fed to
+     the solver, such that it will select package versions in the order
+     specified by the version preference. *)
+  type t = { version : OpamPackage.Version.t }
 
-  let compare_version =
+  let make version = { version }
+
+  let compare (pref : Version_preference.t) { version = x } { version = y } =
     let ord x y = OpamPackage.Version.compare x y |> Ordering.of_int in
-    fun (pref : Version_preference.t) x y ->
-      match pref with
-      | Oldest -> ord x y
-      | Newest -> ord y x
+    match pref with
+    | Oldest -> ord x y
+    | Newest -> ord y x
   ;;
-
-  let compare pref t { avoid; version } =
-    Tuple.T2.compare
-      Bool.compare
-      (compare_version pref)
-      (t.avoid, t.version)
-      (avoid, version)
-  ;;
-
-  let make (package : OpamFile.OPAM.t) =
-    let avoid = List.mem package.flags Pkgflag_AvoidVersion ~equal:Poly.equal in
-    let version = OpamFile.OPAM.package package |> OpamPackage.version in
-    { version; avoid }
-  ;;
-
-  let allowed version = { avoid = false; version }
 end
 
 module Context = struct
@@ -217,7 +198,7 @@ module Context = struct
     let resolved = OpamPackage.Version.Map.singleton version resolved_package in
     (* We don't respect avoid-version for pinned packages. This is intentional. *)
     { unfiltered =
-        [ { priority = Priority.allowed version; opam = opam_file; origin = Pinned } ]
+        [ { priority = Priority.make version; opam = opam_file; origin = Pinned } ]
     ; resolved
     }
   ;;
@@ -371,7 +352,8 @@ module Context = struct
       OpamPackage.Version.Map.values resolved
       |> List.map ~f:(fun resolved_package ->
         let opam = Resolved_package.opam_file resolved_package in
-        { priority = Priority.make opam; opam; origin = Repository })
+        let version = OpamFile.OPAM.package opam |> OpamPackage.version in
+        { priority = Priority.make version; opam; origin = Repository })
       |> List.sort ~compare:(fun x y ->
         Priority.compare t.version_preference x.priority y.priority)
     in
@@ -385,7 +367,7 @@ module Context = struct
     let key = Package_name.of_opam_package_name name in
     match Package_name.Map.find (Lazy.force t.local_packages) key with
     | Some local_package ->
-      let priority = Priority.allowed local_package.version in
+      let priority = Priority.make local_package.version in
       Fiber.return [ { priority; opam = local_package.opam_file; origin = Local } ]
     | None ->
       let+ res =
@@ -782,7 +764,8 @@ module Solver = struct
           match Context.rejection_for_platform context ~platform candidate with
           | Some _ -> None
           | None ->
-            let { Priority.version; avoid } = priority in
+            let { Priority.version } = priority in
+            let avoid = List.mem opam.flags Pkgflag_AvoidVersion ~equal:Poly.equal in
             let pkg = OpamPackage.create name version in
             (* Note: we ignore depopts here: see opam/doc/design/depopts-and-features *)
             let requires =

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -196,7 +196,6 @@ module Context = struct
     let version = Resolved_package.package resolved_package |> OpamPackage.version in
     let opam_file = Resolved_package.opam_file resolved_package in
     let resolved = OpamPackage.Version.Map.singleton version resolved_package in
-    (* We don't respect avoid-version for pinned packages. This is intentional. *)
     { unfiltered =
         [ { priority = Priority.make version; opam = opam_file; origin = Pinned } ]
     ; resolved
@@ -320,6 +319,14 @@ module Context = struct
           try_refute t ~platform package
           |> Option.map ~f:(fun name -> package, Refuted_by name)
         else None)
+  ;;
+
+  (* We don't respect avoid-version for local and pinned packages. *)
+  let avoid_candidate { opam; origin; _ } =
+    match origin with
+    | Local | Pinned -> false
+    | Repository ->
+      List.mem opam.OpamFile.OPAM.flags Pkgflag_AvoidVersion ~equal:Poly.equal
   ;;
 
   let rejection_for_platform t ~platform { opam; origin; _ } =
@@ -765,7 +772,7 @@ module Solver = struct
           | Some _ -> None
           | None ->
             let { Priority.version } = priority in
-            let avoid = List.mem opam.flags Pkgflag_AvoidVersion ~equal:Poly.equal in
+            let avoid = Context.avoid_candidate candidate in
             let pkg = OpamPackage.create name version in
             (* Note: we ignore depopts here: see opam/doc/design/depopts-and-features *)
             let requires =

--- a/test/blackbox-tests/test-cases/pkg/pin-avoid-version.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-avoid-version.t
@@ -24,9 +24,8 @@ coming from the repository:
   > pin-depends: [ "pinned.1.0.0" "file://$PWD/_pinned" ]
   > EOF
 
-FIXME: the solver avoids the pinned package and selects the fallback, while it
-should have picked the pinned one:
+The solver selects the pinned package, despite its avoid-version flag:
 
   $ dune_pkg_lock_normalized
   Solution for dune.lock:
-  - fallback.0.0.1
+  - pinned.1.0.0 (this version should be avoided)

--- a/test/blackbox-tests/test-cases/pkg/pin-avoid-version.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-avoid-version.t
@@ -1,0 +1,32 @@
+Pinned packages ignore the avoid-version flag. This is intentional: a pin
+selects a single version, so there's no other version to fallback to and
+avoiding it would only make the solve fail.
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+  $ make_dune_project 3.13
+  $ mkpkg fallback
+
+The pinned package is flagged with avoid-version:
+
+  $ mkdir _pinned
+  $ cat >_pinned/pinned.opam <<EOF
+  > opam-version: "2.0"
+  > flags: [avoid-version]
+  > EOF
+
+The local package depends on either the pinned package or on a regular package
+coming from the repository:
+
+  $ cat >root.opam <<EOF
+  > opam-version: "2.0"
+  > depends: [ "pinned" | "fallback" ]
+  > pin-depends: [ "pinned.1.0.0" "file://$PWD/_pinned" ]
+  > EOF
+
+FIXME: the solver avoids the pinned package and selects the fallback, while it
+should have picked the pinned one:
+
+  $ dune_pkg_lock_normalized
+  Solution for dune.lock:
+  - fallback.0.0.1


### PR DESCRIPTION
More preparation for the on-demand loading of opam files.

The solver was sorting package versions such that the `avoid-version` ones would come last in the list used by the SAT solver to select from. In practice, this is unnecessary because `avoid-version` packages are first unselectable (we force the SAT solver to find a solution without them), then selectable if no solution exists without (and we minimize how many of them are selected)... so the end result is the same with sorting and without.

There are situations where this refactoring could change the exact solution picked (**if** `avoid-version` is unavoidable **and** multiple solutions exists with the same number of `avoid` selected), because it impacts the depth-first-search bias of the SAT solver... but I hope no one depends on this! (what we do today is unspecified anyway)

On the other end, pre-sorting with `avoid-version` costs a lot: we have to parse each opam file just to check for the existence of the flag for each version of every package.