### PR TITLE
test(pkg): show dune exec run binaries from project dependencies

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/exec-dependency-binaries.t
+++ b/test/blackbox-tests/test-cases/pkg/exec-dependency-binaries.t
@@ -1,0 +1,29 @@
+Binaries installed by lock-dir dependencies can be run with `dune exec`.
+
+  $ make_lockdir
+  $ make_lockpkg foo <<'EOF'
+  > (version 0.0.1)
+  > (build
+  >  (progn
+  >   (system "\| cat > mybin <<'EOI'
+  >           "\| #!/usr/bin/env bash
+  >           "\| echo from foo "$@"
+  >           "\| EOI
+  >   )
+  >   (system "chmod +x mybin")
+  >   (system "echo 'bin: [ \"mybin\" ]' > foo.install")))
+  > EOF
+  $ make_dune_project 3.24
+
+  $ command -v mybin || echo "mybin not on PATH"
+  mybin not on PATH
+
+  $ dune exec mybin
+  from foo
+
+  $ dune exec -- mybin arg1 arg2
+  from foo arg1 arg2
+
+  $ mkdir sub
+  $ cd sub && dune exec --root .. mybin
+  from foo


### PR DESCRIPTION
<!-- Thank you for contributing to dune!

 For general guidelines on contributing to dune, see
 https://github.com/ocaml/dune/blob/main/CONTRIBUTING.md#developing-dune -->

## Description

I discovered this feature while working on https://github.com/ocaml/dune/issues/12914, and found that we currently don't have a test for it. This test essentially shows that it is currently possible to run a binary that is shipped with a dependency. I have examined more behaviors of this, which I'll try to add in follow-up PRs.

This is possible owing to: https://github.com/ocaml/dune/blob/59105f88ea3a86354df6881972ffbfc54af00b2e/src/dune_rules/pkg_rules.ml#L2571-L2588

## Related Issue and Motivation

Relates to work to be done in https://github.com/ocaml/dune/issues/16185

## Checklist

- [x] Tests added, if applicable.
- [x] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes. (NA)
- [x] Documentation added for any user-facing changes. (NA)
