### PR TITLE
fix(pkg): command filter may not be a boolean

### DIFF
--- a/doc/changes/fixed/16313.md
+++ b/doc/changes/fixed/16313.md
@@ -1,0 +1,1 @@
+- Fix a crash when an opam filter is not a boolean (#16313, @art-w)

--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -56,7 +56,7 @@ let partial_eval_filter = function
   | Some f ->
     let env = Fun.const None in
     (match OpamFilter.eval_to_bool env f with
-     | exception Failure _ -> `Filter (Some f)
+     | exception (Failure _ | Invalid_argument _) -> `Filter (Some f)
      | b -> if b then `Filter None else `Skip)
 ;;
 

--- a/test/blackbox-tests/test-cases/pkg/opam-filter-not-a-boolean.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-filter-not-a-boolean.t
@@ -1,0 +1,29 @@
+A command argument can carry a boolean filter. Some packages write that
+filter as an interpolated string rather than as a boolean: (as seen in
+`ocamlsdl.0.9.1`)
+
+  $ mkrepo
+  $ mkpkg string-filter <<'EOF'
+  > build: [
+  >   ["echo" "always"]
+  >   ["configure" "--with-other=%{lib}%/other" {"%{other:installed}%"}]
+  > ]
+  > EOF
+
+As the package `other` is not part of the solution, the interpolation expands
+to the empty string, which is not a boolean. Opam removes these arguments when
+their filter does not evaluate to true. Dune currently crashes:
+
+  $ solve_project <<EOF 2>&1 | head -1
+  > (lang dune 3.11)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends string-filter))
+  > EOF
+  Error: exception Invalid_argument("value_bool: \"\"")
+  [1]
+
+  $ cat ${default_lock_dir}/string-filter.0.0.1.pkg
+  cat: dune.lock/string-filter.0.0.1.pkg: No such file or directory
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/opam-filter-not-a-boolean.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-filter-not-a-boolean.t
@@ -12,18 +12,20 @@ filter as an interpolated string rather than as a boolean: (as seen in
 
 As the package `other` is not part of the solution, the interpolation expands
 to the empty string, which is not a boolean. Opam removes these arguments when
-their filter does not evaluate to true. Dune currently crashes:
+their filter does not evaluate to true. Dune does the same:
 
-  $ solve_project <<EOF 2>&1 | head -1
+  $ solve_project <<EOF
   > (lang dune 3.11)
   > (package
   >  (name x)
   >  (allow_empty)
   >  (depends string-filter))
   > EOF
-  Error: exception Invalid_argument("value_bool: \"\"")
-  [1]
+  Solution for dune.lock:
+  - string-filter.0.0.1
 
   $ cat ${default_lock_dir}/string-filter.0.0.1.pkg
-  cat: dune.lock/string-filter.0.0.1.pkg: No such file or directory
-  [1]
+  (version 0.0.1)
+  
+  (build
+   (all_platforms ((action (progn (run echo always) (run configure))))))


### PR DESCRIPTION
I was testing the `opam_solver` on random packages from the opam repo and stumbled upon this crash (because of [ocamlsdl.0.9.1](https://github.com/ocaml/opam-repository/blob/1e79ccac739fdf75f5425eef07fb8a5482f48528/packages/ocamlsdl/ocamlsdl.0.9.1/opam#L7))