### PR TITLE
test(pkg): demonstrate redundant compiler rebuild for dev tools

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-basic.t
@@ -4,18 +4,32 @@ a lockdir containing an "ocaml" lockfile.
 
   $ mkrepo
   $ make_mock_merlin_package
+  $ cat >>mock-opam-repository/packages/merlin/merlin.0.0.1/opam <<'EOF'
+  > depends: [ "ocaml" ]
+  > EOF
   $ mk_ocaml 5.2.0
+  $ cat >>mock-opam-repository/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0/opam <<'EOF'
+  > build: [ [ "echo" "building fake compiler" ] ]
+  > EOF
 
   $ setup_merlin_workspace
 
   $ make_named_package_project foo 3.16 "(ocaml (= 5.2.0))"
 
-  $ dune build
+  $ DUNE_CACHE=disabled dune build 2>&1 | grep "building fake compiler"
+  building fake compiler
 
-  $ dune tools exec ocamlmerlin
+The dev tool's non-portable lock directory describes the same compiler as the
+project's portable lock directory, but the dev tool currently rebuilds it.
+
+  $ DUNE_CACHE=disabled dune tools exec ocamlmerlin 2>&1 | tee output
   Solution for _build/.dev-tools.locks/merlin:
   - merlin.0.0.1
+  - ocaml.5.2.0
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
+  building fake compiler
        Running 'ocamlmerlin'
   hello from fake ocamlmerlin
+  $ grep "building fake compiler" output
+  building fake compiler


### PR DESCRIPTION
## Description

Add regression coverage for dev tools that use the same compiler as the project. The test gives the fake compiler an observable build action, builds the project, and demonstrates that running Merlin builds the compiler again even though both lock directories select the same compiler.

This is the test-only first change in a stacked fix.

## Testing

- `dune runtest test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-basic.t`