### PR TITLE
refactor(menhir): remove pp_module_as

### DIFF
--- a/src/dune_rules/menhir/menhir_rules.ml
+++ b/src/dune_rules/menhir/menhir_rules.ml
@@ -291,11 +291,7 @@ module Run (P : PARAMS) = struct
       Module.of_source ~visibility:Public ~kind:Impl source
     in
     let* mock_module =
-      Pp_spec.pp_module_as
-        (Compilation_context.preprocessing cctx)
-        name
-        mock_module
-        ~lint:false
+      Pp_spec.pp_module (Compilation_context.preprocessing cctx) mock_module ~lint:false
     in
     let inference_cctx =
       Compilation_context.set_sandbox cctx Sandbox_config.needs_sandboxing

--- a/src/dune_rules/pp_spec.ml
+++ b/src/dune_rules/pp_spec.ml
@@ -5,7 +5,6 @@ type t = (Module.t -> lint:bool -> Module.t Memo.t) Module_name.Per_item.t
 let make x = x
 let dummy : t = Module_name.Per_item.for_all (fun m ~lint:_ -> Memo.return m)
 let pp_module t ?(lint = true) m = Module_name.Per_item.get t (Module.name m) m ~lint
-let pp_module_as t ?(lint = true) name m = Module_name.Per_item.get t name m ~lint
 
 let pped_modules_map preprocess v =
   let map =

--- a/src/dune_rules/pp_spec.mli
+++ b/src/dune_rules/pp_spec.mli
@@ -12,10 +12,6 @@ val make : (Module.t -> lint:bool -> Module.t Memo.t) Module_name.Per_item.t -> 
     translated modules *)
 val pp_module : t -> ?lint:bool -> Module.t -> Module.t Memo.t
 
-(** Preprocess a single module, using the configuration for the given module
-    name. *)
-val pp_module_as : t -> ?lint:bool -> Module_name.t -> Module.t -> Module.t Memo.t
-
 val pped_modules_map
   :  Preprocess.Without_instrumentation.t Preprocess.t Module_name.Per_item.t
   -> Ocaml.Version.t


### PR DESCRIPTION
Remove the redundant `Pp_spec.pp_module_as` helper. Menhir’s mock module already carries the lookup name used by `Pp_spec.pp_module`.