### PR TITLE
test(module): cover logical source paths

### DIFF
--- a/test/blackbox-tests/test-cases/include-qualified/generate-group-interface.t
+++ b/test/blackbox-tests/test-cases/include-qualified/generate-group-interface.t
@@ -47,3 +47,23 @@ Module `Foo_Group__` appears twice (the alias module and the shadowed module):
   
   module Foo__Group__ = struct end
   [@@deprecated "this module is shadowed"]
+
+Nested group interfaces in unwrapped libraries currently use the source-trie
+path with a repeated final component as their canonical path:
+
+  $ mkdir -p unwrapped-canonical/foo/bar
+  $ cat >unwrapped-canonical/dune-project <<'EOF'
+  > (lang dune 3.21)
+  > EOF
+  $ touch unwrapped-canonical/foo/bar/bar.ml
+  $ touch unwrapped-canonical/foo/bar/baz.ml
+  $ cat >unwrapped-canonical/dune <<'EOF'
+  > (include_subdirs qualified)
+  > (library
+  >  (name refs)
+  >  (wrapped false))
+  > EOF
+  $ dune build --root=unwrapped-canonical
+  $ grep -A1 '@canonical Foo.Bar' unwrapped-canonical/_build/default/foo.ml-gen
+  (** @canonical Foo.Bar.Bar *)
+  module Bar = Foo__Bar

--- a/test/blackbox-tests/test-cases/install/dune-package-source-path.t
+++ b/test/blackbox-tests/test-cases/install/dune-package-source-path.t
@@ -97,3 +97,23 @@ Test paths on public libraries with `.` are correct
           (source (path Child Bar) (impl (path sub/child/bar.ml))))))
         (source (path Foo) (impl (path sub/foo.ml))))))
 
+A singleton with a repeated logical path retains an unambiguous installed path:
+
+  $ mkdir -p c/foo/foo
+  $ cat > c/dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name c))
+  > EOF
+  $ cat > c/dune <<EOF
+  > (include_subdirs qualified)
+  > (library
+  >  (name singleton)
+  >  (public_name c.singleton)
+  >  (wrapped false))
+  > EOF
+  $ cat > c/foo/foo/foo.ml <<EOF
+  > let x = "foo"
+  > EOF
+  $ dune build c.install --root c
+  $ grep -o '(path Foo Foo Foo)' c/_build/install/default/lib/c/dune-package
+  (path Foo Foo Foo)

--- a/test/blackbox-tests/test-cases/select-field/select-qualified.t
+++ b/test/blackbox-tests/test-cases/select-field/select-qualified.t
@@ -112,3 +112,28 @@ More levels:
   $ dune exec ./foo.exe
   Test: Unix was found!
   Test: Unix was found!
+
+A selected file can itself be a nested group interface:
+
+  $ mkdir -p selected-group-interface/outer/foo
+  $ cat >selected-group-interface/dune-project <<'EOF'
+  > (lang dune 3.22)
+  > EOF
+  $ cat >selected-group-interface/dune <<'EOF'
+  > (include_subdirs qualified)
+  > (library
+  >  (name selected)
+  >  (wrapped false)
+  >  (libraries
+  >   (select outer/foo/foo.ml from
+  >    (unix -> outer/foo/foo.unix.ml)
+  >    (!unix -> outer/foo/foo.nounix.ml))))
+  > EOF
+  $ touch selected-group-interface/outer/foo/foo.unix.ml
+  $ touch selected-group-interface/outer/foo/foo.nounix.ml
+  $ touch selected-group-interface/outer/foo/bar.ml
+  $ dune build --root=selected-group-interface
+  $ grep -A1 '@canonical Outer.Foo' \
+  > selected-group-interface/_build/default/outer.ml-gen
+  (** @canonical Outer.Foo.Foo *)
+  module Foo = Outer__Foo

--- a/test/blackbox-tests/test-cases/stdlib/stdlib-compilation-depend-on-library.t
+++ b/test/blackbox-tests/test-cases/stdlib/stdlib-compilation-depend-on-library.t
@@ -12,6 +12,7 @@ Test dependency on installed package
   >  (name a)
   >  (public_name a)
   >  (stdlib
+  >   (exit_module Std_exit)
   >   (modules_before_stdlib CamlinternalFormatBasics)
   >   (internal_modules Camlinternal*)))
   > EOF
@@ -23,6 +24,8 @@ Test dependency on installed package
   $ cat > a/a.ml <<EOF
   > module Foo = A__Foo
   > EOF
+
+  $ touch a/camlinternalFoo.ml a/std_exit.ml
 
   $ dune build --root a
 
@@ -38,9 +41,23 @@ Test dependency on installed package
   Installing $TESTCASE_ROOT/prefix/lib/a/a__Foo.cmi
   Installing $TESTCASE_ROOT/prefix/lib/a/a__Foo.cmt
   Installing $TESTCASE_ROOT/prefix/lib/a/a__Foo.cmx
+  Installing $TESTCASE_ROOT/prefix/lib/a/camlinternalFoo.cmi
+  Installing $TESTCASE_ROOT/prefix/lib/a/camlinternalFoo.cmt
+  Installing $TESTCASE_ROOT/prefix/lib/a/camlinternalFoo.cmx
+  Installing $TESTCASE_ROOT/prefix/lib/a/camlinternalFoo.ml
   Installing $TESTCASE_ROOT/prefix/lib/a/dune-package
   Installing $TESTCASE_ROOT/prefix/lib/a/foo.ml
+  Installing $TESTCASE_ROOT/prefix/lib/a/std_exit.cmi
+  Installing $TESTCASE_ROOT/prefix/lib/a/std_exit.cmt
+  Installing $TESTCASE_ROOT/prefix/lib/a/std_exit.cmx
+  Installing $TESTCASE_ROOT/prefix/lib/a/std_exit.ml
   Installing $TESTCASE_ROOT/prefix/lib/a/a.cmxs
+
+  $ grep -o '(path [A-Z][A-Za-z_ ]*)' prefix/lib/a/dune-package
+  (path A)
+  (path CamlinternalFoo)
+  (path A Foo)
+  (path Std_exit)
 
   $ cat >b/dune-project <<EOF
   > (lang dune 3.7)
@@ -59,3 +76,24 @@ Test dependency on installed package
 
   $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root b @install
 
+Unwrapped stdlib modules keep unqualified source paths:
+
+  $ mkdir unwrapped
+  $ cat >unwrapped/dune-project <<'EOF'
+  > (lang dune 3.7)
+  > (package (name unwrapped))
+  > (using experimental_building_ocaml_compiler_with_dune 0.1)
+  > EOF
+  $ cat >unwrapped/dune <<'EOF'
+  > (library
+  >  (name unwrapped)
+  >  (public_name unwrapped)
+  >  (wrapped false)
+  >  (stdlib))
+  > EOF
+  $ touch unwrapped/unwrapped.ml unwrapped/foo.ml
+  $ dune build unwrapped.install --root=unwrapped
+  $ grep -o '(path [A-Z][A-Za-z_ ]*)' \
+  > unwrapped/_build/install/default/lib/unwrapped/dune-package
+  (path Foo)
+  (path Unwrapped)

--- a/test/expect-tests/module_tests.ml
+++ b/test/expect-tests/module_tests.ml
@@ -81,6 +81,25 @@ let make_lib
     ~for_:Ocaml
 ;;
 
+let%expect_test "qualified group alias source path" =
+  let modules =
+    make_lib
+      ~lib_name:"group"
+      [ generated ~obj_name:"Group__A" [ "Group"; "A" ]
+      ; generated ~obj_name:"Group__B" [ "Group"; "B" ]
+      ]
+  in
+  Modules.fold modules ~init:[] ~f:(fun module_ paths ->
+    match Module.kind module_ with
+    | Alias _ -> Module.path module_ :: paths
+    | Intf_only | Virtual | Impl | Impl_vmodule | Wrapped_compat | Root | Parameter ->
+      paths)
+  |> List.rev
+  |> Dyn.list Module_name.Path.to_dyn
+  |> Dune_tests_common.print_dyn;
+  [%expect {| [ [ "Group"; "Group" ] ] |}]
+;;
+
 let kind_name = function
   | Kind.Intf_only -> "intf-only"
   | Virtual -> "virtual"


### PR DESCRIPTION
Add regression coverage for logical module source paths and their serialized representation.

Split out of #15633; this PR does not change behavior.