### PR TITLE
test(module): cover repeated qualified paths

### DIFF
--- a/test/blackbox-tests/test-cases/include-qualified/repeated-directory-names.t
+++ b/test/blackbox-tests/test-cases/include-qualified/repeated-directory-names.t
@@ -1,0 +1,28 @@
+Qualified module groups can repeat the same name at arbitrary depths.
+
+  $ mkdir -p foo/foo/foo/foo
+  $ cat >dune-project <<'EOF'
+  > (lang dune 3.24)
+  > (package (name repeated))
+  > EOF
+  $ cat >dune <<'EOF'
+  > (include_subdirs qualified)
+  > (library
+  >  (name repeated)
+  >  (public_name repeated)
+  >  (wrapped false))
+  > EOF
+  $ touch anchor.ml
+  $ cat >foo/foo/foo/foo/foo.ml <<'EOF'
+  > let value = "deep"
+  > EOF
+
+  $ dune build @check
+
+The installed format keeps the group-interface component that distinguishes
+the source-trie path from the four-component logical module path.
+
+  $ dune build @install
+  $ grep -o '(path Foo Foo Foo Foo Foo)' \
+  > _build/install/default/lib/repeated/dune-package
+  (path Foo Foo Foo Foo Foo)

--- a/test/expect-tests/module_tests.ml
+++ b/test/expect-tests/module_tests.ml
@@ -100,6 +100,32 @@ let%expect_test "qualified group alias source path" =
   [%expect {| [ [ "Group"; "Group" ] ] |}]
 ;;
 
+let%expect_test "repeated qualified group paths" =
+  let modules =
+    make_lib
+      ~lib_name:"foo"
+      [ generated ~obj_name:"Foo__Foo__Foo__Foo__A" [ "Foo"; "Foo"; "Foo"; "Foo"; "A" ]
+      ; generated ~obj_name:"Foo__Foo__Foo__Foo__B" [ "Foo"; "Foo"; "Foo"; "Foo"; "B" ]
+      ]
+  in
+  Modules.fold modules ~init:[] ~f:(fun module_ paths ->
+    match Module.kind module_ with
+    | Alias _ -> Module.path module_ :: paths
+    | Intf_only | Virtual | Impl | Impl_vmodule | Wrapped_compat | Root | Parameter ->
+      paths)
+  |> List.rev
+  |> Dyn.list Module_name.Path.to_dyn
+  |> Dune_tests_common.print_dyn;
+  [%expect
+    {|
+    [ [ "Foo"; "Foo" ]
+    ; [ "Foo"; "Foo"; "Foo" ]
+    ; [ "Foo"; "Foo"; "Foo"; "Foo" ]
+    ; [ "Foo"; "Foo"; "Foo"; "Foo"; "Foo" ]
+    ]
+    |}]
+;;
+
 let kind_name = function
   | Kind.Intf_only -> "intf-only"
   | Virtual -> "virtual"


### PR DESCRIPTION
Add regression coverage for repeated qualified paths such as `Foo.Foo.Foo.Foo`.

Depends on #16320 and prepares the logical source-path refactor.