### PR TITLE
Rocq: Ignore broken .vo symlinks when traversing installed theories

### DIFF
--- a/doc/changes/fixed/16326.md
+++ b/doc/changes/fixed/16326.md
@@ -1,0 +1,1 @@
+- Fix errors when Rocq encounters broken symlinks in installed theories (#16326, @janno)

--- a/src/dune_rules/rocq/rocq_path.ml
+++ b/src/dune_rules/rocq/rocq_path.ml
@@ -54,12 +54,17 @@ let scan_vo ~dir dir_contents =
     let d_s = Filename.to_string d in
     match kind with
     (* Skip some files as Rocq does, for now files with '-' *)
-    | _ when String.contains d_s '-' -> None
-    | (File_kind.S_REG | S_LNK) when String.ends_with ~suffix:".vo" d_s ->
-      Some (Path.relative_fname dir d)
-    | _ -> None
+    | _ when String.contains d_s '-' -> Memo.return None
+    | File_kind.S_REG when String.ends_with ~suffix:".vo" d_s ->
+      Memo.return (Some (Path.relative_fname dir d))
+    | S_LNK when String.ends_with ~suffix:".vo" d_s ->
+      let path = Path.relative_fname dir d in
+      let open Memo.O in
+      let+ exists = Fs_memo.file_exists (Path.as_outside_build_dir_exn path) in
+      Option.some_if exists path
+    | _ -> Memo.return None
   in
-  List.filter_map ~f dir_contents
+  Memo.List.filter_map ~f dir_contents
 ;;
 
 (* Note this will only work for absolute paths *)
@@ -120,7 +125,8 @@ let scan_path ~f ~acc ~prefix dir =
     in [Dir_status] *)
 let scan_user_path root_path =
   let f ~dir ~prefix ~subresults dir_contents =
-    let vo = scan_vo ~dir dir_contents in
+    let open Memo.O in
+    let* vo = scan_vo ~dir dir_contents in
     let vo_r = retrieve_vo subresults in
     let vo = vo @ vo_r in
     Memo.return (build_user_contrib ~vo ~path:dir ~name:prefix :: subresults)
@@ -130,8 +136,9 @@ let scan_user_path root_path =
 
 let scan_vo root_path =
   let f ~dir ~prefix:() ~subresults dir_contents =
-    let vo = scan_vo ~dir dir_contents in
-    Memo.return (vo @ subresults)
+    let open Memo.O in
+    let+ vo = scan_vo ~dir dir_contents in
+    vo @ subresults
   in
   let acc _ _ = () in
   scan_path ~f ~acc ~prefix:() root_path

--- a/test/blackbox-tests/test-cases/rocq/rocq-installed-broken-symlink.t
+++ b/test/blackbox-tests/test-cases/rocq/rocq-installed-broken-symlink.t
@@ -61,14 +61,6 @@ prevent the build.
   > EOF
 
   $ dune build
-  File "theories/dune", lines 1-3, characters 0-44:
-  1 | (rocq.theory
-  2 |  (name repro)
-  3 |  (theories Good))
-  Error: File unavailable:
-  $TESTCASE_ROOT/fake-prefix/lib/coq/user-contrib/Unrelated/Broken.vo
-  Broken symbolic link
-  [1]
 
   $ unlink fake-prefix/lib/coq/user-contrib/Unrelated/Broken.vo
   $ dune build


### PR DESCRIPTION
<!-- Thank you for contributing to dune!

 For general guidelines on contributing to dune, see
 https://github.com/ocaml/dune/blob/main/CONTRIBUTING.md#developing-dune -->

## Description
<!-- Briefly describe your changes -->

`dune` does not clean symlinks in `_build/install` when the underlying files need to be rebuild. In various scenarios, this can lead to failures in unrelated theories when they scan all "installed" rocq theories. I think it only happens when rocq is in the workspace but I am not 100% sure. It definitely does happen when rocq is in the workspace and when it is used in cram tests that get executed at the same time that unrelated theories get their artifacts cleaned and rebuild (leaving broken symlinks momentarily).


The solution in this PR is to test for existence of the symlink target before adding it to the memo.

I have added a very hacky test that forces the issue to appear in a somewhat unrealistic way. Unfortunately, all my attempts to do anything with an up-to-date, real rocq in the workspace are failing for many different reasons and the one working setup that I have requires a bunch of custom patches that no longer work against rocq/master and the version of rocq used is not compatible with dune/main.


## Related Issue and Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it closes an open issue, link to the issue here. -->
<!-- Non-trivial contributions are expected to be preceded by an issue, as
     per CONTRIBUTING.md. -->


The problem has been mentioned in https://github.com/ocaml/dune/issues/6015#issuecomment-2988669658 and it is still a problem to this day.

This is probably related to https://github.com/ocaml/dune/pull/7580



## Checklist

- [x] Tests added, if applicable.
- [ ] [Change log entry added](../CONTRIBUTING.md#updating-the-changelog) for any user-facing changes.
- [ ] Documentation added for any user-facing changes.
