### PR TITLE
test(include-qualified): fix nested virtual description

### DIFF
--- a/test/blackbox-tests/test-cases/include-qualified/nested-virtual.t/run.t
+++ b/test/blackbox-tests/test-cases/include-qualified/nested-virtual.t/run.t
@@ -1,4 +1,4 @@
-We can nested modules virtual
+We can make nested modules virtual
   $ mkdir -p vlib/group impl/group vlib/foo/foo impl/foo/foo
   $ cat >vlib/group/group.mli <<'EOF'
   > val value : int


### PR DESCRIPTION
Fix the opening description in the nested virtual module regression test introduced in #15633.