### PR TITLE
refactor(module-name): remove unused Per_item

### DIFF
--- a/src/dune_lang/module_name.ml
+++ b/src/dune_lang/module_name.ml
@@ -80,39 +80,6 @@ let of_local_lib_name (loc, s) =
   Unchecked.make ~loc (Lib_name.Local.to_string s) |> Unchecked.validate_exn
 ;;
 
-module Per_item = struct
-  include Per_item.Make (String)
-  open Decoder
-
-  let repr value_repr =
-    Repr.view
-      Repr.(pair (list (pair String.repr Int.repr)) (list value_repr))
-      ~to_:enumerate
-  ;;
-
-  let decode ~default a =
-    peek_exn
-    >>= function
-    | List (loc, Atom (_, A "per_module") :: _) ->
-      sum
-        [ ( "per_module"
-          , let+ x =
-              repeat
-                (let+ pp, names = pair a (repeat decode) in
-                 names, pp)
-            in
-            of_mapping x ~default
-            |> function
-            | Ok t -> t
-            | Error (name, _, _) ->
-              User_error.raise
-                ~loc
-                [ Pp.textf "module %s present in two different sets" (to_string name) ] )
-        ]
-    | _ -> a >>| for_all
-  ;;
-end
-
 let of_string_allow_invalid (loc, s) =
   (* TODO add a warning here that is possible to disable *)
   Unchecked.make ~loc s

--- a/src/dune_lang/module_name.mli
+++ b/src/dune_lang/module_name.mli
@@ -43,13 +43,6 @@ val compare : t -> t -> Ordering.t
 val repr : t Repr.t
 val uncapitalize : t -> string
 
-module Per_item : sig
-  include Per_item with type key = t
-
-  val decode : default:'a -> 'a Decoder.t -> 'a t Decoder.t
-  val repr : 'a Repr.t -> 'a t Repr.t
-end
-
 module Infix : Comparator.OPS with type t = t
 
 val of_local_lib_name : Loc.t * Lib_name.Local.t -> t


### PR DESCRIPTION
Remove `Module_name.Per_item` now that all callers use `Module_reference.Per_item` after #15633.