### PR TITLE
refactor(module-reference): encapsulate qualification validation

### DIFF
--- a/src/dune_lang/module_reference.ml
+++ b/src/dune_lang/module_reference.ml
@@ -38,7 +38,6 @@ end
 
 include T
 
-let loc t = t.loc
 let path t = t.path
 let to_string t = Module_name.Path.to_string t.path
 
@@ -46,6 +45,23 @@ let is_qualified t =
   match t.path with
   | _ :: _ :: _ -> true
   | [ _ ] -> false
+;;
+
+let validate_qualified t ~include_subdirs =
+  if
+    is_qualified t
+    &&
+    match include_subdirs with
+    | Include_subdirs.Include Qualified -> false
+    | No | Include Unqualified -> true
+  then
+    User_error.raise
+      ~loc:t.loc
+      [ Pp.textf
+          "Qualified module reference %S may only be used with (include_subdirs \
+           qualified)."
+          (to_string t)
+      ]
 ;;
 
 let make ~loc ~mode path = { loc; path; mode }

--- a/src/dune_lang/module_reference.mli
+++ b/src/dune_lang/module_reference.mli
@@ -6,11 +6,13 @@ open Import
     multiple components, for example [Foo.Bar]. *)
 type t
 
-val loc : t -> Loc.t
 val path : t -> Module_name.Path.t
 val to_string : t -> string
 val of_string : Syntax.Version.t -> Loc.t * string -> t
-val is_qualified : t -> bool
+
+(** Reject a qualified reference unless subdirectories are included with
+    qualified names. *)
+val validate_qualified : t -> include_subdirs:Include_subdirs.t -> unit
 
 module Per_item : sig
   type key = t

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -684,21 +684,7 @@ let has_instances (lib : Buildable.t) =
 
 let validate_qualified_module_references ~include_subdirs per_module =
   Module_reference.Per_item.explicit_references per_module
-  |> List.iter ~f:(fun reference ->
-    if
-      Module_reference.is_qualified reference
-      &&
-      match include_subdirs with
-      | Include_subdirs.Include Qualified -> false
-      | No | Include Unqualified -> true
-    then
-      User_error.raise
-        ~loc:(Module_reference.loc reference)
-        [ Pp.textf
-            "Qualified module reference %S may only be used with (include_subdirs \
-             qualified)."
-            (Module_reference.to_string reference)
-        ])
+  |> List.iter ~f:(Module_reference.validate_qualified ~include_subdirs)
 ;;
 
 let validate_buildable_preprocessing ~include_subdirs ~for_ buildable =

--- a/src/dune_rules/modules_field_evaluator.ml
+++ b/src/dune_rules/modules_field_evaluator.ml
@@ -93,20 +93,7 @@ let eval0 =
       else (
         let reference = Module_reference.of_string version (loc, s) in
         let path = Module_reference.path reference in
-        if
-          Module_reference.is_qualified reference
-          &&
-          match include_subdirs with
-          | Include_subdirs.Include Qualified -> false
-          | No | Include Unqualified -> true
-        then
-          User_error.raise
-            ~loc
-            [ Pp.textf
-                "Qualified module reference %S may only be used with (include_subdirs \
-                 qualified)."
-                (Module_reference.to_string reference)
-            ];
+        Module_reference.validate_qualified reference ~include_subdirs;
         unchecked_path path)
     in
     match Module_name.Unchecked.Path.Map.find all_modules path with


### PR DESCRIPTION
Centralize validation of qualified module references in `Module_reference`, allowing its location and qualification helpers to remain private.

Split out of #16214.