### PR TITLE
fix(melange): fall back to Melange module artifacts

### DIFF
--- a/doc/changes/fixed/16339.md
+++ b/doc/changes/fixed/16339.md
@@ -1,0 +1,3 @@
+- Resolve ``%{cmi:...}``, ``%{cmt:...}``, and ``%{cmti:...}`` against Melange
+  module sets when no OCaml module is selected, while preferring OCaml for
+  modules selected in both modes. (#16339, @anmonteiro)

--- a/src/dune_rules/artifacts_obj.ml
+++ b/src/dune_rules/artifacts_obj.ml
@@ -44,16 +44,18 @@ let module_source_path_without_extension m =
   |> Option.map ~f:(fun p -> fst (Path.Build.split_extension p))
 ;;
 
-let make ~dir ~expander ~lib_config ~libs ~exes ~include_subdirs ~melange_emits =
-  let+ libraries =
-    Memo.List.map libs ~f:(fun ((lib : Library.t), _, _) ->
-      let+ lib_config = lib_config in
+let make ~dir ~for_ ~expander ~lib_config ~libs ~exes ~include_subdirs ~melange_emits =
+  let+ lib_config = lib_config in
+  let libs =
+    List.map libs ~f:(fun ((lib : Library.t), modules, obj_dir) ->
       let name = Lib_name.of_local lib.name in
       let info =
         Library.to_lib_info lib ~expander:(Memo.return expander) ~dir ~lib_config
       in
-      name, info)
-    >>| Lib_name.Map.of_list_exn
+      name, info, modules, obj_dir)
+  in
+  let libraries =
+    List.map libs ~f:(fun (name, info, _, _) -> name, info) |> Lib_name.Map.of_list_exn
   in
   let modules_by_source_path, modules_by_logical_path =
     let add_modules modules obj_dir =
@@ -68,13 +70,22 @@ let make ~dir ~expander ~lib_config ~libs ~exes ~include_subdirs ~melange_emits 
             ))
     in
     let init =
-      List.fold_left
-        exes
-        ~init:(Path.Build.Map.empty, Module_name.Path.Map.empty)
-        ~f:(fun modules (m, obj_dir) -> add_modules modules obj_dir m)
+      let empty = Path.Build.Map.empty, Module_name.Path.Map.empty in
+      match for_ with
+      | Compilation_mode.Ocaml ->
+        List.fold_left exes ~init:empty ~f:(fun modules (m, obj_dir) ->
+          add_modules modules obj_dir m)
+      | Compilation_mode.Melange -> empty
     in
-    List.fold_left libs ~init ~f:(fun modules (_, m, obj_dir) ->
-      add_modules modules obj_dir m)
+    List.fold_left libs ~init ~f:(fun modules (_, info, m, obj_dir) ->
+      if
+        List.mem
+          (Compilation_mode.Set.of_lib_mode_set (Lib_info.modes info)
+           |> Compilation_mode.Set.to_list)
+          for_
+          ~equal:Compilation_mode.equal
+      then add_modules modules obj_dir m
+      else modules)
   in
   let melange_emits =
     match Path.Build.Map.of_list melange_emits with

--- a/src/dune_rules/artifacts_obj.mli
+++ b/src/dune_rules/artifacts_obj.mli
@@ -6,6 +6,7 @@ val empty : t
 
 val make
   :  dir:Path.Build.t
+  -> for_:Compilation_mode.t
   -> expander:Expander0.t
   -> lib_config:Lib_config.t Memo.t
   -> libs:(Library.t * Modules.t * Path.Build.t Obj_dir.t) list

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -518,9 +518,9 @@ let modules_of_lib sctx lib ~for_ =
 ;;
 
 let () =
-  Fdecl.set Expander.lookup_artifacts (fun ~dir ->
+  Fdecl.set Expander.lookup_artifacts (fun ~dir ~for_ ->
     let* t =
       Context.DB.by_dir dir >>| Context.name >>= Super_context.find_exn >>= Load.get ~dir
     in
-    Memo.Lazy.force t.ocaml >>= Ml_sources.artifacts)
+    ml t ~for_ >>= Ml_sources.artifacts)
 ;;

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -175,95 +175,96 @@ let expand_version { scope; _ } ~(source : Dune_lang.Template.Pform.t) s =
          ])
 ;;
 
-let expand_artifact ~source t artifact arg =
-  let path = Path.Build.relative t.dir arg in
-  let loc = Dune_lang.Template.Pform.loc source in
-  let name = Path.Build.basename path in
-  let dir = Path.Build.parent_exn path in
-  if Path.Build.is_root dir
-  then User_error.raise ~loc [ Pp.text "cannot escape the workspace root directory" ];
-  let does_not_exist ~what name =
-    User_error.raise ~loc [ Pp.textf "%s %s does not exist." what name ]
-  in
-  let lookup_artifacts ~for_ =
+let expand_artifact =
+  let lookup_artifacts ~dir ~for_ =
     let lookup = Fdecl.get lookup_artifacts in
     Action_builder.of_memo (lookup ~dir ~for_)
   in
-  match artifact with
-  | Pform.Artifact.Mod kind ->
-    let reference = Module_reference.of_string_path (loc, Filename.to_string name) in
-    let reference_path = Module_reference.path reference in
-    let lookup_module ~for_ =
-      let+ artifacts = lookup_artifacts ~for_ in
-      Module_reference.validate_qualified
-        reference
-        ~include_subdirs:(Artifacts_obj.include_subdirs artifacts);
-      (match Artifacts_obj.lookup_module_by_source_path artifacts path with
-       | Some (_, module_)
-         when not (Module_name.Path.equal reference_path (Module.path module_)) ->
-         User_error.raise
-           ~loc
-           ~hints:
+  fun ~source t artifact arg ->
+    let path = Path.Build.relative t.dir arg in
+    let loc = Dune_lang.Template.Pform.loc source in
+    let name = Path.Build.basename path in
+    let dir = Path.Build.parent_exn path in
+    if Path.Build.is_root dir
+    then User_error.raise ~loc [ Pp.text "cannot escape the workspace root directory" ];
+    let does_not_exist ~what name =
+      User_error.raise ~loc [ Pp.textf "%s %s does not exist." what name ]
+    in
+    match artifact with
+    | Pform.Artifact.Mod kind ->
+      let reference = Module_reference.of_string_path (loc, Filename.to_string name) in
+      let reference_path = Module_reference.path reference in
+      let lookup_module ~for_ =
+        let+ artifacts = lookup_artifacts ~dir ~for_ in
+        Module_reference.validate_qualified
+          reference
+          ~include_subdirs:(Artifacts_obj.include_subdirs artifacts);
+        (match Artifacts_obj.lookup_module_by_source_path artifacts path with
+         | Some (_, module_)
+           when not (Module_name.Path.equal reference_path (Module.path module_)) ->
+           User_error.raise
+             ~loc
+             ~hints:
+               [ Pp.textf
+                   "%s would be a correct module reference"
+                   (Module.path module_ |> Module_name.Path.to_string)
+               ]
              [ Pp.textf
-                 "%s would be a correct module reference"
-                 (Module.path module_ |> Module_name.Path.to_string)
+                 "Module reference %s does not match the module at this source path."
+                 (Module_reference.to_string reference)
              ]
-           [ Pp.textf
-               "Module reference %s does not match the module at this source path."
-               (Module_reference.to_string reference)
-           ]
-       | None | Some _ -> ());
-      match Artifacts_obj.lookup_modules_by_logical_path artifacts reference_path with
-      | [ (obj_dir, module_) ] -> Some (for_, obj_dir, module_)
-      | _ :: _ ->
-        User_error.raise
-          ~loc
-          [ Pp.textf
-              "Module reference %s is ambiguous."
-              (Module_reference.to_string reference)
-          ]
-      | [] -> None
-    in
-    let* module_ =
-      match kind with
-      | Cm_kind (Cmo | Cmx) -> lookup_module ~for_:Compilation_mode.Ocaml
-      | Cm_kind Cmi | Cmt | Cmti ->
-        let* ocaml = lookup_module ~for_:Compilation_mode.Ocaml in
-        (match ocaml with
-         | Some _ -> Action_builder.return ocaml
-         | None -> lookup_module ~for_:Compilation_mode.Melange)
-    in
-    (match module_ with
-     | None -> does_not_exist ~what:"Module" (Module_reference.to_string reference)
-     | Some (for_, obj_dir, m) ->
-       let cmi_kind =
-         match for_ with
-         | Compilation_mode.Ocaml -> Lib_mode.Cm_kind.Ocaml Ocaml.Cm_kind.Cmi
-         | Compilation_mode.Melange -> Lib_mode.Cm_kind.Melange Melange.Cm_kind.Cmi
-       in
-       (match
-          match kind with
-          | Cm_kind Cmi -> Obj_dir.Module.cm_file obj_dir m ~kind:cmi_kind
-          | Cm_kind kind -> Obj_dir.Module.cm_file obj_dir m ~kind:(Ocaml kind)
-          | Cmt -> Obj_dir.Module.cmt_file obj_dir m ~cm_kind:cmi_kind ~ml_kind:Impl
-          | Cmti -> Some (Obj_dir.Module.cmti_file obj_dir m ~cm_kind:cmi_kind)
-        with
-        | None -> Action_builder.return [ Value.String "" ]
-        | Some path -> dep (Path.build path)))
-  | Lib mode ->
-    let* artifacts = lookup_artifacts ~for_:Compilation_mode.Ocaml in
-    let name =
-      Lib_name.parse_string_exn
-        (Dune_lang.Template.Pform.loc source, Filename.to_string name)
-    in
-    (match Artifacts_obj.lookup_library artifacts name with
-     | None -> does_not_exist ~what:"Library" (Lib_name.to_string name)
-     | Some lib ->
-       Mode.Dict.get (Lib_info.archives lib) mode
-       |> Action_builder.List.map ~f:(fun fn ->
-         let fn = Path.build fn in
-         let+ () = Action_builder.path fn in
-         Value.Path fn))
+         | None | Some _ -> ());
+        match Artifacts_obj.lookup_modules_by_logical_path artifacts reference_path with
+        | [ (obj_dir, module_) ] -> Some (for_, obj_dir, module_)
+        | _ :: _ ->
+          User_error.raise
+            ~loc
+            [ Pp.textf
+                "Module reference %s is ambiguous."
+                (Module_reference.to_string reference)
+            ]
+        | [] -> None
+      in
+      let* module_ =
+        match kind with
+        | Cm_kind (Cmo | Cmx) -> lookup_module ~for_:Compilation_mode.Ocaml
+        | Cm_kind Cmi | Cmt | Cmti ->
+          let* ocaml = lookup_module ~for_:Compilation_mode.Ocaml in
+          (match ocaml with
+           | Some _ -> Action_builder.return ocaml
+           | None -> lookup_module ~for_:Compilation_mode.Melange)
+      in
+      (match module_ with
+       | None -> does_not_exist ~what:"Module" (Module_reference.to_string reference)
+       | Some (for_, obj_dir, m) ->
+         let cmi_kind =
+           match for_ with
+           | Compilation_mode.Ocaml -> Lib_mode.Cm_kind.Ocaml Ocaml.Cm_kind.Cmi
+           | Compilation_mode.Melange -> Lib_mode.Cm_kind.Melange Melange.Cm_kind.Cmi
+         in
+         (match
+            match kind with
+            | Cm_kind Cmi -> Obj_dir.Module.cm_file obj_dir m ~kind:cmi_kind
+            | Cm_kind kind -> Obj_dir.Module.cm_file obj_dir m ~kind:(Ocaml kind)
+            | Cmt -> Obj_dir.Module.cmt_file obj_dir m ~cm_kind:cmi_kind ~ml_kind:Impl
+            | Cmti -> Some (Obj_dir.Module.cmti_file obj_dir m ~cm_kind:cmi_kind)
+          with
+          | None -> Action_builder.return [ Value.String "" ]
+          | Some path -> dep (Path.build path)))
+    | Lib mode ->
+      let* artifacts = lookup_artifacts ~dir ~for_:Compilation_mode.Ocaml in
+      let name =
+        Lib_name.parse_string_exn
+          (Dune_lang.Template.Pform.loc source, Filename.to_string name)
+      in
+      (match Artifacts_obj.lookup_library artifacts name with
+       | None -> does_not_exist ~what:"Library" (Lib_name.to_string name)
+       | Some lib ->
+         Mode.Dict.get (Lib_info.archives lib) mode
+         |> Action_builder.List.map ~f:(fun fn ->
+           let fn = Path.build fn in
+           let+ () = Action_builder.path fn in
+           Value.Path fn))
 ;;
 
 let expand_melange_emit ~source t arg =

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -185,18 +185,19 @@ let expand_artifact ~source t artifact arg =
   let does_not_exist ~what name =
     User_error.raise ~loc [ Pp.textf "%s %s does not exist." what name ]
   in
-  let* artifacts =
+  let lookup_artifacts ~for_ =
     let lookup = Fdecl.get lookup_artifacts in
-    Action_builder.of_memo (lookup ~dir)
+    Action_builder.of_memo (lookup ~dir ~for_)
   in
   match artifact with
   | Pform.Artifact.Mod kind ->
-    let module_ =
-      let reference = Module_reference.of_string_path (loc, Filename.to_string name) in
+    let reference = Module_reference.of_string_path (loc, Filename.to_string name) in
+    let reference_path = Module_reference.path reference in
+    let lookup_module ~for_ =
+      let+ artifacts = lookup_artifacts ~for_ in
       Module_reference.validate_qualified
         reference
         ~include_subdirs:(Artifacts_obj.include_subdirs artifacts);
-      let reference_path = Module_reference.path reference in
       (match Artifacts_obj.lookup_module_by_source_path artifacts path with
        | Some (_, module_)
          when not (Module_name.Path.equal reference_path (Module.path module_)) ->
@@ -213,7 +214,7 @@ let expand_artifact ~source t artifact arg =
            ]
        | None | Some _ -> ());
       match Artifacts_obj.lookup_modules_by_logical_path artifacts reference_path with
-      | [ module_ ] -> module_
+      | [ (obj_dir, module_) ] -> Some (for_, obj_dir, module_)
       | _ :: _ ->
         User_error.raise
           ~loc
@@ -221,21 +222,36 @@ let expand_artifact ~source t artifact arg =
               "Module reference %s is ambiguous."
               (Module_reference.to_string reference)
           ]
-      | [] ->
-        User_error.raise
-          ~loc
-          [ Pp.textf "Module %s does not exist." (Module_reference.to_string reference) ]
+      | [] -> None
     in
-    let obj_dir, module_ = module_ in
-    (match
-       match kind with
-       | Cm_kind kind -> Obj_dir.Module.cm_file obj_dir module_ ~kind:(Ocaml kind)
-       | Cmt -> Obj_dir.Module.cmt_file obj_dir module_ ~cm_kind:(Ocaml Cmi) ~ml_kind:Impl
-       | Cmti -> Some (Obj_dir.Module.cmti_file obj_dir module_ ~cm_kind:(Ocaml Cmi))
-     with
-     | None -> Action_builder.return [ Value.String "" ]
-     | Some path -> dep (Path.build path))
+    let* module_ =
+      match kind with
+      | Cm_kind (Cmo | Cmx) -> lookup_module ~for_:Compilation_mode.Ocaml
+      | Cm_kind Cmi | Cmt | Cmti ->
+        let* ocaml = lookup_module ~for_:Compilation_mode.Ocaml in
+        (match ocaml with
+         | Some _ -> Action_builder.return ocaml
+         | None -> lookup_module ~for_:Compilation_mode.Melange)
+    in
+    (match module_ with
+     | None -> does_not_exist ~what:"Module" (Module_reference.to_string reference)
+     | Some (for_, obj_dir, m) ->
+       let cmi_kind =
+         match for_ with
+         | Compilation_mode.Ocaml -> Lib_mode.Cm_kind.Ocaml Ocaml.Cm_kind.Cmi
+         | Compilation_mode.Melange -> Lib_mode.Cm_kind.Melange Melange.Cm_kind.Cmi
+       in
+       (match
+          match kind with
+          | Cm_kind Cmi -> Obj_dir.Module.cm_file obj_dir m ~kind:cmi_kind
+          | Cm_kind kind -> Obj_dir.Module.cm_file obj_dir m ~kind:(Ocaml kind)
+          | Cmt -> Obj_dir.Module.cmt_file obj_dir m ~cm_kind:cmi_kind ~ml_kind:Impl
+          | Cmti -> Some (Obj_dir.Module.cmti_file obj_dir m ~cm_kind:cmi_kind)
+        with
+        | None -> Action_builder.return [ Value.String "" ]
+        | Some path -> dep (Path.build path)))
   | Lib mode ->
+    let* artifacts = lookup_artifacts ~for_:Compilation_mode.Ocaml in
     let name =
       Lib_name.parse_string_exn
         (Dune_lang.Template.Pform.loc source, Filename.to_string name)
@@ -258,7 +274,7 @@ let expand_melange_emit ~source t arg =
   then User_error.raise ~loc [ Pp.text "cannot escape the workspace root directory" ];
   let* artifacts =
     let lookup = Fdecl.get lookup_artifacts in
-    Action_builder.of_memo (lookup ~dir:stanza_dir)
+    Action_builder.of_memo (lookup ~dir:stanza_dir ~for_:Compilation_mode.Melange)
   in
   match Artifacts_obj.lookup_melange_emit artifacts target_dir with
   | None ->

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -136,7 +136,8 @@ val foreign_flags
   : (dir:Path.Build.t -> string list Action_builder.t Foreign_language.Dict.t Memo.t)
       Fdecl.t
 
-val lookup_artifacts : (dir:Path.Build.t -> Artifacts_obj.t Memo.t) Fdecl.t
+val lookup_artifacts
+  : (dir:Path.Build.t -> for_:Compilation_mode.t -> Artifacts_obj.t Memo.t) Fdecl.t
 
 val resolve_pkg_install_file
   : (loc:Loc.t

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -1417,6 +1417,7 @@ let make
       let { Source_file_dir.dir; _ } = Nonempty_list.hd dirs in
       Artifacts_obj.make
         ~dir
+        ~for_
         ~expander:(Expander.to_expander0 expander)
         ~lib_config
         ~libs

--- a/test/blackbox-tests/test-cases/melange/mixed-module-artifact-pforms.t
+++ b/test/blackbox-tests/test-cases/melange/mixed-module-artifact-pforms.t
@@ -39,14 +39,19 @@ The Melange-only module artifacts exist in the Melange object directory.
 
   $ dune build lib/.foo.objs/melange/foo__Melange_only.{cmi,cmt}
 
-Artifact variables do not find modules that are only in the Melange module
-set.
+Artifact variables fall back to the Melange module set when the module is not
+selected for OCaml.
 
   $ dune build '%{cmi:lib/melange_only}'
+  $ dune build '%{cmt:lib/melange_only}'
+
+OCaml-specific artifact variables do not fall back to the Melange module set.
+
+  $ dune build '%{cmo:lib/melange_only}'
   File "command line", line 1, characters 0-23:
   Error: Module Melange_only does not exist.
   [1]
-  $ dune build '%{cmt:lib/melange_only}'
+  $ dune build '%{cmx:lib/melange_only}'
   File "command line", line 1, characters 0-23:
   Error: Module Melange_only does not exist.
   [1]

--- a/test/blackbox-tests/test-cases/melange/module-artifact-pforms.t
+++ b/test/blackbox-tests/test-cases/melange/module-artifact-pforms.t
@@ -26,21 +26,12 @@ The Melange compiler produces all four module artifacts.
   _build/default/.foo.objs/melange/foo.cmt
   _build/default/.foo.objs/melange/foo.cmti
 
-The existing module artifact variables incorrectly resolve artifacts for a
-Melange-only library to the bytecode object directory.
+Module artifact variables resolve artifacts from the Melange object directory
+for a Melange-only library.
 
   $ dune build '%{cmi:foo}'
-  Error: No rule found for .foo.objs/byte/foo.cmi
-  -> required by %{cmi:foo} at command line:1
-  [1]
   $ dune build '%{cmt:foo}'
-  Error: No rule found for .foo.objs/byte/foo.cmt
-  -> required by %{cmt:foo} at command line:1
-  [1]
   $ dune build '%{cmti:foo}'
-  Error: No rule found for .foo.objs/byte/foo.cmti
-  -> required by %{cmti:foo} at command line:1
-  [1]
 
 The variable for Melange's compiled module artifact is not recognized.
 


### PR DESCRIPTION
Resolve cmi, cmt, and cmti against the OCaml module set first, falling back to Melange when the module is not selected for OCaml.

Fixes the regressions in #16337 and #16338. CMJ support is split into anmonteiro/dune#187; documentation remains in anmonteiro/dune#186.