### PR TITLE
test(action-plugin): reproduce missing sandbox dependencies

### DIFF
--- a/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/bin/foo.ml
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/bin/foo.ml
@@ -1,9 +1,65 @@
 open Dune_rpc_lwt.V1.Action_plugin
 
-let action dap =
+let ordinary_action dap =
   let open Lwt.Syntax in
   let* data = read_file dap ~path:"some_dependency" in
   Lwt_io.printl data
+;;
+
+let replace_file path contents =
+  Sys.remove path;
+  let output = open_out path in
+  output_string output contents;
+  close_out output
+;;
+
+let sandbox_action dap =
+  let open Lwt.Syntax in
+  print_endline "starting sandboxed action";
+  if not (List.mem ".sandbox" (String.split_on_char '/' (Sys.getcwd ())))
+  then failwith "expected a sandbox";
+  if Sys.file_exists "../choice" then failwith "undeclared dependency is visible";
+  replace_file "../inputs/static.txt" "local";
+  let* choice, repeated =
+    Lwt.both (read_file dap ~path:"../choice") (read_file dap ~path:"../choice")
+  in
+  if choice <> repeated then failwith "inconsistent dependency contents";
+  let* data = read_file dap ~path:choice in
+  let* listing =
+    read_directory_with_glob dap ~path:"../inputs" ~glob:(Glob.of_string "*.txt")
+  in
+  let* () =
+    let+ repeated = read_file dap ~path:choice in
+    if data <> repeated then failwith "inconsistent dependency contents"
+  in
+  let* static = read_file dap ~path:"../inputs/static.txt" in
+  let* () =
+    let+ empty =
+      read_directory_with_glob dap ~path:"../empty" ~glob:(Glob.of_string "*")
+    in
+    if empty <> [] || not (Sys.is_directory "../empty")
+    then failwith "missing empty dependency directory"
+  in
+  if Sys.file_exists "../inputs/unused" then failwith "unmatched dependency is visible";
+  let* (_ : string) = read_file dap ~path:"../tree/sub/first" in
+  replace_file "../tree/sub/first" "local tree";
+  let* () =
+    let+ tree = read_directory_with_glob dap ~path:".." ~glob:(Glob.of_string "tree") in
+    if tree <> [ "tree" ] then failwith "missing directory target"
+  in
+  let* first = read_file dap ~path:"../tree/sub/first" in
+  let* second = read_file dap ~path:"../tree/sub/second" in
+  if first <> "local tree" || second <> "second"
+  then failwith "incorrect overlapping directory contents";
+  Lwt_io.with_file ~mode:Output "../result" (fun output ->
+    Lwt_io.fprintf output "%s\n%s\n%s\n" data (String.concat ", " listing) static)
+;;
+
+let action dap =
+  match Sys.argv with
+  | [| _ |] -> ordinary_action dap
+  | [| _; "sandbox" |] -> sandbox_action dap
+  | _ -> invalid_arg "invalid arguments"
 ;;
 
 let () = run action

--- a/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/sandbox.t
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/sandbox.t
@@ -1,0 +1,80 @@
+Dynamically requested dependencies must be made available in the running sandbox.
+The client requests dependencies from a subdirectory, concurrently and repeatedly,
+then reads an overlapping glob and an empty directory. Static inputs modified by
+an earlier part of the action must not be replaced by their original contents.
+A directory target requested after one of its files must not replace that file.
+
+  $ cat > dune-project <<'EOF'
+  > (lang dune 3.25)
+  > (using action-plugin 0.1)
+  > EOF
+  $ mkdir inputs empty subdir
+  $ cp bin/foo.exe .
+  $ printf original > inputs/static.txt
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (target choice)
+  >  (deps selection)
+  >  (action (copy selection choice)))
+  > (rule
+  >  (target result)
+  >  (deps inputs/static.txt (sandbox always))
+  >  (action (chdir subdir (dynamic-run ../foo.exe sandbox))))
+  > (rule
+  >  (targets (dir tree))
+  >  (action
+  >   (progn
+  >    (run mkdir -p tree/sub)
+  >    (bash "printf first > tree/sub/first")
+  >    (bash "printf second > tree/sub/second"))))
+  > EOF
+  $ cat > inputs/dune <<'EOF'
+  > (rule
+  >  (target picked.txt)
+  >  (action (write-file %{target} picked)))
+  > (rule
+  >  (target other.txt)
+  >  (action (write-file %{target} other)))
+  > (rule
+  >  (target unused)
+  >  (action (bash "echo 'unmatched dependency was built'; exit 1")))
+  > EOF
+
+The second build should reuse the result. Changing a discovered dependency must
+rerun the action with its new contents, without exposing unmatched dependencies.
+
+  $ for mode in symlink hardlink; do
+  >   echo "$mode:"
+  >   printf ../inputs/picked.txt > selection
+  >   if dune build result --sandbox "$mode" --build-dir "_build-$mode"; then
+  >     cat "_build-$mode/default/result"
+  >     dune build result --sandbox "$mode" --build-dir "_build-$mode"
+  >     printf ../inputs/other.txt > selection
+  >     dune build result --sandbox "$mode" --build-dir "_build-$mode"
+  >     cat "_build-$mode/default/result"
+  >     test ! -e "_build-$mode/default/inputs/unused" &&
+  >       test "$(cat inputs/static.txt)" = original && echo 'checked isolation'
+  >   else
+  >     echo 'sandboxed build failed'
+  >   fi
+  > done 2>&1 | sed -E 's|\.sandbox/[a-f0-9]{32}|.sandbox/SANDBOX|g'
+  symlink:
+  File "dune", lines 5-8, characters 0-124:
+  5 | (rule
+  6 |  (target result)
+  7 |  (deps inputs/static.txt (sandbox always))
+  8 |  (action (chdir subdir (dynamic-run ../foo.exe sandbox))))
+  starting sandboxed action
+  No rule found for
+  _build-symlink/.sandbox/SANDBOX/default/choice
+  sandboxed build failed
+  hardlink:
+  File "dune", lines 5-8, characters 0-124:
+  5 | (rule
+  6 |  (target result)
+  7 |  (deps inputs/static.txt (sandbox always))
+  8 |  (action (chdir subdir (dynamic-run ../foo.exe sandbox))))
+  starting sandboxed action
+  No rule found for
+  _build-hardlink/.sandbox/SANDBOX/default/choice
+  sandboxed build failed


### PR DESCRIPTION
Reproduce sandboxed `dynamic-run` dependency requests being resolved under `.sandbox` instead of the canonical build directory, using symlink and hardlink sandboxes.

Record the current failure so the sandbox-population fix can be reviewed separately.