### PR TITLE
test(action-plugin): reproduce indirect dependency-cycle deadlock

### DIFF
--- a/otherlibs/dune-rpc-lwt/test/action-plugin/depends-on-its-target-by-read-dir/run.t
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/depends-on-its-target-by-read-dir/run.t
@@ -12,7 +12,19 @@
 
   $ cp ./bin/foo.exe ./
 
+Ignore signal-handler output when terminating a deadlocked build, but preserve
+all diagnostics when the build exits without timing out.
+
+  $ build_with_timeout() {
+  >   output=$(mktemp)
+  >   status=0
+  >   timeout 3 dune build "$@" >"$output" 2>&1 || status=$?
+  >   if [ "$status" -ne 124 ]; then cat "$output"; fi
+  >   rm "$output"
+  >   return "$status"
+  > }
+
 Reading a directory containing the action's target currently deadlocks.
 
-  $ timeout 3 dune build some_file
+  $ build_with_timeout some_file
   [124]

--- a/otherlibs/dune-rpc-lwt/test/action-plugin/depends-on-its-target/bin/foo1.ml
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/depends-on-its-target/bin/foo1.ml
@@ -1,10 +1,15 @@
 open Dune_rpc_lwt.V1.Action_plugin
 
-let path = "some_file1"
+let dependency =
+  match Sys.argv with
+  | [| _ |] -> "some_file1"
+  | [| _; dependency |] -> dependency
+  | _ -> invalid_arg "expected at most one dependency argument"
+;;
 
 let action dap =
   let open Lwt.Syntax in
-  let* _ = read_file dap ~path in
+  let* _ = read_file dap ~path:dependency in
   Lwt.return_unit
 ;;
 

--- a/otherlibs/dune-rpc-lwt/test/action-plugin/depends-on-its-target/run.t
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/depends-on-its-target/run.t
@@ -13,15 +13,43 @@
   >  (target some_file2)
   >  (action
   >   (dynamic-run ./foo2.exe)))
+  > \
+  > (rule
+  >  (target some_file3)
+  >  (action
+  >   (dynamic-run ./foo1.exe some_file4)))
+  > \
+  > (rule
+  >  (target some_file4)
+  >  (deps some_file3)
+  >  (action
+  >   (write-file some_file4 done)))
   > EOF
 
   $ cp ./bin/foo1.exe ./
   $ cp ./bin/foo2.exe ./
 
+Ignore signal-handler output when terminating a deadlocked build, but preserve
+all diagnostics when the build exits without timing out.
+
+  $ build_with_timeout() {
+  >   output=$(mktemp)
+  >   status=0
+  >   timeout 3 dune build "$@" >"$output" 2>&1 || status=$?
+  >   if [ "$status" -ne 124 ]; then cat "$output"; fi
+  >   rm "$output"
+  >   return "$status"
+  > }
+
 Direct dependencies on the action's target currently deadlock.
 
-  $ timeout 3 dune build some_file1
+  $ build_with_timeout some_file1
   [124]
 
-  $ timeout 3 dune build some_file2
+  $ build_with_timeout some_file2
+  [124]
+
+An indirect dependency on the action's target currently deadlocks.
+
+  $ build_with_timeout some_file3
   [124]


### PR DESCRIPTION
Add a bounded regression for an indirect cycle: a `dynamic-run` action requests a second target whose rule depends on the first.

The test records the current timeout. Building dependencies from the RPC handler loses the action’s Memo cycle-detection context, so Dune hangs instead of reporting the cycle.

Ignore nondeterministic shutdown output only when a build times out. Preserve diagnostics and exit statuses for all other outcomes.