### PR TITLE
fix(action-plugin): populate sandboxes with dynamic dependencies

### DIFF
--- a/otherlibs/dune-rpc-lwt/test/action-plugin/depend-on-directory-without-targets/run.t
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/depend-on-directory-without-targets/run.t
@@ -33,8 +33,8 @@ A missing directory has an empty listing when the plugin runs directly.
   $ ./foo.exe
   Directory listing: []
 
-A generated empty directory also has an empty listing even though the glob
-dependency does not materialize it.
+A directory dependency builds its generating rule. Dune rejects directory
+targets containing no files, rather than silently returning an empty listing.
 
   $ cat > dune-project << EOF
   > (lang dune 3.24)
@@ -50,7 +50,13 @@ dependency does not materialize it.
   >  (action (dynamic-run ./foo.exe)))
   > EOF
   $ dune build @check-empty
-  Directory listing: []
+  File "dune", lines 4-6, characters 0-61:
+  4 | (rule
+  5 |  (alias check-empty)
+  6 |  (action (dynamic-run ./foo.exe)))
+  Rule produced directory "some_dir" that contains no files nor
+  non-empty subdirectories
+  [1]
 
 A dynamic action may be part of a rule with a directory target. The action
 plugin does not manage the rule's targets.

--- a/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/sandbox.t
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/sandbox.t
@@ -59,22 +59,22 @@ rerun the action with its new contents, without exposing unmatched dependencies.
   >   fi
   > done 2>&1 | sed -E 's|\.sandbox/[a-f0-9]{32}|.sandbox/SANDBOX|g'
   symlink:
-  File "dune", lines 5-8, characters 0-124:
-  5 | (rule
-  6 |  (target result)
-  7 |  (deps inputs/static.txt (sandbox always))
-  8 |  (action (chdir subdir (dynamic-run ../foo.exe sandbox))))
   starting sandboxed action
-  No rule found for
-  _build-symlink/.sandbox/SANDBOX/default/choice
-  sandboxed build failed
+  picked
+  other.txt, picked.txt, static.txt
+  local
+  starting sandboxed action
+  other
+  other.txt, picked.txt, static.txt
+  local
+  checked isolation
   hardlink:
-  File "dune", lines 5-8, characters 0-124:
-  5 | (rule
-  6 |  (target result)
-  7 |  (deps inputs/static.txt (sandbox always))
-  8 |  (action (chdir subdir (dynamic-run ../foo.exe sandbox))))
   starting sandboxed action
-  No rule found for
-  _build-hardlink/.sandbox/SANDBOX/default/choice
-  sandboxed build failed
+  picked
+  other.txt, picked.txt, static.txt
+  local
+  starting sandboxed action
+  other
+  other.txt, picked.txt, static.txt
+  local
+  checked isolation

--- a/src/dune_engine/action_plugin.ml
+++ b/src/dune_engine/action_plugin.ml
@@ -65,7 +65,7 @@ module Server = struct
     let active_action =
       { build_deps = ectx.build_deps
       ; rule_loc = ectx.rule_loc
-      ; working_dir = eenv.working_dir
+      ; working_dir = Path.drop_optional_sandbox_root eenv.working_dir
       ; initialized = false
       }
     in

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -496,7 +496,24 @@ module Internal = struct
               ; action
               }
             in
-            let build_deps deps = Memo.run (build_deps deps) in
+            let build_deps deps =
+              let* facts = Memo.run (build_deps deps) in
+              let+ () =
+                if not is_sandboxed
+                then Fiber.return ()
+                else
+                  Sandbox.add_deps
+                    sandbox
+                    ~dirs:(Dep.Facts.necessary_dirs_for_sandboxing facts)
+                    ~deps:
+                      (Dep.Facts.paths
+                         facts
+                         ~expand_aliases:
+                           (Execution_parameters.expand_aliases_in_sandbox
+                              execution_parameters))
+              in
+              facts
+            in
             Action_exec.exec input ~build_deps
           in
           let* action_exec_result, () =

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -86,9 +86,11 @@ type snapshot = [ `Dir | `File of Stat.t ] Path.Map.t
 
 type real =
   { dir : Path.Build.t
-  ; snapshot : snapshot option
+  ; mutable snapshot : snapshot option
   ; corrections : Corrections.t
-  ; deps : Path.Set.t option
+  ; mode : Sandbox_mode.some
+  ; mutable deps : Path.Set.t
+  ; mutex : Fiber.Mutex.t
   ; loc : Loc.t
   }
 
@@ -158,12 +160,23 @@ let copy_recursively =
       ()
 ;;
 
-let create_dir t dir = Path.mkdir_p (Path.build (map_real_path t dir))
-
-let create_dirs t ~dirs ~rule_dir =
-  create_dir t rule_dir;
-  Path.Build.Set.iter dirs ~f:(fun dir -> create_dir t dir)
+let create_dir t dir =
+  Path.mkdir_p (Path.build (map_real_path t dir));
+  t.snapshot
+  <- Option.map t.snapshot ~f:(fun snapshot ->
+       let rec loop snapshot dir =
+         match Path.Build.parent dir with
+         | None -> snapshot
+         | Some parent ->
+           let path = Path.build (map_real_path t dir) in
+           if Path.Map.mem snapshot path
+           then snapshot
+           else loop (Path.Map.set snapshot path `Dir) parent
+       in
+       loop snapshot dir)
 ;;
+
+let create_dirs t dirs = Path.Build.Set.iter dirs ~f:(fun dir -> create_dir t dir)
 
 let link_function ~(mode : Sandbox_mode.some) =
   let win32_error mode =
@@ -190,8 +203,8 @@ let link_function ~(mode : Sandbox_mode.some) =
        fun src dst -> Io.copy_file ~src ~dst ~chmod ())
 ;;
 
-let link_deps t ~mode ~deps =
-  let link = Staged.unstage (link_function ~mode) in
+let link_deps t ~deps =
+  let link = Staged.unstage (link_function ~mode:t.mode) in
   Path.Set.iter deps ~f:(fun path ->
     match Path.as_in_build_dir path with
     | None ->
@@ -204,6 +217,56 @@ let link_deps t ~mode ~deps =
            build directory instead."
           [ "path", Path.to_dyn path ]
     | Some p -> link path (Path.build (map_real_path t p)))
+;;
+
+let unlinked_deps t deps =
+  let rec already_linked paths path =
+    Path.Set.mem paths path
+    ||
+    match Path.parent path with
+    | None -> false
+    | Some parent -> already_linked paths parent
+  in
+  let rec loop path acc =
+    if already_linked t.deps path || already_linked acc path
+    then acc
+    else (
+      match Path.as_in_build_dir path with
+      | Some p
+        when Fpath.is_directory (Path.Build.to_string (map_real_path t p))
+             && Fpath.is_directory (Path.to_string path) ->
+        (match Path.Untracked.readdir_unsorted path with
+         | Error error -> Unix_error.Detailed.raise error
+         | Ok files ->
+           List.fold_left files ~init:acc ~f:(fun acc name ->
+             loop (Path.relative_fname path name) acc))
+      | _ -> Path.Set.add acc path)
+  in
+  Path.Set.fold deps ~init:Path.Set.empty ~f:loop
+;;
+
+let add_deps t ~dirs ~deps =
+  match t with
+  | No_sandbox _ -> Fiber.return ()
+  | Sandboxed t ->
+    Fiber.Mutex.with_lock t.mutex ~f:(fun () ->
+      let open Fiber.O in
+      let+ (_ : Time.t * Time.t * Time.Span.t option) =
+        maybe_async (fun () ->
+          create_dirs t dirs;
+          let unlinked = unlinked_deps t deps in
+          link_deps t ~deps:unlinked;
+          t.snapshot
+          <- Option.map t.snapshot ~f:(fun snapshot ->
+               Path.Set.fold unlinked ~init:snapshot ~f:(fun path snapshot ->
+                 match Path.as_in_build_dir path with
+                 | None -> snapshot
+                 | Some p ->
+                   let dst = Path.build (map_real_path t p) in
+                   Path.Map.set snapshot dst (`File (Stat.stat (Path.to_string dst)))));
+          t.deps <- Path.Set.union t.deps deps)
+      in
+      ())
 ;;
 
 let snapshot t =
@@ -309,32 +372,31 @@ let create_real
     Path.Build.relative sandbox_dir sandbox_suffix
   in
   let t =
-    { dir = sandbox_dir; snapshot = None; deps = None; loc = rule_loc; corrections }
+    { dir = sandbox_dir
+    ; snapshot = None
+    ; deps
+    ; mutex = Fiber.Mutex.create ()
+    ; mode
+    ; loc = rule_loc
+    ; corrections
+    }
   in
   let open Fiber.O in
   let+ start, stop, queued =
     maybe_async (fun () ->
       Path.rm_rf (Path.build sandbox_dir);
-      create_dirs t ~dirs ~rule_dir;
-      (* CR-someday amokhov: Note that this doesn't link dynamic dependencies, so
-         targets produced dynamically will be unavailable. *)
-      link_deps t ~mode ~deps)
+      create_dir t rule_dir;
+      create_dirs t dirs;
+      link_deps t ~deps)
   in
   Dune_trace.emit ~buffered:true Sandbox (fun () ->
     Dune_trace.Event.sandbox `Create ~start ~stop ~queued t.loc ~dir:t.dir);
-  let deps =
-    match corrections, mode with
-    | Ignore, Patch_back_source_tree -> Some deps
-    | Produce, Patch_back_source_tree ->
-      Code_error.raise "a patch back sandboxed rule may not produce corrections" []
-    | _, (Symlink | Copy | Hardlink) ->
-      (match corrections with
-       | Produce -> Some deps
-       | Ignore -> None)
-  in
-  match mode with
-  | Patch_back_source_tree -> { t with snapshot = Some (snapshot t); deps }
-  | _ -> { t with deps }
+  (match corrections, mode with
+   | Ignore, Patch_back_source_tree -> t.snapshot <- Some (snapshot t)
+   | Produce, Patch_back_source_tree ->
+     Code_error.raise "a patch back sandboxed rule may not produce corrections" []
+   | _, (Symlink | Copy | Hardlink) -> ());
+  t
 ;;
 
 (* Same as [rename] except that if the source doesn't exist we delete the
@@ -438,9 +500,7 @@ let move_real_targets_to_build_dir t ~should_be_skipped ~(targets : Targets.Vali
   let* () =
     match t.corrections with
     | Ignore -> Fiber.return ()
-    | Produce ->
-      let deps = Option.value_exn t.deps in
-      register_corrected_file_promotions t ~deps
+    | Produce -> register_corrected_file_promotions t ~deps:t.deps
   in
   let+ () =
     match t.snapshot with

--- a/src/dune_engine/sandbox.mli
+++ b/src/dune_engine/sandbox.mli
@@ -9,6 +9,8 @@ val root : t -> Path.t option
 (** [map_path t p] returns the path corresponding to [p] inside the sandbox. *)
 val map_path : t -> Path.Build.t -> Path.Build.t
 
+val add_deps : t -> dirs:Path.Build.Set.t -> deps:Path.Set.t -> unit Fiber.t
+
 (** Delete targets left behind by interrupted non-sandboxed actions. *)
 val cleanup_pending_targets : unit -> unit
 


### PR DESCRIPTION
Fix sandboxed `dynamic-run` by resolving dependency requests against the canonical build directory and populating the existing sandbox before recording facts or replying to the plugin.

Reuse sandbox linking and copying, serialize additions, and preserve already materialized inputs across repeated and overlapping requests. Include new inputs in correction and patch-back bookkeeping.

Follow-up to the symlink and hardlink regression in #16340. Live-sandbox throttling is unchanged.