### PR TITLE
test(action-plugin): reproduce late sandbox population

### DIFF
--- a/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/bin/dune
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/bin/dune
@@ -1,3 +1,3 @@
 (executables
  (names foo)
- (libraries dune-rpc-lwt lwt lwt.unix))
+ (libraries dune-rpc-lwt lwt lwt.unix unix))

--- a/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/bin/foo.ml
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/bin/foo.ml
@@ -55,10 +55,33 @@ let sandbox_action dap =
     Lwt_io.fprintf output "%s\n%s\n%s\n" data (String.concat ", " listing) static)
 ;;
 
+let detached_action dap state =
+  let open Lwt.Syntax in
+  let* () =
+    Lwt_io.with_file ~mode:Output (Filename.concat state "pid") (fun output ->
+      Lwt_io.fprintf output "%d" (Unix.getpid ()))
+  in
+  let rec wait_started () =
+    if Sys.file_exists (Filename.concat state "started")
+    then Lwt.return_unit
+    else
+      let* () = Lwt_unix.sleep 0.01 in
+      wait_started ()
+  in
+  let* () =
+    Lwt.choose [ Lwt.map ignore (read_file dap ~path:"slow-input"); wait_started () ]
+  in
+  let* () =
+    Lwt_io.with_file ~mode:Output "detached" (fun output -> Lwt_io.write output "done")
+  in
+  Lwt_io.printl "ran"
+;;
+
 let action dap =
   match Sys.argv with
   | [| _ |] -> ordinary_action dap
   | [| _; "sandbox" |] -> sandbox_action dap
+  | [| _; "detached"; state |] -> detached_action dap state
   | _ -> invalid_arg "invalid arguments"
 ;;
 

--- a/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/sandbox.t
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/sandbox.t
@@ -78,3 +78,57 @@ rerun the action with its new contents, without exposing unmatched dependencies.
   other.txt, picked.txt, static.txt
   local
   checked isolation
+
+An accepted request can outlive the plugin process. The generator acknowledges
+that the request reached Dune, then waits for the plugin to exit. Disable
+background sandbox operations so cleanup finishes before the generator's
+completion is handled, without relying on a delay in the generator.
+
+  $ cat > dune-project <<'EOF'
+  > (lang dune 2.0)
+  > (using action-plugin 0.1)
+  > EOF
+  $ export DUNE_CONFIG__BACKGROUND_SANDBOXES=disabled
+  $ state=$(mktemp -d)
+  $ export PLUGIN_STATE="$state"
+  $ printf first > control
+  $ cat > slow.sh <<'EOF'
+  > if [ -f "$1/pid" ]; then
+  >   touch "$1/started"
+  >   while kill -0 "$(cat "$1/pid")" 2>/dev/null; do sleep 0.01; done
+  > fi
+  > cat control > slow-input
+  > EOF
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (target slow-input)
+  >  (deps control (sandbox none))
+  >  (action (run sh %{dep:slow.sh} %{env:PLUGIN_STATE=unset})))
+  > (rule
+  >  (target detached)
+  >  (deps (sandbox always))
+  >  (action (dynamic-run ./foo.exe detached %{env:PLUGIN_STATE=unset})))
+  > EOF
+  $ cat > sandbox-config <<'EOF'
+  > (lang dune 3.25)
+  > (sandboxing_preference hardlink none)
+  > EOF
+  $ build_detached() {
+  >   timeout 10 dune build -j 2 detached \
+  >     --config-file sandbox-config --build-dir _build-lifetime
+  > }
+  $ build_detached
+  ran
+
+The completed request currently recreates the sandbox after it was destroyed.
+
+  $ find _build-lifetime/.sandbox -name slow-input -exec echo leaked \;
+  leaked
+
+Its dependency is also missing from the cached action result.
+
+  $ rm "$state/pid" "$state/started"
+  $ printf second > control
+  $ build_detached
+  $ cat _build-lifetime/default/slow-input
+  first


### PR DESCRIPTION
Add a regression for an accepted dependency RPC request that finishes after its action-plugin process exits.

Record two current failures: late population recreates the destroyed sandbox, and the dependency is missing from the cached action result, so changing its input does not rebuild the action.

Synchronize the generator with the plugin lifetime and disable background sandbox operations to establish cleanup ordering without an arbitrary delay.

Test-only follow-up to #16342. The lifecycle fix remains separate.