### PR TITLE
fix(action-plugin): drain requests before releasing the sandbox

### DIFF
--- a/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/sandbox.t
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/sandbox.t
@@ -120,15 +120,15 @@ completion is handled, without relying on a delay in the generator.
   $ build_detached
   ran
 
-The completed request currently recreates the sandbox after it was destroyed.
+Accepted requests finish before the sandbox is destroyed.
 
   $ find _build-lifetime/.sandbox -name slow-input -exec echo leaked \;
-  leaked
 
-Its dependency is also missing from the cached action result.
+Their dependencies are recorded in the cached action result.
 
   $ rm "$state/pid" "$state/started"
   $ printf second > control
   $ build_detached
+  ran
   $ cat _build-lifetime/default/slow-input
-  first
+  second

--- a/src/dune_engine/action_plugin.ml
+++ b/src/dune_engine/action_plugin.ml
@@ -41,6 +41,7 @@ module Server = struct
     ; rule_loc : Loc.t
     ; working_dir : Path.t
     ; mutable initialized : bool
+    ; mutable pending : unit Fiber.Ivar.t list
     }
 
   let active = Action_id.Table.create 16
@@ -67,6 +68,7 @@ module Server = struct
       ; rule_loc = ectx.rule_loc
       ; working_dir = Path.drop_optional_sandbox_root eenv.working_dir
       ; initialized = false
+      ; pending = []
       }
     in
     Action_id.Table.add_exn active action_id active_action;
@@ -74,7 +76,7 @@ module Server = struct
       (fun () -> f action_id active_action)
       ~finally:(fun () ->
         Action_id.Table.remove active action_id;
-        Fiber.return ())
+        Fiber.parallel_iter active_action.pending ~f:Fiber.Ivar.read)
   ;;
 
   let build_deps =
@@ -94,10 +96,15 @@ module Server = struct
         to_dune_dep_set deps ~loc:active.rule_loc ~working_dir:active.working_dir
       in
       let open Fiber.O in
-      Fiber.collect_errors (fun () -> active.build_deps deps_to_build)
-      >>| function
-      | Error errors -> Some (build_error_message errors)
-      | Ok () -> None
+      let completed = Fiber.Ivar.create () in
+      active.pending <- completed :: active.pending;
+      Fiber.finalize
+        (fun () ->
+           Fiber.collect_errors (fun () -> active.build_deps deps_to_build)
+           >>| function
+           | Error errors -> Some (build_error_message errors)
+           | Ok () -> None)
+        ~finally:(fun () -> Fiber.Ivar.fill completed ())
   ;;
 
   let initialize _session action_id =


### PR DESCRIPTION
Stop admitting dependency RPC requests when the plugin process exits, then wait for every accepted request before leaving the action’s execution context.

This keeps sandbox population and dependency recording ahead of sandbox cleanup and rule-result caching, even when the plugin disconnects without awaiting a request. It prevents late requests from recreating destroyed sandboxes and losing dependencies from cached action results.

Fixes the behavior recorded by the regression in #16343.