### PR TITLE
test(package-deps): reproduce untracked lock-built libraries

### DIFF
--- a/test/blackbox-tests/dune.jq
+++ b/test/blackbox-tests/dune.jq
@@ -108,6 +108,11 @@ def ruleDepGlobPredicates:
 def ruleHasDepFile($path):
   [ ruleDepFilePaths | select(pathMatches($path)) ] | length > 0;
 
+def ruleHasDepFileOrMatchingGlob($path; $dir; $predicate):
+  ruleHasDepFile($path)
+  or any(ruleDepGlobEntries;
+         .dir == $dir and .predicate == $predicate);
+
 def ruleActionNodes:
   .action | .. | arrays | select(length > 0 and (.[0] | type) == "string");
 

--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -59,6 +59,10 @@
  (applies_to pkg-deps.t))
 
 (cram
+ (deps %{bin:cmp} %{bin:ocamlfind})
+ (applies_to package-library-closure.t))
+
+(cram
  (deps %{bin:curl})
  (applies_to
   unavailable-source-package.t

--- a/test/blackbox-tests/test-cases/pkg/package-library-closure.t
+++ b/test/blackbox-tests/test-cases/pkg/package-library-closure.t
@@ -1,0 +1,161 @@
+A rule depending on a lock-built package must track its required libraries,
+not just the requested package's install cookie.
+
+Library dependencies: a -> b.
+Package dependencies: a -> b, c.
+Package b also installs an unrelated library, b.unrelated.
+
+Keep the package sources outside the workspace so they are built through the
+lock directory, not treated as workspace libraries. Use bytecode so changing
+b's implementation does not change a's compiled archive through inlining.
+
+  $ make_dune_project 3.24
+  $ make_lockdir
+  $ sources="$TMPDIR/package_sources"
+  $ mkdir -p "$sources/a" "$sources/b/unrelated" "$sources/c"
+
+  $ cat >"$sources/a/dune-project" <<'EOF'
+  > (lang dune 3.24)
+  > (package
+  >  (name a)
+  >  (depends b c))
+  > EOF
+  $ cat >"$sources/a/dune" <<'EOF'
+  > (library
+  >  (public_name a)
+  >  (modes byte)
+  >  (libraries b))
+  > EOF
+  $ echo 'let value = B.value + 1' >"$sources/a/a.ml"
+
+  $ cat >"$sources/b/dune-project" <<'EOF'
+  > (lang dune 3.24)
+  > (package (name b))
+  > EOF
+  $ echo '(library (public_name b) (modes byte))' >"$sources/b/dune"
+  $ echo 'let value = 1' >"$sources/b/b.ml"
+  $ cat >"$sources/b/unrelated/dune" <<'EOF'
+  > (library
+  >  (name unrelated)
+  >  (public_name b.unrelated)
+  >  (modes byte))
+  > EOF
+  $ touch "$sources/b/unrelated/unrelated.ml"
+
+  $ cat >"$sources/c/dune-project" <<'EOF'
+  > (lang dune 3.24)
+  > (package (name c))
+  > EOF
+  $ echo '(library (public_name c) (modes byte))' >"$sources/c/dune"
+  $ touch "$sources/c/c.ml"
+
+  $ make_lockpkg b <<EOF
+  > (version 0.0.1)
+  > (source (copy "$sources/b"))
+  > (build (run dune build @install --promote-install-files))
+  > EOF
+  $ make_lockpkg c <<EOF
+  > (version 0.0.1)
+  > (source (copy "$sources/c"))
+  > (build (run dune build @install --promote-install-files))
+  > EOF
+  $ make_lockpkg a <<EOF
+  > (version 0.0.1)
+  > (depends b c)
+  > (source (copy "$sources/a"))
+  > (build (run dune build @install --promote-install-files))
+  > EOF
+
+The consumer declares only package a. Findlib selects libraries a and b;
+this query checks library requirements, not which other libraries are visible.
+
+  $ echo 'let () = Printf.printf "%d\n" A.value' >main.ml
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (targets main.exe libraries)
+  >  (deps main.ml (package a))
+  >  (action
+  >   (progn
+  >    (with-stdout-to libraries
+  >     (run ocamlfind query -recursive -format %p a))
+  >    (run ocamlfind ocamlc -package a -linkpkg -o main.exe main.ml))))
+  > EOF
+  $ dune build main.exe
+  $ sort _build/default/libraries
+  a
+  b
+  $ _build/default/main.exe
+  2
+
+Check that the excluded libraries really were installed, so their absence
+from the consumer's dependencies cannot be explained by missing artifacts.
+
+  $ a_target="$(get_build_pkg_dir a)/target"
+  $ b_lib="$(get_build_pkg_dir b)/target/lib/b"
+  $ c_lib="$(get_build_pkg_dir c)/target/lib/c"
+  $ test -f "$b_lib/b.cmi"
+  $ test -f "$b_lib/b.cma"
+  $ test -f "$b_lib/dune-package"
+  $ test -f "$b_lib/unrelated/unrelated.cmi"
+  $ test -f "$b_lib/unrelated/unrelated.cma"
+  $ test -f "$c_lib/c.cmi"
+  $ test -f "$c_lib/c.cma"
+
+CR-someday alizter: The required interface, archive and metadata should be
+tracked. The unselected libraries' interfaces and archives must stay untracked.
+Accept dependencies represented by direct files or matching selectors.
+
+  $ dune rules --format=json main.exe >rules.json
+  $ jq_dune --arg b "$b_lib" --arg c "$c_lib" '
+  >   rulesMatchingTarget("main.exe") | {
+  >     required_interface:
+  >       ruleHasDepFileOrMatchingGlob($b + "/b.cmi"; $b; "*.cmi"),
+  >     required_archive:
+  >       ruleHasDepFileOrMatchingGlob($b + "/b.cma"; $b; "*.cma"),
+  >     required_metadata: ruleHasDepFile($b + "/dune-package"),
+  >     unrelated_interface:
+  >       ruleHasDepFileOrMatchingGlob(
+  >         $b + "/unrelated/unrelated.cmi"; $b + "/unrelated"; "*.cmi"),
+  >     unrelated_archive:
+  >       ruleHasDepFileOrMatchingGlob(
+  >         $b + "/unrelated/unrelated.cma"; $b + "/unrelated"; "*.cma"),
+  >     package_only_interface:
+  >       ruleHasDepFileOrMatchingGlob($c + "/c.cmi"; $c; "*.cmi"),
+  >     package_only_archive:
+  >       ruleHasDepFileOrMatchingGlob($c + "/c.cma"; $c; "*.cma")
+  >   }' rules.json
+  {
+    "required_interface": false,
+    "required_archive": false,
+    "required_metadata": false,
+    "unrelated_interface": false,
+    "unrelated_archive": false,
+    "package_only_interface": false,
+    "package_only_archive": false
+  }
+
+Changing b's implementation must relink the consumer even if a's artifacts
+and install cookie remain unchanged.
+
+  $ cp "$a_target/cookie" a.cookie.before
+  $ cp "$a_target/lib/a/a.cmi" a.cmi.before
+  $ cp "$a_target/lib/a/a.cma" a.cma.before
+  $ cp "$b_lib/b.cmi" b.cmi.before
+  $ cp "$b_lib/b.cma" b.cma.before
+  $ echo 'let value = 10' >"$sources/b/b.ml"
+  $ dune build main.exe
+  $ cmp a.cookie.before "$a_target/cookie"
+  $ cmp a.cmi.before "$a_target/lib/a/a.cmi"
+  $ cmp a.cma.before "$a_target/lib/a/a.cma"
+  $ cmp b.cmi.before "$b_lib/b.cmi"
+
+The required library's archive really changed.
+
+  $ cmp -s b.cma.before "$b_lib/b.cma"
+  [1]
+
+CR-someday alizter: This should print 11. The consumer was not relinked after
+its required library changed.
+
+  $ _build/default/main.exe
+  2


### PR DESCRIPTION
Adds a standalone regression test for `(deps (package a))` when `a` is built by Dune package management. Related to #15511.

The fixture distinguishes library requirements (`a -> b`) from package dependencies (`a -> b, c`), with an unrelated `b.unrelated` library. It records missing interface, archive, and metadata dependencies while checking that installed but unselected interfaces and archives remain untracked. The observations accept both direct files and matching selectors.

It also demonstrates the incremental-build failure: changing only `b` leaves the bytecode consumer printing `2` instead of `11`. The test verifies that `b.cma` changed while `a`’s artifacts and install cookie remained unchanged.

This is test-only: the cram expectations intentionally record the current faulty behavior, so the test passes without an implementation fix. No user-facing behavior changes or changelog entry.

Validation:
- `@check @fmt`
- `pkg/pkg-deps.t` and `pkg/package-library-closure.t`
- Verified that applying the follow-up fix changes exactly the three required-dependency observations and the stale result, while all exclusion and artifact-stability checks continue to pass.