### PR TITLE
fix(pkg): reuse the project compiler for dev tools

### DIFF
--- a/doc/changes/fixed/16351.md
+++ b/doc/changes/fixed/16351.md
@@ -1,0 +1,3 @@
+- Reuse the project's OCaml compiler when building dev tools that select the
+  same compiler, avoiding redundant compiler builds and stale dependencies
+  (#16351, @Alizter)

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1344,10 +1344,14 @@ module DB = struct
     (* Associate each package's digest with the package and its dependencies. *)
     type t = entry Pkg_digest.Map.t
 
+    let of_list entries =
+      Pkg_digest.Map.of_list_map_exn entries ~f:(fun entry -> entry.pkg_digest, entry)
+    ;;
+
+    let of_entries entries = Package.Name.Map.values entries |> of_list
+
     let of_lock_dir lock_dir ~platform ~system_provided =
-      entries_by_name_of_lock_dir lock_dir ~platform ~system_provided
-      |> Package.Name.Map.values
-      |> Pkg_digest.Map.of_list_map_exn ~f:(fun entry -> entry.pkg_digest, entry)
+      entries_by_name_of_lock_dir lock_dir ~platform ~system_provided |> of_entries
     ;;
 
     (* Helper which is called when both tables have an entry with the same
@@ -1387,23 +1391,86 @@ module DB = struct
     let union = Pkg_digest.Map.union ~f:union_check
     let union_all = Pkg_digest.Map.union_all ~f:union_check
 
-    let of_dev_tool_deps_if_lock_dir_exists dev_tool ~platform ~system_provided =
-      let+ lock_dir_opt = Lock_dir.of_dev_tool_if_lock_dir_exists dev_tool in
-      Option.map lock_dir_opt ~f:(of_lock_dir ~platform ~system_provided)
+    (* Recompute only the dev tool's reachable closure, stopping at the project
+       compiler. The project table supplies the compiler and its dependencies. *)
+    let replace_compiler entries ~root ~project_compiler =
+      let cache = Package.Name.Table.create 10 in
+      let rec replace (entry : entry) =
+        if
+          Package.Name.equal entry.pkg.info.name project_compiler.pkg.info.name
+          && Package_version.equal
+               entry.pkg.info.version
+               project_compiler.pkg.info.version
+        then project_compiler
+        else
+          Package.Name.Table.find_or_add cache entry.pkg.info.name ~f:(fun _ ->
+            let deps =
+              List.map entry.deps ~f:(fun { dep_pkg; dep_loc; dep_pkg_digest = _ } ->
+                let dep_entry =
+                  Package.Name.Map.find_exn entries dep_pkg.info.name |> replace
+                in
+                { dep_pkg = dep_entry.pkg
+                ; dep_loc
+                ; dep_pkg_digest = dep_entry.pkg_digest
+                })
+            in
+            let pkg_digest =
+              Pkg_digest.create
+                entry.pkg
+                (List.map deps ~f:(fun { dep_pkg_digest; _ } -> dep_pkg_digest))
+            in
+            { entry with deps; pkg_digest })
+      in
+      let root = Package.Name.Map.find_exn entries root |> replace in
+      let entries =
+        Package.Name.Table.fold cache ~init:[] ~f:(fun entry entries -> entry :: entries)
+      in
+      of_list entries, root.pkg_digest
     ;;
 
-    let all_existing_dev_tools =
-      Memo.lazy_ ~name:"all-existing-dev-tools" (fun () ->
-        let* platform = Lock_dir.Sys_vars.solver_env in
-        let+ xs =
-          Memo.List.map
-            Pkg_dev_tool.all
-            ~f:
-              (of_dev_tool_deps_if_lock_dir_exists
-                 ~platform
-                 ~system_provided:default_system_provided)
-        in
-        List.filter_opt xs |> union_all)
+    let all_existing_dev_tools () =
+      let* platform = Lock_dir.Sys_vars.solver_env in
+      let* project_compiler =
+        Lock_dir.lock_dir_active Context_name.default
+        >>= function
+        | false -> Memo.return None
+        | true ->
+          let+ lock_dir = Lock_dir.get_exn Context_name.default in
+          Option.map lock_dir.Dune_pkg.Lock_dir.ocaml ~f:(fun (_, package) ->
+            let entries =
+              entries_by_name_of_lock_dir
+                lock_dir
+                ~platform
+                ~system_provided:default_system_provided
+            in
+            Package.Name.Map.find_exn entries package)
+      in
+      let+ tools =
+        Memo.List.filter_map Pkg_dev_tool.all ~f:(fun dev_tool ->
+          let+ lock_dir = Lock_dir.of_dev_tool_if_lock_dir_exists dev_tool in
+          Option.map lock_dir ~f:(fun lock_dir ->
+            let entries =
+              entries_by_name_of_lock_dir
+                lock_dir
+                ~platform
+                ~system_provided:default_system_provided
+            in
+            let root = Pkg_dev_tool.package_name dev_tool in
+            let entries, root_digest =
+              match
+                ( Dune_pkg.Dev_tool.needs_to_build_with_same_compiler_as_project dev_tool
+                , project_compiler )
+              with
+              | true, Some project_compiler ->
+                replace_compiler entries ~root ~project_compiler
+              | false, _ | true, None ->
+                let root = Package.Name.Map.find_exn entries root in
+                of_entries entries, root.pkg_digest
+            in
+            entries, (root, root_digest)))
+      in
+      let entries, roots = List.split tools in
+      union_all entries, Package.Name.Map.of_list_exn roots
     ;;
   end
 
@@ -1457,7 +1524,7 @@ module DB = struct
                let* lock_dir = Lock_dir.get_exn ctx
                and* platform = Lock_dir.Sys_vars.solver_env in
                (if allow_sharing
-                then Memo.Lazy.force Pkg_table.all_existing_dev_tools
+                then Pkg_table.all_existing_dev_tools () >>| fst
                 else Memo.return Pkg_table.empty)
                >>| Pkg_table.union
                      (Pkg_table.of_lock_dir lock_dir ~platform ~system_provided)
@@ -1482,27 +1549,21 @@ module DB = struct
     let system_provided = default_system_provided in
     let inactive_lockdir =
       Memo.lazy_ ~name:"inactive-lockdir-package-db" (fun () ->
-        let+ pkg_digest_table = Memo.Lazy.force Pkg_table.all_existing_dev_tools in
+        let+ pkg_digest_table, _ = Pkg_table.all_existing_dev_tools () in
         create ~pkg_digest_table ~system_provided)
     in
-    let of_dev_tool_memo =
-      Memo.create "pkg-db-dev-tool" ~input:(module Dune_pkg.Dev_tool)
-      @@ fun dev_tool ->
-      let+ lock_dir = Lock_dir.of_dev_tool dev_tool
-      and+ platform = Lock_dir.Sys_vars.solver_env in
-      pkg_digest_of_name
-        lock_dir
-        platform
-        (Pkg_dev_tool.package_name dev_tool)
-        ~system_provided
-    in
     fun dev_tool ->
+      let* (_ : Dune_pkg.Lock_dir.t) = Lock_dir.of_dev_tool dev_tool in
+      let* _, roots = Pkg_table.all_existing_dev_tools () in
       let+ db =
         Lock_dir.lock_dir_active Context_name.default
         >>= function
         | false -> Memo.Lazy.force inactive_lockdir
         | true -> of_ctx Context_name.default ~allow_sharing:true
-      and+ pkg_digest = Memo.exec of_dev_tool_memo dev_tool in
+      in
+      let pkg_digest =
+        Package.Name.Map.find_exn roots (Pkg_dev_tool.package_name dev_tool)
+      in
       db, pkg_digest
   ;;
 end

--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-basic.t
@@ -20,7 +20,8 @@ a lockdir containing an "ocaml" lockfile.
   building fake compiler
 
 The dev tool's non-portable lock directory describes the same compiler as the
-project's portable lock directory, but the dev tool currently rebuilds it.
+project's portable lock directory. The dev tool reuses the compiler already
+built for the project.
 
   $ DUNE_CACHE=disabled dune tools exec ocamlmerlin 2>&1 | tee output
   Solution for _build/.dev-tools.locks/merlin:
@@ -28,8 +29,7 @@ project's portable lock directory, but the dev tool currently rebuilds it.
   - ocaml.5.2.0
   - ocaml-base-compiler.5.2.0
   - ocaml-compiler.5.2.0
-  building fake compiler
        Running 'ocamlmerlin'
   hello from fake ocamlmerlin
   $ grep "building fake compiler" output
-  building fake compiler
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-stale-compiler.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-stale-compiler.t
@@ -103,8 +103,8 @@ any attempt to build the stale dependency is observable.
   $ dune build >/dev/null 2>&1
 
 Delete and relock only Merlin. Ocamllsp's lock directory still contains the old
-compiler, but this must not prevent Merlin from running. Merlin currently
-rebuilds the project compiler despite it already being built.
+compiler, but this does not prevent Merlin from running or cause the project
+compiler to be rebuilt.
 
   $ rm -rf "$dev_tool_lock_dir"
   $ dune tools exec ocamlmerlin >merlin-output 2>&1
@@ -113,11 +113,11 @@ rebuilds the project compiler despite it already being built.
   $ grep -q old-compiler-dependency \
   >   "$ocamllsp_lock_dir"/relocatable-compiler*.pkg
   $ grep "build compiler" merlin-output
-  build compiler d00ed00ed00ed00ed00ed00ed00ed00e relocatable-compiler enabled
+  [1]
 
-The stale dev-tool closure is currently included in @pkg-install, so its old
-compiler dependency is built again.
+Only the compiler closure reachable after substitution is included in
+@pkg-install, so the stale dependency is not rebuilt.
 
   $ dune build @pkg-install >output 2>&1
   $ grep "building old compiler dependency" output
-  building old compiler dependency
+  [1]


### PR DESCRIPTION
## Description

Reuse the project compiler when building compiler-sensitive dev tools whose
lock directories select the same compiler name and version.

For each such dev tool, this change traverses the dependency closure from the
tool package, replaces the matching compiler node with the project compiler
entry, and recomputes the dependent package digests. Only the rewritten,
reachable closure is merged into the package database.

## Motivation

A dev-tool lock directory can retain an older dependency closure after the
project lock directory changes without changing the compiler's name or version.
Previously, Dune merged both digest-keyed closures. This rebuilt a compiler that
was already built for the project and allowed obsolete compiler dependencies
from unrelated dev-tool lock directories into `@pkg-install`.

The regression coverage was merged in #16350. This fix is also a prerequisite
for #16292.

## Testing

- `dune build @check @fmt`
- `dune runtest test/blackbox-tests/test-cases/pkg/merlin`
