### PR TITLE
ci: avoid opam Git maintenance race

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,6 +7,15 @@ on:
     branches:
       - main
 
+env:
+  # Keep Git maintenance in the foreground to avoid a race in opam 2.5.
+  # See https://github.com/ocaml/opam/issues/7031.
+  GIT_CONFIG_COUNT: "2"
+  GIT_CONFIG_KEY_0: gc.autoDetach
+  GIT_CONFIG_VALUE_0: "false"
+  GIT_CONFIG_KEY_1: maintenance.autoDetach
+  GIT_CONFIG_VALUE_1: "false"
+
 permissions:
   # deployments permission to deploy GitHub pages website
   deployments: write

--- a/.github/workflows/bench.yml.in
+++ b/.github/workflows/bench.yml.in
@@ -6,6 +6,15 @@ on:
     branches:
       - main
 
+env:
+  # Keep Git maintenance in the foreground to avoid a race in opam 2.5.
+  # See https://github.com/ocaml/opam/issues/7031.
+  GIT_CONFIG_COUNT: "2"
+  GIT_CONFIG_KEY_0: gc.autoDetach
+  GIT_CONFIG_VALUE_0: "false"
+  GIT_CONFIG_KEY_1: maintenance.autoDetach
+  GIT_CONFIG_VALUE_1: "false"
+
 permissions:
   # deployments permission to deploy GitHub pages website
   deployments: write

--- a/.github/workflows/isolated-package-build.yml
+++ b/.github/workflows/isolated-package-build.yml
@@ -15,6 +15,15 @@ on:
       - 'opam/*.opam'
   workflow_dispatch:
 
+env:
+  # Keep Git maintenance in the foreground to avoid a race in opam 2.5.
+  # See https://github.com/ocaml/opam/issues/7031.
+  GIT_CONFIG_COUNT: "2"
+  GIT_CONFIG_KEY_0: gc.autoDetach
+  GIT_CONFIG_VALUE_0: "false"
+  GIT_CONFIG_KEY_1: maintenance.autoDetach
+  GIT_CONFIG_VALUE_1: "false"
+
 jobs:
   packaging-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/mirage.yml
+++ b/.github/workflows/mirage.yml
@@ -6,6 +6,15 @@ on:
     branches:
       - '*-rc'
 
+env:
+  # Keep Git maintenance in the foreground to avoid a race in opam 2.5.
+  # See https://github.com/ocaml/opam/issues/7031.
+  GIT_CONFIG_COUNT: "2"
+  GIT_CONFIG_KEY_0: gc.autoDetach
+  GIT_CONFIG_VALUE_0: "false"
+  GIT_CONFIG_KEY_1: maintenance.autoDetach
+  GIT_CONFIG_VALUE_1: "false"
+
 jobs:
   build:
     name: Build caldav

--- a/.github/workflows/revdeps-release-coverage.yml
+++ b/.github/workflows/revdeps-release-coverage.yml
@@ -16,7 +16,16 @@ on:
     branches:
       - '*-rc'
   workflow_dispatch:
- 
+
+env:
+  # Keep Git maintenance in the foreground to avoid a race in opam 2.5.
+  # See https://github.com/ocaml/opam/issues/7031.
+  GIT_CONFIG_COUNT: "2"
+  GIT_CONFIG_KEY_0: gc.autoDetach
+  GIT_CONFIG_VALUE_0: "false"
+  GIT_CONFIG_KEY_1: maintenance.autoDetach
+  GIT_CONFIG_VALUE_1: "false"
+
 permissions:
   contents: read
  

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,6 +13,15 @@ concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+env:
+  # Keep Git maintenance in the foreground to avoid a race in opam 2.5.
+  # See https://github.com/ocaml/opam/issues/7031.
+  GIT_CONFIG_COUNT: "2"
+  GIT_CONFIG_KEY_0: gc.autoDetach
+  GIT_CONFIG_VALUE_0: "false"
+  GIT_CONFIG_KEY_1: maintenance.autoDetach
+  GIT_CONFIG_VALUE_1: "false"
+
 permissions:
   contents: read
 

--- a/.github/workflows/workflow.yml.in
+++ b/.github/workflows/workflow.yml.in
@@ -12,6 +12,15 @@ concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+env:
+  # Keep Git maintenance in the foreground to avoid a race in opam 2.5.
+  # See https://github.com/ocaml/opam/issues/7031.
+  GIT_CONFIG_COUNT: "2"
+  GIT_CONFIG_KEY_0: gc.autoDetach
+  GIT_CONFIG_VALUE_0: "false"
+  GIT_CONFIG_KEY_1: maintenance.autoDetach
+  GIT_CONFIG_VALUE_1: "false"
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Description

Force Git's automatic GC and maintenance to remain in the foreground in every workflow that uses `ocaml/setup-ocaml`.

This prevents opam 2.5 from recursively copying its repository while a detached Git maintenance process creates and removes `.git/objects/maintenance.lock`.

## Motivation

Ubuntu opam setup jobs have been failing intermittently with:

```
"lstat" failed on ~/.opam/repo/default/.git/objects/maintenance.lock:
No such file or directory
```

This is the race reported in [ocaml/opam#7031](https://github.com/ocaml/opam/issues/7031). The upstream mitigation in [ocaml/opam#7073](https://github.com/ocaml/opam/pull/7073) is currently only available in opam 2.6 prereleases, while `setup-ocaml` selects stable opam 2.5.2.

## Testing

- `./dune.exe build @check @fmt`
- `./dune.exe runtest .github/workflows`
