### PR TITLE
test(action-plugin): cover patch-back of dynamic dependencies

### DIFF
--- a/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/bin/foo.ml
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/bin/foo.ml
@@ -1,8 +1,8 @@
 open Dune_rpc_lwt.V1.Action_plugin
 
-let ordinary_action dap =
+let ordinary_action dap ~path =
   let open Lwt.Syntax in
-  let* data = read_file dap ~path:"some_dependency" in
+  let* data = read_file dap ~path in
   Lwt_io.printl data
 ;;
 
@@ -79,7 +79,8 @@ let detached_action dap state =
 
 let action dap =
   match Sys.argv with
-  | [| _ |] -> ordinary_action dap
+  | [| _ |] -> ordinary_action dap ~path:"some_dependency"
+  | [| _; "read"; path |] -> ordinary_action dap ~path
   | [| _; "sandbox" |] -> sandbox_action dap
   | [| _; "detached"; state |] -> detached_action dap state
   | _ -> invalid_arg "invalid arguments"

--- a/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/sandbox.t
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/sandbox.t
@@ -132,3 +132,64 @@ Their dependencies are recorded in the cached action result.
   ran
   $ cat _build-lifetime/default/slow-input
   second
+
+Patch-back must track directories populated by dynamic requests, including
+parents created along the way. The input is not a static dependency, so its
+directories are absent from the initial sandbox. Deleting them after the
+request must report both directory deletions, not just the file deletion.
+
+  $ unset DUNE_CONFIG__BACKGROUND_SANDBOXES
+  $ cat > dune-project <<'EOF'
+  > (lang dune 3.25)
+  > (using action-plugin 0.1)
+  > EOF
+  $ mkdir -p todelete/nested
+  $ printf original > todelete/nested/input
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (alias patch-back)
+  >  (deps (sandbox patch_back_source_tree))
+  >  (action
+  >   (progn
+  >    (bash "test ! -e todelete")
+  >    (dynamic-run ./foo.exe read todelete/nested/input)
+  >    (run rm -r todelete))))
+  > EOF
+  $ dune build @patch-back --build-dir _build-patch-back
+  original
+  File "dune", lines 1-8, characters 0-196:
+  1 | (rule
+  2 |  (alias patch-back)
+  3 |  (deps (sandbox patch_back_source_tree))
+  4 |  (action
+  5 |   (progn
+  6 |    (bash "test ! -e todelete")
+  7 |    (dynamic-run ./foo.exe read todelete/nested/input)
+  8 |    (run rm -r todelete))))
+  Error: Directory todelete should be deleted
+  File "dune", lines 1-8, characters 0-196:
+  1 | (rule
+  2 |  (alias patch-back)
+  3 |  (deps (sandbox patch_back_source_tree))
+  4 |  (action
+  5 |   (progn
+  6 |    (bash "test ! -e todelete")
+  7 |    (dynamic-run ./foo.exe read todelete/nested/input)
+  8 |    (run rm -r todelete))))
+  Error: Directory todelete/nested should be deleted
+  File "dune", lines 1-8, characters 0-196:
+  1 | (rule
+  2 |  (alias patch-back)
+  3 |  (deps (sandbox patch_back_source_tree))
+  4 |  (action
+  5 |   (progn
+  6 |    (bash "test ! -e todelete")
+  7 |    (dynamic-run ./foo.exe read todelete/nested/input)
+  8 |    (run rm -r todelete))))
+  Error: File todelete/nested/input should be deleted
+  [1]
+
+The source input remains untouched until the deletions are promoted.
+
+  $ cat todelete/nested/input
+  original


### PR DESCRIPTION
Add end-to-end coverage for `dynamic-run` in a `patch_back_source_tree` sandbox. The plugin reads a nested file absent from the initial sandbox, and the action then deletes its containing directories.

Check that patch-back reports both directory deletions and the file deletion, while leaving the source input untouched. This guards the incremental snapshot bookkeeping introduced in #16342: without registering the newly populated directories, only the file deletion is reported.

Test-only; no implementation changes.