### PR TITLE
test(action-plugin): expose ignored stdout redirection

### DIFF
--- a/otherlibs/dune-rpc-lwt/test/action-plugin/simple-copy/run.t
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/simple-copy/run.t
@@ -27,3 +27,8 @@
   $ dune runtest
   Hello there!
   Hello there!
+
+The output above is misleading: the plugin prints to Dune's stdout instead of
+its redirected target, which is empty.
+
+  $ cat _build/default/some_copy


### PR DESCRIPTION
Inspect the redirected target in the existing action-plugin copy test. Its combined terminal output currently looks correct even though the plugin writes to Dune’s stdout and leaves the target empty.

This records the current broken behavior without changing the implementation; the stdout-forwarding fix can follow separately.