### PR TITLE
test(completion): record semantic directory spacing

### DIFF
--- a/test/blackbox-tests/test-cases/completion/bash.t
+++ b/test/blackbox-tests/test-cases/completion/bash.t
@@ -25,3 +25,34 @@ completion it registered for dune, and exercises that completion registration.
   > sed '/compgen: warning: -F option may not work as you expect/d' stderr
   > EOF
   bash.t
+
+Semantic directory candidates currently use Bash's default trailing-space
+behavior. Use a synthetic completion response so this behavior is covered
+independently of any command-specific semantic completer.
+
+  $ bash <<'EOF'
+  > enable complete compgen
+  > source <(dune completion bash)
+  > _get_comp_words_by_ref() {
+  >   local words_var="${@: -2:1}"
+  >   local cword_var="${@: -1}"
+  >   eval "$words_var=(\"\${COMP_WORDS[@]}\")"
+  >   printf -v "$cword_var" "%s" "$COMP_CWORD"
+  > }
+  > semantic_completion() {
+  >   printf '%s\n' 1 item tests/ item-end
+  > }
+  > compopt() {
+  >   printf '%s\n' "$*" >>compopt.log
+  > }
+  > : >compopt.log
+  > COMP_WORDS=(semantic_completion tes)
+  > COMP_CWORD=1
+  > completion=( $(complete -p dune) )
+  > completion[0]=compgen
+  > unset "completion[${#completion[@]}-1]"
+  > "${completion[@]}" -- tes 2>/dev/null
+  > if test -s compopt.log; then cat compopt.log; else echo "trailing space"; fi
+  > EOF
+  tests/
+  trailing space

--- a/test/blackbox-tests/test-cases/completion/zsh.t
+++ b/test/blackbox-tests/test-cases/completion/zsh.t
@@ -31,3 +31,37 @@ results can be inspected outside the interactive line editor.
   > EOF
   runtest
   zsh.t
+
+Semantic directory candidates currently use Zsh's default trailing-space
+suffix. Use a synthetic completion response so this behavior is covered
+independently of any command-specific semantic completer.
+
+  $ cat > semantic-completion <<'EOF'
+  > #!/bin/sh
+  > printf '%s\n' 1 item tests/ item-end
+  > EOF
+  $ chmod +x semantic-completion
+  $ zsh -f <<EOF
+  > typeset -A compstate
+  > compstate[nmatches]=0
+  > _describe() {
+  >   local completion_name=\$3
+  >   local -a described=( "\${(@P)completion_name}" )
+  >   local completion
+  >   for completion in "\${described[@]}"; do
+  >     print -r -- "\${completion%%:*}"
+  >   done
+  >   if (( \${argv[(I)-S]} )); then
+  >     print -r -- "empty suffix"
+  >   else
+  >     print -r -- "trailing space"
+  >   fi
+  >   (( compstate[nmatches] += \${#described} ))
+  > }
+  > _default() {}
+  > words=("$PWD/semantic-completion" tes)
+  > CURRENT=2
+  > source <(dune completion zsh)
+  > EOF
+  tests/
+  trailing space


### PR DESCRIPTION
## Description

Test bash and zsh scripts and demonstrate that an extra space is emitted when testing directory candidates.


## Related Issue and Motivation

Test for 
- #16357 

## Checklist

- [x] Tests added, if applicable.
