### PR TITLE
fix(completion): keep semantic directories open 

### DIFF
--- a/doc/changes/fixed/16359.md
+++ b/doc/changes/fixed/16359.md
@@ -1,0 +1,2 @@
+- Avoid inserting a space after semantic directory completions in Bash and Zsh
+  (#16359, fixes #16357, @Alizter)

--- a/test/blackbox-tests/test-cases/completion/bash.t
+++ b/test/blackbox-tests/test-cases/completion/bash.t
@@ -26,9 +26,9 @@ completion it registered for dune, and exercises that completion registration.
   > EOF
   bash.t
 
-Semantic directory candidates currently use Bash's default trailing-space
-behavior. Use a synthetic completion response so this behavior is covered
-independently of any command-specific semantic completer.
+Semantic directory candidates suppress Bash's default trailing-space behavior.
+Use a synthetic completion response so this behavior is covered independently
+of any command-specific semantic completer.
 
   $ bash <<'EOF'
   > enable complete compgen
@@ -55,4 +55,4 @@ independently of any command-specific semantic completer.
   > if test -s compopt.log; then cat compopt.log; else echo "trailing space"; fi
   > EOF
   tests/
-  trailing space
+  -o nospace

--- a/test/blackbox-tests/test-cases/completion/zsh.t
+++ b/test/blackbox-tests/test-cases/completion/zsh.t
@@ -32,9 +32,9 @@ results can be inspected outside the interactive line editor.
   runtest
   zsh.t
 
-Semantic directory candidates currently use Zsh's default trailing-space
-suffix. Use a synthetic completion response so this behavior is covered
-independently of any command-specific semantic completer.
+Semantic directory candidates suppress Zsh's default trailing-space suffix.
+Use a synthetic completion response so this behavior is covered independently
+of any command-specific semantic completer.
 
   $ cat > semantic-completion <<'EOF'
   > #!/bin/sh
@@ -64,4 +64,4 @@ independently of any command-specific semantic completer.
   > source <(dune completion zsh)
   > EOF
   tests/
-  trailing space
+  empty suffix

--- a/vendor/cmdliner/src/tool/cmdliner_data.ml
+++ b/vendor/cmdliner/src/tool/cmdliner_data.ml
@@ -67,6 +67,11 @@ let bash_generic_completion fun_name = strf
           item="${prefix:0:2}$item"
         fi
         COMPREPLY+=($item)
+        # Items ending in '/' are directory-like; suppress the trailing
+        # space so the user can chain another tab into the subdirectory.
+        if [[ "$item" == */ ]] && (type compopt &> /dev/null); then
+          compopt -o nospace
+        fi
       elif [[ $type == "restart" ]]; then
           # N.B. only emitted if there is a -- token
           for ((i = 0; i < ${#words[@]}; i++)); do
@@ -87,7 +92,7 @@ let zsh_generic_completion fun_name = strf
   local prefix="${words[CURRENT]}"
   w[CURRENT]="--__complete=${words[CURRENT]}"
   local line="${w[@]:0:1} --__complete ${w[@]:1}"
-  local -a completions
+  local -a completions directory_completions
   local version type group item text_line item_doc msg
   eval $line | {
     read -r version
@@ -99,8 +104,12 @@ let zsh_generic_completion fun_name = strf
       if [[ "$type" == "group" ]]; then
         if [ -n "$completions" ]; then
           _describe -V unsorted completions -U
-          completions=()
         fi
+        if [ -n "$directory_completions" ]; then
+          _describe -V unsorted directory_completions -U -S ''
+        fi
+        completions=()
+        directory_completions=()
         read -r group
       elif [[ "$type" == "message" ]]; then
           msg="";
@@ -133,7 +142,11 @@ let zsh_generic_completion fun_name = strf
             fi
         fi
         item_doc="${item_doc//$'\e'\[(01m|04m|m)/}"
-        completions+=("${item}":"${item_doc}")
+        if [[ "$item" == */ ]]; then
+          directory_completions+=("${item}":"${item_doc}")
+        else
+          completions+=("${item}":"${item_doc}")
+        fi
       elif [[ "$type" == "dirs" || "$type" == "files" ]]; then
           local pre=""
           local pat="$prefix"
@@ -163,6 +176,9 @@ let zsh_generic_completion fun_name = strf
   }
   if [ -n "$completions" ]; then
     _describe -V unsorted completions -U
+  fi
+  if [ -n "$directory_completions" ]; then
+    _describe -V unsorted directory_completions -U -S ''
   fi
 }
 |} fun_name


### PR DESCRIPTION
## Description

Adjust bash and zsh completion support so that directory candidates are not followed by a space. 

- Fixes #16357 
- [x] changelog
- [x] tested on bash
- [ ] tested on zsh