### PR TITLE
test(action-plugin): cover multiple clients initializing one action

### DIFF
--- a/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/bin/foo.ml
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/bin/foo.ml
@@ -77,12 +77,41 @@ let detached_action dap state =
   Lwt_io.printl "ran"
 ;;
 
+let write_connection path =
+  let temp = path ^ ".tmp" in
+  let output = open_out temp in
+  output_string output (Sys.getenv "DUNE_DYNAMIC_RUN_ACTION_ID");
+  output_char output '\n';
+  output_string output (Sys.getenv "DUNE_RPC");
+  output_char output '\n';
+  close_out output;
+  Sys.rename temp path
+;;
+
+let held_action _dap ~connection ~release =
+  let open Lwt.Syntax in
+  let* () =
+    Lwt_io.with_file ~mode:Output "held-target" (fun output -> Lwt_io.write output "held")
+  in
+  write_connection connection;
+  let rec loop () =
+    if Sys.file_exists release
+    then Lwt.return_unit
+    else
+      let* () = Lwt_unix.sleep 0.05 in
+      loop ()
+  in
+  loop ()
+;;
+
 let action dap =
   match Sys.argv with
   | [| _ |] -> ordinary_action dap ~path:"some_dependency"
   | [| _; "read"; path |] -> ordinary_action dap ~path
   | [| _; "sandbox" |] -> sandbox_action dap
   | [| _; "detached"; state |] -> detached_action dap state
+  | [| _; "hold"; connection; release |] -> held_action dap ~connection ~release
+  | [| _; "initialize" |] -> Lwt.return_unit
   | _ -> invalid_arg "invalid arguments"
 ;;
 

--- a/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/run.t
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/run.t
@@ -14,6 +14,11 @@ and requires one dependency can be successfully run.
   > (rule
   >  (alias runtest)
   >  (action (dynamic-run ./foo.exe)))
+  > \
+  > (rule
+  >  (target held-target)
+  >  (action
+  >   (dynamic-run ./foo.exe hold "$PWD/connection" "$PWD/release")))
   > EOF
 
   $ cp ./bin/foo.exe ./
@@ -24,3 +29,27 @@ and requires one dependency can be successfully run.
 
   $ dune runtest
   Hello from some_dependency!
+
+A second client can currently initialize the same active action from another
+RPC session. This is not necessarily a bug: we may support independent clients
+within one action, for example so libraries can discover their own dependencies.
+This test covers initialization only, not dependency requests by the second
+client.
+
+  $ rm -f connection release
+  $ dune build held-target > build.output 2>&1 &
+  $ build_pid=$!
+  $ for _ in $(seq 1 100); do
+  >   test -f connection && break
+  >   sleep 0.05
+  > done
+  $ test -f connection
+  $ action_id=$(sed -n 1p connection)
+  $ dune_rpc=$(sed -n 2p connection)
+  $ (cd _build/default &&
+  >  env DUNE_DYNAMIC_RUN_ACTION_ID="$action_id" DUNE_RPC="$dune_rpc" \
+  >    ./foo.exe initialize)
+  $ touch release
+  $ wait "$build_pid"
+  $ cat _build/default/held-target
+  held


### PR DESCRIPTION
Record that a second RPC client can initialize using the ID of an action that is still running.

This is not necessarily a bug. We may choose to support multiple independent clients within one action, allowing libraries to discover their own dependencies without sharing a client handle.

Test only: this records existing initialization behavior without deciding the session-ownership policy or changing the implementation. It does not test dependency requests from the second client.