### PR TITLE
test(package-deps): cover package-granular library closure

### DIFF
--- a/test/blackbox-tests/test-cases/package-materialization/installed-package.t
+++ b/test/blackbox-tests/test-cases/package-materialization/installed-package.t
@@ -1,15 +1,16 @@
 An action depending on installed package a must track its required library b,
 not merely find it through OCAMLPATH. Package b also installs b.unrelated,
-which must not become a dependency of the action.
+which requires c. Package-granular closure must include both b and c.
 
 Use bytecode so changing b's implementation does not change a through native
 inlining. Test both dune-package and META readers with fresh consumers.
 
-  $ mkdir -p source/b/unrelated prefix dune-consumer meta-consumer
+  $ mkdir -p source/b/unrelated source/c prefix dune-consumer meta-consumer
   $ cat >source/dune-project <<'EOF'
   > (lang dune 3.24)
   > (package (name a))
   > (package (name b))
+  > (package (name c))
   > EOF
   $ cat >source/dune <<'EOF'
   > (library
@@ -24,18 +25,24 @@ inlining. Test both dune-package and META readers with fresh consumers.
   > (library
   >  (name unrelated)
   >  (public_name b.unrelated)
-  >  (modes byte))
+  >  (modes byte)
+  >  (libraries c))
   > EOF
-  $ touch source/b/unrelated/unrelated.ml
+  $ echo 'let value = C.value' >source/b/unrelated/unrelated.ml
+  $ echo '(library (public_name c) (modes byte))' >source/c/dune
+  $ echo 'let value = 7' >source/c/c.ml
+  $ echo 'package data' >source/b/payload
+  $ echo '(install (section share) (package b) (files payload))' >>source/b/dune
   $ dune build --root source @install
   $ dune install --root source --prefix "$PWD/prefix" 2>/dev/null
 
 Check the metadata reader's inputs and the artifacts used in the dependency
-observations, including the sibling whose exclusion we want to verify.
+observations, including the sibling and its dependency, which should also be tracked.
 
   $ export OCAMLPATH="$PWD/prefix/lib"
   $ a_lib="$PWD/prefix/lib/a"
   $ b_lib="$PWD/prefix/lib/b"
+  $ c_lib="$PWD/prefix/lib/c"
   $ test -f "$a_lib/dune-package"
   $ test -f "$b_lib/dune-package"
   $ test -f "$a_lib/META"
@@ -44,6 +51,8 @@ observations, including the sibling whose exclusion we want to verify.
   $ test -f "$b_lib/b.cma"
   $ test -f "$b_lib/unrelated/unrelated.cmi"
   $ test -f "$b_lib/unrelated/unrelated.cma"
+  $ test -f "$c_lib/c.cma"
+  $ test -f prefix/share/b/payload
   $ cp "$a_lib/a.cmi" a.cmi.before
   $ cp "$a_lib/a.cma" a.cma.before
   $ cp "$b_lib/b.cma" b.cma.before
@@ -65,12 +74,11 @@ Both consumers use only (package a), not an explicit dependency on b.
   $ dune-consumer/_build/default/main.exe
   2
 
-CR-someday alizter: The required interface, archive and metadata should be
-tracked. Keep both sibling observations false. Accept direct dependencies
-or matching selectors rather than prescribing their representation.
+CR-someday alizter: Required packages' contents should be tracked, including
+sibling libraries, their requirements, and non-library installed files.
 
   $ dune rules --root dune-consumer --format=json main.exe >dune-rules.json
-  $ jq_dune --arg b "$b_lib" --arg metadata dune-package '
+  $ jq_dune --arg b "$b_lib" --arg c "$c_lib" --arg metadata dune-package '
   >   rulesMatchingTarget("main.exe") | {
   >     reader: $metadata,
   >     required_interface:
@@ -83,7 +91,9 @@ or matching selectors rather than prescribing their representation.
   >         $b + "/unrelated/unrelated.cmi"; $b + "/unrelated"; "*.cmi"),
   >     unrelated_archive:
   >       ruleHasDepFileOrMatchingGlob(
-  >         $b + "/unrelated/unrelated.cma"; $b + "/unrelated"; "*.cma")
+  >         $b + "/unrelated/unrelated.cma"; $b + "/unrelated"; "*.cma"),
+  >     sibling_dependency: ruleHasDepFile($c + "/c.cma"),
+  >     package_data: ruleHasDepFile("share/b/payload")
   >   }' dune-rules.json
   {
     "reader": "dune-package",
@@ -91,7 +101,9 @@ or matching selectors rather than prescribing their representation.
     "required_archive": false,
     "required_metadata": false,
     "unrelated_interface": false,
-    "unrelated_archive": false
+    "unrelated_archive": false,
+    "sibling_dependency": false,
+    "package_data": false
   }
 
 Replace only b's installed archive. Do not reinstall a or clean the consumer:
@@ -115,12 +127,12 @@ Restore b's original archive and remove dune-package files. The second
 consumer must use META, including after its dependency changes.
 
   $ cp b.cma.before "$b_lib/b.cma"
-  $ rm "$a_lib/dune-package" "$b_lib/dune-package"
+  $ rm "$a_lib/dune-package" "$b_lib/dune-package" "$c_lib/dune-package"
   $ dune build --root meta-consumer main.exe
   $ meta-consumer/_build/default/main.exe
   2
   $ dune rules --root meta-consumer --format=json main.exe >meta-rules.json
-  $ jq_dune --arg b "$b_lib" --arg metadata META '
+  $ jq_dune --arg b "$b_lib" --arg c "$c_lib" --arg metadata META '
   >   rulesMatchingTarget("main.exe") | {
   >     reader: $metadata,
   >     required_interface:
@@ -133,7 +145,8 @@ consumer must use META, including after its dependency changes.
   >         $b + "/unrelated/unrelated.cmi"; $b + "/unrelated"; "*.cmi"),
   >     unrelated_archive:
   >       ruleHasDepFileOrMatchingGlob(
-  >         $b + "/unrelated/unrelated.cma"; $b + "/unrelated"; "*.cma")
+  >         $b + "/unrelated/unrelated.cma"; $b + "/unrelated"; "*.cma"),
+  >     sibling_dependency: ruleHasDepFile($c + "/c.cma")
   >   }' meta-rules.json
   {
     "reader": "META",
@@ -141,7 +154,8 @@ consumer must use META, including after its dependency changes.
     "required_archive": false,
     "required_metadata": false,
     "unrelated_interface": false,
-    "unrelated_archive": false
+    "unrelated_archive": false,
+    "sibling_dependency": false
   }
 
 The rebuilt archive still contains b = 10. Copy only that archive, leaving

--- a/test/blackbox-tests/test-cases/package-materialization/transitive-closure.t
+++ b/test/blackbox-tests/test-cases/package-materialization/transitive-closure.t
@@ -441,3 +441,47 @@ The unrelated library from package `bar` is not discoverable.
   64 |    (run %{bin:ocamlfind} query bar.unrelated))))
   ocamlfind: Package `bar.unrelated' not found
   [1]
+
+Package-granular closure must also follow the requirements of sibling libraries
+in an added package, and include that package's non-library install entries.
+It must not follow dependencies that appear only in package metadata.
+
+  $ echo '(package (name sibling-support))' >>dune-project
+  $ mkdir sibling-support-src
+  $ cat >sibling-support-src/dune <<'EOF'
+  > (library (name sibling_support) (public_name sibling-support))
+  > EOF
+  $ echo 'let value = 7' >sibling-support-src/sibling_support.ml
+  $ cat >bar-unrelated-src/dune <<'EOF'
+  > (library
+  >  (name bar_unrelated)
+  >  (public_name bar.unrelated)
+  >  (libraries sibling-support))
+  > EOF
+  $ echo 'let value = Sibling_support.value' >bar-unrelated-src/bar_unrelated.ml
+  $ echo 'package data' >baz-src/payload
+  $ cat >>baz-src/dune <<'EOF'
+  > (install (section share) (package baz) (files payload))
+  > EOF
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (target package-result)
+  >  (deps (package foo))
+  >  (action (with-stdout-to %{target} (echo built))))
+  > EOF
+  $ dune build package-result
+  $ dune rules --format=json package-result | jq_dune '
+  >   rulesMatchingTarget("package-result") | {
+  >     sibling: ruleHasDepFile("lib/bar/unrelated/bar_unrelated.cmi"),
+  >     sibling_dependency:
+  >       ruleHasDepFile("lib/sibling-support/sibling_support.cmi"),
+  >     package_data: ruleHasDepFile("share/baz/payload"),
+  >     package_only_dependency:
+  >       ruleHasDepFile("lib/package-only-dep/package_only_dep.cmi")
+  >   }'
+  {
+    "sibling": false,
+    "sibling_dependency": false,
+    "package_data": false,
+    "package_only_dependency": false
+  }

--- a/test/blackbox-tests/test-cases/pkg/package-library-closure.t
+++ b/test/blackbox-tests/test-cases/pkg/package-library-closure.t
@@ -1,9 +1,10 @@
 A rule depending on a lock-built package must track its required libraries,
 not just the requested package's install cookie.
 
-Library dependencies: a -> b.
-Package dependencies: a -> b, c.
-Package b also installs an unrelated library, b.unrelated.
+Library dependencies: a -> b; b.unrelated -> d.
+Lock package dependencies: provider -> b-provider, c; b-provider -> d.
+The provider names differ from the library namespaces. Package-granular
+closure should include the contents of b-provider and d, but not c.
 
 Keep the package sources outside the workspace so they are built through the
 lock directory, not treated as workspace libraries. Use bytecode so changing
@@ -12,7 +13,7 @@ b's implementation does not change a's compiled archive through inlining.
   $ make_dune_project 3.24
   $ make_lockdir
   $ sources="$TMPDIR/package_sources"
-  $ mkdir -p "$sources/a" "$sources/b/unrelated" "$sources/c"
+  $ mkdir -p "$sources/a" "$sources/b/unrelated" "$sources/c" "$sources/d"
 
   $ cat >"$sources/a/dune-project" <<'EOF'
   > (lang dune 3.24)
@@ -38,9 +39,17 @@ b's implementation does not change a's compiled archive through inlining.
   > (library
   >  (name unrelated)
   >  (public_name b.unrelated)
-  >  (modes byte))
+  >  (modes byte)
+  >  (libraries d))
   > EOF
-  $ touch "$sources/b/unrelated/unrelated.ml"
+  $ echo 'let value = D.value' >"$sources/b/unrelated/unrelated.ml"
+  $ echo 'package data' >"$sources/b/payload"
+  $ cat >"$sources/d/dune-project" <<'EOF'
+  > (lang dune 3.24)
+  > (package (name d))
+  > EOF
+  $ echo '(library (public_name d) (modes byte))' >"$sources/d/dune"
+  $ echo 'let value = 7' >"$sources/d/d.ml"
 
   $ cat >"$sources/c/dune-project" <<'EOF'
   > (lang dune 3.24)
@@ -49,31 +58,61 @@ b's implementation does not change a's compiled archive through inlining.
   $ echo '(library (public_name c) (modes byte))' >"$sources/c/dune"
   $ touch "$sources/c/c.ml"
 
-  $ make_lockpkg b <<EOF
+Use explicit installation manifests to preserve the findlib namespaces even
+though the lock packages have different names.
+
+  $ cat >"$sources/a/provider.install" <<'EOF'
+  > lib_root: [
+  >   "_build/install/default/lib/a/META" {"a/META"}
+  >   "_build/install/default/lib/a/dune-package" {"a/dune-package"}
+  >   "_build/install/default/lib/a/a.cmi" {"a/a.cmi"}
+  >   "_build/install/default/lib/a/a.cma" {"a/a.cma"}
+  > ]
+  > EOF
+  $ cat >"$sources/b/b-provider.install" <<'EOF'
+  > lib_root: [
+  >   "_build/install/default/lib/b/META" {"b/META"}
+  >   "_build/install/default/lib/b/dune-package" {"b/dune-package"}
+  >   "_build/install/default/lib/b/b.cmi" {"b/b.cmi"}
+  >   "_build/install/default/lib/b/b.cma" {"b/b.cma"}
+  >   "_build/install/default/lib/b/unrelated/unrelated.cmi"
+  >     {"b/unrelated/unrelated.cmi"}
+  >   "_build/install/default/lib/b/unrelated/unrelated.cma"
+  >     {"b/unrelated/unrelated.cma"}
+  > ]
+  > share: [ "payload" ]
+  > EOF
+  $ make_lockpkg d <<EOF
   > (version 0.0.1)
-  > (source (copy "$sources/b"))
+  > (source (copy "$sources/d"))
   > (build (run dune build @install --promote-install-files))
+  > EOF
+  $ make_lockpkg b-provider <<EOF
+  > (version 0.0.1)
+  > (depends d)
+  > (source (copy "$sources/b"))
+  > (build (run dune build @install))
   > EOF
   $ make_lockpkg c <<EOF
   > (version 0.0.1)
   > (source (copy "$sources/c"))
   > (build (run dune build @install --promote-install-files))
   > EOF
-  $ make_lockpkg a <<EOF
+  $ make_lockpkg provider <<EOF
   > (version 0.0.1)
-  > (depends b c)
+  > (depends b-provider c)
   > (source (copy "$sources/a"))
-  > (build (run dune build @install --promote-install-files))
+  > (build (run dune build @install))
   > EOF
 
-The consumer declares only package a. Findlib selects libraries a and b;
+The consumer declares only package provider. Findlib selects libraries a and b;
 this query checks library requirements, not which other libraries are visible.
 
   $ echo 'let () = Printf.printf "%d\n" A.value' >main.ml
   $ cat >dune <<'EOF'
   > (rule
   >  (targets main.exe libraries)
-  >  (deps main.ml (package a))
+  >  (deps main.ml (package provider))
   >  (action
   >   (progn
   >    (with-stdout-to libraries
@@ -90,9 +129,11 @@ this query checks library requirements, not which other libraries are visible.
 Check that the excluded libraries really were installed, so their absence
 from the consumer's dependencies cannot be explained by missing artifacts.
 
-  $ a_target="$(get_build_pkg_dir a)/target"
-  $ b_lib="$(get_build_pkg_dir b)/target/lib/b"
+  $ a_target="$(get_build_pkg_dir provider)/target"
+  $ b_target="$(get_build_pkg_dir b-provider)/target"
+  $ b_lib="$b_target/lib/b"
   $ c_lib="$(get_build_pkg_dir c)/target/lib/c"
+  $ d_lib="$(get_build_pkg_dir d)/target/lib/d"
   $ test -f "$b_lib/b.cmi"
   $ test -f "$b_lib/b.cma"
   $ test -f "$b_lib/dune-package"
@@ -100,13 +141,15 @@ from the consumer's dependencies cannot be explained by missing artifacts.
   $ test -f "$b_lib/unrelated/unrelated.cma"
   $ test -f "$c_lib/c.cmi"
   $ test -f "$c_lib/c.cma"
+  $ test -f "$d_lib/d.cma"
+  $ test -f "$b_target/share/b-provider/payload"
 
-CR-someday alizter: The required interface, archive and metadata should be
-tracked. The unselected libraries' interfaces and archives must stay untracked.
-Accept dependencies represented by direct files or matching selectors.
+CR-someday alizter: The required packages' contents should be tracked,
+including b.unrelated, d, and the data file. Package-only dependency c must
+remain untracked.
 
   $ dune rules --format=json main.exe >rules.json
-  $ jq_dune --arg b "$b_lib" --arg c "$c_lib" '
+  $ jq_dune --arg b "$b_lib" --arg c "$c_lib" --arg d "$d_lib" '
   >   rulesMatchingTarget("main.exe") | {
   >     required_interface:
   >       ruleHasDepFileOrMatchingGlob($b + "/b.cmi"; $b; "*.cmi"),
@@ -122,7 +165,9 @@ Accept dependencies represented by direct files or matching selectors.
   >     package_only_interface:
   >       ruleHasDepFileOrMatchingGlob($c + "/c.cmi"; $c; "*.cmi"),
   >     package_only_archive:
-  >       ruleHasDepFileOrMatchingGlob($c + "/c.cma"; $c; "*.cma")
+  >       ruleHasDepFileOrMatchingGlob($c + "/c.cma"; $c; "*.cma"),
+  >     sibling_dependency: ruleHasDepFile($d + "/d.cma"),
+  >     package_data: ruleHasDepFile("share/b-provider/payload")
   >   }' rules.json
   {
     "required_interface": false,
@@ -131,7 +176,9 @@ Accept dependencies represented by direct files or matching selectors.
     "unrelated_interface": false,
     "unrelated_archive": false,
     "package_only_interface": false,
-    "package_only_archive": false
+    "package_only_archive": false,
+    "sibling_dependency": false,
+    "package_data": false
   }
 
 Changing b's implementation must relink the consumer even if a's artifacts


### PR DESCRIPTION
Record missing package contents, sibling dependencies, and stale consumers across workspace, installed metadata, and lock-built providers. Exercise lock-provider names that differ from their library namespaces.