### PR TITLE
test: make sure global git options don't interfere

### DIFF
--- a/otherlibs/dune-build-info/test/run.t
+++ b/otherlibs/dune-build-info/test/run.t
@@ -14,6 +14,8 @@ Test embedding of build information
   >    git init -q;
   >    git config user.name "Test Name"
   >    git config user.email "test@example.com"
+  >    git config commit.gpgsign false;
+  >    git config tag.gpgsign false;
   >    git add .;
   >    git commit -q -m _;
   >    git tag -a 1.0+$i -m _)


### PR DESCRIPTION
Set these config options to false so that the main git config doesn't interfere with the test. We could perhaps sanitize the git config but doesn't seem worth it atm.

This test was failing locally.