### PR TITLE
test(workspace): document empty target lists

### DIFF
--- a/test/blackbox-tests/test-cases/workspaces/empty-targets.t
+++ b/test/blackbox-tests/test-cases/workspaces/empty-targets.t
@@ -1,0 +1,16 @@
+An explicitly empty workspace target list is accepted. The native context is
+still available.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.8)
+  > EOF
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.8)
+  > (context (default (targets)))
+  > EOF
+
+  $ dune build
+
+  $ dune describe contexts
+  default


### PR DESCRIPTION
Document that an empty workspace `(targets)` field is accepted and retains the native context.