### PR TITLE
fix(melange): validate emit target names

### DIFF
--- a/doc/changes/fixed/16371.md
+++ b/doc/changes/fixed/16371.md
@@ -1,0 +1,2 @@
+- Reject `.` and `..` as `melange.emit` targets instead of raising an internal
+  error (#16371, @anmonteiro)

--- a/src/dune_rules/melange/melange_stanzas.ml
+++ b/src/dune_rules/melange/melange_stanzas.ml
@@ -99,20 +99,18 @@ module Emit = struct
       (let* loc = loc in
        let+ target =
          let of_string ~loc s =
-           match String.is_empty s with
-           | true ->
+           match Filename.of_string s with
+           | Some _ -> s
+           | None when String.is_empty s ->
              User_error.raise ~loc [ Pp.textf "The field target can not be empty" ]
-           | false ->
-             (match Filename.dirname s with
-              | "." -> s
-              | _ ->
-                User_error.raise
-                  ~loc
-                  [ Pp.textf
-                      "The field target must use simple names and can not include paths \
-                       to other folders. To emit JavaScript files in another folder, \
-                       move the `melange.emit` stanza to that folder"
-                  ])
+           | None ->
+             User_error.raise
+               ~loc
+               [ Pp.textf
+                   "The field target must use simple names and can not include paths to \
+                    other folders. To emit JavaScript files in another folder, move the \
+                    `melange.emit` stanza to that folder"
+               ]
          in
          field "target" (plain_string (fun ~loc s -> of_string ~loc s))
        and+ alias = field_o "alias" Dune_lang.Alias.decode

--- a/test/blackbox-tests/test-cases/melange/target-validation.t
+++ b/test/blackbox-tests/test-cases/melange/target-validation.t
@@ -23,8 +23,7 @@ Target should not be empty
   Error: The field target can not be empty
   [1]
 
-Special directory names currently bypass target validation and cause an
-internal error during rule generation.
+Special directory names are rejected when parsing the target field.
 
   $ cat > dune <<EOF
   > (library
@@ -36,12 +35,13 @@ internal error during rule generation.
   >  (libraries $lib))
   > EOF
 
-  $ dune build 2>&1 | sed '/^Raised at/,$d'
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
-  providing the file _build/trace.csexp, if possible. This includes build
-  commands, message logs, and file paths.
-  Description:
-    ("Filename.of_string_exn: invalid filename", { filename = "." })
+  $ dune build
+  File "dune", line 5, characters 9-10:
+  5 |  (target .)
+               ^
+  Error: The field target must use simple names and can not include paths to
+  other folders. To emit JavaScript files in another folder, move the
+  `melange.emit` stanza to that folder
   [1]
 
   $ cat > dune <<EOF
@@ -54,12 +54,13 @@ internal error during rule generation.
   >  (libraries $lib))
   > EOF
 
-  $ dune build 2>&1 | sed '/^Raised at/,$d'
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
-  providing the file _build/trace.csexp, if possible. This includes build
-  commands, message logs, and file paths.
-  Description:
-    ("Filename.of_string_exn: invalid filename", { filename = ".." })
+  $ dune build
+  File "dune", line 5, characters 9-11:
+  5 |  (target ..)
+               ^^
+  Error: The field target must use simple names and can not include paths to
+  other folders. To emit JavaScript files in another folder, move the
+  `melange.emit` stanza to that folder
   [1]
 
 Target should not try to descend into subdirectories


### PR DESCRIPTION
Reject special directory names as `melange.emit` targets instead of raising an internal error. Follows #16370.