### PR TITLE
test(toplevel): document missing name validation

### DIFF
--- a/test/blackbox-tests/test-cases/stanzas/toplevel-stanza/name-validation.t
+++ b/test/blackbox-tests/test-cases/stanzas/toplevel-stanza/name-validation.t
@@ -1,0 +1,27 @@
+Custom toplevel names are currently not validated when parsing the stanza.
+
+  $ make_dune_project 3.21
+
+A name containing a path causes an internal error.
+
+  $ cat >dune <<EOF
+  > (toplevel
+  >  (name ../foo))
+  > EOF
+
+  $ dune build 2>&1 | sed '/^Raised at/,$d'
+  Internal error! Please report to https://github.com/ocaml/dune/issues,
+  providing the file _build/trace.csexp, if possible. This includes build
+  commands, message logs, and file paths.
+  Description:
+    ("Filename.of_string_exn: invalid filename", { filename = "../foo.ml-gen" })
+  [1]
+
+An empty name is currently accepted.
+
+  $ cat >dune <<EOF
+  > (toplevel
+  >  (name ""))
+  > EOF
+
+  $ dune build


### PR DESCRIPTION
Record the current crash for path-containing custom toplevel names and acceptance of empty names. Fixed by #16373.