### PR TITLE
fix(toplevel): validate custom toplevel names

### DIFF
--- a/doc/changes/fixed/16373.md
+++ b/doc/changes/fixed/16373.md
@@ -1,0 +1,2 @@
+- Validate custom toplevel names as filenames, reporting an error for empty
+  names and avoiding crashes for names containing paths (#16373, @anmonteiro)

--- a/doc/reference/dune/toplevel.rst
+++ b/doc/reference/dune/toplevel.rst
@@ -3,7 +3,8 @@ toplevel
 
 The ``toplevel`` stanza allows one to define custom toplevels. Custom toplevels
 automatically load a set of specified libraries and are runnable like normal
-executables. Example:
+executables. The ``name`` field must be a nonempty filename without directory
+components. Example:
 
 .. code:: dune
 

--- a/src/dune_rules/stanzas/toplevel_stanza.ml
+++ b/src/dune_rules/stanzas/toplevel_stanza.ml
@@ -18,7 +18,16 @@ let decode =
   let* () = Dune_lang.Syntax.since Stanza.syntax (1, 7) in
   fields
     (let+ loc = loc
-     and+ name = field "name" string
+     and+ name =
+       field
+         "name"
+         (let+ loc, name = located string in
+          match Filename.of_string name with
+          | Some _ -> name
+          | None ->
+            User_error.raise
+              ~loc
+              [ Pp.text "The name field must be a filename without directory components" ])
      and+ libraries = field "libraries" (repeat (located Lib_name.decode)) ~default:[]
      and+ pps =
        field

--- a/test/blackbox-tests/test-cases/stanzas/toplevel-stanza/name-validation.t
+++ b/test/blackbox-tests/test-cases/stanzas/toplevel-stanza/name-validation.t
@@ -1,23 +1,22 @@
-Custom toplevel names are currently not validated when parsing the stanza.
+Custom toplevel names must be filenames.
 
   $ make_dune_project 3.21
 
-A name containing a path causes an internal error.
+Names containing paths are rejected.
 
   $ cat >dune <<EOF
   > (toplevel
   >  (name ../foo))
   > EOF
 
-  $ dune build 2>&1 | sed '/^Raised at/,$d'
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
-  providing the file _build/trace.csexp, if possible. This includes build
-  commands, message logs, and file paths.
-  Description:
-    ("Filename.of_string_exn: invalid filename", { filename = "../foo.ml-gen" })
+  $ dune build
+  File "dune", line 2, characters 7-13:
+  2 |  (name ../foo))
+             ^^^^^^
+  Error: The name field must be a filename without directory components
   [1]
 
-An empty name is currently accepted.
+Empty names are also rejected.
 
   $ cat >dune <<EOF
   > (toplevel
@@ -25,3 +24,8 @@ An empty name is currently accepted.
   > EOF
 
   $ dune build
+  File "dune", line 2, characters 7-9:
+  2 |  (name ""))
+             ^^
+  Error: The name field must be a filename without directory components
+  [1]


### PR DESCRIPTION
Reject invalid custom toplevel names during parsing. Follows #16372.