### PR TITLE
fix(action-plugin): honor stdout redirection

### DIFF
--- a/otherlibs/dune-rpc-lwt/test/action-plugin/simple-copy/run.t
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/simple-copy/run.t
@@ -28,7 +28,8 @@
   Hello there!
   Hello there!
 
-The output above is misleading: the plugin prints to Dune's stdout instead of
-its redirected target, which is empty.
+Check the target itself: combined terminal output could also look correct if
+the plugin ignored its stdout redirection and left an empty target.
 
   $ cat _build/default/some_copy
+  Hello there!

--- a/src/dune_engine/action_plugin.ml
+++ b/src/dune_engine/action_plugin.ml
@@ -140,6 +140,7 @@ let exec ~(ectx : context) ~(eenv : env) prog args =
         Strict
         ~dir:eenv.working_dir
         ~env
+        ~stdout_to:eenv.stdout_to
         ~stderr_to:eenv.stderr_to
         ~stdin_from:eenv.stdin_from
         ~metadata:ectx.metadata


### PR DESCRIPTION
Forward the `dynamic-run` action’s stdout destination to `Process.run`, alongside stdin and stderr. This makes `with-stdout-to` write the plugin’s output to the requested target instead of Dune’s terminal.

Update the regression from #16355 to check that the target contains the expected text. Combined terminal output alone had hidden the empty-target bug.