### PR TITLE
test(action-plugin): expose reads after changing directories

### DIFF
--- a/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/bin/foo.ml
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/bin/foo.ml
@@ -106,6 +106,12 @@ let held_action _dap ~connection ~release =
 
 let action dap =
   match Sys.argv with
+  | [| _; "chdir" |] ->
+    Unix.mkdir "elsewhere" 0o755;
+    Sys.chdir "elsewhere";
+    let open Lwt.Syntax in
+    let* data = read_file dap ~path:"input" in
+    Lwt_io.printl data
   | [| _ |] -> ordinary_action dap ~path:"some_dependency"
   | [| _; "read"; path |] -> ordinary_action dap ~path
   | [| _; "sandbox" |] -> sandbox_action dap

--- a/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/paths.t
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/paths.t
@@ -1,0 +1,23 @@
+The server resolves dependencies from the launch directory, but the client
+currently reads relative to its changed working directory.
+
+  $ cat > dune-project <<'EOF'
+  > (lang dune 2.0)
+  > (using action-plugin 0.1)
+  > EOF
+  $ cp bin/foo.exe .
+  $ cat > dune <<'EOF'
+  > (rule (target input) (action (write-file input anchored)))
+  > (rule
+  >  (target cwd-output)
+  >  (action (with-stdout-to cwd-output (dynamic-run ./foo.exe chdir))))
+  > EOF
+  $ dune build cwd-output
+  File "dune", lines 2-4, characters 0-95:
+  2 | (rule
+  3 |  (target cwd-output)
+  4 |  (action (with-stdout-to cwd-output (dynamic-run ./foo.exe chdir))))
+  read_file: open(input): No such file or directory
+  [1]
+  $ cat _build/default/input
+  anchored


### PR DESCRIPTION
Add a regression where an action plugin changes its working directory before requesting a generated input.

Dune builds the input relative to the launch directory, but the client tries to read it relative to its new directory. Record the missing-file diagnostic and verify that the generated input exists at the intended location.

This PR contains only the reproducer; the path-handling fix and API changes remain separate.