### PR TITLE
test(action-plugin): expose shared-cache exclusion

### DIFF
--- a/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/cache.t
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/cache.t
@@ -1,0 +1,31 @@
+Dynamic actions currently rerun in a fresh workspace even with a shared cache.
+
+  $ export DUNE_CACHE_ROOT="$PWD/.cache"
+  $ export DUNE_CACHE=enabled
+  $ mkdir template
+  $ cp bin/foo.exe template/
+  $ cat > template/dune-project <<'EOF'
+  > (lang dune 2.0)
+  > (using action-plugin 0.1)
+  > EOF
+  $ printf first > template/source
+  $ cat > template/dune <<'EOF'
+  > (rule (target input) (deps source) (action (copy source input)))
+  > (rule
+  >  (target output)
+  >  (action (with-stdout-to output (dynamic-run ./foo.exe read input))))
+  > EOF
+  $ show_runs () {
+  >   dune trace cat | jq -c '
+  >     select(.cat == "process" and .name == "finish")
+  >     | select(.args.prog | endswith("foo.exe"))
+  >     | .args | {prog: (.prog | split("/") | last), process_args, exit}'
+  > }
+  $ cp -R template first
+  $ (cd first && dune build --root . output && show_runs)
+  {"prog":"foo.exe","process_args":["read","input"],"exit":0}
+  $ cp -R template second
+  $ (cd second && dune build --root . output && show_runs)
+  {"prog":"foo.exe","process_args":["read","input"],"exit":0}
+  $ cat second/_build/default/output
+  first


### PR DESCRIPTION
Add a reproducer for dynamic action outputs not being restored from the shared cache in a fresh workspace.

Two identical workspaces build the same action with caching enabled and a shared `DUNE_CACHE_ROOT`. Censored process-event snapshots show the plugin running in both workspaces instead of restoring the second output. The snapshots retain the executable, arguments, and exit status without timing or process IDs.

This records the current limitation only; the shared-cache implementation is not included.