### PR TITLE
test(action-plugin): cover current-directory reads and invalidation

### DIFF
--- a/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/bin/foo.ml
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/bin/foo.ml
@@ -104,14 +104,45 @@ let held_action _dap ~connection ~release =
   loop ()
 ;;
 
+let change_dir dir =
+  if not (Sys.file_exists dir) then Unix.mkdir dir 0o755;
+  Sys.chdir dir
+;;
+
 let action dap =
   match Sys.argv with
-  | [| _; "chdir" |] ->
-    Unix.mkdir "elsewhere" 0o755;
-    Sys.chdir "elsewhere";
+  | [| _; "read-in"; dir; path |] ->
+    change_dir dir;
+    ordinary_action dap ~path
+  | [| _; "list-in"; dir |] ->
+    change_dir dir;
     let open Lwt.Syntax in
-    let* data = read_file dap ~path:"input" in
-    Lwt_io.printl data
+    let* files = read_directory_with_glob dap ~path:"." ~glob:(Glob.of_string "*.txt") in
+    Lwt_list.iter_s Lwt_io.printl files
+  | [| _; "in-flight" |] ->
+    let pending = read_file dap ~path:"input" in
+    change_dir "elsewhere";
+    let open Lwt.Syntax in
+    let* contents = pending in
+    Lwt_io.printl contents
+  | [| _; "list-in-flight" |] ->
+    let pending = read_directory_with_glob dap ~path:"." ~glob:(Glob.of_string "*.txt") in
+    change_dir "elsewhere";
+    let open Lwt.Syntax in
+    let* files = pending in
+    Lwt_list.iter_s Lwt_io.printl files
+  | [| _; "helper-in" |] ->
+    let prog = Filename.concat (Sys.getcwd ()) "foo.exe" in
+    let open Lwt.Syntax in
+    Lwt_process.with_process_in
+      ~cwd:"elsewhere"
+      (prog, [| prog; "read"; "input" |])
+      (fun process ->
+         let* contents = Lwt_io.read process#stdout in
+         let* status = process#status in
+         match status with
+         | Unix.WEXITED 0 -> Lwt_io.print contents
+         | _ -> failwith "helper failed")
   | [| _ |] -> ordinary_action dap ~path:"some_dependency"
   | [| _; "read"; path |] -> ordinary_action dap ~path
   | [| _; "sandbox" |] -> sandbox_action dap

--- a/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/paths.t
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/paths.t
@@ -1,23 +1,115 @@
-The server resolves dependencies from the launch directory, but the client
-currently reads relative to its changed working directory.
+Relative reads should use the client's current directory for both dependency
+requests and I/O. The server currently interprets requests relative to the
+launch directory instead.
 
   $ cat > dune-project <<'EOF'
   > (lang dune 2.0)
   > (using action-plugin 0.1)
   > EOF
   $ cp bin/foo.exe .
+  $ mkdir elsewhere
+  $ echo first > elsewhere/value
+  $ echo root > root.txt
+  $ echo child > elsewhere/child.txt
+  $ cat > elsewhere/dune <<'EOF'
+  > (rule (target input) (action (copy value input)))
+  > EOF
   $ cat > dune <<'EOF'
-  > (rule (target input) (action (write-file input anchored)))
+  > (rule (target input) (action (write-file input launch)))
   > (rule
   >  (target cwd-output)
-  >  (action (with-stdout-to cwd-output (dynamic-run ./foo.exe chdir))))
+  >  (action
+  >   (with-stdout-to cwd-output (dynamic-run ./foo.exe read-in elsewhere input))))
+  > (rule
+  >  (target listing)
+  >  (action (with-stdout-to listing (dynamic-run ./foo.exe list-in elsewhere))))
+  > (rule
+  >  (target in-flight)
+  >  (action (with-stdout-to in-flight (dynamic-run ./foo.exe in-flight))))
+  > (rule
+  >  (target listing-in-flight)
+  >  (action
+  >   (with-stdout-to listing-in-flight (dynamic-run ./foo.exe list-in-flight))))
+  > (rule
+  >  (target parent-output)
+  >  (action
+  >   (with-stdout-to parent-output
+  >    (dynamic-run ./foo.exe read-in elsewhere ../input))))
+  > (rule
+  >  (target helper-output)
+  >  (action (with-stdout-to helper-output (dynamic-run ./foo.exe helper-in))))
   > EOF
+
+A cold read currently builds the wrong input, leaving the requested file absent.
+
+  $ dune build cwd-output > cold.log 2>&1; echo $?
+  1
+  $ test -f _build/default/input
+
+Prebuilding both inputs makes the read succeed, but hides the wrong dependency.
+Changing the file actually read then fails to invalidate the action. These
+prebuilds are separate targets, not static dependencies of cwd-output.
+
+  $ dune build input elsewhere/input
   $ dune build cwd-output
-  File "dune", lines 2-4, characters 0-95:
-  2 | (rule
-  3 |  (target cwd-output)
-  4 |  (action (with-stdout-to cwd-output (dynamic-run ./foo.exe chdir))))
-  read_file: open(input): No such file or directory
-  [1]
-  $ cat _build/default/input
-  anchored
+  $ cat _build/default/cwd-output
+  first
+  
+  $ echo second > elsewhere/value
+  $ dune build elsewhere/input
+  $ dune build cwd-output
+  $ cat _build/default/cwd-output
+  first
+  
+
+Directory listings have the same problem: membership in the directory actually
+read is not tracked.
+
+  $ dune build elsewhere/child.txt
+  $ dune build listing
+  $ cat _build/default/listing
+  child.txt
+  $ echo added > elsewhere/added.txt
+  $ dune build elsewhere/added.txt
+  $ dune build listing
+  $ cat _build/default/listing
+  child.txt
+
+Changing cwd after submitting a request also redirects the eventual I/O.
+
+  $ dune build in-flight listing-in-flight
+  $ cat _build/default/in-flight
+  second
+  
+  $ cat _build/default/listing-in-flight
+  added.txt
+  child.txt
+
+Parent-relative paths should also be interpreted from the current cwd. Helpers
+may start in a different directory while sharing the same action ID.
+
+  $ dune build parent-output > parent.log 2>&1; echo $?
+  1
+  $ dune build helper-output > helper.log 2>&1; echo $?
+  1
+  $ cat _build/default/helper-output
+
+The same cold read must work in sandboxes, without prebuilding the input or
+assuming the sandbox has the same root as the canonical build tree.
+
+  $ for mode in copy symlink hardlink; do
+  >   dune build --sandbox=$mode --build-dir=_build-$mode \
+  >     cwd-output > $mode.log 2>&1
+  >   echo "$mode: $?"
+  > done
+  copy: 1
+  symlink: 1
+  hardlink: 1
+
+The build directory may itself be reached through a symlink. The client's
+physical cwd and Dune's spelling of the root still refer to the same tree.
+
+  $ mkdir _build-physical
+  $ ln -s _build-physical _build-linked
+  $ dune build --build-dir=_build-linked cwd-output > linked.log 2>&1; echo $?
+  1

--- a/test/expect-tests/dune_action_plugin/dune_action_test.ml
+++ b/test/expect-tests/dune_action_plugin/dune_action_test.ml
@@ -38,6 +38,26 @@ let%expect_test _ =
   |}]
 ;;
 
+let%expect_test "standalone reads use the current directory" =
+  let cwd = Sys.getcwd () in
+  Fun.protect
+    ~finally:(fun () -> Sys.chdir cwd)
+    (fun () ->
+       let dap = outside_of_dune in
+       Sys.chdir "some_dir";
+       let open Lwt.Syntax in
+       Lwt_main.run
+         (let* contents = read_file dap ~path:"some_file" in
+          print_endline contents;
+          let+ entries = read_directory_with_glob dap ~path:"." ~glob:Glob.universal in
+          print_endline (String.concat "," entries)));
+  [%expect
+    {|
+    Hello from foo!
+    some_file,subdir
+    |}]
+;;
+
 let run_action_expect_throws action =
   try
     run action;


### PR DESCRIPTION
Extends the cwd regression from #16377 to cover ordinary current-directory semantics for action-plugin reads.

Prebuilding both candidate inputs can make a read succeed while hiding that Dune tracked the wrong file. These tests expose the resulting stale output after changing the file actually read, and the equivalent problem with directory membership.

Also covers cold generated inputs, cwd changes while requests are pending, parent-relative paths, a helper launched in another directory, copy/symlink/hardlink sandboxes, a symlinked build directory, and existing standalone behavior.