### PR TITLE
perf(stdune): reuse concat lists in tail-recursive traversals

### DIFF
--- a/otherlibs/stdune/src/appendable_list.ml
+++ b/otherlibs/stdune/src/appendable_list.ml
@@ -44,45 +44,55 @@ let to_list_rev =
 let to_list xs = List.rev (to_list_rev xs)
 
 let length =
-  let rec loop1 len t stack =
+  let rec loop1 len t rest stack =
     match t with
-    | Empty -> loop0 len stack
-    | Singleton _ -> loop0 (len + 1) stack
-    | Cons (_, xs) -> loop1 (len + 1) xs stack
-    | List xs -> loop0 (len + List.length xs) stack
-    | Append (xs, ys) -> loop1 len xs (ys :: stack)
-    | Concat [] -> loop0 len stack
-    | Concat (x :: xs) -> loop1 len x (Concat xs :: stack)
-  and loop0 len stack =
-    match stack with
-    | [] -> len
-    | t :: stack -> loop1 len t stack
+    | Empty | Concat [] -> loop0 len rest stack
+    | Singleton _ -> loop0 (len + 1) rest stack
+    | Cons (_, xs) -> loop1 (len + 1) xs rest stack
+    | List xs -> loop0 (len + List.length xs) rest stack
+    | Append (xs, ys) -> loop1 len xs (ys :: rest) stack
+    | Concat xs ->
+      (match rest with
+       | [] -> loop0 len xs stack
+       | _ :: _ -> loop0 len xs (rest :: stack))
+  and loop0 len rest stack =
+    match rest with
+    | t :: rest -> loop1 len t rest stack
+    | [] ->
+      (match stack with
+       | [] -> len
+       | rest :: stack -> loop0 len rest stack)
   in
-  fun t -> loop1 0 t []
+  fun t -> loop1 0 t [] []
 ;;
 
 let iter =
-  let rec loop1 f t stack =
+  let rec loop1 f t rest stack =
     match t with
-    | Empty -> loop0 f stack
+    | Empty | Concat [] -> loop0 f rest stack
     | Singleton x ->
       f x;
-      loop0 f stack
+      loop0 f rest stack
     | Cons (x, xs) ->
       f x;
-      loop1 f xs stack
+      loop1 f xs rest stack
     | List xs ->
       List.iter xs ~f;
-      loop0 f stack
-    | Append (xs, ys) -> loop1 f xs (ys :: stack)
-    | Concat [] -> loop0 f stack
-    | Concat (x :: xs) -> loop1 f x (Concat xs :: stack)
-  and loop0 f stack =
-    match stack with
-    | [] -> ()
-    | t :: stack -> loop1 f t stack
+      loop0 f rest stack
+    | Append (xs, ys) -> loop1 f xs (ys :: rest) stack
+    | Concat xs ->
+      (match rest with
+       | [] -> loop0 f xs stack
+       | _ :: _ -> loop0 f xs (rest :: stack))
+  and loop0 f rest stack =
+    match rest with
+    | t :: rest -> loop1 f t rest stack
+    | [] ->
+      (match stack with
+       | [] -> ()
+       | rest :: stack -> loop0 f rest stack)
   in
-  fun t ~f -> loop1 f t []
+  fun t ~f -> loop1 f t [] []
 ;;
 
 let to_immutable_array (type a) (t : a t) =

--- a/otherlibs/stdune/test/appendable_list_quick_tests.ml
+++ b/otherlibs/stdune/test/appendable_list_quick_tests.ml
@@ -1,0 +1,71 @@
+open Base
+open Base_quickcheck.Export
+module Al = Stdune.Appendable_list
+
+module Input = struct
+  type t =
+    | Empty
+    | Singleton of int
+    | Cons of int * t
+    | Of_list of int list
+    | Append of t * t
+    | Concat of t list
+  [@@deriving sexp_of, quickcheck]
+
+  let rec to_appendable_list = function
+    | Empty -> Al.empty
+    | Singleton x -> Al.singleton x
+    | Cons (x, xs) -> Al.cons x (to_appendable_list xs)
+    | Of_list xs -> Al.of_list xs
+    | Append (xs, ys) -> Al.(to_appendable_list xs @ to_appendable_list ys)
+    | Concat xs -> Al.concat (List.map xs ~f:to_appendable_list)
+  ;;
+
+  let rec to_list = function
+    | Empty -> []
+    | Singleton x -> [ x ]
+    | Cons (x, xs) -> x :: to_list xs
+    | Of_list xs -> xs
+    | Append (xs, ys) -> List.append (to_list xs) (to_list ys)
+    | Concat xs -> List.concat_map xs ~f:to_list
+  ;;
+end
+
+let quick_test_config =
+  { Base_quickcheck.Test.default_config with
+    test_count = 200
+  ; sizes = Sequence.cycle_list_exn (List.init 11 ~f:Fn.id)
+  }
+;;
+
+let%quick_test ("traversals agree with lists" [@config quick_test_config]) =
+  fun (input : Input.t) ->
+  let xs = Input.to_appendable_list input in
+  let expected = Input.to_list input in
+  assert (Al.length xs = List.length expected);
+  assert (Bool.equal (Al.is_empty xs) (List.is_empty expected));
+  assert (List.equal Int.equal (Al.to_list xs) expected);
+  assert (List.equal Int.equal (Al.to_list_rev xs) (List.rev expected));
+  assert (
+    List.equal
+      Int.equal
+      (Stdune.Array.Immutable.to_list (Al.to_immutable_array xs))
+      expected);
+  let visited = ref [] in
+  Al.iter xs ~f:(fun x -> visited := x :: !visited);
+  assert (List.equal Int.equal (List.rev !visited) expected)
+;;
+
+let%quick_test ("map agrees with List.map" [@config quick_test_config]) =
+  fun (input : Input.t) (f : int -> int) ->
+  let actual = Al.map (Input.to_appendable_list input) ~f |> Al.to_list in
+  let expected = List.map (Input.to_list input) ~f in
+  assert (List.equal Int.equal actual expected)
+;;
+
+let%quick_test ("exists agrees with List.exists" [@config quick_test_config]) =
+  fun (input : Input.t) (f : int -> bool) ->
+  let actual = Al.exists (Input.to_appendable_list input) ~f in
+  let expected = List.exists (Input.to_list input) ~f in
+  assert (Bool.equal actual expected)
+;;

--- a/otherlibs/stdune/test/appendable_list_tests.ml
+++ b/otherlibs/stdune/test/appendable_list_tests.ml
@@ -60,6 +60,80 @@ let%expect_test "concat" =
     9 |}]
 ;;
 
+let check_traversal xs expected =
+  assert (Al.length xs = List.length expected);
+  let remaining = ref expected in
+  Al.iter xs ~f:(fun x ->
+    match !remaining with
+    | [] -> Code_error.raise "unexpected element" []
+    | y :: rest ->
+      assert (x = y);
+      remaining := rest);
+  assert (List.is_empty !remaining);
+  assert (Array.Immutable.to_list (Al.to_immutable_array xs) = expected)
+;;
+
+let%expect_test "traverse mixed appends and concats in order" =
+  let xs =
+    Al.concat
+      [ Al.empty
+      ; Al.cons 0 (Al.of_list [ 1; 2 ])
+      ; Al.(
+          concat [ singleton 3; concat [ empty; of_list [ 4; 5 ]; empty ] ]
+          @ concat [ singleton 6; empty; singleton 7 ])
+      ; Al.concat [ Al.empty; Al.empty ]
+      ; Al.singleton 8
+      ; Al.empty
+      ]
+  in
+  check_traversal xs (List.init 9 ~f:Fun.id);
+  [%expect {||}]
+;;
+
+let%expect_test "traverse wide concats" =
+  let expected = List.init 100 ~f:Fun.id in
+  check_traversal (Al.concat (List.map expected ~f:Al.singleton)) expected;
+  [%expect {||}]
+;;
+
+let%expect_test "traverse cons chains" =
+  let rec make n acc = if n < 0 then acc else make (n - 1) (Al.cons n acc) in
+  check_traversal (make 99 Al.empty) (List.init 100 ~f:Fun.id);
+  [%expect {||}]
+;;
+
+let%expect_test "traverse left-nested appends" =
+  let rec make n acc =
+    if n = 100 then acc else make (n + 2) Al.(acc @ of_list [ n; n + 1 ])
+  in
+  check_traversal (make 0 Al.empty) (List.init 100 ~f:Fun.id);
+  [%expect {||}]
+;;
+
+let%expect_test "traverse right-nested appends" =
+  let rec make n acc =
+    if n < 0 then acc else make (n - 2) Al.(of_list [ n; n + 1 ] @ acc)
+  in
+  check_traversal (make 98 Al.empty) (List.init 100 ~f:Fun.id);
+  [%expect {||}]
+;;
+
+let%expect_test "traverse left-nested concats" =
+  let rec make n acc =
+    if n = 100 then acc else make (n + 1) (Al.concat [ acc; Al.empty; Al.singleton n ])
+  in
+  check_traversal (make 0 Al.empty) (List.init 100 ~f:Fun.id);
+  [%expect {||}]
+;;
+
+let%expect_test "traverse right-nested concats" =
+  let rec make n acc =
+    if n < 0 then acc else make (n - 1) (Al.concat [ Al.singleton n; Al.empty; acc ])
+  in
+  check_traversal (make 99 Al.empty) (List.init 100 ~f:Fun.id);
+  [%expect {||}]
+;;
+
 let%expect_test "is_empty" =
   let assert_empty l = assert (Al.is_empty l) in
   assert_empty Al.empty;

--- a/otherlibs/stdune/test/dune
+++ b/otherlibs/stdune/test/dune
@@ -3,6 +3,7 @@
  (modules
   :standard
   \
+  appendable_list_quick_tests
   path_external_build_tests
   path_tests
   proc_linux_tests
@@ -23,6 +24,15 @@
   ppx_inline_test.config)
  (preprocess
   (pps ppx_expect)))
+
+(library
+ (name appendable_list_quick_tests)
+ (modules appendable_list_quick_tests)
+ (optional)
+ (inline_tests)
+ (libraries stdune base ppx_inline_test.config)
+ (preprocess
+  (pps ppx_quick_test)))
 
 (library
  (name stdune_path_tests)


### PR DESCRIPTION
`Appendable_list.length` and `iter` currently allocate a `Concat` wrapper
and a stack cell for every concat child. Reuse the existing child list as
the current worklist instead, with a separate stack of deferred sibling
lists. Entering a concat only allocates when there are pending siblings
to save.

This preserves traversal order and constant call-stack usage without
changing the representation or public API. `Cons` and `List` traversal
remain allocation-free, and `Append` retains its existing allocation cost.

A local OCaml 5.5 microbenchmark traversing 100,000 singleton concat
children, repeated 100 times, gives:

| Traversal | Allocated words before → after | ns/element before → after |
| --- | --- | --- |
| `length` | 500,000 → 0 | 4.56 → 1.90 |
| `iter` | 500,000 → 0 | 5.08 → 2.56 |

The preceding test commit includes examples of mixed constructors, wide
concats, cons chains, and left-/right-nested appends and concats. These
check length, iteration order, and immutable-array conversion with inputs
of at most 100 elements.

It also follows the existing `ppx_quick_test` setup to compare generated
construction trees with an independent OCaml-list model. Three properties
cover traversals, conversions, emptiness, `map`, and `exists`, using 200
deterministic samples each and generator sizes from 0 to 10.

Local full-suite validation encounters the same two bubblewrap uid-map
permission failures as the baseline.
