### PR TITLE
refactor(engine): remove stale File_selector comment

### DIFF
--- a/src/dune_engine/file_selector.ml
+++ b/src/dune_engine/file_selector.ml
@@ -1,10 +1,7 @@
 open Import
 
 type t =
-  { (* CR-someday rgrinberg: this [dir] is ignored when evaluating the
-       selector with [test]. It's better to just drop it completely and
-       provide the directory explicitly when building or evaluating *)
-    dir : Path.t
+  { dir : Path.t
   ; predicate : Predicate_lang.Glob.t
   ; only_generated_files : bool
   }


### PR DESCRIPTION
Remove a stale note about the deleted `File_selector.test` evaluator. The current API tests basenames explicitly and uses the directory when building the selector.