### PR TITLE
refactor(stdune): move RPC conversion combinators to Stdune

### DIFF
--- a/bin/monitor.ml
+++ b/bin/monitor.ml
@@ -9,7 +9,6 @@ include struct
   module Progress = Progress
   module Job = Job
   module Sub = Sub
-  module Conv = Conv
 end
 
 (** Utility module for generating [Map] modules for [Diagnostic]s and [Job]s which use

--- a/bin/rpc/rpc_status.ml
+++ b/bin/rpc/rpc_status.ml
@@ -123,7 +123,7 @@ let term =
     server_response_map ~where ~f:(fun clients ->
       List.iter clients ~f:(fun (client, menu) ->
         let id =
-          let sexp = Dune_rpc.Conv.to_sexp Dune_rpc.Id.sexp client in
+          let sexp = Conv.to_sexp Dune_rpc.Id.sexp client in
           Sexp.to_string sexp
         in
         let message =

--- a/otherlibs/dune-rpc/action_id.mli
+++ b/otherlibs/dune-rpc/action_id.mli
@@ -1,3 +1,5 @@
+open Import
+
 type t
 
 val gen : unit -> t

--- a/otherlibs/dune-rpc/diagnostics_v1.mli
+++ b/otherlibs/dune-rpc/diagnostics_v1.mli
@@ -1,5 +1,7 @@
 (** V1 of the diagnostics module. *)
 
+open Import
+
 module Related : sig
   type t
 

--- a/otherlibs/dune-rpc/exported_types.mli
+++ b/otherlibs/dune-rpc/exported_types.mli
@@ -1,5 +1,7 @@
 (** Types exposed to end-user consumers of [dune_rpc.mli]. *)
 
+open Import
+
 module Pp : sig
   include module type of Stdune.Pp
 

--- a/otherlibs/dune-rpc/import.ml
+++ b/otherlibs/dune-rpc/import.ml
@@ -7,6 +7,7 @@ include struct
   module Int = Int
   module Poly = Poly
   module Code_error = Code_error
+  module Conv = Conv
   module Env = Env
   module Comparable = Comparable
   module Repr = Repr

--- a/otherlibs/dune-rpc/private.ml
+++ b/otherlibs/dune-rpc/private.ml
@@ -1,6 +1,5 @@
 module Action_id = Action_id
 module Action_plugin = Action_plugin
-module Conv = Conv
 module Dep = Dep
 module Versioned = Versioned
 module Menu = Menu

--- a/otherlibs/dune-rpc/procedures.mli
+++ b/otherlibs/dune-rpc/procedures.mli
@@ -1,3 +1,4 @@
+open Import
 open Types
 open Exported_types
 

--- a/otherlibs/dune-rpc/registry.mli
+++ b/otherlibs/dune-rpc/registry.mli
@@ -1,3 +1,5 @@
+open Import
+
 module File : sig
   type t =
     { path : string

--- a/otherlibs/stdune/src/conv.ml
+++ b/otherlibs/stdune/src/conv.ml
@@ -1,4 +1,4 @@
-open Import
+module Float = Stdlib.Float
 
 (* Mini clone of Dune_lang.Decoder. Main advantage is that it forbids all the
    crazy stuff and is automatically bi-directional *)

--- a/otherlibs/stdune/src/conv.mli
+++ b/otherlibs/stdune/src/conv.mli
@@ -1,7 +1,5 @@
 (** Bidirectional parsing of canonical s-expressions *)
 
-open Import
-
 type ('a, 'k) t
 type values
 type 'a value = ('a, values) t

--- a/otherlibs/stdune/src/stdune.ml
+++ b/otherlibs/stdune/src/stdune.ml
@@ -14,6 +14,7 @@ module Array = Array
 module Bytes = Bytes
 module Char = Char
 module Comparator = Comparator
+module Conv = Conv
 module Dune_sexp = Dune_sexp
 module Either = Either
 module Exn = Exn

--- a/src/dune_engine/action_runner_protocol.ml
+++ b/src/dune_engine/action_runner_protocol.ml
@@ -26,7 +26,6 @@ module Request = struct
 end
 
 module Decl = struct
-  module Conv = Dune_rpc.Conv
   module Decl = Dune_rpc.Decl
 
   let marshal () =

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_jobs.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_jobs.ml
@@ -7,7 +7,6 @@ module Dune_rpc = Dune_rpc.Private
 include struct
   open Dune_rpc
   module Job = Job
-  module Conv = Conv
 end
 
 let files = List.iter ~f:(fun (f, contents) -> Io.String_path.write_file f contents)


### PR DESCRIPTION
Make the bidirectional S-expression codec available as `Stdune.Conv` without depending on `dune-rpc`. Move version handling and schema-digest generation with it, preserving existing behavior and wire formats.

Update callers to use `Stdune.Conv` and remove the RPC conversion module and re-export.