### PR TITLE
fix(action-plugin): resolve client paths from the current directory

### DIFF
--- a/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.mli
+++ b/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.mli
@@ -20,7 +20,12 @@ module V1 : sig
     module Error = Dune_rpc.V1.Action_plugin.Error
 
     val outside_of_dune : t
+
+    (** Relative paths use the current directory at the time of the call,
+        including when cwd changes while the dependency is being built. *)
     val read_file : t -> path:string -> string Lwt.t
+
+    (** Relative paths use the current directory at the time of the call. *)
     val read_directory_with_glob : t -> path:string -> glob:Glob.t -> string list Lwt.t
 
     (** Run a dynamic action using Lwt for RPC communication. This function never

--- a/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/paths.t
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/paths.t
@@ -1,6 +1,5 @@
-Relative reads should use the client's current directory for both dependency
-requests and I/O. The server currently interprets requests relative to the
-launch directory instead.
+Relative reads use the client's current directory for both dependency requests
+and I/O. Clients translate requests into Dune's root-relative namespace.
 
   $ cat > dune-project <<'EOF'
   > (lang dune 2.0)
@@ -40,15 +39,16 @@ launch directory instead.
   >  (action (with-stdout-to helper-output (dynamic-run ./foo.exe helper-in))))
   > EOF
 
-A cold read currently builds the wrong input, leaving the requested file absent.
+A cold read builds the current directory's input, not the launch directory's.
 
   $ dune build cwd-output > cold.log 2>&1; echo $?
-  1
+  0
   $ test -f _build/default/input
+  [1]
 
-Prebuilding both inputs makes the read succeed, but hides the wrong dependency.
-Changing the file actually read then fails to invalidate the action. These
-prebuilds are separate targets, not static dependencies of cwd-output.
+Changing the file actually read invalidates the action, even when both inputs
+are already built. These prebuilds are separate targets, not static dependencies
+of cwd-output.
 
   $ dune build input elsewhere/input
   $ dune build cwd-output
@@ -59,11 +59,10 @@ prebuilds are separate targets, not static dependencies of cwd-output.
   $ dune build elsewhere/input
   $ dune build cwd-output
   $ cat _build/default/cwd-output
-  first
+  second
   
 
-Directory listings have the same problem: membership in the directory actually
-read is not tracked.
+Directory listings track membership in the directory actually read.
 
   $ dune build elsewhere/child.txt
   $ dune build listing
@@ -73,23 +72,24 @@ read is not tracked.
   $ dune build elsewhere/added.txt
   $ dune build listing
   $ cat _build/default/listing
+  added.txt
   child.txt
 
-Changing cwd after submitting a request also redirects the eventual I/O.
+Changing cwd after submitting a request does not redirect the eventual I/O.
 
   $ dune build in-flight listing-in-flight
   $ cat _build/default/in-flight
-  second
-  
+  launch
   $ cat _build/default/listing-in-flight
-  added.txt
-  child.txt
+  root.txt
 
 Parent-relative paths should also be interpreted from the current cwd. Helpers
 may start in a different directory while sharing the same action ID.
 
   $ dune build parent-output > parent.log 2>&1; echo $?
-  1
+  0
+  $ cat _build/default/parent-output
+  launch
   $ dune build helper-output > helper.log 2>&1; echo $?
   1
   $ cat _build/default/helper-output
@@ -102,9 +102,14 @@ assuming the sandbox has the same root as the canonical build tree.
   >     cwd-output > $mode.log 2>&1
   >   echo "$mode: $?"
   > done
-  copy: 1
-  symlink: 1
-  hardlink: 1
+  copy: 0
+  symlink: 0
+  hardlink: 0
+  $ cat _build-copy/default/cwd-output
+  second
+  
+  $ cmp _build-copy/default/cwd-output _build-symlink/default/cwd-output
+  $ cmp _build-copy/default/cwd-output _build-hardlink/default/cwd-output
 
 The build directory may itself be reached through a symlink. The client's
 physical cwd and Dune's spelling of the root still refer to the same tree.
@@ -112,4 +117,7 @@ physical cwd and Dune's spelling of the root still refer to the same tree.
   $ mkdir _build-physical
   $ ln -s _build-physical _build-linked
   $ dune build --build-dir=_build-linked cwd-output > linked.log 2>&1; echo $?
-  1
+  0
+  $ cat _build-linked/default/cwd-output
+  second
+  

--- a/otherlibs/dune-rpc/action_plugin.ml
+++ b/otherlibs/dune-rpc/action_plugin.ml
@@ -1,6 +1,8 @@
 open Import
 module Glob = Glob
 module Build_deps = Procedures.Public.Action_plugin.Build_deps
+module Initialize_response = Procedures.Public.Action_plugin.Initialize_response
+module Path = Stdune.Path
 
 type action_id = Action_id.t
 
@@ -18,6 +20,35 @@ let validate_path path =
          "Path %S is absolute. All paths used with Dune_rpc.V1.Action_plugin must be \
           relative."
          path)
+;;
+
+(* Unlike Path.External.reach, the wire namespace requires relative paths on
+   Windows too. Split off the volume before using the local-path operation. *)
+let relative_dir ~root dir =
+  let split dir =
+    let rec loop dir components =
+      let parent = Filename.dirname dir in
+      if String.equal parent dir
+      then (
+        let volume =
+          if Sys.win32
+          then
+            String.map dir ~f:(function
+              | '\\' -> '/'
+              | c -> c)
+            |> String.lowercase_ascii
+          else dir
+        in
+        volume, Path.Local.of_comps components)
+      else loop parent (Filename.of_string_exn (Filename.basename dir) :: components)
+    in
+    loop dir []
+  in
+  let root_volume, root = split root in
+  let volume, dir = split dir in
+  if not (String.equal root_volume volume)
+  then Error.raise "The current directory and action root are on different volumes.";
+  Path.Local.reach dir ~from:root
 ;;
 
 module type Rpc_client = Client.Public
@@ -44,6 +75,7 @@ struct
     | Under_dune of
         { client : Client.t
         ; action_id : action_id
+        ; root : string
         ; build_deps_request : (Build_deps.t, string option) Client.Versioned.request
         }
 
@@ -64,8 +96,8 @@ struct
   let create client ~action_id =
     let* initialize_request = prepare_request client Rpc.initialize_request in
     let* build_deps_request = prepare_request client Rpc.build_deps_request in
-    let* () = request client initialize_request action_id in
-    Fiber.return (Under_dune { client; action_id; build_deps_request })
+    let* { Initialize_response.root } = request client initialize_request action_id in
+    Fiber.return (Under_dune { client; action_id; root; build_deps_request })
   ;;
 
   let run chan ~action_id ~f =
@@ -81,33 +113,45 @@ struct
   let build_deps t deps =
     match t with
     | Outside_of_dune -> Fiber.return ()
-    | Under_dune { client; action_id; build_deps_request } ->
+    | Under_dune { client; action_id; build_deps_request; root = _ } ->
       let* response = request client build_deps_request { Build_deps.action_id; deps } in
       (match response with
        | None -> Fiber.return ()
        | Some message -> Error.raise message)
   ;;
 
-  let read_file t ~path =
+  let resolve_path t path =
     validate_path path;
-    let* () = build_deps t (Dep.Set.singleton (Dep.File path)) in
-    match Stdune.Io.String_path.read_file path with
+    let cwd = Sys.getcwd () in
+    let dependency =
+      match t with
+      | Outside_of_dune -> path
+      | Under_dune { root; _ } -> Filename.concat (relative_dir ~root cwd) path
+    in
+    Filename.concat cwd path, dependency
+  ;;
+
+  let read_file t ~path =
+    let absolute_path, dependency = resolve_path t path in
+    let* () = build_deps t (Dep.Set.singleton (Dep.File dependency)) in
+    match Stdune.Io.String_path.read_file absolute_path with
     | contents -> Fiber.return contents
-    | exception Unix.Unix_error (error, syscall, arg) ->
-      let error = Stdune.Unix_error.Detailed.create error ~syscall ~arg in
+    | exception Unix.Unix_error (error, syscall, _) ->
+      let error = Stdune.Unix_error.Detailed.create error ~syscall ~arg:path in
       Error.raise ("read_file: " ^ Stdune.Unix_error.Detailed.to_string_hum error)
     | exception Sys_error error -> Error.raise ("read_file: " ^ error)
   ;;
 
   let read_directory_with_glob t ~path ~glob =
-    validate_path path;
-    let dep = Dep.Glob { path; glob = Glob.to_string glob } in
+    let absolute_path, dependency = resolve_path t path in
+    let dep = Dep.Glob { path = dependency; glob = Glob.to_string glob } in
     let* () = build_deps t (Dep.Set.singleton dep) in
     let entries =
-      match Stdune.Readdir.read_directory path with
+      match Stdune.Readdir.read_directory absolute_path with
       | Ok entries -> Stdune.Filename.L.to_string entries
       | Error ((Unix.ENOENT | ENOTDIR), _, _) -> []
-      | Error error ->
+      | Error (error, syscall, _) ->
+        let error = Stdune.Unix_error.Detailed.create error ~syscall ~arg:path in
         Error.raise ("read_directory: " ^ Stdune.Unix_error.Detailed.to_string_hum error)
     in
     List.filter entries ~f:(Glob.test glob)

--- a/otherlibs/dune-rpc/action_plugin.mli
+++ b/otherlibs/dune-rpc/action_plugin.mli
@@ -18,7 +18,11 @@ end
 
 module Rpc : sig
   val action_id_env_variable : Stdune.Env.Var.t
-  val initialize : (Action_id.t, unit) Types.Decl.Request.t
+
+  val initialize
+    : ( Action_id.t
+        , Procedures.Public.Action_plugin.Initialize_response.t )
+        Types.Decl.Request.t
 
   val build_deps
     : (Procedures.Public.Action_plugin.Build_deps.t, string option) Types.Decl.Request.t

--- a/otherlibs/dune-rpc/import.ml
+++ b/otherlibs/dune-rpc/import.ml
@@ -19,6 +19,7 @@ include struct
   module Fdecl = Fdecl
   module Univ_map = Univ_map
   module Comparable_intf = Comparable_intf
+  module Filename = Filename
 
   module Path = struct
     (* we don't want to depend on build or source directories here *)

--- a/otherlibs/dune-rpc/procedures.ml
+++ b/otherlibs/dune-rpc/procedures.ml
@@ -174,9 +174,23 @@ module Public = struct
       ;;
     end
 
+    module Initialize_response = struct
+      type t = { root : string }
+
+      let conv =
+        let open Conv in
+        let to_ root = { root } in
+        let from { root } = root in
+        iso (record (field "root" (required string))) to_ from
+      ;;
+    end
+
     module Initialize = struct
       let v1 =
-        Decl.Request.make_current_gen ~req:Action_id.conv ~resp:Conv.unit ~version:1
+        Decl.Request.make_current_gen
+          ~req:Action_id.conv
+          ~resp:Initialize_response.conv
+          ~version:1
       ;;
 
       let decl =

--- a/otherlibs/dune-rpc/procedures.mli
+++ b/otherlibs/dune-rpc/procedures.mli
@@ -24,7 +24,15 @@ module Public : sig
       val conv : t Conv.value
     end
 
-    val initialize : (Action_id.t, unit) Decl.Request.t
+    module Initialize_response : sig
+      (** [root] is the absolute path of the action's sandbox-mapped build-context
+          root. Dependency paths are relative to this root. *)
+      type t = { root : string }
+
+      val conv : t Conv.value
+    end
+
+    val initialize : (Action_id.t, Initialize_response.t) Decl.Request.t
     val build_deps : (Build_deps.t, string option) Decl.Request.t
   end
 end

--- a/otherlibs/dune-rpc/registry.ml
+++ b/otherlibs/dune-rpc/registry.ml
@@ -1,17 +1,14 @@
 open Import
 
+(* CR-someday rgrinberg: use [Stdune.Filename.t] properly *)
+module Filename = Stdlib.Filename
+
 module File = struct
   type t =
     { path : string
     ; contents : string
     }
 end
-
-let _pid_of_path path =
-  Filename.basename path
-  |> Filename.chop_suffix_opt ~suffix:".pid"
-  |> Option.bind ~f:Int.of_string
-;;
 
 module Dune = struct
   module T = struct

--- a/otherlibs/dune-rpc/v1.mli
+++ b/otherlibs/dune-rpc/v1.mli
@@ -580,11 +580,14 @@ module Action_plugin : sig
     (** Run [f] using a connection to the Dune RPC server. *)
     val run : Chan.t -> action_id:action_id -> f:(t -> unit Fiber.t) -> unit Fiber.t
 
-    (** Read [path] after asking Dune to build it. *)
+    (** Read [path] after asking Dune to build it. Relative paths use the current
+        directory at the time of this call, even if it changes while waiting for
+        Dune. *)
     val read_file : t -> path:string -> string Fiber.t
 
     (** Read entries of [path] matching [glob] after asking Dune to build the
-        corresponding directory dependency. An absent directory produces an
+        corresponding directory dependency. Relative paths use the current
+        directory at the time of this call. An absent directory produces an
         empty listing.
 
         BUG: the returned listing includes directories even though that dependency

--- a/otherlibs/stdune/src/path.mli
+++ b/otherlibs/stdune/src/path.mli
@@ -71,6 +71,7 @@ module Local : sig
   val explode : t -> Filename.t list
   val descendant : t -> of_:t -> t option
   val of_comps : Filename.t list -> t
+  val reach : t -> from:t -> string
 
   module Table : Hashtbl.S with type key = t
 end

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -326,7 +326,7 @@ let exec
       let+ facts = build_deps deps in
       dynamic_deps_stages := (deps, facts) :: !dynamic_deps_stages
     in
-    { targets; metadata; context; sandbox; rule_loc; build_deps }
+    { targets; root; metadata; context; sandbox; rule_loc; build_deps }
   and eenv =
     let env =
       match

--- a/src/dune_engine/action_intf.ml
+++ b/src/dune_engine/action_intf.ml
@@ -107,6 +107,7 @@ end
 module Exec = struct
   type context =
     { targets : Targets.Validated.t option
+    ; root : Path.t
     ; context : Build_context.t option
     ; metadata : Process_metadata.t
     ; sandbox : Process.Sandbox.t option

--- a/src/dune_engine/action_plugin.ml
+++ b/src/dune_engine/action_plugin.ml
@@ -8,8 +8,8 @@ include struct
 end
 
 let to_dune_dep_set =
-  let of_action_plugin_dep ~loc ~working_dir : Dune_rpc.Dep.t -> Dep.t =
-    let to_dune_path = Path.relative working_dir in
+  let of_action_plugin_dep ~loc ~root : Dune_rpc.Dep.t -> Dep.t =
+    let to_dune_path = Path.relative root in
     function
     | File fn -> Dep.file (to_dune_path fn)
     | Directory dir ->
@@ -26,20 +26,25 @@ let to_dune_dep_set =
       in
       Dep.file_selector selector
   in
-  fun set ~loc ~working_dir ->
-    Dune_rpc.Dep.Set.to_list_map set ~f:(of_action_plugin_dep ~loc ~working_dir)
+  fun set ~loc ~root ->
+    let root = Path.drop_optional_sandbox_root root in
+    Dune_rpc.Dep.Set.to_list_map set ~f:(of_action_plugin_dep ~loc ~root)
     |> Dep.Set.of_list
 ;;
 
 module Server = struct
   module Rpc = Action_plugin.Rpc
   module Build_deps = Dune_rpc.Procedures.Public.Action_plugin.Build_deps
+
+  module Initialize_response =
+    Dune_rpc.Procedures.Public.Action_plugin.Initialize_response
+
   module Handler = Root.Rpc.Server.Handler
 
   type active =
     { build_deps : Dep.Set.t -> unit Fiber.t
     ; rule_loc : Loc.t
-    ; working_dir : Path.t
+    ; root : Path.t
     ; mutable initialized : bool
     ; mutable pending : unit Fiber.Ivar.t list
     }
@@ -61,15 +66,11 @@ module Server = struct
               ()))
   ;;
 
-  let with_active ~(ectx : context) ~(eenv : env) f =
+  let with_active ~(ectx : context) f =
+    let { Action.Ext.Exec.build_deps; rule_loc; root; _ } = ectx in
     let action_id = Action_id.gen () in
     let active_action =
-      { build_deps = ectx.build_deps
-      ; rule_loc = ectx.rule_loc
-      ; working_dir = Path.drop_optional_sandbox_root eenv.working_dir
-      ; initialized = false
-      ; pending = []
-      }
+      { build_deps; rule_loc; root; initialized = false; pending = [] }
     in
     Action_id.Table.add_exn active action_id active_action;
     Fiber.finalize
@@ -91,10 +92,8 @@ module Server = struct
       | { Exn_with_backtrace.exn; _ } :: _ -> exception_message exn
     in
     fun _session { Build_deps.action_id; deps } ->
-      let active = find_active action_id in
-      let deps_to_build =
-        to_dune_dep_set deps ~loc:active.rule_loc ~working_dir:active.working_dir
-      in
+      let ({ rule_loc; root; _ } as active) = find_active action_id in
+      let deps_to_build = to_dune_dep_set deps ~loc:rule_loc ~root in
       let open Fiber.O in
       let completed = Fiber.Ivar.create () in
       active.pending <- completed :: active.pending;
@@ -108,9 +107,11 @@ module Server = struct
   ;;
 
   let initialize _session action_id =
-    let active = find_active action_id in
+    let ({ root; _ } as active) = find_active action_id in
     active.initialized <- true;
-    Fiber.return ()
+    (* Match Sys.getcwd even when the build directory is a symlink. *)
+    let root = Unix.realpath (Path.to_absolute_filename root) in
+    Fiber.return { Initialize_response.root }
   ;;
 
   let implement_handler handler =
@@ -122,7 +123,7 @@ end
 let exec ~(ectx : context) ~(eenv : env) prog args =
   let open Fiber.O in
   let prog_name = Path.reach ~from:eenv.working_dir prog in
-  Server.with_active ~ectx ~eenv (fun action_id active_action ->
+  Server.with_active ~ectx (fun action_id active_action ->
     let env =
       let where =
         match Root.Rpc.Where.default () with

--- a/test/expect-tests/dune_rpc/digests.ml
+++ b/test/expect-tests/dune_rpc/digests.ml
@@ -142,7 +142,7 @@ let%expect_test "print digests for all declared RPCs" =
     dap/initialize
       Version 1:
         Request: String
-        Response: Unit
+        Response: 0762ced460c7fc004b73a87b2eaf4664
     dap/build-deps
       Version 1:
         Request: 042dc00d68ff9ee66979e82fefde258a


### PR DESCRIPTION
Resolve action-plugin dependency paths from the client’s current directory rather than its launch directory. Capture paths before waiting for Dune so a concurrent directory change cannot redirect file or directory reads.

Return the physical, sandbox-mapped build-context root in an initialization response record and translate requests into that root-relative namespace.

Related to #5681.