### PR TITLE
fix(action-plugin): connect helpers from different directories

### DIFF
--- a/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/paths.t
+++ b/otherlibs/dune-rpc-lwt/test/action-plugin/one-dependency/paths.t
@@ -91,8 +91,10 @@ may start in a different directory while sharing the same action ID.
   $ cat _build/default/parent-output
   launch
   $ dune build helper-output > helper.log 2>&1; echo $?
-  1
+  0
   $ cat _build/default/helper-output
+  second
+  
 
 The same cold read must work in sandboxes, without prebuilding the input or
 assuming the sandbox has the same root as the canonical build tree.

--- a/otherlibs/dune-rpc/action_plugin.ml
+++ b/otherlibs/dune-rpc/action_plugin.ml
@@ -181,6 +181,9 @@ let run_context () =
   | Some action_id, _ ->
     let where =
       match Where.of_env Env.initial with
+      | Ok (`Unix socket) when not (Filename.is_relative socket) ->
+        let dir = relative_dir ~root:(Sys.getcwd ()) (Filename.dirname socket) in
+        `Unix (Filename.concat dir (Filename.basename socket))
       | Ok where -> where
       | Error `Missing -> Error.raise "unable to find a dune rpc server"
       | Error (`Exn exn) ->

--- a/otherlibs/dune-rpc/v1.mli
+++ b/otherlibs/dune-rpc/v1.mli
@@ -558,7 +558,9 @@ module Action_plugin : sig
         ; where : Where.t
         }
 
-  (** Determine whether the program is running as a Dune dynamic action. *)
+  (** Determine whether the program is running as a Dune dynamic action.
+      Connect before changing directories: Unix socket addresses may be relative
+      to the current directory to accommodate socket path length limits. *)
   val run_context : unit -> run_context
 
   module Error : sig

--- a/src/dune_engine/action_plugin.ml
+++ b/src/dune_engine/action_plugin.ml
@@ -127,7 +127,7 @@ let exec ~(ectx : context) ~(eenv : env) prog args =
     let env =
       let where =
         match Root.Rpc.Where.default () with
-        | `Unix path -> `Unix (Path.reach (Path.of_string path) ~from:eenv.working_dir)
+        | `Unix path -> `Unix (Path.to_absolute_filename (Path.of_string path))
         | where -> where
       in
       Dune_rpc.Where.add_to_env where eenv.env


### PR DESCRIPTION
A dynamic action can launch a subprocess in another working directory. That subprocess inherits DUNE_RPC, but an address relative to the parent’s launch directory no longer locates the server.

Advertise an absolute RPC endpoint, then shorten Unix socket addresses relative to each client’s cwd at discovery time to preserve the socket path-length budget. Document that clients must connect before changing directories again, and flip the existing helper regression from failure to success.

Follow-up to #16384. Related to #5681.