### PR TITLE
fix(menhir): validate merge target names

### DIFF
--- a/doc/changes/fixed/16387.md
+++ b/doc/changes/fixed/16387.md
@@ -1,0 +1,2 @@
+- Reject invalid Menhir `merge_into` names during parsing to prevent internal
+  errors (#16387, @anmonteiro)

--- a/doc/reference/dune/menhir.rst
+++ b/doc/reference/dune/menhir.rst
@@ -28,6 +28,7 @@ is:
 - ``(merge_into <base_name>)`` is used to define modular parsers. This
   correspond to the ``--base`` command line option of ``menhir``. With this
   option, a single parser named ``base_name`` is generated.
+  The base name must be a nonempty filename without directory components.
 
 - ``(flags <option1> <option2> ...)`` is used to pass extra flags to Menhir.
 

--- a/src/dune_rules/menhir/menhir_stanza.ml
+++ b/src/dune_rules/menhir/menhir_stanza.ml
@@ -18,7 +18,18 @@ type t =
 
 let decode =
   fields
-    (let+ merge_into = field_o "merge_into" string
+    (let+ merge_into =
+       field_o
+         "merge_into"
+         (let+ loc, merge_into = located string in
+          match Filename.of_string merge_into with
+          | Some _ -> merge_into
+          | None ->
+            User_error.raise
+              ~loc
+              [ Pp.text
+                  "The merge_into field must be a filename without directory components"
+              ])
      and+ flags = Ordered_set_lang.Unexpanded.field "flags"
      and+ modules =
        Ordered_set_lang.Unexpanded.field

--- a/test/blackbox-tests/test-cases/menhir/merge-into-validation.t
+++ b/test/blackbox-tests/test-cases/menhir/merge-into-validation.t
@@ -1,4 +1,4 @@
-Invalid merge_into names currently cause internal errors during rule generation.
+The merge_into field must name a file in the stanza directory.
 
   $ make_menhir_project 3.21 3.0
 
@@ -8,22 +8,11 @@ Invalid merge_into names currently cause internal errors during rule generation.
   >  (modules parser))
   > EOF
 
-  $ dune build 2>&1 | sed '/^Raised at/,$d'
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
-  providing the file _build/trace.csexp, if possible. This includes build
-  commands, message logs, and file paths.
-  Description:
-    ("[gen_rules] returned rules in a directory that is not a descendant of the directory it was called for",
-     { dir = In_build_dir "default"
-     ; example =
-         Rule
-           { targets =
-               { root = In_build_dir "."
-               ; files = set { "parser.ml"; "parser.mli" }
-               ; dirs = set {}
-               }
-           }
-     })
+  $ dune build
+  File "dune", line 2, characters 13-22:
+  2 |  (merge_into ../parser)
+                   ^^^^^^^^^
+  Error: The merge_into field must be a filename without directory components
   [1]
 
   $ cat >dune <<EOF
@@ -32,20 +21,9 @@ Invalid merge_into names currently cause internal errors during rule generation.
   >  (modules parser))
   > EOF
 
-  $ dune build 2>&1 | sed '/^Raised at/,$d'
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
-  providing the file _build/trace.csexp, if possible. This includes build
-  commands, message logs, and file paths.
-  Description:
-    ("[gen_rules] returned rules in a directory that is not a descendant of the directory it was called for",
-     { dir = In_build_dir "default"
-     ; example =
-         Rule
-           { targets =
-               { root = In_build_dir "."
-               ; files = set { "default.ml"; "default.mli" }
-               ; dirs = set {}
-               }
-           }
-     })
+  $ dune build
+  File "dune", line 2, characters 13-15:
+  2 |  (merge_into "")
+                   ^^
+  Error: The merge_into field must be a filename without directory components
   [1]


### PR DESCRIPTION
Validate Menhir `merge_into` names before generating rules. Follows #16386.