### PR TITLE
test(inline-tests): document empty mode lists

### DIFF
--- a/test/blackbox-tests/test-cases/inline-tests/inline_tests-multi-mode.t
+++ b/test/blackbox-tests/test-cases/inline-tests/inline_tests-multi-mode.t
@@ -29,3 +29,29 @@ Reproduction case for #3347
   $ dune runtest
   Test byte
   Test native
+
+An explicitly empty mode list is accepted and runs no tests, even after a
+source change.
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name test)
+  >  (libraries test_backend)
+  >  (modules test)
+  >  (inline_tests (modes)))
+  > 
+  > (library
+  >  (name test_backend)
+  >  (modules ())
+  >  (inline_tests.backend
+  >   (generate_runner
+  >    (progn
+  >     (echo "Printf.eprintf \"Test %s\"\n")
+  >     (echo "  (match Sys.backend_type with")
+  >     (echo "   | Bytecode -> \"byte\"\n")
+  >     (echo "   | Native -> \"native\"\n")
+  >     (echo "   | Other s -> s)\n")))))
+  > EOF
+
+  $ echo 'let value = 42' >test.ml
+  $ dune runtest


### PR DESCRIPTION
Document that an explicitly empty inline-test mode list is accepted and runs no tests.