### PR TITLE
test(install): document empty entry lists

### DIFF
--- a/test/blackbox-tests/test-cases/stanzas/install/install-empty.t
+++ b/test/blackbox-tests/test-cases/stanzas/install/install-empty.t
@@ -1,0 +1,22 @@
+Empty install entry lists are accepted. The install manifest contains only
+the package metadata.
+
+  $ make_dune_project 3.11
+  $ touch foo.opam
+
+  $ cat >dune <<EOF
+  > (install
+  >  (section share)
+  >  (files)
+  >  (dirs)
+  >  (source_trees))
+  > EOF
+
+  $ dune build @install
+
+  $ cat _build/default/foo.install
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+    "_build/install/default/lib/foo/opam"
+  ]


### PR DESCRIPTION
Document that empty files, dirs, and source_trees lists are accepted and add no entries to the install manifest.